### PR TITLE
Refine gallery tags and add tag filtering

### DIFF
--- a/gbdraw/web/gallery/examples.json
+++ b/gbdraw/web/gallery/examples.json
@@ -4,8 +4,7 @@
     "title": "Human mitochondrial genome: first circular figure",
     "tags": [
       "Circular",
-      "GenBank",
-      "Beginner"
+      "Interactive SVG"
     ],
     "svg": "./examples/HmmtDNA_basic_circular.svg",
     "svgType": "interactive",
@@ -23,10 +22,8 @@
     "commandKind": "runnable",
     "commandNote": "Download HmmtDNA.gbk from the Files tab, then run this command in the same directory.",
     "description": "Create a first circular genome figure from one small GenBank record without running a sequence search.",
-    "difficulty": "Beginner",
     "workflow": "Circular basics",
     "inputSummary": "1 GenBank file",
-    "estimatedTime": "Under 5 min",
     "displayOrder": 10,
     "tutorial": "./tutorials/HmmtDNA_basic_circular.json",
     "tutorialStatus": "ready"
@@ -36,8 +33,7 @@
     "title": "Lambda phage: first linear figure",
     "tags": [
       "Linear",
-      "GenBank",
-      "Beginner"
+      "Interactive SVG"
     ],
     "svg": "./examples/lambda_basic_linear.svg",
     "svgType": "interactive",
@@ -55,10 +51,8 @@
     "commandKind": "runnable",
     "commandNote": "Download NC_001416.gb from the Files tab, then run this command in the same directory.",
     "description": "Create a labeled linear genome figure and learn strand separation, the ruler, and SVG export.",
-    "difficulty": "Beginner",
     "workflow": "Linear basics",
     "inputSummary": "1 GenBank file",
-    "estimatedTime": "Under 5 min",
     "displayOrder": 20,
     "tutorial": "./tutorials/lambda_basic_linear.json",
     "tutorialStatus": "ready"
@@ -68,8 +62,7 @@
     "title": "Human mitochondrial genome (AT skew)",
     "tags": [
       "Circular",
-      "GenBank",
-      "Intermediate"
+      "Interactive SVG"
     ],
     "svg": "./examples/HmmtDNA_ATskew.svg",
     "svgType": "interactive",
@@ -87,10 +80,8 @@
     "commandKind": "runnable",
     "commandNote": "Download both HmmtDNA.gbk and HmmtDNA_qualifier_priority.tsv from Files before running the command.",
     "description": "Add an AT skew ring and qualifier-based labels to a compact circular mitochondrial diagram.",
-    "difficulty": "Intermediate",
     "workflow": "Circular quantitative tracks",
     "inputSummary": "1 GenBank + 1 qualifier TSV",
-    "estimatedTime": "5-10 min",
     "displayOrder": 30,
     "tutorial": "./tutorials/HmmtDNA_ATskew.json",
     "tutorialStatus": "ready"
@@ -100,8 +91,7 @@
     "title": "<i>Nicotiana tabacum</i> chloroplast genome regions",
     "tags": [
       "Circular",
-      "Organellar",
-      "Intermediate"
+      "Interactive SVG"
     ],
     "svg": "./examples/tobacco-chloroplast.svg",
     "svgType": "interactive",
@@ -119,10 +109,8 @@
     "commandKind": "runnable",
     "commandNote": "Download NC_001879.gbk and the three Gallery TSV files, then run the command in the same directory.",
     "description": "Mark LSC, SSC, IRa, and IRb as bracket annotations inside a color-coded chloroplast gene map.",
-    "difficulty": "Intermediate",
     "workflow": "Circular region annotations",
     "inputSummary": "1 GenBank + 3 TSV files",
-    "estimatedTime": "5-10 min",
     "displayOrder": 40,
     "tutorial": "./tutorials/tobacco-chloroplast.json",
     "tutorialStatus": "ready"
@@ -133,7 +121,7 @@
     "tags": [
       "Circular",
       "Multi-record",
-      "Intermediate"
+      "Interactive SVG"
     ],
     "svg": "./examples/Vnig_TUMSAT-TG-2018.svg",
     "svgType": "interactive",
@@ -151,10 +139,8 @@
     "commandKind": "runnable",
     "commandNote": "Download the pinned RefSeq assembly named in Files; no sequence search is required.",
     "description": "Arrange two chromosomes and four plasmids from one multi-record GenBank file on a shared circular canvas.",
-    "difficulty": "Intermediate",
     "workflow": "Circular multi-record canvas",
     "inputSummary": "1 multi-record GenBank file",
-    "estimatedTime": "5-15 min",
     "displayOrder": 50,
     "tutorial": "./tutorials/Vnig_TUMSAT-TG-2018.json",
     "tutorialStatus": "ready"
@@ -164,8 +150,9 @@
     "title": "Hepatoplasmataceae collinear protein-match blocks",
     "tags": [
       "Linear",
-      "Collinear",
-      "Advanced"
+      "Collinear groups",
+      "LOSAT",
+      "Interactive SVG"
     ],
     "svg": "./examples/hepatoplasmataceae_collinear.svg",
     "svgType": "interactive",
@@ -187,10 +174,8 @@
     "commandKind": "runnable",
     "commandNote": "Download the five accession-pinned GenBank inputs from Files. The command runs LOSATP locally.",
     "description": "Combine compatible protein-match anchors into collinear blocks across five related genomes.",
-    "difficulty": "Advanced",
     "workflow": "LOSATP collinear blocks",
     "inputSummary": "5 GenBank files",
