### PR TITLE
Depth track state reconciliation for web UI

### DIFF
--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -36,6 +36,17 @@ import {
   getDepthTrackLabelFromFile,
   isDepthTrackAutoLabel
 } from './depth-tracks.js';
+import {
+  compactDepthFileSlots,
+  depthFileSlotsFromValue,
+  ensureDepthTrackConfigCount as ensureDepthTrackConfigCountEntries,
+  isDefaultManagedDepthSlot,
+  normalizeDepthTrackConfig as normalizeDepthTrackConfigEntry,
+  reindexDepthSlots,
+  removeDepthTrackAt,
+  syncDepthSlotLabels,
+  uploadedDepthFileCount
+} from './depth-track-state.js';
 
 const { onMounted, onUnmounted, watch, nextTick, computed, ref, reactive } = window.Vue;
 
@@ -262,11 +273,7 @@ export const createAppSetup = () => {
     '#17BECF',
     '#7F7F7F'
   ];
-  const depthFileSlotsFromValue = (value) => {
-    if (Array.isArray(value)) return value.slice();
-    return value ? [value] : [];
-  };
-  const depthFileCount = (value) => depthFileSlotsFromValue(value).filter(Boolean).length;
+  const depthFileCount = (value) => uploadedDepthFileCount(value);
   const depthTrackCountLabel = (value) => {
     const count = depthFileCount(value);
     return count === 1 ? '1 TSV' : `${count} TSVs`;
@@ -277,13 +284,6 @@ export const createAppSetup = () => {
     circular: 1,
     linearByUid: {}
   });
-  const compactDepthFileSlots = (slots) => {
-    const next = Array.isArray(slots) ? slots.slice() : [];
-    while (next.length > 0 && !next[next.length - 1]) {
-      next.pop();
-    }
-    return next;
-  };
   const sourceDepthTrackCount = (slots, uiCount = 1) => Math.max(
     1,
     Number(uiCount) || 1,
@@ -312,23 +312,18 @@ export const createAppSetup = () => {
     depthTrackUiCounts.linearByUid[uid] = Math.max(1, Number(count) || 1);
   };
   const depthTrackFallbackColor = (index) => depthTrackDefaultColors[index % depthTrackDefaultColors.length];
-  const normalizeDepthTrackNumber = (value) => {
-    if (value === null || value === undefined || value === '') return null;
-    const numeric = Number(value);
-    return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
-  };
-  const normalizeDepthTrackConfig = (entry, index) => {
-    const source = entry && typeof entry === 'object' && !Array.isArray(entry) ? entry : {};
-    const hasHeight = Object.prototype.hasOwnProperty.call(source, 'height');
-    return {
-      label: String(source.label ?? getDepthTrackFallbackLabel(index)),
-      color: String(source.color || (index === 0 ? adv.depth_color : depthTrackFallbackColor(index))),
-      height: normalizeDepthTrackNumber(hasHeight ? source.height : adv.depth_height),
-      large_tick_interval: normalizeDepthTrackNumber(source.large_tick_interval ?? source.tick_interval),
-      small_tick_interval: normalizeDepthTrackNumber(source.small_tick_interval),
-      tick_font_size: normalizeDepthTrackNumber(source.tick_font_size)
-    };
-  };
+  const depthTrackConfigDefaults = () => ({
+    labelForIndex: getDepthTrackFallbackLabel,
+    colorForIndex: depthTrackFallbackColor,
+    depthColor: adv.depth_color,
+    depthHeight: adv.depth_height,
+    largeTickInterval: null,
+    smallTickInterval: null,
+    tickFontSize: null
+  });
+  const normalizeDepthTrackConfig = (entry, index) => (
+    normalizeDepthTrackConfigEntry(entry, index, depthTrackConfigDefaults())
+  );
   const activeDepthTrackCount = () => {
     if (mode.value === 'linear') {
       return linearSeqs.reduce(
@@ -343,13 +338,12 @@ export const createAppSetup = () => {
   };
   const ensureDepthTrackConfigCount = (count = activeDepthTrackCount()) => {
     const targetCount = Math.max(1, Number(count) || 1);
-    for (let index = 0; index < adv.depth_tracks.length; index += 1) {
-      const normalized = normalizeDepthTrackConfig(adv.depth_tracks[index], index);
-      Object.assign(adv.depth_tracks[index], normalized);
-    }
-    while (adv.depth_tracks.length < targetCount) {
-      adv.depth_tracks.push(normalizeDepthTrackConfig(null, adv.depth_tracks.length));
-    }
+    const normalized = ensureDepthTrackConfigCountEntries(
+      adv.depth_tracks,
+      targetCount,
+      depthTrackConfigDefaults()
+    );
+    adv.depth_tracks.splice(0, adv.depth_tracks.length, ...normalized);
   };
   const circularDepthTrackRows = computed(() => rowsForDepthTrackCount(
     sourceDepthTrackCount(files.c_depth, depthTrackUiCounts.circular)
@@ -371,42 +365,19 @@ export const createAppSetup = () => {
     const config = depthTrackConfigForIndex(index);
     return String(config?.label ?? '');
   };
-  const representativeDepthFileForIndex = (index) => {
-    const idx = Math.max(0, Number(index) || 0);
-    const circularFile = getCircularDepthFile(idx);
-    if (circularFile) return circularFile;
-    for (const seq of linearSeqs) {
-      const file = getLinearDepthFile(seq, idx);
-      if (file) return file;
-    }
-    return null;
-  };
-  const depthTrackLabelLooksAutomatic = (label, index) => {
-    const text = String(label ?? '').trim();
-    if (!text) return true;
-    if (text === getDepthTrackFallbackLabel(index)) return true;
-    const representativeFile = representativeDepthFileForIndex(index);
-    return Boolean(representativeFile && text === getDepthTrackLabelFromFile(representativeFile, index));
-  };
   const depthTrackSlotCollections = () => [
     Array.isArray(adv.circular_track_slots) ? adv.circular_track_slots : [],
     Array.isArray(adv.linear_track_slots) ? adv.linear_track_slots : []
   ];
   const syncDepthTrackSlotLabelsForTrack = (index) => {
-    const idx = Math.max(0, Number(index) || 0);
-    const label = getDepthTrackLabel(idx);
     depthTrackSlotCollections().forEach((slots) => {
-      slots.forEach((slot) => {
-        if (!slot || slot.renderer !== 'depth') return;
-        if (normalizeDepthSlotTrackIndex(slot) !== idx) return;
-        slot.params = slot.params && typeof slot.params === 'object' ? { ...slot.params } : {};
-        if (String(label).trim()) {
-          slot.params.legend_label = label;
-        } else {
-          delete slot.params.legend_label;
-        }
+      syncDepthSlotLabels({
+        slots,
+        depthTracks: adv.depth_tracks,
+        activeCount: adv.depth_tracks.length
       });
     });
+    void index;
   };
   const setDepthTrackLabel = (index, value) => {
     const idx = Math.max(0, Number(index) || 0);
@@ -433,21 +404,29 @@ export const createAppSetup = () => {
     if (!slot || slot.renderer !== 'depth') return;
     syncDepthTrackSlotLabelsForTrack(normalizeDepthSlotTrackIndex(slot));
   };
-  const syncDepthTrackLabelsFromSlots = () => {
-    depthTrackSlotCollections().forEach((slots) => {
-      slots.forEach((slot) => {
-        if (!slot || slot.renderer !== 'depth') return;
-        const slotLabel = String(slot.params?.legend_label ?? '').trim();
-        if (!slotLabel) return;
-        const idx = normalizeDepthSlotTrackIndex(slot);
-        const config = depthTrackConfigForIndex(idx);
-        if (String(config.label ?? '').trim() === slotLabel) return;
-        if (!depthTrackLabelLooksAutomatic(config.label, idx)) return;
-        config.label = slotLabel;
-      });
-    });
-  };
   const depthTrackAutoLabels = [];
+  const refreshDepthTrackLabelsAfterRemoval = (previousFiles, nextFiles, removedIndex) => {
+    depthFileSlotsFromValue(nextFiles).forEach((file, newIndex) => {
+      const oldIndex = newIndex >= removedIndex ? newIndex + 1 : newIndex;
+      const config = adv.depth_tracks[newIndex];
+      if (!config) return;
+      const oldFile = depthFileSlotsFromValue(previousFiles)[oldIndex] || null;
+      const currentLabel = String(config.label ?? '').trim();
+      if (
+        isDepthTrackAutoLabel(currentLabel, oldIndex, oldFile) ||
+        currentLabel === depthTrackAutoLabels[oldIndex]
+      ) {
+        const nextLabel = file
+          ? getDepthTrackLabelFromFile(file, newIndex)
+          : getDepthTrackFallbackLabel(newIndex);
+        config.label = nextLabel;
+        depthTrackAutoLabels[newIndex] = nextLabel;
+      } else {
+        depthTrackAutoLabels[newIndex] = currentLabel;
+      }
+    });
+    depthTrackAutoLabels.length = depthFileSlotsFromValue(nextFiles).length;
+  };
   const updateDepthTrackLabelFromFile = (index, file, previousFile = null) => {
     if (!file) return;
     const config = adv.depth_tracks[index];
@@ -505,32 +484,72 @@ export const createAppSetup = () => {
     const idx = Number(index);
     if (!Number.isInteger(idx) || idx < 0) return;
     const count = sourceDepthTrackCount(files.c_depth, depthTrackUiCounts.circular);
-    const slots = depthFileSlotsFromValue(files.c_depth);
-    if (count <= 1) {
-      slots[0] = null;
-      depthTrackUiCounts.circular = 1;
-    } else {
-      slots.splice(idx, 1);
-      depthTrackUiCounts.circular = Math.max(1, count - 1);
-    }
-    files.c_depth = compactDepthFileSlots(slots);
+    const removal = removeDepthTrackAt({
+      files: files.c_depth,
+      depthTracks: adv.depth_tracks,
+      index: idx,
+      minCount: 1,
+      defaults: depthTrackConfigDefaults()
+    });
+    files.c_depth = removal.files;
+    adv.depth_tracks.splice(0, adv.depth_tracks.length, ...removal.depthTracks);
+    depthTrackUiCounts.circular = count <= 1 ? 1 : Math.max(1, count - 1);
+    refreshDepthTrackLabelsAfterRemoval(removal.previousFiles, files.c_depth, idx);
     ensureDepthTrackConfigCount(activeDepthTrackCount());
+    const activeFileCount = uploadedDepthFileCount(files.c_depth);
+    adv.circular_track_slots.splice(
+      0,
+      adv.circular_track_slots.length,
+      ...reindexDepthSlots({
+        slots: adv.circular_track_slots,
+        removedIndex: idx,
+        activeCount: activeFileCount,
+        managedPredicate: isDefaultManagedDepthSlot
+      })
+    );
+    syncDepthTrackSlotLabelsForTrack(idx);
+    circularTrackSlotEditor.normalizeCircularTrackSlots();
+    if (adv.circular_track_slots_enabled && form.show_depth && activeFileCount > 0) {
+      circularTrackSlotEditor.ensureCircularTrackDepthSlot();
+    }
   };
   const removeLinearDepthTrack = (seq, index) => {
     if (!seq) return;
     const idx = Number(index);
     if (!Number.isInteger(idx) || idx < 0) return;
     const count = sourceDepthTrackCount(seq.depth, linearDepthTrackUiCount(seq));
-    const slots = depthFileSlotsFromValue(seq.depth);
-    if (count <= 1) {
-      slots[0] = null;
-      setLinearDepthTrackUiCount(seq, 1);
-    } else {
-      slots.splice(idx, 1);
-      setLinearDepthTrackUiCount(seq, count - 1);
-    }
-    seq.depth = compactDepthFileSlots(slots);
+    const removal = removeDepthTrackAt({
+      files: seq.depth,
+      depthTracks: adv.depth_tracks,
+      index: idx,
+      minCount: 1,
+      defaults: depthTrackConfigDefaults()
+    });
+    seq.depth = removal.files;
+    adv.depth_tracks.splice(0, adv.depth_tracks.length, ...removal.depthTracks);
+    setLinearDepthTrackUiCount(seq, count <= 1 ? 1 : count - 1);
+    refreshDepthTrackLabelsAfterRemoval(removal.previousFiles, seq.depth, idx);
     ensureDepthTrackConfigCount(activeDepthTrackCount());
+    const activeFileCount = linearSeqs.reduce(
+      (maxCount, item) => Math.max(maxCount, uploadedDepthFileCount(item.depth)),
+      0
+    );
+    adv.linear_track_slots.splice(
+      0,
+      adv.linear_track_slots.length,
+      ...reindexDepthSlots({
+        slots: adv.linear_track_slots,
+        removedIndex: idx,
+        activeCount: activeFileCount,
+        managedPredicate: isDefaultManagedDepthSlot
+      })
+    );
+    syncDepthTrackSlotLabelsForTrack(idx);
+    linearTrackSlotEditor.syncLinearDepthSlotHeightsFromDepthTracks();
+    linearTrackSlotEditor.normalizeLinearTrackSlots();
+    if (adv.linear_track_slots_enabled && form.show_depth && activeFileCount > 0) {
+      linearTrackSlotEditor.ensureLinearTrackDepthSlots();
+    }
   };
   watch(
     () => [
@@ -679,7 +698,6 @@ export const createAppSetup = () => {
         circularTrackSlotEditor.ensureCircularTrackDepthSlot();
       }
       if (slotsEnabled) {
-        syncDepthTrackLabelsFromSlots();
         adv.depth_tracks.forEach((_track, index) => syncDepthTrackSlotLabelsForTrack(index));
       }
     }
@@ -696,7 +714,6 @@ export const createAppSetup = () => {
     ([slotsEnabled]) => {
       if (slotsEnabled) {
         linearTrackSlotEditor.reconcileLinearTrackSlotsFromSimpleControls();
-        syncDepthTrackLabelsFromSlots();
         adv.depth_tracks.forEach((_track, index) => syncDepthTrackSlotLabelsForTrack(index));
       }
     },

--- a/gbdraw/web/js/app/circular-track-slots.js
+++ b/gbdraw/web/js/app/circular-track-slots.js
@@ -5,6 +5,11 @@ import {
   orderedConservationSources,
   safeConservationSlotId
 } from './conservation-series.js';
+import {
+  dropInvalidManagedDepthSlots,
+  isDefaultManagedDepthSlot,
+  uploadedDepthFileCount
+} from './depth-track-state.js';
 
 const SUPPORTED_RENDERERS = [
   'features',
@@ -298,16 +303,9 @@ const cloneParams = (params = {}) => {
   return { ...params };
 };
 
-const depthFileSlotsFromValue = (value) => {
-  if (Array.isArray(value)) return value.slice();
-  return value ? [value] : [];
-};
-
 const circularDepthTrackCountForState = (state) => {
   if (!Boolean(state?.form?.show_depth)) return 0;
-  const fileCount = depthFileSlotsFromValue(state?.files?.c_depth).length;
-  if (fileCount > 0) return fileCount;
-  return 1;
+  return uploadedDepthFileCount(state?.files?.c_depth);
 };
 
 const normalizeSlotSide = (value) => normalizeOptionalPlacement(value);
@@ -1042,6 +1040,16 @@ export const createCircularTrackSlotEditor = ({ state }) => {
     normalizeSlotsInPlace();
     const desiredCount = desiredCircularDepthTrackCount();
     if (desiredCount <= 0) {
+      state.adv.circular_track_slots.splice(
+        0,
+        state.adv.circular_track_slots.length,
+        ...dropInvalidManagedDepthSlots({
+          slots: state.adv.circular_track_slots,
+          activeCount: 0,
+          managedPredicate: isDefaultManagedDepthSlot
+        })
+      );
+      normalizeSlotsInPlace();
       return;
     }
 
@@ -1067,13 +1075,22 @@ export const createCircularTrackSlotEditor = ({ state }) => {
       return;
     }
 
+    state.adv.circular_track_slots.splice(
+      0,
+      state.adv.circular_track_slots.length,
+      ...dropInvalidManagedDepthSlots({
+        slots: state.adv.circular_track_slots,
+        activeCount: desiredCount,
+        managedPredicate: isDefaultManagedDepthSlot
+      })
+    );
     const slots = state.adv.circular_track_slots;
     const existingIds = new Set(
       slots.map((slot) => String(slot?.id || '').trim()).filter(Boolean)
     );
     const depthEntries = slots
       .map((slot, index) => ({ slot, index }))
-      .filter((entry) => entry.slot?.renderer === 'depth');
+      .filter((entry) => entry.slot?.renderer === 'depth' && entry.slot.enabled !== false);
     const claimedTrackIndexes = new Set();
     const duplicateDepthEntries = [];
 
@@ -1091,7 +1108,9 @@ export const createCircularTrackSlotEditor = ({ state }) => {
         }
         claimedTrackIndexes.add(trackIndex);
       } else {
-        duplicateDepthEntries.push(entry);
+        if (isDefaultManagedDepthSlot(entry.slot)) {
+          duplicateDepthEntries.push(entry);
+        }
       }
     });
 

--- a/gbdraw/web/js/app/depth-track-state.js
+++ b/gbdraw/web/js/app/depth-track-state.js
@@ -1,0 +1,313 @@
+const DEPTH_TRACK_FALLBACK_COLORS = [
+  '#4A90E2',
+  '#E45756',
+  '#2CA02C',
+  '#F28E2B',
+  '#9467BD',
+  '#8C564B',
+  '#17BECF',
+  '#7F7F7F'
+];
+
+const normalizePositiveNumber = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+};
+
+const normalizeOptionalText = (value) => {
+  const text = String(value ?? '').trim();
+  return text.length > 0 ? text : null;
+};
+
+const cloneParams = (params = {}) => {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) return {};
+  return { ...params };
+};
+
+const fallbackLabel = (index) => {
+  const numericIndex = Math.max(0, Number(index) || 0);
+  return numericIndex === 0 ? 'Depth' : `Depth ${numericIndex + 1}`;
+};
+
+const fallbackColor = (index, defaults = {}) => {
+  if (typeof defaults.colorForIndex === 'function') {
+    return String(defaults.colorForIndex(index) || '');
+  }
+  if (index === 0 && defaults.depthColor) return String(defaults.depthColor);
+  return DEPTH_TRACK_FALLBACK_COLORS[index % DEPTH_TRACK_FALLBACK_COLORS.length];
+};
+
+export const depthFileBaseName = (file) => {
+  const rawName = String(file?.name || '').split(/[\\/]/).pop().trim();
+  if (!rawName) return '';
+  return rawName.replace(/\.[^.]+$/, '').trim() || rawName;
+};
+
+export const depthLabelMatchesFile = (label, file) => {
+  const labelText = String(label || '').toLowerCase();
+  const fileText = depthFileBaseName(file).toLowerCase();
+  if (!labelText || !fileText) return false;
+  if (labelText.includes(fileText) || fileText.includes(labelText)) return true;
+  const accessionTokens = fileText.match(/[a-z]{2,5}\d{5,}/g) || [];
+  return accessionTokens.some((token) => labelText.includes(token));
+};
+
+export const depthFileSlotsFromValue = (value) => {
+  if (Array.isArray(value)) return value.slice();
+  return value ? [value] : [];
+};
+
+export const compactDepthFileSlots = (slots) => {
+  const next = depthFileSlotsFromValue(slots);
+  while (next.length > 0 && !next[next.length - 1]) {
+    next.pop();
+  }
+  return next;
+};
+
+export const uploadedDepthFileCount = (value) => (
+  depthFileSlotsFromValue(value).filter(Boolean).length
+);
+
+export const normalizeDepthTrackConfig = (entry, index, defaults = {}) => {
+  const source = entry && typeof entry === 'object' && !Array.isArray(entry) ? entry : {};
+  const hasHeight = Object.prototype.hasOwnProperty.call(source, 'height');
+  const labelForIndex = typeof defaults.labelForIndex === 'function'
+    ? defaults.labelForIndex
+    : fallbackLabel;
+  return {
+    label: String(source.label ?? labelForIndex(index)),
+    color: String(source.color || fallbackColor(index, defaults)),
+    height: normalizePositiveNumber(hasHeight ? source.height : defaults.depthHeight),
+    large_tick_interval: normalizePositiveNumber(
+      source.large_tick_interval ?? source.tick_interval ?? defaults.largeTickInterval
+    ),
+    small_tick_interval: normalizePositiveNumber(
+      source.small_tick_interval ?? defaults.smallTickInterval
+    ),
+    tick_font_size: normalizePositiveNumber(
+      source.tick_font_size ?? defaults.tickFontSize
+    )
+  };
+};
+
+export const ensureDepthTrackConfigCount = (tracks, count, defaults = {}) => {
+  const rawTracks = Array.isArray(tracks) ? tracks : [];
+  const targetCount = Math.max(1, Number(count) || 1);
+  const normalized = rawTracks.map((entry, index) => (
+    normalizeDepthTrackConfig(entry, index, defaults)
+  ));
+  while (normalized.length < targetCount) {
+    normalized.push(normalizeDepthTrackConfig(null, normalized.length, defaults));
+  }
+  return normalized;
+};
+
+export const reconcileDepthTracksToFiles = ({
+  files,
+  depthTracks,
+  targetCount,
+  defaults = {}
+} = {}) => {
+  const fileSlots = Array.isArray(files) ? files : depthFileSlotsFromValue(files);
+  const rawTracks = Array.isArray(depthTracks) ? depthTracks : [];
+  const usedTrackIndexes = new Set();
+  return Array.from({ length: Math.max(1, Number(targetCount) || 1) }, (_, index) => {
+    const file = fileSlots[index] || null;
+    let sourceIndex = index;
+    if (
+      file &&
+      rawTracks[index] &&
+      !depthLabelMatchesFile(rawTracks[index]?.label, file)
+    ) {
+      const matchingIndex = rawTracks.findIndex((entry, candidateIndex) => (
+        candidateIndex > index &&
+        !usedTrackIndexes.has(candidateIndex) &&
+        depthLabelMatchesFile(entry?.label, file)
+      ));
+      if (matchingIndex >= 0) sourceIndex = matchingIndex;
+    }
+    usedTrackIndexes.add(sourceIndex);
+    return normalizeDepthTrackConfig(rawTracks[sourceIndex], index, defaults);
+  });
+};
+
+export const removeDepthTrackAt = ({
+  files,
+  depthTracks,
+  index,
+  minCount = 1,
+  defaults = {}
+} = {}) => {
+  const idx = Number(index);
+  const originalFiles = depthFileSlotsFromValue(files);
+  const originalTracks = Array.isArray(depthTracks) ? depthTracks.slice() : [];
+  if (!Number.isInteger(idx) || idx < 0) {
+    return {
+      files: compactDepthFileSlots(originalFiles),
+      depthTracks: ensureDepthTrackConfigCount(originalTracks, minCount, defaults),
+      removed: false,
+      removedFile: null,
+      previousFiles: originalFiles
+    };
+  }
+  const visibleCount = Math.max(minCount, originalFiles.length, 1);
+  const nextFiles = originalFiles.slice();
+  const nextTracks = originalTracks.slice();
+  const removedFile = nextFiles[idx] || null;
+  if (visibleCount <= 1) {
+    nextFiles[0] = null;
+    nextTracks.splice(0, nextTracks.length);
+  } else {
+    nextFiles.splice(idx, 1);
+    if (idx < nextTracks.length) nextTracks.splice(idx, 1);
+  }
+  const compactedFiles = compactDepthFileSlots(nextFiles);
+  const normalizedTracks = ensureDepthTrackConfigCount(
+    nextTracks,
+    Math.max(minCount, compactedFiles.length),
+    defaults
+  );
+  return {
+    files: compactedFiles,
+    depthTracks: normalizedTracks,
+    removed: true,
+    removedFile,
+    previousFiles: originalFiles
+  };
+};
+
+export const depthSlotTrackIndex = (slot, fallbackIndex = null) => {
+  const rawTrackIndex = slot?.params?.track_index;
+  if (rawTrackIndex !== null && rawTrackIndex !== undefined && rawTrackIndex !== '') {
+    const parsed = Number(rawTrackIndex);
+    if (Number.isInteger(parsed) && parsed >= 0) return parsed;
+  }
+  const idMatch = String(slot?.id || '').trim().match(/^depth_(\d+)$/);
+  if (idMatch) return Math.max(0, Number(idMatch[1]) - 1);
+  if (fallbackIndex !== null && fallbackIndex !== undefined) {
+    const fallback = Number(fallbackIndex);
+    if (Number.isInteger(fallback) && fallback >= 0) return fallback;
+  }
+  return null;
+};
+
+const slotHasGeometry = (slot) => (
+  normalizeOptionalText(slot?.width) !== null ||
+  normalizeOptionalText(slot?.radius) !== null ||
+  normalizeOptionalText(slot?.spacing) !== null ||
+  normalizeOptionalText(slot?.inner_gap_px) !== null ||
+  normalizeOptionalText(slot?.outer_gap_px) !== null ||
+  Number(slot?.z || 0) !== 0
+);
+
+const paramsOnlyAllowedKeys = (params, allowedKeys) => {
+  const allowed = new Set(allowedKeys);
+  return Object.entries(cloneParams(params)).every(([key, value]) => (
+    allowed.has(String(key)) || normalizeOptionalText(value) === null
+  ));
+};
+
+export const isDefaultManagedDepthSlot = (slot) => {
+  if (!slot || typeof slot !== 'object' || Array.isArray(slot)) return false;
+  if (String(slot.renderer || '') !== 'depth') return false;
+  if (slotHasGeometry(slot)) return false;
+  const id = String(slot.id || '').trim();
+  if (!/^depth(?:_\d+)?$/.test(id)) return false;
+  return paramsOnlyAllowedKeys(slot.params, ['track_index', 'legend_label', 'managed']);
+};
+
+const cloneSlot = (slot) => ({
+  ...slot,
+  params: cloneParams(slot?.params)
+});
+
+const disableInvalidManualDepthSlot = (slot) => {
+  const next = cloneSlot(slot);
+  next.enabled = false;
+  if (/^depth(?:_\d+)?$/.test(String(next.id || '').trim())) {
+    next.id = `disabled_${next.id}`;
+  }
+  delete next.params.track_index;
+  delete next.params.legend_label;
+  return next;
+};
+
+export const reindexDepthSlots = ({
+  slots,
+  removedIndex,
+  activeCount,
+  managedPredicate = isDefaultManagedDepthSlot
+} = {}) => {
+  const idx = Number(removedIndex);
+  const count = Math.max(0, Number(activeCount) || 0);
+  if (!Array.isArray(slots) || !Number.isInteger(idx) || idx < 0) {
+    return Array.isArray(slots) ? slots.map((slot) => cloneSlot(slot)) : [];
+  }
+  const nextSlots = [];
+  slots.forEach((slot, ordinal) => {
+    if (!slot || String(slot.renderer || '') !== 'depth') {
+      nextSlots.push(cloneSlot(slot));
+      return;
+    }
+    const oldTrackIndex = depthSlotTrackIndex(slot, ordinal);
+    const isManaged = managedPredicate(slot);
+    if (oldTrackIndex === null || oldTrackIndex === idx) {
+      if (!isManaged) nextSlots.push(disableInvalidManualDepthSlot(slot));
+      return;
+    }
+    const newTrackIndex = oldTrackIndex > idx ? oldTrackIndex - 1 : oldTrackIndex;
+    if (newTrackIndex < 0 || newTrackIndex >= count) {
+      if (!isManaged) nextSlots.push(disableInvalidManualDepthSlot(slot));
+      return;
+    }
+    const next = cloneSlot(slot);
+    next.params.track_index = newTrackIndex;
+    nextSlots.push(next);
+  });
+  return nextSlots;
+};
+
+export const dropInvalidManagedDepthSlots = ({
+  slots,
+  activeCount,
+  managedPredicate = isDefaultManagedDepthSlot
+} = {}) => {
+  const count = Math.max(0, Number(activeCount) || 0);
+  if (!Array.isArray(slots)) return [];
+  return slots
+    .map((slot, ordinal) => {
+      if (!slot || String(slot.renderer || '') !== 'depth') return cloneSlot(slot);
+      const trackIndex = depthSlotTrackIndex(slot, ordinal);
+      if (trackIndex !== null && trackIndex >= 0 && trackIndex < count) {
+        const next = cloneSlot(slot);
+        next.params.track_index = trackIndex;
+        return next;
+      }
+      return managedPredicate(slot) ? null : disableInvalidManualDepthSlot(slot);
+    })
+    .filter(Boolean);
+};
+
+export const syncDepthSlotLabels = ({ slots, depthTracks, activeCount = null } = {}) => {
+  if (!Array.isArray(slots)) return;
+  const count = activeCount === null || activeCount === undefined
+    ? (Array.isArray(depthTracks) ? depthTracks.length : 0)
+    : Math.max(0, Number(activeCount) || 0);
+  slots.forEach((slot, ordinal) => {
+    if (!slot || String(slot.renderer || '') !== 'depth') return;
+    const trackIndex = depthSlotTrackIndex(slot, ordinal);
+    if (trackIndex === null || trackIndex < 0 || trackIndex >= count) {
+      return;
+    }
+    const label = String(depthTracks?.[trackIndex]?.label ?? '').trim();
+    slot.params = cloneParams(slot.params);
+    slot.params.track_index = trackIndex;
+    if (label) {
+      slot.params.legend_label = label;
+    } else {
+      delete slot.params.legend_label;
+    }
+  });
+};

--- a/gbdraw/web/js/app/linear-track-slots.js
+++ b/gbdraw/web/js/app/linear-track-slots.js
@@ -1,3 +1,8 @@
+import {
+  dropInvalidManagedDepthSlots,
+  uploadedDepthFileCount
+} from './depth-track-state.js';
+
 const SUPPORTED_RENDERERS = [
   'features',
   'dinucleotide_content',
@@ -103,12 +108,8 @@ const defaultSlot = (renderer, overrides = {}) => {
 export const linearDepthTrackCountForState = (state) => {
   if (!Boolean(state?.form?.show_depth)) return 0;
   const seqs = Array.isArray(state?.linearSeqs) ? state.linearSeqs : [];
-  const counts = seqs.map((seq) => {
-    const value = seq?.depth;
-    if (Array.isArray(value)) return value.filter(Boolean).length;
-    return value ? 1 : 0;
-  });
-  return Math.max(1, ...counts);
+  const counts = seqs.map((seq) => uploadedDepthFileCount(seq?.depth));
+  return Math.max(0, ...counts);
 };
 
 export const createDefaultLinearTrackSlots = ({
@@ -175,7 +176,15 @@ export const normalizeLinearTrackSlots = (slots, nt = 'GC', trackLayout = 'middl
       }
       if (renderer === 'depth') {
         const trackIndex = normalizeTrackIndex(params.track_index);
-        params.track_index = trackIndex === null ? 0 : trackIndex;
+        if (trackIndex === null) {
+          if (slot.enabled === false) {
+            delete params.track_index;
+          } else {
+            params.track_index = 0;
+          }
+        } else {
+          params.track_index = trackIndex;
+        }
       }
       if (renderer === 'dinucleotide_content' || renderer === 'dinucleotide_skew') {
         params.nt = normalizeNt(params.nt ?? params.dinucleotide, nt);
@@ -338,7 +347,6 @@ const isDefaultManagedLinearSlot = (slot, renderer = null) => {
   if (!hasBlankLinearSlotGeometry(slot)) return false;
   const id = String(slot.id || '').trim();
   const params = cloneParams(slot.params);
-  if (normalizeOptionalText(params.legend_label) !== null) return false;
   if (params.managed === DEFAULT_LINEAR_SLOT_MANAGER) return true;
 
   if (normalizedRenderer === 'features') {
@@ -351,7 +359,7 @@ const isDefaultManagedLinearSlot = (slot, renderer = null) => {
     return id === 'gc_skew' && paramsMatchAllowedKeys(params, ['nt', 'dinucleotide']);
   }
   if (normalizedRenderer === 'depth') {
-    return /^depth(?:_\d+)?$/.test(id) && paramsMatchAllowedKeys(params, ['track_index']);
+    return /^depth(?:_\d+)?$/.test(id) && paramsMatchAllowedKeys(params, ['track_index', 'legend_label']);
   }
   return false;
 };
@@ -686,12 +694,29 @@ export const createLinearTrackSlotEditor = ({ state }) => {
   const ensureLinearTrackDepthSlots = () => {
     const desiredCount = linearDepthTrackCountForState(state);
     if (!Boolean(form.show_depth) || desiredCount <= 0) {
-      removeDefaultManagedSlots('depth');
+      adv.linear_track_slots.splice(
+        0,
+        adv.linear_track_slots.length,
+        ...dropInvalidManagedDepthSlots({
+          slots: adv.linear_track_slots,
+          activeCount: 0,
+          managedPredicate: (slot) => isDefaultManagedLinearSlot(slot, 'depth')
+        })
+      );
       normalizeCurrentSlots();
       return;
     }
 
     normalizeCurrentSlots();
+    adv.linear_track_slots.splice(
+      0,
+      adv.linear_track_slots.length,
+      ...dropInvalidManagedDepthSlots({
+        slots: adv.linear_track_slots,
+        activeCount: desiredCount,
+        managedPredicate: (slot) => isDefaultManagedLinearSlot(slot, 'depth')
+      })
+    );
     const slots = adv.linear_track_slots;
     const managedDepthEntries = slots
       .map((slot, index) => ({ slot, index }))

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -31,6 +31,11 @@ import {
   getDepthTrackFallbackLabel,
   getDepthTrackLabelFromFile
 } from './depth-tracks.js';
+import {
+  depthFileSlotsFromValue,
+  depthSlotTrackIndex,
+  syncDepthSlotLabels
+} from './depth-track-state.js';
 
 const downloadTextFile = (filename, text) => {
   const safeName = filename || 'losat.tsv';
@@ -1820,9 +1825,6 @@ json.dumps({
           args.push('--depth_tick_font_size', adv.depth_tick_font_size);
         }
       };
-      const depthFileSlotsFromValue = (value) => (
-        Array.isArray(value) ? value.slice() : (value ? [value] : [])
-      );
       const normalizeDepthTrackValue = (value) => {
         if (value === null || value === undefined || value === '') return null;
         const numeric = Number(value);
@@ -1904,52 +1906,33 @@ json.dumps({
         }
         return adv.depth_tracks[idx];
       };
-      const depthSlotTrackIndex = (slot, fallbackIndex = 0, trackCount = null) => {
-        const rawTrackIndex = Number(slot?.params?.track_index);
-        const parsed = Number.isInteger(rawTrackIndex) && rawTrackIndex >= 0
-          ? rawTrackIndex
-          : Math.max(0, Number(fallbackIndex) || 0);
-        if (Number.isInteger(trackCount) && trackCount > 0) {
-          return Math.min(parsed, trackCount - 1);
-        }
-        return parsed;
-      };
-      const depthLabelLooksAutomatic = (label, trackIndex, file = null) => {
-        const text = String(label ?? '').trim();
-        if (!text) return true;
-        if (text === getDepthTrackFallbackLabel(trackIndex)) return true;
-        return Boolean(file && text === getDepthTrackLabelFromFile(file, trackIndex));
-      };
       const syncDepthSlotLegendLabelsFromTrackConfigs = (slots, trackFiles = []) => {
         if (!Array.isArray(slots)) return;
-        const trackCount = Math.max(
-          1,
-          Array.isArray(adv.depth_tracks) ? adv.depth_tracks.length : 0,
-          Array.isArray(trackFiles) ? trackFiles.length : 0
-        );
+        const trackCount = Array.isArray(trackFiles)
+          ? trackFiles.length
+          : 0;
+        for (let trackIndex = 0; trackIndex < trackCount; trackIndex += 1) {
+          ensureDepthTrackConfigAt(trackIndex);
+        }
+        syncDepthSlotLabels({
+          slots,
+          depthTracks: adv.depth_tracks,
+          activeCount: trackCount
+        });
+      };
+      const validateEnabledDepthSlots = (slots, activeCount, kind) => {
+        const count = Math.max(0, Number(activeCount) || 0);
         let fallbackIndex = 0;
-        slots.forEach((slot) => {
-          if (!slot || String(slot.renderer || '') !== 'depth') return;
-          const trackIndex = depthSlotTrackIndex(slot, fallbackIndex, trackCount);
-          const config = ensureDepthTrackConfigAt(trackIndex);
-          const file = Array.isArray(trackFiles) ? (trackFiles[trackIndex] || null) : null;
-          const slotLabel = String(slot.params?.legend_label ?? '').trim();
-          const configLabel = String(config.label ?? '').trim();
-          if (slotLabel && slotLabel !== configLabel && depthLabelLooksAutomatic(configLabel, trackIndex, file)) {
-            config.label = slotLabel;
-          }
-          const resolvedLabel = String(config.label ?? '').trim() ||
-            slotLabel ||
-            getDepthTrackLabelFromFile(file, trackIndex) ||
-            getDepthTrackFallbackLabel(trackIndex);
-          slot.params = slot.params && typeof slot.params === 'object' ? { ...slot.params } : {};
-          slot.params.track_index = trackIndex;
-          if (resolvedLabel.trim()) {
-            slot.params.legend_label = resolvedLabel;
-          } else {
-            delete slot.params.legend_label;
-          }
-          fallbackIndex = trackIndex + 1;
+        (Array.isArray(slots) ? slots : []).forEach((slot) => {
+          if (!slot || slot.enabled === false || String(slot.renderer || '') !== 'depth') return;
+          const trackIndex = depthSlotTrackIndex(slot, fallbackIndex);
+          fallbackIndex += 1;
+          if (trackIndex !== null && trackIndex >= 0 && trackIndex < count) return;
+          const slotId = String(slot.id || 'depth').trim() || 'depth';
+          const indexText = trackIndex === null ? 'unknown' : String(trackIndex);
+          throw new Error(
+            `${kind} depth slot '${slotId}' references removed depth track index ${indexText}. Select an existing Depth TSV or remove the slot.`
+          );
         });
       };
       const linearDepthRepresentativeFiles = () => {
@@ -2281,6 +2264,7 @@ json.dumps({
             args.push('--gc_skew_radius', adv.gc_skew_radius_circular);
           }
         }
+        const circularDepthEntries = depthTrackEntriesFromSlots(files.c_depth);
         if (useCircularTrackSlots) {
           args.push('--circular_track_axis_index', String(adv.circular_track_slots_axis_index));
           const circularDepthSlotIndexes = new Set();
@@ -2291,7 +2275,6 @@ json.dumps({
             const trackIndex = Number.isInteger(parsedTrackIndex) && parsedTrackIndex >= 0
               ? parsedTrackIndex
               : circularDepthSlotOrdinal;
-            circularDepthSlotIndexes.add(trackIndex);
             if (!slot.params || !Number.isInteger(parsedTrackIndex) || parsedTrackIndex < 0) {
               slot.params = { ...(slot.params || {}), track_index: trackIndex };
             }
@@ -2299,8 +2282,14 @@ json.dumps({
           });
           syncDepthSlotLegendLabelsFromTrackConfigs(
             circularTrackSlots,
-            depthFileSlotsFromValue(files.c_depth)
+            circularDepthEntries.map((entry) => entry.file)
           );
+          validateEnabledDepthSlots(circularTrackSlots, circularDepthEntries.length, 'Circular');
+          circularTrackSlots.forEach((slot, slotIndex) => {
+            if (slot?.enabled === false || String(slot?.renderer || '') !== 'depth') return;
+            const trackIndex = depthSlotTrackIndex(slot, slotIndex);
+            if (trackIndex !== null) circularDepthSlotIndexes.add(trackIndex);
+          });
           const usedCircularSlotIds = new Set(
             circularTrackSlots.map((slot) => String(slot?.id || '').trim()).filter(Boolean)
           );
@@ -2313,7 +2302,6 @@ json.dumps({
               })
             );
           });
-          const circularDepthEntries = depthTrackEntriesFromSlots(files.c_depth);
           if (circularDepthEntries.length > 1) {
             for (let depthIndex = 0; depthIndex < circularDepthEntries.length; depthIndex += 1) {
               if (circularDepthSlotIndexes.has(depthIndex)) continue;
@@ -2328,7 +2316,6 @@ json.dumps({
             }
           }
         }
-        const circularDepthEntries = depthTrackEntriesFromSlots(files.c_depth);
         const hasCircularDepthFile = circularDepthEntries.length > 0;
         const circularSlotNeedsDepth = useCircularTrackSlots && hasEnabledCircularTrackRenderer(circularTrackSlots, 'depth');
         if (form.show_depth || circularSlotNeedsDepth) {
@@ -2721,9 +2708,7 @@ json.dumps({
             slot.params = slot.params && typeof slot.params === 'object' ? { ...slot.params } : {};
             const rawTrackIndex = Number(slot.params.track_index);
             if (!Number.isInteger(rawTrackIndex) || rawTrackIndex < 0) {
-              slot.params.track_index = Math.min(nextDepthIndex, Math.max(0, depthTrackCount - 1));
-            } else {
-              slot.params.track_index = Math.min(rawTrackIndex, Math.max(0, depthTrackCount - 1));
+              slot.params.track_index = nextDepthIndex;
             }
             syncLinearDepthSlotHeightFromTrackConfig(slot);
             nextDepthIndex = Number(slot.params.track_index) + 1;
@@ -2732,6 +2717,7 @@ json.dumps({
             linearTrackSlots,
             linearDepthRepresentativeFiles()
           );
+          validateEnabledDepthSlots(linearTrackSlots, depthTrackCount, 'Linear');
           linearTrackSlotAxisIndex = clampLinearTrackAxisIndex(
             adv.linear_track_slots_axis_index,
             linearTrackSlots.length

--- a/gbdraw/web/js/config.js
+++ b/gbdraw/web/js/config.js
@@ -1,5 +1,5 @@
 export const GBDRAW_WHEEL_NAME = "gbdraw-0.12.0-py3-none-any.whl";
-export const GBDRAW_WHEEL_CACHE_BUST = "20260616-211526";
+export const GBDRAW_WHEEL_CACHE_BUST = "20260616-233842";
 export const PYODIDE_INDEX_URL = "./vendor/pyodide/v0.29.0/full/";
 export const PYODIDE_LOCAL_WHEELS = [
   "./vendor/pyodide-wheels/six-1.17.0-py2.py3-none-any.whl",

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -13,6 +13,13 @@ import {
   resolveLinearTrackAxisIndex
 } from '../app/linear-track-slots.js';
 import {
+  depthFileSlotsFromValue,
+  dropInvalidManagedDepthSlots,
+  reconcileDepthTracksToFiles,
+  syncDepthSlotLabels,
+  uploadedDepthFileCount
+} from '../app/depth-track-state.js';
+import {
   DEPTH_FILE_ENCODING,
   decodeDepthText,
   encodeDepthText,
@@ -1282,6 +1289,87 @@ const applyFiles = (filesData) => {
   return { collapsedLinearSeqs: false };
 };
 
+const representativeLinearDepthFiles = () => {
+  const rows = state.linearSeqs.map((seq) => depthFileSlotsFromValue(seq.depth));
+  const maxDepthTracks = Math.max(...rows.map((row) => row.length), 0);
+  return Array.from({ length: maxDepthTracks }, (_, trackIndex) => (
+    rows.map((row) => row[trackIndex]).find(Boolean) || null
+  ));
+};
+
+const reconcileDepthTrackStateAfterSessionFiles = () => {
+  const circularDepthCount = uploadedDepthFileCount(state.files.c_depth);
+  const linearDepthCount = state.linearSeqs.reduce(
+    (maxCount, seq) => Math.max(maxCount, uploadedDepthFileCount(seq.depth)),
+    0
+  );
+  const targetDepthTrackCount = Math.max(1, circularDepthCount, linearDepthCount);
+  const depthFilesForTracks = circularDepthCount > 0
+    ? depthFileSlotsFromValue(state.files.c_depth).filter(Boolean)
+    : representativeLinearDepthFiles();
+  const normalizedTracks = reconcileDepthTracksToFiles({
+    files: depthFilesForTracks,
+    depthTracks: state.adv.depth_tracks,
+    targetCount: targetDepthTrackCount,
+    defaults: {
+      depthColor: state.adv.depth_color,
+      depthHeight: state.adv.depth_height,
+      largeTickInterval: state.adv.depth_tick_interval,
+      smallTickInterval: state.adv.depth_small_tick_interval,
+      tickFontSize: state.adv.depth_tick_font_size
+    }
+  });
+  state.adv.depth_tracks.splice(0, state.adv.depth_tracks.length, ...normalizedTracks);
+
+  state.adv.circular_track_slots.splice(
+    0,
+    state.adv.circular_track_slots.length,
+    ...dropInvalidManagedDepthSlots({
+      slots: state.adv.circular_track_slots,
+      activeCount: circularDepthCount
+    })
+  );
+  syncDepthSlotLabels({
+    slots: state.adv.circular_track_slots,
+    depthTracks: state.adv.depth_tracks,
+    activeCount: circularDepthCount
+  });
+  state.adv.circular_track_slots.splice(
+    0,
+    state.adv.circular_track_slots.length,
+    ...applyCircularTrackOrderPlacements(
+      state.adv.circular_track_slots,
+      state.adv.nt,
+      state.form.track_type,
+      state.adv.circular_track_slots_axis_index
+    )
+  );
+
+  state.adv.linear_track_slots.splice(
+    0,
+    state.adv.linear_track_slots.length,
+    ...dropInvalidManagedDepthSlots({
+      slots: state.adv.linear_track_slots,
+      activeCount: linearDepthCount
+    })
+  );
+  syncDepthSlotLabels({
+    slots: state.adv.linear_track_slots,
+    depthTracks: state.adv.depth_tracks,
+    activeCount: linearDepthCount
+  });
+  state.adv.linear_track_slots.splice(
+    0,
+    state.adv.linear_track_slots.length,
+    ...applyLinearTrackOrderPlacements(
+      state.adv.linear_track_slots,
+      state.adv.linear_track_slots_axis_index,
+      state.adv.nt,
+      state.form.linear_track_layout
+    )
+  );
+};
+
 export const exportConfig = () => {
   const configData = buildConfigData();
   downloadJson(configData, 'gbdraw_config.json');
@@ -1538,6 +1626,7 @@ export const importSession = async (e) => {
     restoreSessionPlotTitlePositions(ui);
 
     const { collapsedLinearSeqs } = applyFiles(data.files);
+    reconcileDepthTrackStateAfterSessionFiles();
     applyLosatCache(data.losatCache?.entries);
     if (collapsedLinearSeqs) {
       state.losatCacheInfo.value = [];

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}

--- a/tests/web/depth-track-session.playwright.spec.js
+++ b/tests/web/depth-track-session.playwright.spec.js
@@ -1,0 +1,122 @@
+const { test, expect } = require('@playwright/test');
+const { createReadStream, existsSync } = require('node:fs');
+const { createServer } = require('node:http');
+const { extname, join, normalize, resolve, sep } = require('node:path');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const sessionPath = join(repoRoot, 'tests/test_inputs/2026-06-16_wssv.gbdraw-session.json');
+
+const contentTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.wasm': 'application/wasm',
+  '.whl': 'application/octet-stream',
+  '.data': 'application/octet-stream'
+};
+
+let server;
+let baseUrl;
+
+test.beforeAll(async () => {
+  await new Promise((resolveServer, rejectServer) => {
+    server = createServer((request, response) => {
+      const url = new URL(request.url || '/', 'http://127.0.0.1');
+      const requestedPath = normalize(decodeURIComponent(url.pathname)).replace(/^(\.\.(?:\/|\\|$))+/, '');
+      const filePath = resolve(repoRoot, requestedPath.replace(/^[/\\]+/, ''));
+      if (!filePath.startsWith(`${repoRoot}${sep}`) && filePath !== repoRoot) {
+        response.writeHead(403);
+        response.end('Forbidden');
+        return;
+      }
+      const finalPath = filePath === repoRoot ? join(repoRoot, 'gbdraw/web/index.html') : filePath;
+      if (!existsSync(finalPath)) {
+        response.writeHead(404);
+        response.end('Not found');
+        return;
+      }
+      response.writeHead(200, {
+        'Content-Type': contentTypes[extname(finalPath)] || 'application/octet-stream'
+      });
+      createReadStream(finalPath).pipe(response);
+    });
+    server.once('error', rejectServer);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      baseUrl = `http://127.0.0.1:${address.port}`;
+      resolveServer();
+    });
+  });
+});
+
+test.afterAll(async () => {
+  await new Promise((resolveClose) => server.close(resolveClose));
+});
+
+test('WSSV depth session removes stale circular depth metadata and slots', async ({ page }) => {
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.goto(`${baseUrl}/gbdraw/web/index.html`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+
+  await page.locator('input[accept=".json"]').nth(1).setInputFiles(sessionPath);
+  await page.waitForFunction(() => {
+    const app = window.__GBDRAW_APP__;
+    return Array.isArray(app?.files?.c_depth) && app.files.c_depth.length === 2;
+  });
+
+  const loaded = await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    return {
+      names: app.files.c_depth.map((file) => file?.name || ''),
+      labels: app.adv.depth_tracks.map((track) => track?.label || ''),
+      slots: app.adv.circular_track_slots
+        .filter((slot) => slot?.renderer === 'depth')
+        .map((slot) => ({
+          id: slot.id,
+          enabled: slot.enabled !== false,
+          trackIndex: slot.params?.track_index,
+          legendLabel: slot.params?.legend_label
+        }))
+    };
+  });
+
+  expect(loaded.names).toHaveLength(2);
+  expect(loaded.labels).toHaveLength(2);
+  expect(loaded.labels[1]).toContain('SRR14027721');
+  expect(loaded.slots.filter((slot) => slot.enabled).map((slot) => slot.trackIndex)).toEqual([0, 1]);
+  expect(loaded.slots.filter((slot) => slot.enabled).map((slot) => slot.legendLabel)).toEqual(loaded.labels);
+
+  await page.evaluate(() => window.__GBDRAW_APP__.removeCircularDepthTrack(1));
+  await page.waitForFunction(() => {
+    const app = window.__GBDRAW_APP__;
+    return Array.isArray(app.files.c_depth) &&
+      app.files.c_depth.length === 1 &&
+      app.adv.circular_track_slots
+        .filter((slot) => slot?.renderer === 'depth' && slot.enabled !== false)
+        .every((slot) => Number(slot.params?.track_index) < 1);
+  });
+
+  const afterRemoval = await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    return {
+      names: app.files.c_depth.map((file) => file?.name || ''),
+      labels: app.adv.depth_tracks.map((track) => track?.label || ''),
+      slots: app.adv.circular_track_slots
+        .filter((slot) => slot?.renderer === 'depth')
+        .map((slot) => ({
+          id: slot.id,
+          enabled: slot.enabled !== false,
+          trackIndex: slot.params?.track_index,
+          legendLabel: slot.params?.legend_label
+        }))
+    };
+  });
+
+  expect(afterRemoval.names).toHaveLength(1);
+  expect(afterRemoval.labels[0]).toContain('SRR14027705');
+  expect(afterRemoval.slots.filter((slot) => slot.enabled).map((slot) => slot.trackIndex)).toEqual([0]);
+  expect(afterRemoval.slots.some((slot) => Number(slot.trackIndex) >= 1)).toBe(false);
+  expect(afterRemoval.slots.some((slot) => String(slot.legendLabel || '').includes('SRR14027712'))).toBe(false);
+});

--- a/tests/web/depth-track-state.test.mjs
+++ b/tests/web/depth-track-state.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const sourceUrl = new URL('../../gbdraw/web/js/app/depth-track-state.js', import.meta.url);
+const tempDir = await mkdtemp(join(tmpdir(), 'gbdraw-depth-track-state-'));
+const tempModulePath = join(tempDir, 'depth-track-state.mjs');
+await writeFile(tempModulePath, await readFile(sourceUrl, 'utf8'));
+
+const {
+  depthFileSlotsFromValue,
+  reindexDepthSlots,
+  reconcileDepthTracksToFiles,
+  removeDepthTrackAt,
+  syncDepthSlotLabels
+} = await import(pathToFileURL(tempModulePath));
+
+const file = (name) => ({ name });
+const labels = (tracks) => tracks.map((track) => track.label);
+const depthIndexes = (slots) => slots
+  .filter((slot) => slot.renderer === 'depth' && slot.enabled !== false)
+  .map((slot) => slot.params.track_index);
+const depthLabels = (slots) => slots
+  .filter((slot) => slot.renderer === 'depth' && slot.enabled !== false)
+  .map((slot) => slot.params.legend_label);
+const depthSlots = (count) => Array.from({ length: count }, (_, index) => ({
+  id: `depth_${index + 1}`,
+  renderer: 'depth',
+  params: {
+    track_index: index,
+    legend_label: ['24 hpi', '12 hpi', '6 hpi'][index]
+  }
+}));
+
+{
+  const removal = removeDepthTrackAt({
+    files: [file('24 hpi.tsv'), file('12 hpi.tsv'), file('6 hpi.tsv')],
+    depthTracks: [{ label: '24 hpi' }, { label: '12 hpi' }, { label: '6 hpi' }],
+    index: 1
+  });
+  const slots = reindexDepthSlots({
+    slots: depthSlots(3),
+    removedIndex: 1,
+    activeCount: depthFileSlotsFromValue(removal.files).length
+  });
+  syncDepthSlotLabels({ slots, depthTracks: removal.depthTracks, activeCount: 2 });
+
+  assert.deepEqual(removal.files.map((entry) => entry.name), ['24 hpi.tsv', '6 hpi.tsv']);
+  assert.deepEqual(labels(removal.depthTracks), ['24 hpi', '6 hpi']);
+  assert.deepEqual(depthIndexes(slots), [0, 1]);
+  assert.deepEqual(depthLabels(slots), ['24 hpi', '6 hpi']);
+}
+
+{
+  const removal = removeDepthTrackAt({
+    files: [file('24 hpi.tsv'), file('12 hpi.tsv'), file('6 hpi.tsv')],
+    depthTracks: [{ label: '24 hpi' }, { label: '12 hpi' }, { label: '6 hpi' }],
+    index: 0
+  });
+  const slots = reindexDepthSlots({
+    slots: depthSlots(3),
+    removedIndex: 0,
+    activeCount: 2
+  });
+  syncDepthSlotLabels({ slots, depthTracks: removal.depthTracks, activeCount: 2 });
+
+  assert.deepEqual(removal.files.map((entry) => entry.name), ['12 hpi.tsv', '6 hpi.tsv']);
+  assert.deepEqual(labels(removal.depthTracks), ['12 hpi', '6 hpi']);
+  assert.deepEqual(depthIndexes(slots), [0, 1]);
+  assert.deepEqual(depthLabels(slots), ['12 hpi', '6 hpi']);
+}
+
+{
+  const removal = removeDepthTrackAt({
+    files: [file('24 hpi.tsv'), file('12 hpi.tsv'), file('6 hpi.tsv')],
+    depthTracks: [{ label: '24 hpi' }, { label: '12 hpi' }, { label: '6 hpi' }],
+    index: 2
+  });
+  const slots = reindexDepthSlots({
+    slots: depthSlots(3),
+    removedIndex: 2,
+    activeCount: 2
+  });
+  syncDepthSlotLabels({ slots, depthTracks: removal.depthTracks, activeCount: 2 });
+
+  assert.deepEqual(removal.files.map((entry) => entry.name), ['24 hpi.tsv', '12 hpi.tsv']);
+  assert.deepEqual(labels(removal.depthTracks), ['24 hpi', '12 hpi']);
+  assert.deepEqual(depthIndexes(slots), [0, 1]);
+}
+
+{
+  const removal = removeDepthTrackAt({
+    files: [file('24 hpi.tsv')],
+    depthTracks: [{ label: '24 hpi' }],
+    index: 0
+  });
+  const slots = reindexDepthSlots({
+    slots: depthSlots(1),
+    removedIndex: 0,
+    activeCount: 0
+  });
+
+  assert.deepEqual(removal.files, []);
+  assert.deepEqual(depthIndexes(slots), []);
+  assert.equal(removal.depthTracks.length, 1);
+}
+
+{
+  const slots = reindexDepthSlots({
+    slots: [
+      { id: 'depth_1', renderer: 'depth', params: { track_index: 0 } },
+      { id: 'custom_removed', renderer: 'depth', width: '10px', params: { track_index: 1 } },
+      { id: 'depth_3', renderer: 'depth', params: { track_index: 2 } }
+    ],
+    removedIndex: 1,
+    activeCount: 2
+  });
+
+  const custom = slots.find((slot) => slot.id === 'custom_removed');
+  assert.equal(custom.enabled, false);
+  assert.equal(Object.hasOwn(custom.params, 'track_index'), false);
+  assert.deepEqual(depthIndexes(slots), [0, 1]);
+}
+
+{
+  const reconciled = reconcileDepthTracksToFiles({
+    files: [
+      file('UAZ00-173B.SRR14027705.minimap2.depth.tsv'),
+      file('UAZ00-173B.SRR14027721.minimap2.depth.tsv')
+    ],
+    depthTracks: [
+      { label: '24 hpi SRR14027705)' },
+      { label: '6 hpi (SRR14027712)' },
+      { label: '6 hpi (SRR14027721)' }
+    ],
+    targetCount: 2
+  });
+
+  assert.deepEqual(labels(reconciled), ['24 hpi SRR14027705)', '6 hpi (SRR14027721)']);
+}
+
+console.log(`depth-track-state tests passed (${fileURLToPath(sourceUrl)})`);


### PR DESCRIPTION
- Centralize Depth TSV file, metadata, slot index, and legend label reconciliation in a shared web helper 
- Reindex circular/linear depth track slots transactionally when Depth TSV entries are removed 
- Treat depth slot legend_label as derived from adv.depth_tracks 
- Reconcile stale depth metadata/slots on session restore
- Add Node helper coverage and a Playwright regression for stale circular depth slots after session load/removal 
- Tighten generation-time validation for invalid depth slot indexes