-    "estimatedTime": "10-20 min plus search",
     "displayOrder": 60,
     "tutorial": "./tutorials/hepatoplasmataceae_collinear.json",
     "tutorialStatus": "ready"
@@ -201,8 +186,9 @@
     "tags": [
       "Linear",
       "Multi-record",
-      "Collinear",
-      "Advanced"
+      "Collinear groups",
+      "LOSAT",
+      "Static SVG"
     ],
     "svg": "./examples/vibrio-harveyi-group-collinear.svg",
     "svgType": "static",
@@ -224,10 +210,8 @@
     "commandKind": "runnable",
     "commandNote": "Run from a source checkout so the records table can read the five GBFF files under tests/test_inputs/.",
     "description": "Compare all 11 replicons from five Harveyi-group Vibrio assemblies as five multi-record rows.",
-    "difficulty": "Advanced",
     "workflow": "Multi-record LOSATP collinear blocks",
     "inputSummary": "5 multi-record GenBank files; 11 replicons",
-    "estimatedTime": "Session: under 5 min; full search: 20-40 min",
     "displayOrder": 65,
     "tutorial": "./tutorials/vibrio-harveyi-group-collinear.json",
     "tutorialStatus": "ready"
@@ -238,7 +222,8 @@
     "tags": [
       "Linear",
       "Similarity groups",
-      "Advanced"
+      "LOSAT",
+      "Interactive SVG"
     ],
     "svg": "./examples/hepatoplasmataceae_orthogroup.svg",
     "svgType": "interactive",
@@ -260,10 +245,8 @@
     "commandKind": "runnable",
     "commandNote": "Download the five accession-pinned GenBank inputs from Files. The CLI value remains orthogroup for compatibility.",
     "description": "Compare the same five genomes with similarity-group links instead of collinear blocks.",
-    "difficulty": "Advanced",
     "workflow": "LOSATP similarity groups",
     "inputSummary": "5 GenBank files",
-    "estimatedTime": "10-20 min plus search",
     "displayOrder": 70,
     "tutorial": "./tutorials/hepatoplasmataceae_orthogroup.json",
     "tutorialStatus": "ready"
@@ -274,7 +257,8 @@
     "tags": [
       "Linear",
       "Similarity groups",
-      "Advanced"
+      "LOSAT",
+      "Interactive SVG"
     ],
     "svg": "./examples/BGC0000708-BGC0000713.svg",
     "svgType": "interactive",
@@ -296,10 +280,8 @@
     "commandKind": "runnable",
     "commandNote": "Files provides the five MIBiG records and all three repository-managed TSV files used by the command.",
     "description": "Compare five biosynthetic gene clusters while preserving antiSMASH categories and concise gene labels.",
-    "difficulty": "Advanced",
     "workflow": "LOSATP similarity groups and color rules",
     "inputSummary": "5 GenBank + 3 color/label TSV files",
-    "estimatedTime": "10-20 min plus search",
     "displayOrder": 80,
     "tutorial": "./tutorials/BGC0000708-BGC0000713.json",
     "tutorialStatus": "ready"
@@ -310,7 +292,8 @@
     "tags": [
       "Linear",
       "Similarity groups",
-      "Advanced"
+      "LOSAT",
+      "Interactive SVG"
     ],
     "svg": "./examples/majanivirus_orthogroup.svg",
     "svgType": "interactive",
@@ -336,10 +319,8 @@
     "commandKind": "runnable",
     "commandNote": "Download the nine accession-pinned records and both repository-managed color tables from Files.",
     "description": "Inspect dense protein-similarity links and product-based feature colors across nine viral genomes.",
-    "difficulty": "Advanced",
     "workflow": "LOSATP similarity groups",
     "inputSummary": "9 GenBank + 2 color TSV files",
-    "estimatedTime": "15-40 min plus search",
     "displayOrder": 90,
     "tutorial": "./tutorials/majanivirus_orthogroup.json",
     "tutorialStatus": "ready"
@@ -350,7 +331,7 @@
     "tags": [
       "Circular",
       "LOSAT",
-      "Advanced"
+      "Interactive SVG"
     ],
     "svg": "./examples/WSSV_genome_comparison.svg",
     "svgType": "interactive",
@@ -368,10 +349,8 @@
     "commandKind": "provenance",
     "commandNote": "This records the original prepared-input workflow and is not directly runnable from public downloads. Load the bundled session first; Shantou2019 has no recorded public accession.",
     "description": "Inspect one viral reference against 20 prepared assemblies as concentric BLAST/LOSAT comparison rings.",
-    "difficulty": "Advanced",
     "workflow": "Session-based circular comparison case study",
     "inputSummary": "Bundled session; prepared 20-assembly input set not fully public",
-    "estimatedTime": "Session: under 5 min; preparation/search: hours",
     "displayOrder": 100,
     "tutorial": "./tutorials/WSSV_genome_comparison.json",
     "tutorialStatus": "ready"

--- a/gbdraw/web/gallery/gallery.css
+++ b/gbdraw/web/gallery/gallery.css
@@ -141,6 +141,56 @@ h1 {
     white-space: nowrap;
 }
 
+.tag-filter {
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--line);
+}
+
+.tag-filter__heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 6px;
+}
+
+.tag-filter__label {
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 720;
+}
+
+.tag-filter__clear {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--accent-strong);
+    font: inherit;
+    font-size: 0.7rem;
+    font-weight: 720;
+    cursor: pointer;
+}
+
+.tag-filter__clear:hover,
+.tag-filter__clear:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+.tag-filter__list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+}
+
+.no-tag-matches {
+    padding: 14px 8px;
+    color: var(--muted);
+    font-size: 0.82rem;
+    text-align: center;
+}
+
 .sample-list {
     display: grid;
     gap: 8px;
@@ -264,6 +314,29 @@ h1 {
     color: #42515d;
     font-size: 0.66rem;
     font-weight: 720;
+}
+
+button.tag {
+    font-family: inherit;
+    cursor: pointer;
+}
+
+.tag--filter {
+    min-height: 24px;
+    padding: 2px 8px;
+}
+
+button.tag:hover,
+button.tag:focus-visible {
+    border-color: var(--accent);
+    color: var(--accent-strong);
+    outline: none;
+}
+
+button.tag[aria-pressed="true"] {
+    border-color: var(--accent);
+    background: var(--accent);
+    color: #ffffff;
 }
 
 .sample-card__size {

--- a/gbdraw/web/gallery/gallery.js
+++ b/gbdraw/web/gallery/gallery.js
@@ -3,6 +3,9 @@ const COMMON_COLOR_RULE_GUIDE_PATH = './tutorials/_common-color-rule-guide.json'
 
 const sampleList = document.querySelector('#sample-list');
 const sampleCount = document.querySelector('#sample-count');
+const tagFilterList = document.querySelector('#tag-filter-list');
+const clearTagFiltersButton = document.querySelector('#clear-tag-filters');
+const noTagMatches = document.querySelector('#no-tag-matches');
 const selectedTitle = document.querySelector('#selected-title');
 const selectedDescription = document.querySelector('#selected-description');
 const selectedMeta = document.querySelector('#selected-meta');
@@ -38,6 +41,17 @@ const TAB_HASHES = {
   files: 'Files'
 };
 
+const TAG_ORDER = [
+  'Circular',
+  'Linear',
+  'Multi-record',
+  'Collinear groups',
+  'Similarity groups',
+  'LOSAT',
+  'Interactive SVG',
+  'Static SVG'
+];
+
 const normalizeHash = () => decodeURIComponent(window.location.hash.replace(/^#/, '')).trim();
 
 const getTabFromHash = () => {
@@ -67,6 +81,7 @@ let tutorialRequestToken = 0;
 let mediaLightbox = null;
 let commonColorRuleGuide = null;
 let commonColorRuleGuidePromise = null;
+const activeTagFilters = new Set();
 const tutorialCache = new Map();
 
 const getAbsoluteSampleUrl = (sample) => new URL(sample.svg, window.location.href).href;
@@ -715,9 +730,41 @@ const plainTitle = (sample) => {
   return template.content.textContent || sample.title || sample.id;
 };
 
-const renderTags = (parent, tags) => {
+const renderTags = (parent, tags, { filterable = false } = {}) => {
   clearChildren(parent);
-  tags.forEach((tag) => appendText(parent, 'span', 'tag', tag));
+  tags.forEach((tag) => {
+    if (!filterable) {
+      appendText(parent, 'span', 'tag', tag);
+      return;
+    }
+    const button = appendText(parent, 'button', 'tag', tag);
+    button.type = 'button';
+    button.setAttribute('aria-pressed', activeTagFilters.has(tag) ? 'true' : 'false');
+    button.title = `Filter examples by ${tag}`;
+    button.addEventListener('click', () => toggleTagFilter(tag));
+  });
+};
+
+const availableTags = () =>
+  TAG_ORDER.filter((tag) => examples.some((sample) => asArray(sample.tags).includes(tag)));
+
+const filteredExamples = () => {
+  if (!activeTagFilters.size) return examples;
+  return examples.filter((sample) => {
+    const sampleTags = asArray(sample.tags);
+    return Array.from(activeTagFilters).every((tag) => sampleTags.includes(tag));
+  });
+};
+
+const renderTagFilters = () => {
+  clearChildren(tagFilterList);
+  availableTags().forEach((tag) => {
+    const button = appendText(tagFilterList, 'button', 'tag tag--filter', tag);
+    button.type = 'button';
+    button.setAttribute('aria-pressed', activeTagFilters.has(tag) ? 'true' : 'false');
+    button.addEventListener('click', () => toggleTagFilter(tag));
+  });
+  clearTagFiltersButton.hidden = activeTagFilters.size === 0;
 };
 
 const setLoading = (sample) => {
@@ -769,9 +816,13 @@ const copyText = async (text) => {
 
 const renderSampleList = () => {
   clearChildren(sampleList);
-  sampleCount.textContent = `${examples.length} examples`;
+  const visibleExamples = filteredExamples();
+  sampleCount.textContent = activeTagFilters.size
+    ? `${visibleExamples.length} of ${examples.length} examples`
+    : `${examples.length} examples`;
+  noTagMatches.hidden = visibleExamples.length !== 0;
 
-  examples.forEach((sample, index) => {
+  visibleExamples.forEach((sample, index) => {
     const button = document.createElement('button');
     button.type = 'button';
     button.className = 'sample-card';
@@ -796,13 +847,13 @@ const renderSampleList = () => {
       body,
       'span',
       'sample-card__meta',
-      [sample.difficulty, sample.workflow].filter(Boolean).join(' · ')
+      sample.workflow || ''
     );
     appendText(
       body,
       'span',
       'sample-card__meta sample-card__meta--secondary',
-      [sample.inputSummary, sample.estimatedTime].filter(Boolean).join(' · ')
+      sample.inputSummary || ''
     );
     const tagRow = document.createElement('span');
     tagRow.className = 'tag-row';
@@ -822,6 +873,27 @@ const renderSampleList = () => {
     button.addEventListener('click', () => selectSample(sample.id));
     sampleList.appendChild(button);
   });
+};
+
+const updateTagFilterResults = () => {
+  renderTagFilters();
+  renderSampleList();
+  const visibleExamples = filteredExamples();
+  if (visibleExamples.length && !visibleExamples.some((sample) => sample.id === selectedId)) {
+    selectSample(visibleExamples[0].id);
+    return;
+  }
+  const sample = selectedSample();
+  if (sample) renderTags(selectedTags, sample.tags, { filterable: true });
+};
+
+const toggleTagFilter = (tag) => {
+  if (activeTagFilters.has(tag)) {
+    activeTagFilters.delete(tag);
+  } else {
+    activeTagFilters.add(tag);
+  }
+  updateTagFilterResults();
 };
 
 const updatePressedState = () => {
@@ -881,11 +953,11 @@ const selectSample = (id, { updateUrl = true } = {}) => {
   selectedTitle.innerHTML = sample.title;
   selectedDescription.textContent = sample.description || '';
   selectedDescription.hidden = !sample.description;
-  selectedMeta.textContent = [sample.difficulty, sample.workflow, sample.inputSummary, sample.estimatedTime]
+  selectedMeta.textContent = [sample.workflow, sample.inputSummary]
     .filter(Boolean)
     .join(' · ');
   selectedMeta.hidden = !selectedMeta.textContent;
-  renderTags(selectedTags, sample.tags);
+  renderTags(selectedTags, sample.tags, { filterable: true });
   fileSize.textContent = sample.fileSizeLabel;
   commandBlock.textContent = sample.command;
   const isRunnable = sample.commandKind === 'runnable';
@@ -959,6 +1031,11 @@ copyCommandButton.addEventListener('click', async () => {
   }
 });
 
+clearTagFiltersButton.addEventListener('click', () => {
+  activeTagFilters.clear();
+  updateTagFilterResults();
+});
+
 tabButtons.forEach((button, index) => {
   button.addEventListener('click', () => {
     setActiveTab(button.dataset.galleryTab);
@@ -1009,6 +1086,7 @@ fetch('./examples.json', { cache: 'no-cache' })
     const legacySampleId = getLegacySampleIdFromHash();
     const initialId = pathSampleId || legacySampleId || examples[0]?.id || DEFAULT_SAMPLE_ID;
     selectedId = initialId;
+    renderTagFilters();
     renderSampleList();
     selectSample(initialId, { updateUrl: !legacySampleId });
   })

--- a/gbdraw/web/gallery/index.html
+++ b/gbdraw/web/gallery/index.html
@@ -29,9 +29,17 @@
         <aside class="sample-panel" aria-labelledby="sample-list-title">
             <div class="panel-heading">
                 <h2 id="sample-list-title">Examples</h2>
-                <span id="sample-count" class="sample-count"></span>
+                <span id="sample-count" class="sample-count" aria-live="polite"></span>
+            </div>
+            <div class="tag-filter">
+                <div class="tag-filter__heading">
+                    <span id="tag-filter-label" class="tag-filter__label">Filter by tag</span>
+                    <button id="clear-tag-filters" class="tag-filter__clear" type="button" hidden>Clear</button>
+                </div>
+                <div id="tag-filter-list" class="tag-filter__list" role="group" aria-labelledby="tag-filter-label"></div>
             </div>
             <div id="sample-list" class="sample-list" role="list"></div>
+            <p id="no-tag-matches" class="no-tag-matches" hidden>No examples match the selected tags.</p>
         </aside>
 
         <section class="viewer-panel" aria-live="polite">

--- a/gbdraw/web/gallery/tutorials/BGC0000708-BGC0000713.json
+++ b/gbdraw/web/gallery/tutorials/BGC0000708-BGC0000713.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Compare five aminoglycoside biosynthetic gene clusters",
   "summary": "Run LOSATP in the browser, assign CDS-derived proteins from five biosynthetic gene clusters to gbdraw similarity groups, apply antiSMASH gene_kind color rules, and label the first record.",
-  "estimatedTime": "10-20 min after inputs are available",
-  "difficulty": "Advanced",
   "appMode": "Linear",
   "primaryWorkflow": "LOSATP similarity groups (Orthogroups mode) with feature color rules",
   "requirements": ["GenBank features that retain antiSMASH qualifiers such as gene_kind."],

--- a/gbdraw/web/gallery/tutorials/HmmtDNA_ATskew.json
+++ b/gbdraw/web/gallery/tutorials/HmmtDNA_ATskew.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Human mitochondrial genome with an AT skew track",
   "summary": "Add GC content, GC skew, and AT skew tracks to a circular human mitochondrial genome diagram, then configure its ticks, feature labels, and legend.",
-  "estimatedTime": "5-10 min after the input is available",
-  "difficulty": "Intermediate",
   "appMode": "Circular",
   "primaryWorkflow": "Circular custom track slots with AT skew",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/HmmtDNA_basic_circular.json
+++ b/gbdraw/web/gallery/tutorials/HmmtDNA_basic_circular.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Create your first circular genome figure",
   "summary": "Upload one small GenBank record, choose a circular preset, show feature labels and GC tracks, and export the result without running a sequence search.",
-  "estimatedTime": "Under 5 min",
-  "difficulty": "Beginner",
   "appMode": "Circular",
   "primaryWorkflow": "Circular basics",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/Vnig_TUMSAT-TG-2018.json
+++ b/gbdraw/web/gallery/tutorials/Vnig_TUMSAT-TG-2018.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Vibrio nigripulchritudo chromosomes and plasmids on one canvas",
   "summary": "Arrange two chromosomes and four plasmids from one RefSeq GBFF file on a shared circular canvas. The example uses automatic record sizing, two rows, GC content, GC skew, and a left legend.",
-  "estimatedTime": "5-15 min after the input is available",
-  "difficulty": "Intermediate",
   "appMode": "Circular",
   "primaryWorkflow": "Circular multi-record canvas",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/WSSV_genome_comparison.json
+++ b/gbdraw/web/gallery/tutorials/WSSV_genome_comparison.json
@@ -1,10 +1,8 @@
 {
   "id": "WSSV_genome_comparison",
   "version": 1,
-  "title": "Advanced session-based WSSV comparison case study",
+  "title": "Session-based WSSV comparison case study",
   "summary": "Load the bundled session first to inspect a White spot syndrome virus reference and 20 prepared BLAST/LOSAT comparison rings. The displayed prepared-input command documents provenance; it is not a directly runnable public recipe.",
-  "estimatedTime": "Session inspection: under 5 min; input preparation: hours; search: 10-30 min; render and interaction: under 5 min",
-  "difficulty": "Advanced",
   "appMode": "Circular",
   "primaryWorkflow": "Circular nucleotide-similarity rings with LOSAT blastn",
   "requirements": ["Start by loading the bundled Gallery session. A manual rebuild requires all 20 prepared comparison assemblies, and several are available only inside that session."],

--- a/gbdraw/web/gallery/tutorials/hepatoplasmataceae_collinear.json
+++ b/gbdraw/web/gallery/tutorials/hepatoplasmataceae_collinear.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Plot collinear protein-match blocks across five Hepatoplasmataceae genomes",
   "summary": "Run LOSATP in the browser and combine compatible protein-match anchors into collinear blocks across five Hepatoplasmataceae genomes.",
-  "estimatedTime": "10-20 min after inputs are available",
-  "difficulty": "Advanced",
   "appMode": "Linear",
   "primaryWorkflow": "LOSATP collinear blocks",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/hepatoplasmataceae_orthogroup.json
+++ b/gbdraw/web/gallery/tutorials/hepatoplasmataceae_orthogroup.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Plot CDS protein-similarity links across five Hepatoplasmataceae genomes",
   "summary": "Run LOSATP in the browser, assign CDS-derived proteins to gbdraw similarity groups, and draw links between group members in five Hepatoplasmataceae genomes.",
-  "estimatedTime": "10-20 min after inputs are available",
-  "difficulty": "Advanced",
   "appMode": "Linear",
   "primaryWorkflow": "LOSATP similarity groups (Orthogroups mode)",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/lambda_basic_linear.json
+++ b/gbdraw/web/gallery/tutorials/lambda_basic_linear.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Create your first linear genome figure",
   "summary": "Upload one small phage GenBank record, separate the strands, show labels and a ruler, and export the result without running a sequence search.",
-  "estimatedTime": "Under 5 min",
-  "difficulty": "Beginner",
   "appMode": "Linear",
   "primaryWorkflow": "Linear basics",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/majanivirus_orthogroup.json
+++ b/gbdraw/web/gallery/tutorials/majanivirus_orthogroup.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Plot CDS protein-similarity links across nine majanivirus genomes",
   "summary": "Run LOSATP in the browser, assign CDS-derived proteins from nine majanivirus genomes to gbdraw similarity groups, apply product-based feature colors, and draw curved links between group members.",
-  "estimatedTime": "15-40 min after inputs are available",
-  "difficulty": "Advanced",
   "appMode": "Linear",
   "primaryWorkflow": "LOSATP similarity-group comparison (Orthogroups mode)",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/tobacco-chloroplast.json
+++ b/gbdraw/web/gallery/tutorials/tobacco-chloroplast.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Annotate the four regions of a tobacco chloroplast genome",
   "summary": "Import the LSC, SSC, IRa, and IRb boundaries for NC_001879.2, bind them to a circular annotation track, and keep chloroplast feature colors, radial labels, and GC content visible.",
-  "estimatedTime": "10-15 min after the input is available",
-  "difficulty": "Intermediate",
   "appMode": "Circular",
   "primaryWorkflow": "Circular region annotations with custom track slots",
   "downloads": [

--- a/gbdraw/web/gallery/tutorials/vibrio-harveyi-group-collinear.json
+++ b/gbdraw/web/gallery/tutorials/vibrio-harveyi-group-collinear.json
@@ -3,8 +3,6 @@
   "version": 1,
   "title": "Compare every replicon across five Vibrio Harveyi-group assemblies",
   "summary": "Arrange 11 chromosomes and plasmids from five RefSeq assemblies as five Linear rows, run LOSATP collinear analysis between adjacent rows, and color the resulting blocks by orientation and identity.",
-  "estimatedTime": "Session: under 5 min; full browser search: 20-40 min",
-  "difficulty": "Advanced",
   "appMode": "Linear",
   "primaryWorkflow": "Multi-record LOSATP collinear blocks",
   "downloads": [

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -837,7 +837,11 @@ def test_interactive_gallery_shell_is_static_and_sandboxed() -> None:
     assert "allow-same-origin" not in gallery_html
     assert 'id="demo-frame"' in gallery_html
     assert 'id="session-link"' in gallery_html
+    assert 'id="tag-filter-list"' in gallery_html
+    assert 'id="clear-tag-filters"' in gallery_html
     assert "fetch('./examples.json'" in gallery_js
+    assert "activeTagFilters" in gallery_js
+    assert "filteredExamples" in gallery_js
     assert "frame.src = sample.svg" in gallery_js
     assert "sample.session" in gallery_js
     assert "Vnig_TUMSAT-TG-2018" in gallery_js
@@ -876,6 +880,45 @@ def test_interactive_gallery_examples_are_wired() -> None:
         "WSSV_genome_comparison",
     ]
     examples = json.loads((GALLERY_ROOT / "examples.json").read_text(encoding="utf-8"))
+    expected_tags = {
+        "HmmtDNA_basic_circular": ["Circular", "Interactive SVG"],
+        "lambda_basic_linear": ["Linear", "Interactive SVG"],
+        "HmmtDNA_ATskew": ["Circular", "Interactive SVG"],
+        "tobacco-chloroplast": ["Circular", "Interactive SVG"],
+        "Vnig_TUMSAT-TG-2018": ["Circular", "Multi-record", "Interactive SVG"],
+        "hepatoplasmataceae_collinear": [
+            "Linear",
+            "Collinear groups",
+            "LOSAT",
+            "Interactive SVG",
+        ],
+        "vibrio-harveyi-group-collinear": [
+            "Linear",
+            "Multi-record",
+            "Collinear groups",
+            "LOSAT",
+            "Static SVG",
+        ],
+        "hepatoplasmataceae_orthogroup": [
+            "Linear",
+            "Similarity groups",
+            "LOSAT",
+            "Interactive SVG",
+        ],
+        "BGC0000708-BGC0000713": [
+            "Linear",
+            "Similarity groups",
+            "LOSAT",
+            "Interactive SVG",
+        ],
+        "majanivirus_orthogroup": [
+            "Linear",
+            "Similarity groups",
+            "LOSAT",
+            "Interactive SVG",
+        ],
+        "WSSV_genome_comparison": ["Circular", "LOSAT", "Interactive SVG"],
+    }
 
     assert [entry["id"] for entry in examples] == expected_ids
     assert [entry["displayOrder"] for entry in examples] == sorted(
@@ -897,15 +940,15 @@ def test_interactive_gallery_examples_are_wired() -> None:
     for entry in examples:
         assert entry["title"]
         assert entry["description"]
-        assert entry["difficulty"] in {"Beginner", "Intermediate", "Advanced"}
+        assert "difficulty" not in entry
         assert entry["workflow"]
         assert entry["inputSummary"]
-        assert entry["estimatedTime"]
+        assert "estimatedTime" not in entry
         assert isinstance(entry["displayOrder"], int)
         assert entry["commandKind"] in {"runnable", "provenance"}
         assert entry["commandNote"]
         assert not entry.get("interactiveStep")
-        assert entry["tags"]
+        assert entry["tags"] == expected_tags[entry["id"]]
         assert entry["command"].startswith("gbdraw ")
         assert "interactive-svg" not in entry["command"]
         assert entry["fileSizeLabel"]
@@ -971,7 +1014,6 @@ def test_interactive_gallery_examples_are_wired() -> None:
         assert b"WEBP" in thumbnail_header
         _assert_white_gallery_thumbnail(thumbnail_path)
 
-    assert [entry["difficulty"] for entry in examples[:2]] == ["Beginner", "Beginner"]
     provenance = [entry for entry in examples if entry["commandKind"] == "provenance"]
     assert [entry["id"] for entry in provenance] == ["WSSV_genome_comparison"]
     assert "not directly runnable" in provenance[0]["commandNote"]

--- a/tests/web/gallery-tutorial.playwright.spec.js
+++ b/tests/web/gallery-tutorial.playwright.spec.js
@@ -417,7 +417,7 @@ test('Gallery renders the WSSV nucleotide-similarity tutorial and media', async 
 
   await page.getByRole('tab', { name: 'Tutorial' }).click();
   await expect(
-    page.getByRole('heading', { name: 'Advanced session-based WSSV comparison case study' })
+    page.getByRole('heading', { name: 'Session-based WSSV comparison case study' })
   ).toBeVisible();
   const tutorialPanel = page.getByRole('tabpanel', { name: 'Tutorial' });
   await expect(tutorialPanel.getByText('Load the bundled session first', { exact: true })).toBeVisible();
@@ -835,14 +835,50 @@ test('Gallery copy link button copies the selected sample URL', async ({ page })
   );
 });
 
-test('Gallery orders Beginner examples first and distinguishes runnable commands', async ({ page }) => {
+test('Gallery uses workflow tags and distinguishes runnable commands', async ({ page }) => {
   await page.goto(`${baseUrl}/gallery/`, { waitUntil: 'domcontentloaded' });
 
   const cards = page.locator('.sample-card');
-  await expect(cards).toHaveCount(10);
-  await expect(cards.nth(0)).toContainText('Beginner');
+  await expect(cards).toHaveCount(11);
+  await expect(cards.nth(0)).not.toContainText('Beginner');
+  await expect(cards.nth(0)).not.toContainText('Under 5 min');
+  await expect(cards.nth(0).locator('.tag')).toHaveText(['Circular', 'Interactive SVG']);
   await expect(cards.nth(0)).toContainText('Circular basics');
   await expect(cards.nth(1)).toContainText('Linear basics');
+
+  const tagFilters = page.getByRole('group', { name: 'Filter by tag' });
+  await tagFilters.getByRole('button', { name: 'Linear', exact: true }).click();
+  await expect(cards).toHaveCount(6);
+  await expect(page.locator('#sample-count')).toHaveText('6 of 11 examples');
+  await tagFilters.getByRole('button', { name: 'LOSAT', exact: true }).click();
+  await expect(cards).toHaveCount(5);
+  await expect(page.locator('#sample-count')).toHaveText('5 of 11 examples');
+  await expect(cards.locator('.tag-row')).toContainText(['LOSAT', 'LOSAT', 'LOSAT', 'LOSAT', 'LOSAT']);
+  await tagFilters.getByRole('button', { name: 'Circular', exact: true }).click();
+  await expect(cards).toHaveCount(0);
+  await expect(page.locator('#no-tag-matches')).toBeVisible();
+  await expect(page.locator('#sample-count')).toHaveText('0 of 11 examples');
+  await page.getByRole('button', { name: 'Clear', exact: true }).click();
+  await expect(cards).toHaveCount(11);
+  await expect(page.locator('#sample-count')).toHaveText('11 examples');
+
+  const staticCard = page.locator('[data-sample-id="vibrio-harveyi-group-collinear"]');
+  await expect(staticCard.locator('.tag')).toHaveText([
+    'Linear',
+    'Multi-record',
+    'Collinear groups',
+    'LOSAT',
+    'Static SVG'
+  ]);
+  await staticCard.click();
+  await page.locator('#selected-tags').getByRole('button', { name: 'Static SVG' }).click();
+  await expect(cards).toHaveCount(1);
+  await expect(tagFilters.getByRole('button', { name: 'Static SVG' })).toHaveAttribute(
+    'aria-pressed',
+    'true'
+  );
+  await page.getByRole('button', { name: 'Clear', exact: true }).click();
+  await page.locator('[data-sample-id="HmmtDNA_basic_circular"]').click();
 
   await page.getByRole('tab', { name: 'Command' }).click();
   await expect(page.getByText('Runnable', { exact: true })).toBeVisible();

--- a/tools/prepare_interactive_gallery_assets.py
+++ b/tools/prepare_interactive_gallery_assets.py
@@ -38,10 +38,8 @@ class GallerySessionExample:
     title: str
     tags: tuple[str, ...]
     description: str
-    difficulty: str
     workflow: str
     input_summary: str
-    estimated_time: str
     display_order: int
     command_kind: str
     command_note: str
@@ -203,12 +201,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="HmmtDNA_basic_circular",
         title="Human mitochondrial genome: first circular figure",
-        tags=("Circular", "GenBank", "Beginner"),
+        tags=("Circular", "Interactive SVG"),
         description="Create a first circular genome figure from one small GenBank record without running a sequence search.",
-        difficulty="Beginner",
         workflow="Circular basics",
         input_summary="1 GenBank file",
-        estimated_time="Under 5 min",
         display_order=10,
         command_kind="runnable",
         command_note="Download HmmtDNA.gbk from the Files tab, then run this command in the same directory.",
@@ -217,12 +213,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="lambda_basic_linear",
         title="Lambda phage: first linear figure",
-        tags=("Linear", "GenBank", "Beginner"),
+        tags=("Linear", "Interactive SVG"),
         description="Create a labeled linear genome figure and learn strand separation, the ruler, and SVG export.",
-        difficulty="Beginner",
         workflow="Linear basics",
         input_summary="1 GenBank file",
-        estimated_time="Under 5 min",
         display_order=20,
         command_kind="runnable",
         command_note="Download NC_001416.gb from the Files tab, then run this command in the same directory.",
@@ -231,12 +225,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="HmmtDNA_ATskew",
         title="Human mitochondrial genome (AT skew)",
-        tags=("Circular", "GenBank", "Intermediate"),
+        tags=("Circular", "Interactive SVG"),
         description="Add an AT skew ring and qualifier-based labels to a compact circular mitochondrial diagram.",
-        difficulty="Intermediate",
         workflow="Circular quantitative tracks",
         input_summary="1 GenBank + 1 qualifier TSV",
-        estimated_time="5-10 min",
         display_order=30,
         command_kind="runnable",
         command_note="Download both HmmtDNA.gbk and HmmtDNA_qualifier_priority.tsv from Files before running the command.",
@@ -245,12 +237,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="tobacco-chloroplast",
         title="<i>Nicotiana tabacum</i> chloroplast genome regions",
-        tags=("Circular", "Organellar", "Intermediate"),
+        tags=("Circular", "Interactive SVG"),
         description="Mark LSC, SSC, IRa, and IRb as bracket annotations inside a color-coded chloroplast gene map.",
-        difficulty="Intermediate",
         workflow="Circular region annotations",
         input_summary="1 GenBank + 3 TSV files",
-        estimated_time="5-10 min",
         display_order=40,
         command_kind="runnable",
         command_note="Download NC_001879.gbk and the three Gallery TSV files, then run the command in the same directory.",
@@ -259,12 +249,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="Vnig_TUMSAT-TG-2018",
         title="<i>Vibrio nigripulchritudo</i> TUMSAT-TG-2018",
-        tags=("Circular", "Multi-record", "Intermediate"),
+        tags=("Circular", "Multi-record", "Interactive SVG"),
         description="Arrange two chromosomes and four plasmids from one multi-record GenBank file on a shared circular canvas.",
-        difficulty="Intermediate",
         workflow="Circular multi-record canvas",
         input_summary="1 multi-record GenBank file",
-        estimated_time="5-15 min",
         display_order=50,
         command_kind="runnable",
         command_note="Download the pinned RefSeq assembly named in Files; no sequence search is required.",
@@ -272,12 +260,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="hepatoplasmataceae_collinear",
         title="Hepatoplasmataceae collinear protein-match blocks",
-        tags=("Linear", "Collinear", "Advanced"),
+        tags=("Linear", "Collinear groups", "LOSAT", "Interactive SVG"),
         description="Combine compatible protein-match anchors into collinear blocks across five related genomes.",
-        difficulty="Advanced",
         workflow="LOSATP collinear blocks",
         input_summary="5 GenBank files",
-        estimated_time="10-20 min plus search",
         display_order=60,
         command_kind="runnable",
         command_note="Download the five accession-pinned GenBank inputs from Files. The command runs LOSATP locally.",
@@ -285,12 +271,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="vibrio-harveyi-group-collinear",
         title="<i>Vibrio</i> Harveyi group multi-record collinearity",
-        tags=("Linear", "Multi-record", "Collinear", "Advanced"),
+        tags=("Linear", "Multi-record", "Collinear groups", "LOSAT", "Static SVG"),
         description="Compare all 11 replicons from five Harveyi-group Vibrio assemblies as five multi-record rows.",
-        difficulty="Advanced",
         workflow="Multi-record LOSATP collinear blocks",
         input_summary="5 multi-record GenBank files; 11 replicons",
-        estimated_time="Session: under 5 min; full search: 20-40 min",
         display_order=65,
         command_kind="runnable",
         command_note="Run from a source checkout so the records table can read the five GBFF files under tests/test_inputs/.",
@@ -310,12 +294,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="hepatoplasmataceae_orthogroup",
         title="Hepatoplasmataceae CDS protein-similarity links",
-        tags=("Linear", "Similarity groups", "Advanced"),
+        tags=("Linear", "Similarity groups", "LOSAT", "Interactive SVG"),
         description="Compare the same five genomes with similarity-group links instead of collinear blocks.",
-        difficulty="Advanced",
         workflow="LOSATP similarity groups",
         input_summary="5 GenBank files",
-        estimated_time="10-20 min plus search",
         display_order=70,
         command_kind="runnable",
         command_note="Download the five accession-pinned GenBank inputs from Files. The CLI value remains orthogroup for compatibility.",
@@ -323,12 +305,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="BGC0000708-BGC0000713",
         title="Aminoglycoside biosynthetic gene clusters from <i>Streptomyces</i> spp.",
-        tags=("Linear", "Similarity groups", "Advanced"),
+        tags=("Linear", "Similarity groups", "LOSAT", "Interactive SVG"),
         description="Compare five biosynthetic gene clusters while preserving antiSMASH categories and concise gene labels.",
-        difficulty="Advanced",
         workflow="LOSATP similarity groups and color rules",
         input_summary="5 GenBank + 3 color/label TSV files",
-        estimated_time="10-20 min plus search",
         display_order=80,
         command_kind="runnable",
         command_note="Files provides the five MIBiG records and all three repository-managed TSV files used by the command.",
@@ -337,12 +317,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="majanivirus_orthogroup",
         title="Majanivirus CDS protein-similarity links",
-        tags=("Linear", "Similarity groups", "Advanced"),
+        tags=("Linear", "Similarity groups", "LOSAT", "Interactive SVG"),
         description="Inspect dense protein-similarity links and product-based feature colors across nine viral genomes.",
-        difficulty="Advanced",
         workflow="LOSATP similarity groups",
         input_summary="9 GenBank + 2 color TSV files",
-        estimated_time="15-40 min plus search",
         display_order=90,
         command_kind="runnable",
         command_note="Download the nine accession-pinned records and both repository-managed color tables from Files.",
@@ -350,12 +328,10 @@ EXAMPLES: tuple[GallerySessionExample, ...] = (
     GallerySessionExample(
         id="WSSV_genome_comparison",
         title="White spot syndrome virus nucleotide-similarity rings",
-        tags=("Circular", "LOSAT", "Advanced"),
+        tags=("Circular", "LOSAT", "Interactive SVG"),
         description="Inspect one viral reference against 20 prepared assemblies as concentric BLAST/LOSAT comparison rings.",
-        difficulty="Advanced",
         workflow="Session-based circular comparison case study",
         input_summary="Bundled session; prepared 20-assembly input set not fully public",
-        estimated_time="Session: under 5 min; preparation/search: hours",
         display_order=100,
         command_kind="provenance",
         command_note="This records the original prepared-input workflow and is not directly runnable from public downloads. Load the bundled session first; Shantou2019 has no recorded public accession.",
@@ -745,10 +721,8 @@ def prepare_gallery_assets() -> list[dict[str, object]]:
             "commandKind": example.command_kind,
             "commandNote": example.command_note,
             "description": example.description,
-            "difficulty": example.difficulty,
             "workflow": example.workflow,
             "inputSummary": example.input_summary,
-            "estimatedTime": example.estimated_time,
             "displayOrder": example.display_order,
         }
         tutorial_path = GALLERY_ROOT / "tutorials" / f"{example.id}.json"


### PR DESCRIPTION
Replace difficulty and input-format tags with workflow and SVG-type tags. Remove difficulty and estimated-time metadata from gallery examples and tutorials. Add AND-based tag filtering with result counts, clear controls, and an empty state. Make selected-example tags clickable and update the related tests.