### PR TITLE
fix(web): require explicit annotation record targets

### DIFF
--- a/docs/PYTHON_API_BREAKING_REDESIGN_PLAN.md
+++ b/docs/PYTHON_API_BREAKING_REDESIGN_PLAN.md
@@ -1,0 +1,900 @@
+# Python API Breaking Redesign Plan
+
+- Status: proposed
+- Date: 2026-07-19
+- Baseline: `0.14.0b0`
+- Target: the next intentionally breaking beta before the 1.0 public contract
+- Scope: Python library API, CLI/Python boundary, Web/Pyodide boundary, typed render requests, session conversion, public documentation, and contract tests
+
+## 1. Decision
+
+Replace the current layered compatibility API with one small Python drawing API and
+one explicit integration API.
+
+The final public boundary will be:
+
+```text
+gbdraw                 ordinary Python drawing workflows
+gbdraw.integration     typed request, session, and table integrations
+gbdraw.errors          structured library exceptions
+```
+
+Rendering, layout, parsing, and SVG implementation modules remain implementation
+details. They may stay in their current physical packages when moving them would add
+churn without improving the public dependency boundary.
+
+This plan intentionally breaks existing Python imports and signatures. It does not
+preserve the following as public contracts:
+
+- `gbdraw.api`
+- `DiagramOptions`
+- `ColorOptions`, `TrackOptions`, and `OutputOptions`
+- `build_circular_diagram`, `build_circular_multi_diagram`, and
+  `build_linear_diagram`
+- `assemble_circular_diagram_from_record`,
+  `assemble_circular_diagram_from_records`, and
+  `assemble_linear_diagram_from_records`
+- public configurator and canvas-configurator classes
+- raw layout strings such as `"#1@1"` in the Python API
+- unstructured `config_overrides` in the ordinary drawing API
+
+Temporary adapters may exist while the implementation branch is in progress. They
+must not remain in the final release unless a separately approved use case requires
+them.
+
+This document is a standalone replacement plan. Unfinished earlier Python API plans
+are not prerequisites and do not constrain this redesign. Current code, current
+tests, supported session documents, and verified rendering behavior are the sources
+of truth.
+
+## 2. Why the current boundary should be replaced
+
+The current repository has several overlapping abstractions:
+
+1. `gbdraw` exports a 20-symbol beginner-facing interface.
+2. `gbdraw.api` exports a much larger integration and rendering surface.
+3. `gbdraw.interface` translates `CircularOptions` and `LinearOptions` back into the
+   shared `DiagramOptions` representation.
+4. `build_*` functions expand `DiagramOptions` into long `assemble_*` calls.
+5. CLI handlers still call the long assemblers directly for important workflows.
+6. Typed request and session models also contain the shared `DiagramOptions` rather
+   than the mode-specific beginner options.
+7. Web/Pyodide execution still has an argument-array execution path even though
+   session documents contain a typed render-request payload.
+
+The result is a small outer API over a large compatibility core. Adding a new option
+often requires forwarding it through several models and adapters, while users still
+see two namespaces that both appear public.
+
+The redesign makes the mode-specific typed request the authoritative input to
+rendering. Every other entry point converts to that request exactly once.
+
+## 3. Goals
+
+1. Make the first successful diagram require no knowledge of internal config,
+   renderer classes, `svgwrite`, or output prefixes.
+2. Give every drawing setting one clear owner and one typed representation.
+3. Use separate Circular and Linear option types so wrong-mode settings cannot be
+   represented.
+4. Keep file parsing, validation, rendering, and export failures inside one
+   documented exception hierarchy.
+5. Remove string mini-languages from the Python object model.
+6. Make CLI, Web, session replay, and direct Python calls render through the same
+   request and validation path.
+7. Keep `Diagram` as the only ordinary result type and keep file output separate
+   from drawing intent.
+8. Preserve current default SVG geometry unless a geometry change is separately
+   proposed and reviewed.
+9. Publish usable type information in built wheels.
+10. Reduce code and forwarding paths after the new request path is complete.
+
+## 4. Non-goals
+
+- Do not rewrite low-level SVG drawers solely to rename the public API.
+- Do not change CLI option names as part of the Python API redesign.
+- Do not change visible Web controls or post-render editing behavior unless required
+  to remove the argument-array Python bridge.
+- Do not make browser-only editing actions part of the Python drawing API.
+- Do not introduce a plugin framework, general request DSL, or fluent builder API.
+- Do not add tutorial-only functions such as `load_example()` to the production
+  package.
+- Do not regenerate reference SVGs for an API-only refactor.
+- Do not drop readable version 31 or 32 session files merely because the Python
+  object model changes.
+
+## 5. Target user experience
+
+### 5.1 Minimal Circular diagram
+
+```python
+from gbdraw import draw_circular, read_genbank
+
+records = read_genbank("genome.gb")
+diagram = draw_circular(records)
+diagram.save("genome.svg")
+```
+
+`read_genbank()` continues to return all records. `draw_circular()` accepts one
+`SeqRecord` or a sequence, so the quick start does not discard additional records
+with `[0]`.
+
+### 5.2 Customized Circular diagram
+
+```python
+from gbdraw import CircularOptions, draw_circular, read_genbank
+from gbdraw.options import FeatureOptions, GcOptions, TitleOptions
+
+options = CircularOptions(
+    features=FeatureOptions(types=("CDS", "tRNA", "rRNA")),
+    gc=GcOptions(window=1_000, step=100),
+    title=TitleOptions(text="Example genome", position="top"),
+)
+
+diagram = draw_circular(read_genbank("genome.gb"), options=options)
+diagram.save("genome.svg")
+```
+
+### 5.3 Linear comparison
+
+```python
+from gbdraw import LinearOptions, draw_linear, read_genbank
+from gbdraw.options import ComparisonOptions, Thresholds
+
+records = read_genbank(("reference.gb", "comparison.gb"))
+options = LinearOptions(
+    comparison=ComparisonOptions.from_blast(
+        "reference.comparison.tblastx.tsv",
+        thresholds=Thresholds(identity=70),
+    )
+)
+
+diagram = draw_linear(records, options=options)
+diagram.save("comparison.svg")
+```
+
+`from_blast()` is justified because it replaces several mutually exclusive source
+fields. Convenience constructors must not be added for simple field assignment.
+
+### 5.4 Typed placement
+
+```python
+from gbdraw import CircularLayout, RecordPlacement
+
+layout = CircularLayout(
+    placements=(
+        RecordPlacement(record=0, row=0, column=0),
+        RecordPlacement(record=1, row=0, column=1),
+    )
+)
+```
+
+Python indices are zero-based. CLI and TSV parsers may keep their existing user
+syntax but must convert it at the parsing boundary.
+
+### 5.5 Error handling
+
+```python
+from gbdraw import GbdrawError
+
+try:
+    diagram.save("genome.pdf")
+except GbdrawError as exc:
+    print(f"gbdraw failed: {exc}")
+```
+
+## 6. Public module contract
+
+### 6.1 `gbdraw`
+
+The package root is the ordinary workflow facade. Keep its `__all__` intentionally
+small.
+
+Required root exports:
+
+- `draw_circular`
+- `draw_linear`
+- `read_genbank`
+- `read_gff`
+- `Diagram`
+- `CircularOptions`
+- `LinearOptions`
+- `CircularLayout`
+- `LinearLayout`
+- `RecordPlacement`
+- `GbdrawError`
+- `InputError`
+- `OptionError`
+- `DependencyError`
+- `RenderError`
+- `ExportError`
+- `__version__`
+
+Specialized option types live in `gbdraw.options`. Frequently used types may be
+re-exported from the root only when a real quick-start workflow becomes shorter.
+Their defining module remains `gbdraw.options`.
+
+### 6.2 `gbdraw.options`
+
+This module owns the public immutable drawing configuration:
+
+- `CircularOptions`
+- `LinearOptions`
+- `FeatureOptions`
+- `LabelOptions`
+- `TitleOptions`
+- `LegendOptions`
+- `GcOptions`
+- `DepthTrack`
+- `CircularTrackOptions`
+- `LinearTrackOptions`
+- `ConservationOptions`
+- `ConservationTrack`
+- `ComparisonOptions`
+- `ComparisonTrack`
+- `ProteinComparisonOptions`
+- `CollinearityOptions`
+- `Thresholds`
+- `CircularLayout`
+- `LinearLayout`
+- `RecordPlacement`
+
+The implementation may combine or remove a proposed type if the field inventory
+shows that it does not reduce caller and implementation complexity. The acceptance
+criterion is ownership clarity, not the exact number of dataclasses.
+
+### 6.3 `gbdraw.integration`
+
+This is the only advanced public namespace. It owns typed orchestration rather than
+rendering primitives:
+
+- `CircularRequest`
+- `LinearRequest`
+- `DiagramRequest`
+- `RecordInput`
+- `GenBankSource`
+- `GffFastaSource`
+- `InMemorySource`
+- `RecordSelector`
+- `Region`
+- `OutputPlan`
+- `RenderResult`
+- `render`
+- `render_to_files`
+- validated table models and readers
+- session document load, materialization, conversion, render, and save functions
+- session-specific exception types
+
+Do not export canvas configurators, SVG groups, assembler functions, parser
+internals, or `svgwrite.Drawing` from this namespace.
+
+### 6.4 `gbdraw.errors`
+
+Use one structured hierarchy:
+
+```text
+GbdrawError
+├── InputError
+│   ├── InputNotFoundError
+│   └── InputFormatError
+├── OptionError
+├── DependencyError
+├── RenderError
+├── ExportError
+└── SessionError
+    ├── SessionFormatError
+    ├── SessionVersionError
+    └── SessionResourceError
+```
+
+Each expected error should expose:
+
+- `code`: stable machine-readable identifier
+- `path`: optional option or input location such as
+  `comparison.thresholds.identity`
+- `hint`: optional recovery guidance
+
+Preserve the original exception with exception chaining. Do not introduce a custom
+`Result[T, E]` abstraction.
+
+## 7. Option ownership rules
+
+The shared 71-field `DiagramOptions` is deleted. Replace it with mode-specific
+composition.
+
+### 7.1 Common ownership
+
+| Concern | Owner |
+|---|---|
+| feature selection, colors, visibility, shapes | `FeatureOptions` |
+| label filtering and overrides | `LabelOptions` |
+| plot title | `TitleOptions` |
+| legend placement and style | `LegendOptions` |
+| GC content/skew calculation and visibility | `GcOptions` |
+| one quantitative depth series and its sampling/style | `DepthTrack` |
+| annotation sets and track binding | a typed annotation option under `gbdraw.options` |
+
+### 7.2 Circular ownership
+
+| Concern | Owner |
+|---|---|
+| Circular track order and axis placement | `CircularTrackOptions` |
+| conservation sources, ring geometry, and thresholds | `ConservationOptions` |
+| species/strain definition policy | a Circular definition option block |
+| multi-record sizing and placement | `CircularLayout` |
+
+### 7.3 Linear ownership
+
+| Concern | Owner |
+|---|---|
+| Linear track order and axis placement | `LinearTrackOptions` |
+| nucleotide comparison sources and thresholds | `ComparisonOptions` |
+| protein comparison execution | `ProteinComparisonOptions` |
+| collinearity parameters | `CollinearityOptions` |
+| row gap and record placement | `LinearLayout` |
+
+Thresholds belong to the feature that consumes them. `LinearOptions` must not carry
+a detached shared `thresholds` field.
+
+Sampling fields belong to `GcOptions` or `DepthTrack`. `CircularOptions` and
+`LinearOptions` must not expose detached `window`, `step`, `depth_window`, or
+`depth_step` fields.
+
+### 7.4 Advanced config
+
+Remove `config_overrides: Mapping[str, object]` from the ordinary API. It bypasses
+type checking and makes internal TOML paths part of the public contract.
+
+For settings that are not yet modeled:
+
+1. Add them to an existing owner when they are genuinely user-facing.
+2. Add one focused option block when doing so reduces complexity.
+3. Keep renderer-only settings private.
+4. Permit a typed `GbdrawConfig` only in `gbdraw.integration` for advanced
+   integration during the transition.
+
+Do not replace one untyped mapping with another differently named mapping.
+
+## 8. Input and table boundary
+
+### 8.1 Ordinary record input
+
+`read_genbank()` and `read_gff()` remain explicit format readers. They return all
+parsed records and raise `InputError` subclasses for expected file and parse
+failures.
+
+`draw_circular()` and `draw_linear()` accept:
+
+- one `SeqRecord`
+- a non-empty sequence of `SeqRecord`
+
+They do not accept arbitrary file paths. Keeping reading explicit avoids ambiguous
+format detection and keeps GFF3/FASTA pairing clear.
+
+### 8.2 Integration record input
+
+`RecordInput` combines exactly one source with optional selection, region, stable
+key, label, reverse-complement flag, and typed placement.
+
+Prefer named constructors for mutually exclusive sources:
+
+```python
+RecordInput.from_genbank(path, selector=...)
+RecordInput.from_gff(gff_path, fasta_path, selector=...)
+RecordInput.from_record(record)
+```
+
+The source subclasses may remain public for serialization and type narrowing, but
+ordinary callers should not need to construct them directly.
+
+### 8.3 Tables
+
+Paths and DataFrames are accepted only at public input boundaries. Normalize them
+immediately into capability-specific validated models such as:
+
+- `FeatureColorTable`
+- `FeatureVisibilityTable`
+- `LabelWhitelist`
+- `QualifierPriority`
+- `LabelOverrides`
+- `DepthTable`
+- `ConservationTable`
+- `ComparisonTable`
+
+Each model provides `from_tsv()` and `from_dataframe()`. Validation, required
+columns, coordinate conventions, and path-dependency resolution have one owner.
+
+Do not propagate parallel `*_table` and `*_file` fields into requests or renderers.
+
+## 9. Remove string mini-languages from Python
+
+Raw strings remain valid only at CLI, TSV, and old-session decode boundaries.
+
+Replace Python-facing layout strings with `RecordPlacement`.
+
+Replace Python-facing track-slot strings with typed values containing:
+
+- renderer enum
+- side enum
+- optional width or height
+- optional gap
+- visibility
+- axis relationship where applicable
+
+Existing parser functions may remain internal adapters for CLI and old session
+documents. Renderers receive only typed, validated slot objects.
+
+Selectors and regions follow the same rule: parse text once at the input boundary,
+then pass typed `RecordSelector` and `Region` values.
+
+## 10. Authoritative render request
+
+### 10.1 Request types
+
+```python
+@dataclass(frozen=True)
+class CircularRequest:
+    records: tuple[RecordInput, ...]
+    options: CircularOptions
+    layout: CircularLayout | None = None
+
+
+@dataclass(frozen=True)
+class LinearRequest:
+    records: tuple[RecordInput, ...]
+    options: LinearOptions
+    layout: LinearLayout | None = None
+```
+
+`DiagramRequest` is the union of these two types. There is no shared
+`DiagramOptions` and no runtime wrong-mode option filtering.
+
+### 10.2 Output separation
+
+Drawing intent and file output policy are separate:
+
+```python
+diagram = render(request)
+result = render_to_files(request, OutputPlan(...))
+```
+
+`render(request)` returns `Diagram` and performs no filesystem writes.
+
+`render_to_files()` returns a structured `RenderResult` containing only paths that
+exist, the normalized request, records used, warnings, and format metadata.
+
+`Diagram.save()` remains the simple one-file API. `Diagram.to_svg()` and
+`Diagram.to_bytes()` remain the in-memory APIs.
+
+### 10.3 Resolution stages
+
+Use explicit internal stages:
+
+```text
+CircularRequest | LinearRequest
+        ↓ validate and load inputs
+ResolvedCircularRequest | ResolvedLinearRequest
+        ↓ compute features, tracks, labels, and layout
+RenderModel
+        ↓ SVG drawers and groups
+Diagram
+```
+
+The exact internal type names may differ, but each stage must have one direction.
+Do not translate a new option model back into the deleted legacy model.
+
+## 11. CLI and Web integration
+
+### 11.1 CLI
+
+Keep `argparse` and current option names. Change the handler boundary:
+
+```text
+argparse.Namespace
+        ↓ mode-specific CLI adapter
+CircularRequest | LinearRequest
+        ↓ shared render path
+Diagram or RenderResult
+```
+
+After migration, `gbdraw.circular` and `gbdraw.linear` must not call public or
+private long-form assemblers. Each mode has one adapter that converts parsed CLI
+values into the typed request.
+
+CLI warning-and-skip policies may differ from strict library behavior, but the
+request validation and rendering implementation remain shared.
+
+### 11.2 Web/Pyodide
+
+The Web app already builds a structured render-request payload for sessions. Use
+that payload as the Pyodide execution boundary.
+
+Replace:
+
+```text
+JavaScript form → CLI argument array → Python CLI owner → renderer
+```
+
+with:
+
+```text
+JavaScript form → versioned render-request payload
+                → Python request decoder → shared render path
+```
+
+Do not expose Python dataclass implementation details to JavaScript. The JSON
+payload remains versioned and is decoded into the Python request types.
+
+Keep browser-only PNG/PDF export and post-render editing outside the Python output
+API.
+
+## 12. Session compatibility
+
+The request representation changes incompatibly, so new sessions need the next
+available render-request schema and session version. At the current baseline these
+would be render-request schema 3 and session version 33; confirm the live constants
+immediately before implementation and increment from those values if they changed.
+
+Rules:
+
+1. New writers emit only the new mode-specific option structure.
+2. Python and Web readers continue accepting supported version 31 and 32 documents.
+3. Old render-request schemas decode through a dedicated conversion module into the
+   new request types.
+4. Old documents are never converted by reconstructing CLI argument arrays.
+5. Saved results and editor state remain separate from drawing intent.
+6. Materialized embedded paths remain valid only inside the materialization context.
+7. Remove an old session reader only through a separate compatibility decision,
+   not as an incidental effect of this API redesign.
+
+The old `DiagramOptions` payload is therefore a wire-compatibility input for old
+sessions, not a runtime model used by new rendering.
+
+## 13. Implementation workstreams
+
+### Phase 0: Freeze evidence and approve the target contract
+
+Tasks:
+
+1. Record the current `gbdraw.__all__`, `gbdraw.api.__all__`, relevant signatures,
+   option fields/defaults, session versions, and render-request schemas.
+2. Build a field inventory mapping every current `DiagramOptions` field to:
+   - a new option owner;
+   - integration-only typed config;
+   - internal renderer state; or
+   - intentional removal with migration guidance.
+3. Inventory all imports of `gbdraw.api`, `assemble_*`, `build_*`, and
+   `DiagramOptions` in package code and tests.
+4. Record hashes for tracked reference SVGs and run comparison-only tests.
+5. Add an ADR approving the public namespace, request/output separation, and old
+   session read policy.
+
+Exit criteria:
+
+- No current option lacks a disposition.
+- The proposed `gbdraw.__all__` and `gbdraw.integration.__all__` are reviewed as
+  explicit lists.
+- Rendering evidence is captured before implementation.
+
+### Phase 1: Add the new option and error models
+
+Tasks:
+
+1. Create `gbdraw.options` with the mode-specific immutable option model.
+2. Create `gbdraw.errors` and migrate existing exception classes into the new
+   hierarchy.
+3. Add field-level validation at option construction time.
+4. Move comparison thresholds, GC sampling, and depth sampling to their consuming
+   owners.
+5. Add structured `code`, `path`, and `hint` properties.
+6. Add tests for defaults, invalid values, mode separation, equality, and repr.
+
+Exit criteria:
+
+- `CircularOptions` contains no Linear-only field and vice versa.
+- No ordinary option field accepts an untyped override mapping.
+- Expected invalid inputs raise only documented `GbdrawError` subclasses.
+
+### Phase 2: Add typed inputs, tables, placements, and track slots
+
+Tasks:
+
+1. Implement `RecordPlacement` and typed track-slot values.
+2. Implement capability-specific table models and conversion constructors.
+3. Make CLI/session string parsers return the typed models.
+4. Make path/DataFrame normalization occur once at the boundary.
+5. Add zero-based Python placement tests and explicit CLI/session conversion tests.
+
+Exit criteria:
+
+- New Python examples contain no `"#1@1"`-style layout token.
+- Render code receives no parallel file/DataFrame field pair.
+- Required table columns and coordinate conventions are tested in one owner.
+
+### Phase 3: Make the new requests drive rendering
+
+Tasks:
+
+1. Create `CircularRequest` and `LinearRequest` using the new option types.
+2. Separate `OutputPlan` from both request types.
+3. Extract input resolution into mode-neutral and mode-specific pure functions.
+4. Refactor diagram assembly to consume resolved request fields directly.
+5. Return `Diagram` from the shared in-memory render function.
+6. Return `RenderResult` from the shared multi-file function.
+7. Keep a temporary legacy-to-new adapter only while downstream callers migrate.
+
+Exit criteria:
+
+- The render path does not construct `DiagramOptions`.
+- New requests do not call `build_*` or public `assemble_*` functions.
+- Default Circular and Linear reference SVG comparisons are unchanged.
+
+### Phase 4: Rewire the ordinary Python facade
+
+Tasks:
+
+1. Replace `gbdraw.interface` translation logic with direct construction of the new
+   in-memory request.
+2. Keep `draw_circular()` and `draw_linear()` signatures limited to records,
+   mode-specific options, and layout.
+3. Keep `Diagram` independent of `svgwrite` in its public annotations and docs.
+4. Re-export the approved root symbols, including exceptions.
+5. Add `py.typed` to the wheel and a packaged-consumer type-check test.
+6. Rewrite the quick start without environment-variable scaffolding.
+
+Exit criteria:
+
+- The ordinary workflow imports only from `gbdraw` and `gbdraw.options`.
+- A source-checkout and installed-wheel quick start both run unchanged.
+- Static type tooling recognizes the installed package as typed.
+
+### Phase 5: Rewire CLI and Web/Pyodide
+
+Tasks:
+
+1. Change Circular and Linear CLI handlers to build the new requests.
+2. Remove direct assembler calls from both handlers.
+3. Decode the Web render-request payload directly in Pyodide.
+4. Remove the Web path that invokes Python by reconstructing CLI argument arrays for
+   current sessions and normal generation.
+5. Preserve legacy CLI/session replay only in isolated compatibility modules.
+6. Compare CLI, direct Python, and Web/Pyodide request projections for representative
+   Circular and Linear cases.
+
+Exit criteria:
+
+- Ordinary Web generation does not depend on CLI argument positions.
+- CLI and Python render the same geometry from equivalent typed requests.
+- Browser generation, interactive SVG, and session save/load checks pass.
+
+### Phase 6: Migrate the session schema
+
+Tasks:
+
+1. Define the new render-request JSON schema from the new mode-specific requests.
+2. Update Python encode/decode and Web encode/decode together.
+3. Increment the request schema and session version.
+4. Add version 31/32 conversion fixtures for both Circular and Linear modes.
+5. Write only the new schema after loading an old supported document.
+6. Verify embedded resource lifetime and cleanup on success and failure.
+
+Exit criteria:
+
+- New Python and Web sessions round-trip without field loss.
+- Supported old sessions render through the new request path.
+- No supported session conversion calls an argparse parser.
+
+### Phase 7: Delete the legacy Python API
+
+Tasks:
+
+1. Remove `DiagramOptions`, `ColorOptions`, `TrackOptions`, and `OutputOptions`.
+2. Remove public `assemble_*` and `build_*` functions.
+3. Remove public configurator and canvas-configurator exports.
+4. Move remaining integration symbols from `gbdraw.api` to
+   `gbdraw.integration`.
+5. Delete `gbdraw.api` after all package imports have migrated.
+6. Delete temporary new-to-legacy and legacy-to-new adapters.
+7. Remove obsolete forwarding tests and replace them with request-to-owner tests.
+
+Exit criteria:
+
+- `rg` finds no package import of `gbdraw.api`, `DiagramOptions`, or a removed
+  assembler.
+- There is one active options model and one active request model.
+- Removing the compatibility modules reduces total code; the redesign must not end
+  as an additional permanent layer.
+
+### Phase 8: Documentation and release migration
+
+Tasks:
+
+1. Rewrite `docs/PYTHON_API.md` around the ordinary workflow.
+2. Add an exhaustive generated or mechanically checked option reference.
+3. Add a separate `docs/PYTHON_INTEGRATION_API.md` for requests, sessions, and
+   tables.
+4. Update README, docs index, workflow guide, tutorials, export docs, FAQ, release
+   notes, and affected examples.
+5. Add an old-to-new migration table for every removed public symbol.
+6. Explain typed placement and table schemas with copy-pasteable examples.
+7. Execute every documented Python block in tests.
+
+Exit criteria:
+
+- The first Python example is self-contained after its stated setup step.
+- No documentation recommends `gbdraw.api`, `DiagramOptions`, `build_*`, or
+  `assemble_*`.
+- The ordinary guide and integration guide do not claim the same entry point.
+
+## 14. Deletion and migration matrix
+
+| Removed contract | Replacement |
+|---|---|
+| `gbdraw.api` | `gbdraw.integration` for orchestration; `gbdraw` for drawing |
+| `DiagramOptions` | `CircularOptions` or `LinearOptions` |
+| `ColorOptions` | fields owned by `FeatureOptions` |
+| `TrackOptions` | `CircularTrackOptions` or `LinearTrackOptions` |
+| `OutputOptions` | drawing fields in `TitleOptions`/`LegendOptions`; filesystem fields in `OutputPlan` |
+| `build_circular_diagram` | `draw_circular` or `integration.render(CircularRequest(...))` |
+| `build_circular_multi_diagram` | `draw_circular(..., layout=CircularLayout(...))` |
+| `build_linear_diagram` | `draw_linear` or `integration.render(LinearRequest(...))` |
+| three public `assemble_*` functions | private assembly called only by the shared render path |
+| `CircularMultiRecordOptions` | `CircularLayout` |
+| `LinearMultiRecordOptions` | `LinearLayout` |
+| `RenderOutputRequest` | `OutputPlan`, separate from drawing request |
+| layout strings | `RecordPlacement` |
+| raw track-slot strings | typed Circular/Linear slot values |
+| `config_overrides` | typed option owner or integration-only `GbdrawConfig` |
+| direct `svgwrite.Drawing` result | `Diagram` |
+
+## 15. Test strategy
+
+### 15.1 Public contract
+
+- Replace the current snapshot with separate snapshots for:
+  - `gbdraw.__all__`;
+  - `gbdraw.options.__all__`;
+  - `gbdraw.integration.__all__`;
+  - option/request dataclass fields and defaults;
+  - public function and method signatures;
+  - exception inheritance and error codes.
+- Review the snapshot diff manually. Do not accept a bulk rewrite without mapping
+  every removal and addition to this plan.
+
+### 15.2 Behavior and forwarding
+
+- Test each non-default option at the function that consumes it.
+- Test that no value is accepted and then ignored.
+- Test aliases only at CLI/session parse boundaries; the Python object model should
+  contain normalized values.
+- Test file and DataFrame forms for every table input and compare normalized content.
+- Test wrong-mode construction at type/model boundaries rather than during render.
+
+### 15.3 Cross-surface parity
+
+For representative cases, compare the resolved request and SVG output from:
+
+- direct Python facade;
+- `gbdraw.integration` request;
+- Circular CLI;
+- Linear CLI;
+- Web/Pyodide payload;
+- new session replay;
+- supported old session conversion.
+
+Cover at least:
+
+- single-record Circular;
+- multi-record Circular with typed placement;
+- Linear nucleotide comparison;
+- depth tracks;
+- conservation rings;
+- protein comparison and collinearity;
+- feature color/visibility/shape tables;
+- labels and annotations;
+- static and interactive SVG;
+- strict local binary export.
+
+### 15.4 Rendering regression
+
+Run comparison-only reference tests throughout the refactor. Updating public APIs
+does not justify changed SVG geometry.
+
+If a geometry change is unavoidable:
+
+1. isolate it from the API refactor;
+2. explain why the new request changes rendering semantics;
+3. review the SVG diff;
+4. update references only with the explicit reference-update command;
+5. record the behavior change in release notes.
+
+### 15.5 Errors and cleanup
+
+Test:
+
+- missing and unreadable inputs;
+- malformed GenBank, GFF3, FASTA, BLAST, depth, and table inputs;
+- invalid option paths and values;
+- missing optional exporters or external binaries;
+- stale output files and overwrite policy;
+- temporary session resource cleanup on success and exceptions;
+- exception chaining and stable `code` values.
+
+## 16. Required verification gates
+
+Run the smallest focused suite after each phase, then complete the following gates
+before deleting the legacy API:
+
+```bash
+pytest tests/test_public_contract.py -v
+pytest tests/test_python_interface.py -v
+pytest tests/test_api_library_usage.py -v
+pytest tests/test_api_requests.py -v
+pytest tests/test_api_request_render.py -v
+pytest tests/test_api_session.py -v
+pytest tests/test_session_io.py -v
+pytest tests/test_session_request_codec.py -v
+pytest tests/test_output_comparison.py::TestOutputComparison -v
+pytest tests/ -v -m "not slow"
+ruff check gbdraw/
+python -m build
+```
+
+Tests will be renamed as ownership changes. Preserve the behaviors represented by
+the list rather than keeping obsolete filenames.
+
+When Web execution changes, also run:
+
+```bash
+node --check gbdraw/web/js/app/run-analysis.js
+node --check gbdraw/web/js/services/config.js
+node --check gbdraw/web/js/services/session-request.js
+```
+
+Run the relevant Web unit and Playwright checks through the available Node or Python
+Playwright installation. If Chromium is blocked by the agent sandbox, rerun the same
+local check with sandbox escalation.
+
+## 17. Completion criteria
+
+The redesign is complete only when all of the following are true:
+
+1. The documented quick start runs from a clean installation with the stated input
+   setup.
+2. Ordinary users need only `gbdraw` and `gbdraw.options`.
+3. Advanced integrations use only `gbdraw.integration` and documented domain
+   modules.
+4. `gbdraw.api` and all long public assemblers are removed.
+5. `DiagramOptions` is removed from runtime code and remains only in old-session
+   decoding fixtures or migration documentation, if needed.
+6. CLI, Web, Python, and session rendering share one typed request path.
+7. New Python code uses no raw layout or track-slot string DSL.
+8. File output is separate from drawing requests.
+9. All expected failures inherit from root-exported `GbdrawError`.
+10. The installed wheel contains `py.typed` and passes a consumer type-check test.
+11. Default reference SVG comparisons pass without updates.
+12. New and supported old sessions render successfully through the new request
+    types.
+13. The final change deletes more compatibility and forwarding code than it adds in
+    permanent adapters.
+14. Documentation and release notes provide a complete old-to-new migration map.
+
+## 18. Recommended implementation order
+
+Implement this as one coordinated breaking-release branch but keep commits and
+review units phase-oriented:
+
+1. contract ADR and field inventory;
+2. new options and errors;
+3. typed inputs, tables, placement, and slots;
+4. request-driven rendering;
+5. ordinary facade;
+6. CLI adapter;
+7. Web/Pyodide adapter;
+8. session schema and old-session conversion;
+9. legacy deletion;
+10. docs, packaging, full verification, and release notes.
+
+Do not begin by renaming `gbdraw.api`. First make the new request own rendering;
+otherwise the rename only relocates the current compatibility layers. Delete the old
+namespace after all production callers have moved and the shared render path has
+passed geometry and session regression gates.

--- a/gbdraw/io/genome.py
+++ b/gbdraw/io/genome.py
@@ -129,6 +129,9 @@ def merge_gff_fasta_records(
 ) -> List[SeqRecord]:
     merged_records: List[SeqRecord] = []
     fasta_dict: Dict[str, SeqRecord] = {record.id: record for record in fasta_records}
+    fasta_order: Dict[str, int] = {
+        record.id: index for index, record in enumerate(fasta_records)
+    }
     for gff_record in gff_records:
         if gff_record.id in fasta_dict:
             try:
@@ -151,7 +154,7 @@ def merge_gff_fasta_records(
             raise ValidationError(
                 f"No matching FASTA record found for GFF record {gff_record.id}. Please ensure that all GFF records have corresponding FASTA entries."
             )
-    return merged_records
+    return sorted(merged_records, key=lambda record: fasta_order[record.id])
 
 
 def _gff3_feature_id(feature: SeqFeature) -> str | None:

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1717,6 +1717,27 @@
                                         </select>
                                         <button type="button" class="btn btn-danger h-6 w-6 p-0 text-[10px]" @click="removeAnnotation(set, item)" title="Delete annotation"><i class="ph ph-trash"></i></button>
                                     </div>
+                                    <div>
+                                        <label class="mb-0.5 flex items-center gap-1 text-[9px] text-slate-500">
+                                            Target record
+                                            <span v-if="annotationRecordRequired()" class="font-semibold text-red-600">Required</span>
+                                        </label>
+                                        <select
+                                            :value="annotationRecordValue(item)"
+                                            @change="setAnnotationRecord(item, $event.target.value)"
+                                            :disabled="annotationRecordDisabled(item)"
+                                            :class="annotationRecordMissing(item) ? 'border-red-400 bg-red-50' : ''"
+                                            class="form-input px-1 py-0.5 text-[10px] disabled:bg-slate-100 disabled:text-slate-500"
+                                            aria-label="Annotation target record"
+                                        >
+                                            <option
+                                                v-for="option in annotationRecordOptions(item)"
+                                                :key="`${option.value}:${option.synthetic ? 'synthetic' : 'record'}`"
+                                                :value="option.value"
+                                            >{{ option.label }}</option>
+                                        </select>
+                                        <p v-if="annotationRecordMissing(item)" class="mt-0.5 text-[9px] text-red-600">{{ annotationRecordMissingMessage(item) }}</p>
+                                    </div>
                                     <div v-if="item.target.kind === 'coordinateSpan'" class="grid grid-cols-2 gap-1">
                                         <input type="number" min="1" v-model.number="item.target.start" class="form-input px-1 py-0.5 text-[10px]" placeholder="Start (1-based)">
                                         <input type="number" min="1" v-model.number="item.target.end" class="form-input px-1 py-0.5 text-[10px]" placeholder="End (inclusive)">
@@ -2549,16 +2570,13 @@
                                                 type="button"
                                                 class="btn btn-secondary text-[10px] py-1 px-2"
                                                 @click="refreshCircularRecordOrder"
-                                                :disabled="cInputType !== 'gb'"
+                                                :disabled="cInputType === 'gb' ? !files.c_gb : (!files.c_gff || !files.c_fasta)"
                                             >
                                                 Reload Records
                                             </button>
                                         </div>
-                                        <div v-if="cInputType !== 'gb'" class="text-[10px] text-slate-500 bg-slate-50 border border-slate-200 rounded p-1.5">
-                                            Record Order is available for GenBank input.
-                                        </div>
-                                        <div v-else-if="adv.multi_record_positions.length === 0" class="text-[10px] text-slate-500 bg-slate-50 border border-slate-200 rounded p-1.5">
-                                            Upload a GenBank file to load records.
+                                        <div v-if="adv.multi_record_positions.length === 0" class="text-[10px] text-slate-500 bg-slate-50 border border-slate-200 rounded p-1.5">
+                                            Upload a sequence file to load records.
                                         </div>
                                         <div v-else class="space-y-1 bg-slate-50 border border-slate-200 rounded p-1.5">
                                             <div

--- a/gbdraw/web/js/app/annotations.js
+++ b/gbdraw/web/js/app/annotations.js
@@ -1,9 +1,21 @@
 import { createAnnotationSet, normalizeAnnotationSets, uniqueAnnotationSetId } from './annotations/state.js';
 import { coordinateTarget, featureTarget, featureTargetsFromSelection } from './annotations/target-actions.js';
 import { parseAnnotationTable } from './annotations/table-codec.js';
+import {
+  createAnnotationRecordSelector,
+  reconcileAnnotationRecordBindings
+} from './annotations/record-selector.js';
 
-export const createAnnotationEditor = ({ state }) => {
-  const replaceSets = (sets) => state.annotationSets.splice(0, state.annotationSets.length, ...normalizeAnnotationSets(sets));
+export const createAnnotationEditor = ({ state, getRecordCatalog }) => {
+  const recordSelector = createAnnotationRecordSelector({ getCatalog: getRecordCatalog });
+  const reconcileRecords = (sets = state.annotationSets) => {
+    reconcileAnnotationRecordBindings(sets, getRecordCatalog?.());
+    return sets;
+  };
+  const replaceSets = (sets) => {
+    state.annotationSets.splice(0, state.annotationSets.length, ...normalizeAnnotationSets(sets));
+    reconcileRecords();
+  };
   const addAnnotationSet = (base = 'annotations') => {
     const set = createAnnotationSet({ id: uniqueAnnotationSetId(state.annotationSets, base) });
     state.annotationSets.push(set);
@@ -42,6 +54,7 @@ export const createAnnotationEditor = ({ state }) => {
     const targets = featureTargetsFromSelection(state.selectedFeatures?.value ?? state.selectedFeatures ?? []);
     const items = targets.map((target, index) => ({ id: `feature_${set.annotations.length + index + 1}`, target, label: '', mark: 'bracket', lane: null, style: null, legendLabel: null, metadata: {} }));
     set.annotations.push(...items);
+    reconcileRecords(items.length ? [{ annotations: items }] : []);
     return items;
   };
   const removeAnnotation = (set, item) => {
@@ -50,9 +63,11 @@ export const createAnnotationEditor = ({ state }) => {
   };
   const setAnnotationTargetKind = (item, kind) => {
     if (!item) return;
+    const record = item.target?.record ?? null;
     item.target = kind === 'featureSpan'
       ? featureTarget({ selector: 'locus_tag=' })
       : coordinateTarget({ start: 1, end: 1 });
+    item.target.record = record;
   };
   const importAnnotationTable = (text) => replaceSets(parseAnnotationTable(text));
   const importAnnotationTableFile = async (event) => {
@@ -64,6 +79,14 @@ export const createAnnotationEditor = ({ state }) => {
   return {
     addAnnotationSet, renameAnnotationSet, duplicateAnnotationSet, removeAnnotationSet,
     addCoordinateAnnotation, addSelectedFeatures, removeAnnotation, setAnnotationTargetKind,
-    importAnnotationTable, importAnnotationTableFile, replaceAnnotationSets: replaceSets
+    importAnnotationTable, importAnnotationTableFile, replaceAnnotationSets: replaceSets,
+    recordOptionsFor: recordSelector.optionsFor,
+    recordValueFor: recordSelector.valueFor,
+    setRecordValue: recordSelector.setValue,
+    recordIsRequired: recordSelector.isRequired,
+    recordIsMissing: recordSelector.isMissing,
+    recordIsDisabled: recordSelector.isDisabled,
+    recordMissingMessage: recordSelector.missingMessage,
+    reconcileRecordBindings: reconcileRecords
   };
 };

--- a/gbdraw/web/js/app/annotations/record-catalog.js
+++ b/gbdraw/web/js/app/annotations/record-catalog.js
@@ -1,0 +1,166 @@
+import {
+  annotationRecordSelectorFromValue,
+  parseAnnotationRecordSelectorValue
+} from './target-actions.js';
+import { buildDisambiguatedRecordEntries, formatRecordLength } from '../record-options.js';
+
+const cleanText = (value) => String(value ?? '').trim();
+const fileFingerprint = (file) => file
+  ? [String(file.name || ''), Number(file.size || 0)]
+  : null;
+
+export const annotationSourceKey = ({
+  scope,
+  uid = '',
+  inputType = 'gb',
+  primaryFile = null,
+  pairedFile = null
+}) => JSON.stringify([
+  cleanText(scope),
+  cleanText(uid),
+  cleanText(inputType),
+  fileFingerprint(primaryFile),
+  fileFingerprint(pairedFile)
+]);
+
+const normalizeRecord = (record, fallbackIndex, sourceKey) => {
+  const length = Number(record?.recordLength ?? record?.record_length);
+  const selector = cleanText(record?.selector) || `#${fallbackIndex + 1}`;
+  const parsedSelector = parseAnnotationRecordSelectorValue(selector).selector;
+  const localIndex = parsedSelector?.kind === 'recordIndex' ? parsedSelector.index : fallbackIndex;
+  const recordId = cleanText(record?.recordId ?? record?.record_id) || `Record_${fallbackIndex + 1}`;
+  const recordLength = Number.isInteger(length) && length > 0 ? length : null;
+  return {
+    sourceKey,
+    localIndex,
+    key: `${sourceKey}::${JSON.stringify([localIndex, recordId, recordLength])}`,
+    recordId,
+    recordLength
+  };
+};
+
+const sourceRecords = (source, fallbackSourceKey) => (
+  (Array.isArray(source?.records) ? source.records : [])
+    .map((record, index) => normalizeRecord(
+      record,
+      index,
+      cleanText(source?.sourceKey) || fallbackSourceKey
+    ))
+);
+
+const selectSourceRecords = (records, selectorValue) => {
+  const parsed = parseAnnotationRecordSelectorValue(selectorValue);
+  if (parsed.error) return { records: [], error: parsed.error, explicit: true };
+  const selector = parsed.selector;
+  if (!selector) return { records, error: '', explicit: false };
+  if (selector.kind === 'recordIndex') {
+    const selected = records.find((record) => record.localIndex === selector.index);
+    return {
+      records: selected ? [selected] : [],
+      error: selected ? '' : `record selector #${selector.index + 1} is out of range`,
+      explicit: true
+    };
+  }
+  const matches = records.filter((record) => record.recordId === selector.value);
+  if (matches.length !== 1) {
+    return {
+      records: [],
+      error: matches.length > 1
+        ? `record ID ${JSON.stringify(selector.value)} is duplicated; choose a #index entry`
+        : `record ID ${JSON.stringify(selector.value)} is not available`,
+      explicit: true
+    };
+  }
+  return { records: matches, error: '', explicit: true };
+};
+
+const finalizeRecords = (records) => {
+  const indexed = records.map((record, index) => ({ ...record, selector: `#${index + 1}` }));
+  return buildDisambiguatedRecordEntries(indexed).map((record, index) => ({
+    ...record,
+    index,
+    backendSelector: annotationRecordSelectorFromValue(record.value),
+    label: `#${index + 1} · ${record.recordId}${record.recordLength ? ` · ${formatRecordLength(record.recordLength)}` : ''}`
+  }));
+};
+
+const catalogStatus = (issues, sources) => {
+  if (issues.length === 0) return 'ready';
+  if (sources.some((source) => source?.status === 'error')) return 'error';
+  return sources.some((source) => source?.status === 'loading') ? 'loading' : 'error';
+};
+
+const buildLinearCatalog = (sources, inputType, loadComparison) => {
+  const normalizedSources = Array.isArray(sources) ? sources : [];
+  const records = [];
+  const issues = [];
+  normalizedSources.forEach((source, sourceIndex) => {
+    const sourceLabel = `Sequence #${sourceIndex + 1}`;
+    if (!source?.hasInput) {
+      issues.push(`${sourceLabel}: upload the required sequence file(s).`);
+      return;
+    }
+    if (source?.status !== 'ready') {
+      issues.push(source?.status === 'error'
+        ? `${sourceLabel}: ${cleanText(source?.error) || 'record discovery failed.'}`
+        : `${sourceLabel}: wait for the record list to finish loading.`);
+      return;
+    }
+    const selected = selectSourceRecords(sourceRecords(source, `linear-source-${sourceIndex + 1}`), source?.selector);
+    if (selected.error) {
+      issues.push(`${sourceLabel}: ${selected.error}.`);
+      return;
+    }
+    let materialized = selected.records;
+    if (!selected.explicit && loadComparison) {
+      const truncate = cleanText(inputType) === 'gff' || normalizedSources.length > 1;
+      if (truncate) materialized = materialized.slice(0, 1);
+    }
+    records.push(...materialized);
+  });
+  const finalized = finalizeRecords(records);
+  return {
+    mode: 'linear',
+    status: catalogStatus(issues, normalizedSources),
+    records: finalized,
+    issues,
+    requiresSelection: finalized.length > 1,
+    allowExplicitSelectors: true,
+    signature: finalized.map((record) => record.key).join('|')
+  };
+};
+
+const buildCircularCatalog = (source, multiRecordCanvas) => {
+  const issues = [];
+  if (!source?.hasInput) {
+    issues.push('Upload the required circular sequence file(s).');
+  } else if (source?.status !== 'ready') {
+    issues.push(source?.status === 'error'
+      ? cleanText(source?.error) || 'Circular record discovery failed.'
+      : 'Wait for the circular record list to finish loading.');
+  }
+  const records = issues.length === 0 ? finalizeRecords(sourceRecords(source, 'circular-source')) : [];
+  const allowExplicitSelectors = Boolean(multiRecordCanvas) || records.length <= 1;
+  return {
+    mode: 'circular',
+    status: issues.length === 0 ? 'ready' : (source?.status === 'loading' ? 'loading' : 'error'),
+    records,
+    issues,
+    requiresSelection: Boolean(multiRecordCanvas) && records.length > 1,
+    allowExplicitSelectors,
+    signature: records.map((record) => record.key).join('|')
+  };
+};
+
+export const buildAnnotationRecordCatalog = ({
+  mode,
+  inputType = 'gb',
+  loadComparison = false,
+  multiRecordCanvas = false,
+  circularSource = null,
+  linearSources = []
+} = {}) => (
+  cleanText(mode) === 'linear'
+    ? buildLinearCatalog(linearSources, inputType, Boolean(loadComparison))
+    : buildCircularCatalog(circularSource, Boolean(multiRecordCanvas))
+);

--- a/gbdraw/web/js/app/annotations/record-selector.js
+++ b/gbdraw/web/js/app/annotations/record-selector.js
@@ -1,0 +1,157 @@
+import {
+  annotationRecordSelectorValue,
+  parseAnnotationRecordSelectorValue
+} from './target-actions.js';
+
+export const ANNOTATION_RECORD_BINDING_KEY = '_gbdraw_web_target_record_key';
+
+const cleanText = (value) => String(value ?? '').trim();
+
+const bindingFor = (annotation) => cleanText(annotation?.metadata?.[ANNOTATION_RECORD_BINDING_KEY]);
+export const annotationRecordBinding = bindingFor;
+
+const selectorFromTarget = (annotation) => {
+  const raw = annotation?.target?.record;
+  if (raw == null) return { selector: null, error: '' };
+  if (raw?.kind === 'recordIndex') {
+    const index = Number(raw.index);
+    return Number.isInteger(index) && index >= 0
+      ? { selector: { kind: 'recordIndex', index }, error: '' }
+      : { selector: null, error: 'Record index must be a non-negative integer.' };
+  }
+  if (raw?.kind === 'recordId') {
+    const parsed = parseAnnotationRecordSelectorValue(raw.value);
+    if (parsed.error || parsed.selector?.kind !== 'recordId') {
+      return { selector: null, error: parsed.error || 'Record ID is reserved as an unspecified selector.' };
+    }
+    return parsed;
+  }
+  return { selector: null, error: 'Unsupported record selector.' };
+};
+export const annotationRecordSelectorFromTarget = selectorFromTarget;
+
+const recordForSelector = (records, selector) => {
+  if (!selector) return null;
+  if (selector.kind === 'recordIndex') return records[selector.index] || null;
+  const matches = records.filter((record) => record.recordId === selector.value);
+  return matches.length === 1 ? matches[0] : null;
+};
+
+const resolvedRecord = (catalog, annotation) => {
+  const records = Array.isArray(catalog?.records) ? catalog.records : [];
+  const binding = bindingFor(annotation);
+  if (binding) return records.find((record) => record.key === binding) || null;
+  const parsed = selectorFromTarget(annotation);
+  return parsed.error ? null : recordForSelector(records, parsed.selector);
+};
+export const resolveAnnotationRecord = resolvedRecord;
+
+const setBinding = (annotation, key) => {
+  if (!annotation || typeof annotation !== 'object') return;
+  if (!annotation.metadata || typeof annotation.metadata !== 'object' || Array.isArray(annotation.metadata)) {
+    annotation.metadata = {};
+  }
+  if (key) annotation.metadata[ANNOTATION_RECORD_BINDING_KEY] = key;
+  else delete annotation.metadata[ANNOTATION_RECORD_BINDING_KEY];
+};
+
+export const annotationRecordValue = (catalog, annotation) => {
+  const binding = bindingFor(annotation);
+  if (binding) return binding;
+  const record = resolvedRecord(catalog, annotation);
+  if (record) return record.key;
+  const saved = annotationRecordSelectorValue(annotation?.target?.record);
+  return saved ? `saved:${saved}` : '';
+};
+
+export const setAnnotationRecordValue = (catalog, annotation, value) => {
+  if (!annotation?.target) return;
+  const key = cleanText(value);
+  if (!key) {
+    annotation.target.record = null;
+    setBinding(annotation, '');
+    return;
+  }
+  const record = (Array.isArray(catalog?.records) ? catalog.records : [])
+    .find((candidate) => candidate.key === key);
+  if (!record) return;
+  annotation.target.record = { ...record.backendSelector };
+  setBinding(annotation, record.key);
+};
+
+export const reconcileAnnotationRecordBindings = (sets, catalog) => {
+  const records = Array.isArray(catalog?.records) ? catalog.records : [];
+  (Array.isArray(sets) ? sets : []).forEach((set) => {
+    (Array.isArray(set?.annotations) ? set.annotations : []).forEach((annotation) => {
+      if (!annotation?.target) return;
+      const binding = bindingFor(annotation);
+      const record = binding
+        ? records.find((candidate) => candidate.key === binding)
+        : resolvedRecord(catalog, annotation);
+      if (!record) return;
+      annotation.target.record = { ...record.backendSelector };
+      setBinding(annotation, record.key);
+    });
+  });
+};
+
+export const annotationRecordOptions = (catalog, annotation) => {
+  const records = catalog?.allowExplicitSelectors === false
+    ? []
+    : (Array.isArray(catalog?.records) ? catalog.records : []);
+  const currentValue = annotationRecordValue(catalog, annotation);
+  const options = records.map((record) => ({
+    value: record.key,
+    label: record.label,
+    synthetic: false
+  }));
+  const selectedIsMissing = Boolean(currentValue) && !options.some((option) => option.value === currentValue);
+  const savedSelector = annotationRecordSelectorValue(annotation?.target?.record) || 'saved target';
+  return [
+    {
+      value: '',
+      label: catalog?.allowExplicitSelectors === false
+        ? 'Automatic (current output record)'
+        : (catalog?.status !== 'ready'
+            ? 'Record list unavailable'
+            : (records.length > 1 ? 'Select target record' : 'Automatic (single record)')),
+      synthetic: false
+    },
+    ...(selectedIsMissing
+      ? [{ value: currentValue, label: `${savedSelector} (target record unavailable)`, synthetic: true }]
+      : []),
+    ...options
+  ];
+};
+
+export const createAnnotationRecordSelector = ({ getCatalog }) => {
+  const catalog = () => getCatalog?.() || {
+    status: 'error', records: [], issues: [], requiresSelection: false, allowExplicitSelectors: true
+  };
+  const isMissing = (annotation) => {
+    const current = catalog();
+    if (current.status !== 'ready') return false;
+    const parsed = selectorFromTarget(annotation);
+    if (parsed.error) return true;
+    if (!parsed.selector) return Boolean(current.requiresSelection);
+    if (current.allowExplicitSelectors === false) return true;
+    return !resolvedRecord(current, annotation);
+  };
+  return {
+    optionsFor: (annotation) => annotationRecordOptions(catalog(), annotation),
+    valueFor: (annotation) => annotationRecordValue(catalog(), annotation),
+    setValue: (annotation, value) => setAnnotationRecordValue(catalog(), annotation, value),
+    isRequired: () => Boolean(catalog().requiresSelection),
+    isMissing,
+    isDisabled: (annotation) => {
+      const current = catalog();
+      if (current.status !== 'ready') return true;
+      return current.allowExplicitSelectors === false && annotation?.target?.record == null;
+    },
+    missingMessage: (annotation) => (
+      catalog().allowExplicitSelectors === false && selectorFromTarget(annotation).selector
+        ? 'Clear the target record or enable Multi-record canvas.'
+        : 'Choose the record that this annotation targets.'
+    )
+  };
+};

--- a/gbdraw/web/js/app/annotations/table-codec.js
+++ b/gbdraw/web/js/app/annotations/table-codec.js
@@ -1,5 +1,10 @@
 import { createAnnotationSet, createDefaultAnnotationStyle, normalizeAnnotationSets } from './state.js';
-import { coordinateTarget, featureTarget } from './target-actions.js';
+import {
+  annotationRecordSelectorValue,
+  coordinateTarget,
+  featureTarget,
+  parseAnnotationRecordSelectorValue
+} from './target-actions.js';
 
 const REQUIRED = ['set_id', 'id', 'mark'];
 const COLUMNS = [
@@ -16,7 +21,6 @@ const boolValue = (value, fallback = false) => {
   if (['false', '0', 'no', 'off'].includes(text)) return false;
   throw new Error(`Invalid boolean value: ${value}`);
 };
-const recordText = (record) => record?.kind === 'recordId' ? record.value : (record?.kind === 'recordIndex' ? `#${record.index + 1}` : '');
 const styleFromRow = (row) => {
   const hasStyle = COLUMNS.slice(15).some((name) => row[name] !== '');
   if (!hasStyle) return null;
@@ -52,9 +56,14 @@ export const parseAnnotationTable = (text) => {
     const row = Object.fromEntries(header.map((name, column) => [name, values[column] ?? '']));
     const rowNumber = index + 2;
     if (!row.set_id || !row.id) throw new Error(`Annotation table row ${rowNumber}: set_id and id are required.`);
-    const record = row.record?.startsWith('#')
-      ? { recordId: null, recordIndex: Math.max(0, Number(row.record.slice(1)) - 1) }
-      : { recordId: row.record || null, recordIndex: null };
+    const parsedRecord = parseAnnotationRecordSelectorValue(row.record);
+    if (parsedRecord.error) {
+      throw new Error(`Annotation table row ${rowNumber}, column 'record': ${parsedRecord.error}`);
+    }
+    const recordSelector = parsedRecord.selector;
+    const record = recordSelector?.kind === 'recordIndex'
+      ? { recordId: null, recordIndex: recordSelector.index }
+      : { recordId: recordSelector?.value || null, recordIndex: null };
     const hasCoordinates = Boolean(row.start || row.end);
     const hasFeature = Boolean(row.feature_selector);
     if (hasCoordinates === hasFeature) throw new Error(`Annotation table row ${rowNumber}: provide exactly one coordinate or feature target.`);
@@ -84,7 +93,7 @@ export const encodeAnnotationTable = (sets) => {
     const style = annotation.style || set.defaultStyle || {};
     const hatch = style.hatch || {};
     const row = {
-      set_id: set.id, id: annotation.id, mark: annotation.mark, record: recordText(target.record),
+      set_id: set.id, id: annotation.id, mark: annotation.mark, record: annotationRecordSelectorValue(target.record),
       start: coordinate ? target.start : '', end: coordinate ? target.end : '', coordinate_space: coordinate ? target.coordinateSpace : '',
       wraps_origin: coordinate && (target.wrapsOrigin || Number(target.start) > Number(target.end)) ? 'true' : '', out_of_bounds: coordinate ? target.outOfBounds : '',
       feature_selector: coordinate ? '' : selectors, envelope: coordinate ? '' : target.envelope, circular_path: coordinate ? '' : target.circularPath,

--- a/gbdraw/web/js/app/annotations/target-actions.js
+++ b/gbdraw/web/js/app/annotations/target-actions.js
@@ -1,18 +1,67 @@
+import { isUnspecifiedRecordSelectorValue } from '../record-options.js';
+
 const cleanNullable = (value) => {
   const text = String(value ?? '').trim();
   return text || null;
 };
 
-const recordSelector = (recordId, recordIndex) => {
+export const parseAnnotationRecordSelectorValue = (value) => {
+  const text = cleanNullable(value);
+  if (isUnspecifiedRecordSelectorValue(text)) {
+    return { selector: null, error: '' };
+  }
+  if (!text.startsWith('#')) {
+    return { selector: { kind: 'recordId', value: text }, error: '' };
+  }
+  const indexText = text.slice(1).trim();
+  if (!/^[0-9]+$/.test(indexText)) {
+    return {
+      selector: null,
+      error: `Invalid record selector ${JSON.stringify(text)}. Use #<number> or record_id.`
+    };
+  }
+  const index = Number(indexText) - 1;
+  if (!Number.isSafeInteger(index) || index < 0) {
+    return {
+      selector: null,
+      error: `Record index must be >= 1 in selector ${JSON.stringify(text)}.`
+    };
+  }
+  return { selector: { kind: 'recordIndex', index }, error: '' };
+};
+
+export const isSafeRecordIdSelector = (value) => {
+  const parsed = parseAnnotationRecordSelectorValue(value);
+  return !parsed.error && parsed.selector?.kind === 'recordId';
+};
+
+export const annotationRecordSelector = (recordId, recordIndex) => {
   const id = cleanNullable(recordId);
-  if (id) return { kind: 'recordId', value: id };
-  if (recordIndex != null && recordIndex !== '') return { kind: 'recordIndex', index: Math.max(0, Number(recordIndex) || 0) };
+  if (id && isSafeRecordIdSelector(id)) return { kind: 'recordId', value: id };
+  if (recordIndex == null || recordIndex === '') return null;
+  const index = Number(recordIndex);
+  if (Number.isInteger(index) && index >= 0) return { kind: 'recordIndex', index };
   return null;
+};
+
+export const annotationRecordSelectorValue = (selector) => {
+  if (selector?.kind === 'recordId') return cleanNullable(selector.value) || '';
+  if (selector?.kind === 'recordIndex') {
+    const index = Number(selector.index);
+    return Number.isInteger(index) && index >= 0 ? `#${index + 1}` : '';
+  }
+  return '';
+};
+
+export const annotationRecordSelectorFromValue = (value) => {
+  const parsed = parseAnnotationRecordSelectorValue(value);
+  if (parsed.error) throw new Error(parsed.error);
+  return parsed.selector;
 };
 
 export const coordinateTarget = ({ start, end, recordId = null, recordIndex = null, coordinateSpace = 'source' }) => ({
   kind: 'coordinateSpan',
-  record: recordSelector(recordId, recordIndex),
+  record: annotationRecordSelector(recordId, recordIndex),
   start: Number(start),
   end: Number(end),
   coordinateSpace: coordinateSpace === 'local' ? 'local' : 'source',
@@ -33,7 +82,7 @@ const parseFeatureSelector = (value) => {
 
 export const featureTarget = ({ selector, selectors = null, recordId = null, recordIndex = null, extent = 'outer_bounds', circularPath = 'shortest' }) => ({
   kind: 'featureSpan',
-  record: recordSelector(recordId, recordIndex),
+  record: annotationRecordSelector(recordId, recordIndex),
   selectors: (Array.isArray(selectors) ? selectors : String(selector || '').split(';')).filter((value) => String(value?.value ?? value).trim()).map(parseFeatureSelector),
   envelope: extent === 'segments' ? 'segments' : 'outer_bounds',
   circularPath: ['forward', 'reverse'].includes(circularPath) ? circularPath : 'shortest'
@@ -50,7 +99,7 @@ export const featureTargetsFromSelection = (features, options = {}) => (
       ...options,
       selector,
       recordId: options.recordId ?? feature?.record_id ?? null,
-      recordIndex: options.recordIndex ?? feature?.record_index ?? null
+      recordIndex: options.recordIndex ?? feature?.record_index ?? feature?.record_idx ?? feature?.fileIdx ?? null
     });
   })
 );

--- a/gbdraw/web/js/app/annotations/validation.js
+++ b/gbdraw/web/js/app/annotations/validation.js
@@ -1,0 +1,54 @@
+import {
+  annotationRecordBinding,
+  annotationRecordSelectorFromTarget,
+  resolveAnnotationRecord
+} from './record-selector.js';
+
+const cleanText = (value) => String(value ?? '').trim();
+
+const annotationLabel = (set, annotation) => (
+  `${cleanText(set?.id) || 'annotations'}/${cleanText(annotation?.id) || 'region'}`
+);
+
+const allAnnotations = (sets) => (
+  (Array.isArray(sets) ? sets : []).flatMap((set) => (
+    (Array.isArray(set?.annotations) ? set.annotations : []).map((annotation) => ({ set, annotation }))
+  ))
+);
+
+const selectorError = (selector, records) => {
+  if (selector.kind === 'recordIndex') {
+    return selector.index < records.length ? '' : `record index #${selector.index + 1} is out of range`;
+  }
+  const matches = records.filter((record) => record.recordId === selector.value);
+  if (matches.length === 0) return `record ID ${JSON.stringify(selector.value)} is not available`;
+  if (matches.length > 1) return `record ID ${JSON.stringify(selector.value)} is duplicated; choose a #index entry`;
+  return '';
+};
+
+export const validateAnnotationRecordTargets = (sets, catalog) => {
+  const annotations = allAnnotations(sets);
+  if (annotations.length === 0) return '';
+  const catalogIssue = Array.isArray(catalog?.issues) ? catalog.issues[0] : '';
+  if (catalogIssue) return `Region annotations: ${catalogIssue}`;
+
+  const records = Array.isArray(catalog?.records) ? catalog.records : [];
+  for (const { set, annotation } of annotations) {
+    const label = annotationLabel(set, annotation);
+    const parsed = annotationRecordSelectorFromTarget(annotation);
+    if (parsed.error) return `Choose a valid target record for region annotation ${label}.`;
+    if (!parsed.selector) {
+      if (catalog?.requiresSelection) return `Choose a target record for region annotation ${label}.`;
+      continue;
+    }
+    if (catalog?.allowExplicitSelectors === false) {
+      return `Region annotation ${label}: clear the target record or enable Multi-record canvas.`;
+    }
+    if (annotationRecordBinding(annotation) && !resolveAnnotationRecord(catalog, annotation)) {
+      return `Region annotation ${label}: the selected target record is no longer available; choose it again.`;
+    }
+    const error = selectorError(parsed.selector, records);
+    if (error) return `Region annotation ${label}: ${error}.`;
+  }
+  return '';
+};

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -53,6 +53,14 @@ import {
 } from './circular-track-slots.js';
 import { createLinearTrackSlotEditor } from './linear-track-slots.js';
 import { createAnnotationEditor } from './annotations.js';
+import {
+  annotationSourceKey,
+  buildAnnotationRecordCatalog
+} from './annotations/record-catalog.js';
+import {
+  reconcileAnnotationRecordBindings
+} from './annotations/record-selector.js';
+import { validateAnnotationRecordTargets } from './annotations/validation.js';
 import { createLosatSettings } from './losat-settings.js';
 import { createAutoValueDisplay } from './auto-value-display.js';
 import { createLinearRecordSelector } from './linear-record-selector.js';
@@ -65,9 +73,10 @@ import {
 import {
   addLinearComparison as appendLinearComparison,
   adjacentRowPairs,
+  hasLinearComparisonIntent,
   reconcileLinearComparisons
 } from './linear-comparisons.js';
-import { discoverSequenceRecords } from './record-discovery.js';
+import { discoverGffFastaRecords, discoverSequenceRecords } from './record-discovery.js';
 import {
   conservationSourceDescriptors,
   defaultConservationSeriesLabel,
@@ -154,6 +163,7 @@ export const createAppSetup = () => {
     rightDrawerTab,
     linearReorderNotice,
     circularRecordList,
+    circularRecordDiscovery,
     paletteDefinitions,
     paletteNames,
     selectedPalette,
@@ -339,12 +349,83 @@ export const createAppSetup = () => {
   const linearRecordSelector = createLinearRecordSelector({
     state,
     reactive,
-    recordReader: (options) => discoverSequenceRecords({
-      ...options,
-      pyodide: getPyodide(),
-      writeFileToFs: pyodideManager.writeFileToFs
-    })
+    recordReader: ({ inputType, primaryFile, pairedFile, temporaryPathPrefix }) => (
+      inputType === 'gff'
+        ? discoverGffFastaRecords({
+            gffFile: primaryFile,
+            fastaFile: pairedFile,
+            pyodide: getPyodide(),
+            writeFileToFs: pyodideManager.writeFileToFs,
+            gffTemporaryPath: `${temporaryPathPrefix}.gff`,
+            fastaTemporaryPath: `${temporaryPathPrefix}.fasta`
+          })
+        : discoverSequenceRecords({
+            file: primaryFile,
+            format: 'genbank',
+            pyodide: getPyodide(),
+            writeFileToFs: pyodideManager.writeFileToFs,
+            temporaryPath: `${temporaryPathPrefix}.gb`
+          })
+    )
   });
+  const getAnnotationRecordCatalog = (loadComparisonOverride = null) => {
+    const inputType = mode.value === 'linear' ? lInputType.value : cInputType.value;
+    const circularPrimaryFile = cInputType.value === 'gff' ? files.c_gff : files.c_gb;
+    const circularPairedFile = cInputType.value === 'gff' ? files.c_fasta : null;
+    const circularHasInput = Boolean(
+      circularPrimaryFile && (cInputType.value !== 'gff' || circularPairedFile)
+    );
+    const circularIsCurrent =
+      circularRecordDiscovery.inputType === cInputType.value &&
+      circularRecordDiscovery.primaryFile === circularPrimaryFile &&
+      circularRecordDiscovery.pairedFile === circularPairedFile;
+    const loadComparison = loadComparisonOverride == null
+      ? hasLinearComparisonIntent({
+          layoutEnabled: linearRecordLayoutEnabled.value,
+          comparisons: linearComparisons,
+          sequences: linearSeqs,
+          blastSource: blastSource.value
+        })
+      : Boolean(loadComparisonOverride);
+    return buildAnnotationRecordCatalog({
+      mode: mode.value,
+      inputType,
+      loadComparison,
+      multiRecordCanvas: form.multi_record_canvas,
+      circularSource: {
+        sourceKey: annotationSourceKey({
+          scope: 'circular',
+          inputType: cInputType.value,
+          primaryFile: circularPrimaryFile,
+          pairedFile: circularPairedFile
+        }),
+        hasInput: circularHasInput,
+        status: circularIsCurrent
+          ? circularRecordDiscovery.status
+          : (circularHasInput ? 'loading' : 'idle'),
+        error: circularIsCurrent ? circularRecordDiscovery.error : '',
+        records: circularIsCurrent ? circularRecordList.value : []
+      },
+      linearSources: linearSeqs.map((seq) => {
+        const primaryFile = lInputType.value === 'gff' ? seq.gff : seq.gb;
+        const pairedFile = lInputType.value === 'gff' ? seq.fasta : null;
+        return {
+          sourceKey: annotationSourceKey({
+            scope: 'linear',
+            uid: seq.uid,
+            inputType: lInputType.value,
+            primaryFile,
+            pairedFile
+          }),
+          selector: seq.region_record_id,
+          hasInput: Boolean(primaryFile && (lInputType.value !== 'gff' || pairedFile)),
+          status: linearRecordSelector.statusFor(seq),
+          error: linearRecordSelector.errorFor(seq),
+          records: linearRecordSelector.recordsFor(seq)
+        };
+      })
+    });
+  };
   const previewRuntime = createPreviewRuntime({ state, serializeSvg: serializeCleanSvg });
   setPreviewRuntime(previewRuntime);
 
@@ -488,7 +569,20 @@ export const createAppSetup = () => {
   const circularConservationFastaInput = ref(null);
   const circularTrackSlotEditor = createCircularTrackSlotEditor({ state });
   const linearTrackSlotEditor = createLinearTrackSlotEditor({ state });
-  const annotationEditor = createAnnotationEditor({ state });
+  const annotationEditor = createAnnotationEditor({ state, getRecordCatalog: getAnnotationRecordCatalog });
+  watch(
+    () => {
+      const catalog = getAnnotationRecordCatalog();
+      return `${catalog.status}:${catalog.signature}`;
+    },
+    () => {
+      const catalog = getAnnotationRecordCatalog();
+      if (catalog.status === 'ready') {
+        reconcileAnnotationRecordBindings(annotationSets, catalog);
+      }
+    },
+    { immediate: true }
+  );
   const circularConservationLayoutWarning = computed(() => estimateCircularConservationLayoutWarning(state));
   const losatSettings = createLosatSettings({ state });
   const autoValueDisplay = createAutoValueDisplay(state);
@@ -1124,7 +1218,12 @@ export const createAppSetup = () => {
     getPyodide,
     writeFileToFs: pyodideManager.writeFileToFs,
     refreshFeatureOverrides: featureActions.refreshFeatureOverrides,
-    resetPreviewViewport
+    resetPreviewViewport,
+    validateAnnotationTargets: ({ loadComparison }) => {
+      const catalog = getAnnotationRecordCatalog(loadComparison);
+      reconcileAnnotationRecordBindings(annotationSets, catalog);
+      return validateAnnotationRecordTargets(annotationSets, catalog);
+    }
   });
   const resultsManager = createResultsManager({
     state,
@@ -1468,6 +1567,26 @@ export const createAppSetup = () => {
         processingStatus.value = '';
         generationCancelRequested.value = false;
         return { status: wasCanceled ? 'canceled' : 'error' };
+      }
+    }
+
+    const hasRegionAnnotations = annotationSets.some((set) => (
+      Array.isArray(set?.annotations) && set.annotations.length > 0
+    ));
+    if (hasRegionAnnotations) {
+      let catalog = getAnnotationRecordCatalog();
+      if (catalog.status !== 'ready') {
+        if (mode.value === 'linear') await linearRecordSelector.refresh();
+        else await refreshCircularRecordOrder();
+        catalog = getAnnotationRecordCatalog();
+      }
+      reconcileAnnotationRecordBindings(annotationSets, catalog);
+      const annotationTargetError = validateAnnotationRecordTargets(annotationSets, catalog);
+      if (annotationTargetError) {
+        errorLog.value = { summary: annotationTargetError, details: [] };
+        processing.value = false;
+        processingStatus.value = '';
+        return { status: 'error' };
       }
     }
 
@@ -2302,6 +2421,13 @@ export const createAppSetup = () => {
     removeAnnotation: annotationEditor.removeAnnotation,
     setAnnotationTargetKind: annotationEditor.setAnnotationTargetKind,
     importAnnotationTableFile: annotationEditor.importAnnotationTableFile,
+    annotationRecordOptions: annotationEditor.recordOptionsFor,
+    annotationRecordValue: annotationEditor.recordValueFor,
+    setAnnotationRecord: annotationEditor.setRecordValue,
+    annotationRecordRequired: annotationEditor.recordIsRequired,
+    annotationRecordMissing: annotationEditor.recordIsMissing,
+    annotationRecordDisabled: annotationEditor.recordIsDisabled,
+    annotationRecordMissingMessage: annotationEditor.recordMissingMessage,
     circularConservationLayoutWarning,
     circularConservationFastaInput,
     circularConservationSeriesRows,

--- a/gbdraw/web/js/app/linear-comparisons.js
+++ b/gbdraw/web/js/app/linear-comparisons.js
@@ -2,6 +2,18 @@ let comparisonCounter = 0;
 
 const keyFor = (queryUid, subjectUid) => `${queryUid}->${subjectUid}`;
 
+export const hasLinearComparisonIntent = ({
+  layoutEnabled = false,
+  comparisons = [],
+  sequences = [],
+  blastSource = 'upload'
+} = {}) => {
+  const records = Array.isArray(sequences) ? sequences : [];
+  if (layoutEnabled) return Array.isArray(comparisons) && comparisons.length > 0;
+  if (String(blastSource || '') === 'losat') return records.length > 1;
+  return records.slice(0, -1).some((sequence) => Boolean(sequence?.blast));
+};
+
 export const reconcileLinearComparisons = (sequences, comparisons = []) => {
   const valid = new Set((Array.isArray(sequences) ? sequences : []).map((sequence) => String(sequence?.uid || '')));
   const seen = new Set();

--- a/gbdraw/web/js/app/linear-record-selector.js
+++ b/gbdraw/web/js/app/linear-record-selector.js
@@ -1,3 +1,5 @@
+import { buildDisambiguatedRecordEntries, formatRecordLength } from './record-options.js';
+
 export const AUTOMATIC_RECORD_OPTION_LABEL = 'Automatic (no explicit selector)';
 export const RECORDS_LOADING_LABEL = 'Loading records...';
 export const RECORD_FILE_REQUIRED_LABEL = 'Upload a sequence file first';
@@ -5,27 +7,15 @@ export const RECORD_READ_ERROR_LABEL = 'Records could not be loaded';
 
 const currentSelectorValue = (seq) => String(seq?.region_record_id ?? '').trim();
 
-export const formatRecordLength = (value) => {
-  const numeric = Number(value);
-  if (!Number.isInteger(numeric) || numeric <= 0) return 'length unavailable';
-  return `${numeric.toLocaleString('en-US')} bp`;
-};
+export { formatRecordLength };
 
 export const buildRecordOptions = (records, currentValue = '') => {
   const normalizedRecords = Array.isArray(records) ? records : [];
-  const idCounts = new Map();
-  normalizedRecords.forEach((record) => {
-    const recordId = String(record?.recordId ?? '').trim();
-    idCounts.set(recordId, (idCounts.get(recordId) || 0) + 1);
-  });
-
-  const options = normalizedRecords.map((record, index) => {
-    const selector = String(record?.selector ?? `#${index + 1}`).trim() || `#${index + 1}`;
-    const recordId = String(record?.recordId ?? '').trim() || `Record_${index + 1}`;
-    const duplicate = (idCounts.get(recordId) || 0) > 1;
+  const options = buildDisambiguatedRecordEntries(normalizedRecords).map((record) => {
+    const { selector, recordId, usesIndex, value } = record;
     return {
-      value: duplicate ? selector : recordId,
-      label: `${recordId} (${formatRecordLength(record?.recordLength)})${duplicate ? ` [${selector}]` : ''}`,
+      value,
+      label: `${recordId} (${formatRecordLength(record?.recordLength)})${usesIndex ? ` [${selector}]` : ''}`,
       synthetic: false
     };
   });
@@ -48,7 +38,10 @@ export const buildRecordOptions = (records, currentValue = '') => {
 const emptySelectorState = () => ({
   status: 'idle',
   records: [],
-  error: ''
+  error: '',
+  inputType: '',
+  primaryFile: null,
+  pairedFile: null
 });
 
 const sanitizePathSegment = (value) =>
@@ -64,19 +57,41 @@ export const createLinearRecordSelector = ({
   let refreshGeneration = 0;
 
   const uidFor = (seq) => String(seq?.uid ?? '').trim();
-  const sourceFileFor = (seq, inputType = state.lInputType.value) =>
-    inputType === 'gff' ? seq?.fasta : seq?.gb;
+  const sourceFilesFor = (seq, inputType = state.lInputType.value) => (
+    inputType === 'gff'
+      ? { primaryFile: seq?.gff || null, pairedFile: seq?.fasta || null }
+      : { primaryFile: seq?.gb || null, pairedFile: null }
+  );
 
   const stateFor = (seq) => {
     const uid = uidFor(seq);
-    return (uid && selectorStateByUid[uid]) || emptySelectorState();
+    const stored = (uid && selectorStateByUid[uid]) || emptySelectorState();
+    const inputType = state.lInputType.value;
+    const { primaryFile, pairedFile } = sourceFilesFor(seq, inputType);
+    if (
+      stored.inputType !== inputType ||
+      stored.primaryFile !== primaryFile ||
+      stored.pairedFile !== pairedFile
+    ) {
+      return {
+        ...emptySelectorState(),
+        status: primaryFile && (inputType !== 'gff' || pairedFile) ? 'loading' : 'idle',
+        inputType,
+        primaryFile,
+        pairedFile
+      };
+    }
+    return stored;
   };
 
   const replaceState = (uid, nextState) => {
     selectorStateByUid[uid] = {
       status: nextState.status,
       records: Array.isArray(nextState.records) ? nextState.records : [],
-      error: String(nextState.error || '')
+      error: String(nextState.error || ''),
+      inputType: String(nextState.inputType || ''),
+      primaryFile: nextState.primaryFile || null,
+      pairedFile: nextState.pairedFile || null
     };
   };
 
@@ -87,11 +102,13 @@ export const createLinearRecordSelector = ({
     });
   };
 
-  const isCurrentRequest = ({ generation, uid, file, inputType }) => {
+  const isCurrentRequest = ({ generation, uid, primaryFile, pairedFile, inputType }) => {
     if (generation !== refreshGeneration) return false;
     if (state.mode.value !== 'linear' || state.lInputType.value !== inputType) return false;
     const currentSeq = state.linearSeqs.find((seq) => uidFor(seq) === uid);
-    return Boolean(currentSeq) && sourceFileFor(currentSeq, inputType) === file;
+    if (!currentSeq) return false;
+    const currentFiles = sourceFilesFor(currentSeq, inputType);
+    return currentFiles.primaryFile === primaryFile && currentFiles.pairedFile === pairedFile;
   };
 
   const refresh = async () => {
@@ -104,37 +121,44 @@ export const createLinearRecordSelector = ({
     }
 
     const inputType = state.lInputType.value;
-    const format = inputType === 'gff' ? 'fasta' : 'genbank';
     const targets = [];
     for (const seq of state.linearSeqs) {
       const uid = uidFor(seq);
       if (!uid) continue;
-      const file = sourceFileFor(seq, inputType);
-      if (!file) {
-        replaceState(uid, emptySelectorState());
+      const { primaryFile, pairedFile } = sourceFilesFor(seq, inputType);
+      if (!primaryFile || (inputType === 'gff' && !pairedFile)) {
+        replaceState(uid, { ...emptySelectorState(), inputType, primaryFile, pairedFile });
         continue;
       }
-      replaceState(uid, { status: 'loading', records: [], error: '' });
-      targets.push({ uid, file });
+      replaceState(uid, {
+        status: 'loading', records: [], error: '', inputType, primaryFile, pairedFile
+      });
+      targets.push({ uid, primaryFile, pairedFile });
     }
     if (!state.pyodideReady.value) return;
 
-    for (const { uid, file } of targets) {
+    for (const { uid, primaryFile, pairedFile } of targets) {
       try {
         const records = await recordReader({
-          file,
-          format,
-          temporaryPath: `/record-selector-${sanitizePathSegment(uid)}-${generation}.${format === 'fasta' ? 'fasta' : 'gb'}`
+          inputType,
+          primaryFile,
+          pairedFile,
+          temporaryPathPrefix: `/record-selector-${sanitizePathSegment(uid)}-${generation}`
         });
-        if (!isCurrentRequest({ generation, uid, file, inputType })) return;
-        replaceState(uid, { status: 'ready', records, error: '' });
+        if (!isCurrentRequest({ generation, uid, primaryFile, pairedFile, inputType })) return;
+        replaceState(uid, {
+          status: 'ready', records, error: '', inputType, primaryFile, pairedFile
+        });
       } catch (error) {
-        if (!isCurrentRequest({ generation, uid, file, inputType })) return;
+        if (!isCurrentRequest({ generation, uid, primaryFile, pairedFile, inputType })) return;
         logger.warn?.(`Failed to read records for ${uid}:`, error);
         replaceState(uid, {
           status: 'error',
           records: [],
-          error: 'Could not read records from this file.'
+          error: 'Could not read records from this file.',
+          inputType,
+          primaryFile,
+          pairedFile
         });
       }
     }
@@ -160,6 +184,8 @@ export const createLinearRecordSelector = ({
   };
 
   const isDisabled = (seq) => stateFor(seq).status !== 'ready';
+  const statusFor = (seq) => stateFor(seq).status;
+  const recordsFor = (seq) => stateFor(seq).records.slice();
   const errorFor = (seq) => stateFor(seq).error;
   const warningFor = (seq) => {
     const selectorState = stateFor(seq);
@@ -174,6 +200,8 @@ export const createLinearRecordSelector = ({
     refresh,
     purgeInactiveState,
     optionsFor,
+    statusFor,
+    recordsFor,
     isDisabled,
     errorFor,
     warningFor

--- a/gbdraw/web/js/app/python-helpers.js
+++ b/gbdraw/web/js/app/python-helpers.js
@@ -1350,6 +1350,32 @@ def list_sequence_records(path, format):
     except Exception:
         return json.dumps({"error": traceback.format_exc()})
 
+def list_gff_fasta_records(gff_path, fasta_path):
+    """List records in the same FASTA order used by diagram generation."""
+    try:
+        from gbdraw.io.genome import load_gff_fasta
+        records = load_gff_fasta(
+            [gff_path],
+            [fasta_path],
+            "linear",
+            selected_features_set=(),
+            keep_all_features=False,
+            load_comparison=False,
+            record_selectors=[""],
+            reverse_flags=[False],
+        )
+        payload = [
+            {
+                "selector": f"#{idx + 1}",
+                "record_id": str(record.id or f"Record_{idx + 1}"),
+                "record_length": len(record.seq),
+            }
+            for idx, record in enumerate(records)
+        ]
+        return json.dumps({"records": payload})
+    except Exception:
+        return json.dumps({"error": traceback.format_exc()})
+
 def generate_legend_entry_svg(caption, color, y_offset, rect_size=14, font_size=14, font_family="Arial", x_offset=0, stroke_color="black", stroke_width=0.5):
     """Generate SVG elements for a single legend entry"""
     from xml.sax.saxutils import escape as xml_escape

--- a/gbdraw/web/js/app/record-discovery.js
+++ b/gbdraw/web/js/app/record-discovery.js
@@ -24,6 +24,25 @@ export const normalizeSequenceRecords = (payload) => {
   return records;
 };
 
+const readRecordPayload = (pyodide, helperName, args) => {
+  const helper = pyodide.globals.get(helperName);
+  try {
+    if (typeof helper !== 'function') throw new Error('Record discovery helper is unavailable.');
+    const rawPayload = helper(...args);
+    return normalizeSequenceRecords(JSON.parse(String(rawPayload || '{}')));
+  } finally {
+    helper?.destroy?.();
+  }
+};
+
+const unlinkIfPresent = (pyodide, path) => {
+  try {
+    pyodide.FS.unlink(path);
+  } catch (_error) {
+    // The file may not have been staged when discovery fails early.
+  }
+};
+
 export const discoverSequenceRecords = async ({
   file,
   format,
@@ -36,21 +55,40 @@ export const discoverSequenceRecords = async ({
   if (typeof writeFileToFs !== 'function') throw new Error('File staging is unavailable.');
   if (!temporaryPath) throw new Error('A temporary path is required.');
 
-  let listRecords = null;
   try {
     const staged = await writeFileToFs(file, temporaryPath);
     if (!staged) throw new Error('Could not stage the sequence file.');
-    listRecords = pyodide.globals.get('list_sequence_records');
-    if (typeof listRecords !== 'function') throw new Error('Record discovery helper is unavailable.');
-    const rawPayload = listRecords(temporaryPath, format);
-    const payload = JSON.parse(String(rawPayload || '{}'));
-    return normalizeSequenceRecords(payload);
+    return readRecordPayload(pyodide, 'list_sequence_records', [temporaryPath, format]);
   } finally {
-    listRecords?.destroy?.();
-    try {
-      pyodide.FS.unlink(temporaryPath);
-    } catch (_error) {
-      // The file may not have been staged when discovery fails early.
-    }
+    unlinkIfPresent(pyodide, temporaryPath);
+  }
+};
+
+export const discoverGffFastaRecords = async ({
+  gffFile,
+  fastaFile,
+  pyodide,
+  writeFileToFs,
+  gffTemporaryPath,
+  fastaTemporaryPath
+}) => {
+  if (!gffFile || !fastaFile) throw new Error('GFF3 and FASTA files are required.');
+  if (!pyodide) throw new Error('Python environment is not ready.');
+  if (typeof writeFileToFs !== 'function') throw new Error('File staging is unavailable.');
+  if (!gffTemporaryPath || !fastaTemporaryPath) throw new Error('Temporary paths are required.');
+
+  try {
+    const gffStaged = await writeFileToFs(gffFile, gffTemporaryPath);
+    if (!gffStaged) throw new Error('Could not stage the GFF3 file.');
+    const fastaStaged = await writeFileToFs(fastaFile, fastaTemporaryPath);
+    if (!fastaStaged) throw new Error('Could not stage the FASTA file.');
+    return readRecordPayload(
+      pyodide,
+      'list_gff_fasta_records',
+      [gffTemporaryPath, fastaTemporaryPath]
+    );
+  } finally {
+    unlinkIfPresent(pyodide, gffTemporaryPath);
+    unlinkIfPresent(pyodide, fastaTemporaryPath);
   }
 };

--- a/gbdraw/web/js/app/record-options.js
+++ b/gbdraw/web/js/app/record-options.js
@@ -1,0 +1,42 @@
+const cleanText = (value) => String(value ?? '').trim();
+const NULL_RECORD_SELECTOR_TOKENS = new Set([
+  'none', 'null', 'jsnull', 'undefined', 'jsundefined', '-'
+]);
+
+export const isUnspecifiedRecordSelectorValue = (value) => {
+  const text = cleanText(value);
+  return !text || NULL_RECORD_SELECTOR_TOKENS.has(text.toLowerCase());
+};
+
+const isSafeRecordId = (value) => {
+  const recordId = cleanText(value);
+  return !isUnspecifiedRecordSelectorValue(recordId) && !recordId.startsWith('#');
+};
+
+export const formatRecordLength = (value) => {
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) return 'length unavailable';
+  return `${numeric.toLocaleString('en-US')} bp`;
+};
+
+export const buildDisambiguatedRecordEntries = (records) => {
+  const normalized = (Array.isArray(records) ? records : []).map((record, index) => ({
+    ...record,
+    selector: cleanText(record?.selector) || `#${index + 1}`,
+    recordId: cleanText(record?.recordId) || `Record_${index + 1}`
+  }));
+  const idCounts = new Map();
+  normalized.forEach((record) => {
+    idCounts.set(record.recordId, (idCounts.get(record.recordId) || 0) + 1);
+  });
+  return normalized.map((record) => {
+    const duplicate = (idCounts.get(record.recordId) || 0) > 1;
+    const usesIndex = duplicate || !isSafeRecordId(record.recordId);
+    return {
+      ...record,
+      duplicate,
+      usesIndex,
+      value: usesIndex ? record.selector : record.recordId
+    };
+  });
+};

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -71,7 +71,7 @@ import {
   normalizeCircularPlotTitlePosition,
   normalizeLinearPlotTitlePosition
 } from './plot-title-position.js';
-import { discoverSequenceRecords } from './record-discovery.js';
+import { discoverGffFastaRecords, discoverSequenceRecords } from './record-discovery.js';
 
 const hashText = async (text) => {
   if (globalThis.crypto?.subtle) {
@@ -646,7 +646,8 @@ export const createRunAnalysis = ({
   getPyodide,
   writeFileToFs,
   refreshFeatureOverrides,
-  resetPreviewViewport
+  resetPreviewViewport,
+  validateAnnotationTargets = null
 }) => {
   const {
     pyodideReady,
@@ -709,6 +710,7 @@ export const createRunAnalysis = ({
     orthogroupDescriptionOverrides,
     selectedOrthogroupId,
     circularRecordList,
+    circularRecordDiscovery,
     files,
     linearSeqs,
     linearRecordLayoutEnabled,
@@ -1562,34 +1564,53 @@ json.dumps({
       adv.multi_record_positions = [];
     }
     const pyodide = getPyodide();
-    const sourceFile = files.c_gb;
+    const inputType = cInputType.value;
+    const primaryFile = inputType === 'gff' ? files.c_gff : files.c_gb;
+    const pairedFile = inputType === 'gff' ? files.c_fasta : null;
+    const hasCompleteInput = Boolean(primaryFile && (inputType !== 'gff' || pairedFile));
+    Object.assign(circularRecordDiscovery, {
+      status: hasCompleteInput ? 'loading' : 'idle',
+      error: '',
+      inputType,
+      primaryFile: primaryFile || null,
+      pairedFile: pairedFile || null
+    });
     if (
       mode.value !== 'circular' ||
-      cInputType.value !== 'gb' ||
-      !sourceFile ||
+      !hasCompleteInput ||
       !pyodideReady.value ||
       !pyodide
     ) {
       circularRecordList.value = [];
-      if (!files.c_gb || cInputType.value !== 'gb') {
+      if (!hasCompleteInput) {
         adv.multi_record_positions.splice(0, adv.multi_record_positions.length);
       }
       return;
     }
 
     try {
-      const records = await discoverSequenceRecords({
-        file: sourceFile,
-        format: 'genbank',
-        pyodide,
-        writeFileToFs,
-        temporaryPath: `/record-discovery-circular-${refreshGeneration}.gb`
-      });
+      const records = inputType === 'gff'
+        ? await discoverGffFastaRecords({
+            gffFile: primaryFile,
+            fastaFile: pairedFile,
+            pyodide,
+            writeFileToFs,
+            gffTemporaryPath: `/record-discovery-circular-${refreshGeneration}.gff`,
+            fastaTemporaryPath: `/record-discovery-circular-${refreshGeneration}.fasta`
+          })
+        : await discoverSequenceRecords({
+            file: primaryFile,
+            format: 'genbank',
+            pyodide,
+            writeFileToFs,
+            temporaryPath: `/record-discovery-circular-${refreshGeneration}.gb`
+          });
       if (
         refreshGeneration !== circularRecordRefreshGeneration ||
         mode.value !== 'circular' ||
-        cInputType.value !== 'gb' ||
-        files.c_gb !== sourceFile
+        cInputType.value !== inputType ||
+        (inputType === 'gff' ? files.c_gff : files.c_gb) !== primaryFile ||
+        (inputType === 'gff' ? files.c_fasta : null) !== pairedFile
       ) return;
       const nextRecords = records.map((entry) => ({
         selector: entry.selector,
@@ -1597,17 +1618,21 @@ json.dumps({
         record_length: entry.recordLength
       }));
       circularRecordList.value = nextRecords;
+      circularRecordDiscovery.status = 'ready';
       const nextPositions = mergeCircularRecordPositions(nextRecords, adv.multi_record_positions);
       adv.multi_record_positions.splice(0, adv.multi_record_positions.length, ...nextPositions);
     } catch (error) {
       if (
         refreshGeneration !== circularRecordRefreshGeneration ||
         mode.value !== 'circular' ||
-        cInputType.value !== 'gb' ||
-        files.c_gb !== sourceFile
+        cInputType.value !== inputType ||
+        (inputType === 'gff' ? files.c_gff : files.c_gb) !== primaryFile ||
+        (inputType === 'gff' ? files.c_fasta : null) !== pairedFile
       ) return;
       console.warn('Failed to refresh circular record order:', error);
       circularRecordList.value = [];
+      circularRecordDiscovery.status = 'error';
+      circularRecordDiscovery.error = 'Could not read records from the circular input file(s).';
       adv.multi_record_positions.splice(0, adv.multi_record_positions.length);
     }
   };
@@ -1780,6 +1805,7 @@ json.dumps({
 
     try {
       let args = [];
+      let annotationLoadComparison = false;
       const pendingMatchSequenceSources = [];
       const queueMatchSequenceSource = (source) => {
         if (!source?.key || !source?.sequence) return;
@@ -4274,6 +4300,18 @@ json.dumps({
         }
         if (explicitComparisonsTablePath) args.push('--comparisons_table', explicitComparisonsTablePath);
         else if (blastArgs.length) args.push('-b', ...blastArgs);
+        annotationLoadComparison = Boolean(explicitComparisonsTablePath || blastArgs.length);
+      }
+
+      if (typeof validateAnnotationTargets === 'function' && annotationSets.length > 0) {
+        const annotationError = validateAnnotationTargets({
+          loadComparison: mode.value === 'linear' ? annotationLoadComparison : false
+        });
+        if (annotationError) throw new Error(annotationError);
+        stageTextFile('/web_annotations.tsv', encodeAnnotationTable(annotationSets), {
+          name: 'annotations.tsv',
+          slot: 'generatedFiles.web_annotations'
+        });
       }
 
       console.log('CMD:', args.join(' '));

--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -763,7 +763,7 @@ export const setupWatchers = ({
   watch(() => state.adv.plot_title_font_size, scheduleCircularDefinitionUpdate);
   watch(() => state.adv.keep_full_definition_with_plot_title, scheduleCircularDefinitionUpdate);
   watch(
-    () => [mode.value, cInputType.value, files.c_gb, pyodideReady.value],
+    () => [mode.value, cInputType.value, files.c_gb, files.c_gff, files.c_fasta, pyodideReady.value],
     async () => {
       if (typeof refreshCircularRecordOrder !== 'function') return;
       await refreshCircularRecordOrder();
@@ -776,7 +776,8 @@ export const setupWatchers = ({
       pyodideReady.value,
       ...linearSeqs.flatMap((seq) => [
         seq.uid,
-        lInputType.value === 'gff' ? seq.fasta : seq.gb
+        lInputType.value === 'gff' ? seq.gff : seq.gb,
+        lInputType.value === 'gff' ? seq.fasta : null
       ])
     ],
     async () => {

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -600,6 +600,13 @@ const showRightDrawer = ref(false);
 const rightDrawerTab = ref('features'); // 'legend' | 'features' | 'orthogroups'
 const linearReorderNotice = ref('');
 const circularRecordList = ref([]); // [{ selector: '#1', record_id: 'NC_xxx' }]
+const circularRecordDiscovery = reactive({
+  status: 'idle',
+  error: '',
+  inputType: '',
+  primaryFile: null,
+  pairedFile: null
+});
 
 // Color & Filter State
 const paletteDefinitions = ref({});
@@ -1146,6 +1153,7 @@ export const state = {
   rightDrawerTab,
   linearReorderNotice,
   circularRecordList,
+  circularRecordDiscovery,
   paletteDefinitions,
   paletteNames,
   selectedPalette,

--- a/tests/test_gff_multipart.py
+++ b/tests/test_gff_multipart.py
@@ -7,6 +7,39 @@ from gbdraw.features.coordinates import get_exon_and_intron_coordinates
 from gbdraw.io.genome import load_gff_fasta
 
 
+def test_load_gff_fasta_preserves_fasta_record_order(tmp_path: Path) -> None:
+    gff_path = tmp_path / "records.gff3"
+    fasta_path = tmp_path / "records.fasta"
+    gff_path.write_text(
+        "\n".join(
+            [
+                "##gff-version 3",
+                "##sequence-region record_a 1 4",
+                "record_a\ttest\tgene\t1\t4\t.\t+\t.\tID=gene_a",
+                "##sequence-region record_b 1 4",
+                "record_b\ttest\tgene\t1\t4\t.\t+\t.\tID=gene_b",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    fasta_path.write_text(">record_b\nCCCC\n>record_a\nAAAA\n", encoding="utf-8")
+
+    records = load_gff_fasta(
+        [str(gff_path)],
+        [str(fasta_path)],
+        mode="linear",
+        selected_features_set={"gene"},
+    )
+
+    assert [record.id for record in records] == ["record_b", "record_a"]
+    assert [str(record.seq) for record in records] == ["CCCC", "AAAA"]
+    assert [record.features[0].qualifiers["ID"] for record in records] == [
+        ["gene_b"],
+        ["gene_a"],
+    ]
+
+
 def test_load_gff_fasta_collapses_same_id_rows_into_compound_location(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -311,6 +311,8 @@ def test_linear_record_selector_source_contract() -> None:
     assert "linearRecordOptions(seq)" in index_html
     assert "linearRecordSelectorDisabled(seq)" in index_html
     assert "def list_sequence_records(path, format):" in helper_js
+    assert "def list_gff_fasta_records(gff_path, fasta_path):" in helper_js
+    assert "load_gff_fasta(" in helper_js
     assert 'format_map = {"genbank": "genbank", "fasta": "fasta"}' in helper_js
     assert "def list_genbank_records(" not in helper_js
     assert (WEB_ROOT / "js" / "app" / "record-discovery.js").is_file()
@@ -3989,7 +3991,11 @@ def test_build_py_copies_offline_gui_assets(tmp_path: Path) -> None:
         build_root / "gbdraw" / "web" / "js" / "workers" / "losat-threaded-worker.js",
         build_root / "gbdraw" / "web" / "js" / "workers" / "losat-wasi-thread-worker.js",
         build_root / "gbdraw" / "web" / "js" / "app" / "record-discovery.js",
+        build_root / "gbdraw" / "web" / "js" / "app" / "record-options.js",
         build_root / "gbdraw" / "web" / "js" / "app" / "linear-record-selector.js",
+        build_root / "gbdraw" / "web" / "js" / "app" / "annotations" / "record-catalog.js",
+        build_root / "gbdraw" / "web" / "js" / "app" / "annotations" / "record-selector.js",
+        build_root / "gbdraw" / "web" / "js" / "app" / "annotations" / "validation.js",
         build_root / "gbdraw" / "web" / "wasm" / "losat" / "losat.wasm",
         build_root / "gbdraw" / "web" / "wasm" / "losat" / "losat-threaded.wasm",
         *(build_root / "gbdraw" / "web" / path for path in verify_module.REQUIRED_UI_FONT_FILES),
@@ -4038,7 +4044,11 @@ def test_built_wheel_contains_offline_gui_assets(tmp_path: Path) -> None:
         assert browser_wheels == [browser_wheel_member]
         assert gallery_members == []
         assert "gbdraw/web/js/app/record-discovery.js" in outer_names
+        assert "gbdraw/web/js/app/record-options.js" in outer_names
         assert "gbdraw/web/js/app/linear-record-selector.js" in outer_names
+        assert "gbdraw/web/js/app/annotations/record-catalog.js" in outer_names
+        assert "gbdraw/web/js/app/annotations/record-selector.js" in outer_names
+        assert "gbdraw/web/js/app/annotations/validation.js" in outer_names
 
 
 @pytest.mark.slow

--- a/tests/web/annotations.test.mjs
+++ b/tests/web/annotations.test.mjs
@@ -10,11 +10,26 @@ await writeFile(join(tempRoot, 'package.json'), '{"type":"module"}', 'utf8');
 const load = (path) => import(pathToFileURL(join(tempRoot, 'js', path)));
 
 const { createAnnotationSet, normalizeAnnotationSets } = await load('app/annotations/state.js');
-const { coordinateTarget, featureTarget } = await load('app/annotations/target-actions.js');
+const {
+  annotationRecordSelector,
+  annotationRecordSelectorFromValue,
+  annotationRecordSelectorValue,
+  coordinateTarget,
+  featureTarget,
+  parseAnnotationRecordSelectorValue
+} = await load('app/annotations/target-actions.js');
+const { buildAnnotationRecordCatalog } = await load('app/annotations/record-catalog.js');
+const {
+  annotationRecordOptions,
+  reconcileAnnotationRecordBindings,
+  setAnnotationRecordValue
+} = await load('app/annotations/record-selector.js');
+const { validateAnnotationRecordTargets } = await load('app/annotations/validation.js');
 const { encodeAnnotationTable, parseAnnotationTable } = await load('app/annotations/table-codec.js');
 const { createAnnotationEditor } = await load('app/annotations.js');
 const { buildLinearTrackSlotSpec, normalizeLinearTrackSlots } = await load('app/linear-track-slots.js');
 const { buildCircularTrackSlotSpec, normalizeCircularTrackSlots } = await load('app/circular-track-slots.js');
+const { hasLinearComparisonIntent } = await load('app/linear-comparisons.js');
 
 const set = createAnnotationSet({
   id: 'review',
@@ -33,6 +48,18 @@ assert.equal(restored[0].id, 'review');
 assert.equal(restored[0].annotations[0].target.start, 10);
 assert.equal(restored[0].annotations[1].target.selectors[0].value, 'ABC_1');
 
+assert.equal(annotationRecordSelectorValue(annotationRecordSelectorFromValue('')), '');
+assert.equal(annotationRecordSelectorValue(annotationRecordSelectorFromValue('RecA')), 'RecA');
+assert.equal(annotationRecordSelectorValue(annotationRecordSelectorFromValue('#2')), '#2');
+assert.equal(annotationRecordSelectorValue(annotationRecordSelectorFromValue('# 2')), '#2');
+assert.equal(annotationRecordSelectorFromValue('NULL'), null);
+assert.throws(() => annotationRecordSelectorFromValue('#0'), /must be >= 1/);
+assert.throws(() => annotationRecordSelectorFromValue('#record'), /Invalid record selector/);
+assert.deepEqual(parseAnnotationRecordSelectorValue('RecA').selector, { kind: 'recordId', value: 'RecA' });
+assert.deepEqual(annotationRecordSelector(null, 0), { kind: 'recordIndex', index: 0 });
+assert.equal(annotationRecordSelector(null, -1), null);
+assert.equal(annotationRecordSelector(null, 'not-a-number'), null);
+
 const state = {
   annotationSets: [],
   selectedFeatures: { value: [] },
@@ -41,11 +68,189 @@ const state = {
 const editor = createAnnotationEditor({ state });
 const created = editor.addAnnotationSet('review');
 editor.addCoordinateAnnotation(created, { start: 5, end: 8 });
+created.annotations[0].target.record = { kind: 'recordIndex', index: 1 };
+editor.setAnnotationTargetKind(created.annotations[0], 'featureSpan');
+assert.deepEqual(created.annotations[0].target.record, { kind: 'recordIndex', index: 1 });
+editor.setAnnotationTargetKind(created.annotations[0], 'coordinateSpan');
+assert.deepEqual(created.annotations[0].target.record, { kind: 'recordIndex', index: 1 });
 const copied = editor.duplicateAnnotationSet(created);
 assert.equal(state.annotationSets.length, 2);
 assert.notEqual(copied.id, created.id);
 editor.removeAnnotationSet(copied);
 assert.equal(state.annotationSets.length, 1);
+
+const linearCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  linearSources: [
+    {
+      sourceKey: 'source-a',
+      hasInput: true,
+      status: 'ready',
+      selector: '',
+      records: [{ selector: '#1', recordId: 'RecA', recordLength: 100 }]
+    },
+    {
+      sourceKey: 'source-b',
+      hasInput: true,
+      status: 'ready',
+      selector: '',
+      records: [{ selector: '#1', recordId: 'RecB', recordLength: 200 }]
+    }
+  ]
+});
+assert.deepEqual(linearCatalog.records.map((record) => record.value), ['RecA', 'RecB']);
+assert.match(linearCatalog.records[0].label, /#1 · RecA · 100 bp/);
+
+const duplicateCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  linearSources: [
+    { sourceKey: 'dup-a', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'dup', recordLength: 10 }] },
+    { sourceKey: 'dup-b', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'dup', recordLength: 20 }] }
+  ]
+});
+assert.deepEqual(duplicateCatalog.records.map((record) => record.value), ['#1', '#2']);
+
+const targetSet = createAnnotationSet({
+  id: 'targets',
+  annotations: [{ id: 'window', target: coordinateTarget({ start: 1, end: 5 }), label: '', mark: 'band' }]
+});
+assert.match(validateAnnotationRecordTargets([targetSet], linearCatalog), /targets\/window/);
+const featureTargetSet = createAnnotationSet({
+  id: 'features',
+  annotations: [{ id: 'gene', target: featureTarget({ selector: 'locus_tag=ABC_1' }), label: '', mark: 'bracket' }]
+});
+assert.match(validateAnnotationRecordTargets([featureTargetSet], linearCatalog), /features\/gene/);
+assert.deepEqual(
+  annotationRecordOptions(linearCatalog, targetSet.annotations[0]).map((option) => option.value),
+  ['', linearCatalog.records[0].key, linearCatalog.records[1].key]
+);
+setAnnotationRecordValue(linearCatalog, targetSet.annotations[0], linearCatalog.records[1].key);
+assert.deepEqual(targetSet.annotations[0].target.record, { kind: 'recordId', value: 'RecB' });
+assert.equal(validateAnnotationRecordTargets([targetSet], linearCatalog), '');
+assert.equal(encodeAnnotationTable([targetSet]).trim().split('\n')[1].split('\t')[3], 'RecB');
+delete targetSet.annotations[0].metadata._gbdraw_web_target_record_key;
+targetSet.annotations[0].target.record = { kind: 'recordIndex', index: 2 };
+assert.match(validateAnnotationRecordTargets([targetSet], linearCatalog), /out of range/);
+targetSet.annotations[0].target.record = { kind: 'recordId', value: 'missing' };
+assert.match(validateAnnotationRecordTargets([targetSet], linearCatalog), /not available/);
+setAnnotationRecordValue(duplicateCatalog, targetSet.annotations[0], duplicateCatalog.records[0].key);
+assert.equal(validateAnnotationRecordTargets([targetSet], duplicateCatalog), '');
+targetSet.annotations[0].target.record = { kind: 'recordIndex', index: -1 };
+delete targetSet.annotations[0].metadata._gbdraw_web_target_record_key;
+assert.match(
+  validateAnnotationRecordTargets([targetSet], linearCatalog),
+  /valid target record/
+);
+
+const automaticSourceCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  linearSources: [{
+    sourceKey: 'automatic',
+    hasInput: true,
+    status: 'ready',
+    selector: '',
+    records: [{ recordId: 'RecA' }, { recordId: 'RecB' }]
+  }]
+});
+assert.deepEqual(automaticSourceCatalog.records.map((record) => record.recordId), ['RecA', 'RecB']);
+assert.deepEqual(automaticSourceCatalog.issues, []);
+
+const selectedSourceCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  linearSources: [{
+    sourceKey: 'selected',
+    hasInput: true,
+    status: 'ready',
+    selector: '#2',
+    records: [{ recordId: 'RecA' }, { recordId: 'RecB' }]
+  }]
+});
+assert.deepEqual(selectedSourceCatalog.records.map((record) => record.recordId), ['RecB']);
+
+const gbComparisonCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  inputType: 'gb',
+  loadComparison: true,
+  linearSources: [
+    { sourceKey: 'gb-a', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'A1' }, { recordId: 'A2' }] },
+    { sourceKey: 'gb-b', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'B1' }, { recordId: 'B2' }] }
+  ]
+});
+assert.deepEqual(gbComparisonCatalog.records.map((record) => record.recordId), ['A1', 'B1']);
+const singleGbComparisonCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear', inputType: 'gb', loadComparison: true,
+  linearSources: [{ sourceKey: 'gb-only', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'A1' }, { recordId: 'A2' }] }]
+});
+assert.deepEqual(singleGbComparisonCatalog.records.map((record) => record.recordId), ['A1', 'A2']);
+const gffComparisonCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear', inputType: 'gff', loadComparison: true,
+  linearSources: [{ sourceKey: 'gff-only', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'G1' }, { recordId: 'G2' }] }]
+});
+assert.deepEqual(gffComparisonCatalog.records.map((record) => record.recordId), ['G1']);
+assert.equal(hasLinearComparisonIntent({ sequences: [{}, {}], blastSource: 'losat' }), true);
+assert.equal(hasLinearComparisonIntent({ sequences: [{}], blastSource: 'losat' }), false);
+assert.equal(hasLinearComparisonIntent({ sequences: [{ blast: {} }, {}], blastSource: 'upload' }), true);
+assert.equal(hasLinearComparisonIntent({ layoutEnabled: true, comparisons: [{}], sequences: [] }), true);
+
+const duplicateTargetSet = createAnnotationSet({
+  id: 'duplicates',
+  annotations: [{ id: 'same', target: coordinateTarget({ start: 1, end: 2 }), mark: 'band' }]
+});
+setAnnotationRecordValue(duplicateCatalog, duplicateTargetSet.annotations[0], duplicateCatalog.records[1].key);
+assert.deepEqual(duplicateTargetSet.annotations[0].target.record, { kind: 'recordIndex', index: 1 });
+const reorderedDuplicateCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  linearSources: [
+    { sourceKey: 'dup-b', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'dup', recordLength: 20 }] },
+    { sourceKey: 'dup-a', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'dup', recordLength: 10 }] }
+  ]
+});
+reconcileAnnotationRecordBindings([duplicateTargetSet], reorderedDuplicateCatalog);
+assert.deepEqual(duplicateTargetSet.annotations[0].target.record, { kind: 'recordIndex', index: 0 });
+assert.equal(validateAnnotationRecordTargets([duplicateTargetSet], reorderedDuplicateCatalog), '');
+const replacedSourceCatalog = buildAnnotationRecordCatalog({
+  mode: 'linear',
+  linearSources: [{ sourceKey: 'replacement', hasInput: true, status: 'ready', selector: '', records: [{ recordId: 'dup' }] }]
+});
+assert.match(validateAnnotationRecordTargets([duplicateTargetSet], replacedSourceCatalog), /no longer available/);
+
+targetSet.annotations[0].target.record = { kind: 'recordId', value: 'RecA' };
+targetSet.annotations[0].metadata = {};
+const circularMultiOutputCatalog = buildAnnotationRecordCatalog({
+  mode: 'circular',
+  multiRecordCanvas: false,
+  circularSource: {
+    sourceKey: 'circular', hasInput: true, status: 'ready',
+    records: [{ record_id: 'RecA' }, { record_id: 'RecB' }]
+  }
+});
+assert.match(validateAnnotationRecordTargets([targetSet], circularMultiOutputCatalog), /enable Multi-record canvas/);
+
+const circularSingleCatalog = buildAnnotationRecordCatalog({
+  mode: 'circular',
+  circularSource: { sourceKey: 'single', hasInput: true, status: 'ready', records: [{ record_id: 'RecA' }] }
+});
+targetSet.annotations[0].target.record = null;
+assert.equal(validateAnnotationRecordTargets([targetSet], circularSingleCatalog), '');
+
+const tableLines = table.trimEnd().split('\n');
+const tableHeader = tableLines[0].split('\t');
+const recordColumn = tableHeader.indexOf('record');
+const spacedIndexRow = tableLines[1].split('\t');
+spacedIndexRow[recordColumn] = '# 2';
+const spacedIndexSets = parseAnnotationTable(`${tableLines[0]}\n${spacedIndexRow.join('\t')}\n`);
+assert.deepEqual(spacedIndexSets[0].annotations[0].target.record, { kind: 'recordIndex', index: 1 });
+const nullRecordRow = tableLines[1].split('\t');
+nullRecordRow[recordColumn] = 'NULL';
+const nullRecordSets = parseAnnotationTable(`${tableLines[0]}\n${nullRecordRow.join('\t')}\n`);
+assert.equal(nullRecordSets[0].annotations[0].target.record, null);
+assert.match(validateAnnotationRecordTargets(nullRecordSets, linearCatalog), /Choose a target record/);
+const invalidIndexRow = tableLines[1].split('\t');
+invalidIndexRow[recordColumn] = '#0';
+assert.throws(
+  () => parseAnnotationTable(`${tableLines[0]}\n${invalidIndexRow.join('\t')}\n`),
+  /row 2, column 'record'/
+);
 
 const linearSlot = normalizeLinearTrackSlots([{
   id: 'notes', renderer: 'annotations', side: 'overlay',
@@ -62,4 +267,3 @@ const circularSlot = normalizeCircularTrackSlots([{
 assert.equal(circularSlot.side, 'outside');
 assert.match(buildCircularTrackSlotSpec(circularSlot), /set_id=review/);
 assert.match(buildCircularTrackSlotSpec(circularSlot), /overflow=compress/);
-

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -77,3 +77,106 @@ test('Linear record rows and N-to-M comparison batches remain keyed by sequence 
   await expect(page.locator('input[aria-label="Linear record row"]')).toHaveCount(4);
   await expect(page.getByText('All adjacent-row pairs', { exact: true })).toBeVisible();
 });
+
+test('Region annotations expose and persist an explicit target-record selection', async ({ page }) => {
+  await page.goto(`${baseUrl}/gbdraw/web/index.html`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+
+  const genbank = `LOCUS       RecA                      10 bp    DNA     linear   UNA 01-JAN-2000
+DEFINITION  first.
+ACCESSION   RecA
+VERSION     RecA
+KEYWORDS    .
+SOURCE      synthetic construct
+  ORGANISM  synthetic construct
+            .
+FEATURES             Location/Qualifiers
+ORIGIN
+        1 aaaaaaaaaa
+//
+LOCUS       RecB                      12 bp    DNA     linear   UNA 01-JAN-2000
+DEFINITION  second.
+ACCESSION   RecB
+VERSION     RecB
+KEYWORDS    .
+SOURCE      synthetic construct
+  ORGANISM  synthetic construct
+            .
+FEATURES             Location/Qualifiers
+ORIGIN
+        1 cccccccccccc
+//
+`;
+  await page.evaluate((content) => {
+    const app = window.__GBDRAW_APP__;
+    app.mode = 'linear';
+    app.lInputType = 'gb';
+    app.setLinearSeqPrimaryFile(0, 'gb', new File([content], 'two-records.gb', {
+      type: 'text/plain',
+      lastModified: 1
+    }));
+    const set = app.addAnnotationSet('review');
+    app.addCoordinateAnnotation(set, { start: 1, end: 10 });
+  }, genbank);
+
+  await page.getByText('Region Annotations', { exact: false }).click();
+  const selector = page.getByLabel('Annotation target record');
+  await expect(selector).toHaveCount(1);
+  await expect(selector).toHaveValue('');
+  await expect(selector.locator('option')).toHaveText([
+    'Select target record',
+    '#1 · RecA · 10 bp',
+    '#2 · RecB · 12 bp'
+  ], { timeout: 60000 });
+  await expect(page.getByText('Choose the record that this annotation targets.')).toBeVisible();
+
+  const rejected = await page.evaluate(() => window.__GBDRAW_APP__.runAnalysis());
+  expect(rejected).toEqual({ status: 'error' });
+  await expect(page.getByText('Choose a target record for region annotation review/region_1.')).toBeVisible();
+
+  await selector.selectOption({ label: '#2 · RecB · 12 bp' });
+  await expect(page.getByText('Choose the record that this annotation targets.')).toHaveCount(0);
+  const target = await page.evaluate(() => (
+    window.__GBDRAW_APP__.annotationSets[0].annotations[0].target.record
+  ));
+  expect(target).toEqual({ kind: 'recordId', value: 'RecB' });
+});
+
+test('GFF annotation targets follow FASTA record order', async ({ page }) => {
+  await page.goto(`${baseUrl}/gbdraw/web/index.html`, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+
+  const gff = `##gff-version 3
+##sequence-region RecB 1 12
+RecB\ttest\tgene\t1\t3\t.\t+\t.\tID=gene_b
+##sequence-region RecA 1 10
+RecA\ttest\tgene\t2\t4\t.\t+\t.\tID=gene_a
+`;
+  const fasta = `>RecB
+CCCCCCCCCCCC
+>RecA
+AAAAAAAAAA
+`;
+  await page.evaluate(({ gffText, fastaText }) => {
+    const app = window.__GBDRAW_APP__;
+    app.mode = 'linear';
+    app.lInputType = 'gff';
+    app.setLinearSeqPrimaryFile(0, 'gff', new File([gffText], 'records.gff3', {
+      type: 'text/plain',
+      lastModified: 2
+    }));
+    app.setLinearSeqPrimaryFile(0, 'fasta', new File([fastaText], 'records.fasta', {
+      type: 'text/plain',
+      lastModified: 3
+    }));
+    const set = app.addAnnotationSet('gff-review');
+    app.addCoordinateAnnotation(set, { start: 1, end: 3 });
+  }, { gffText: gff, fastaText: fasta });
+
+  await page.getByText('Region Annotations', { exact: false }).click();
+  await expect(page.getByLabel('Annotation target record').locator('option')).toHaveText([
+    'Select target record',
+    '#1 · RecB · 12 bp',
+    '#2 · RecA · 10 bp'
+  ], { timeout: 60000 });
+});

--- a/tests/web/record-selector.test.mjs
+++ b/tests/web/record-selector.test.mjs
@@ -10,6 +10,7 @@ const tempRoot = await mkdtemp(join(tmpdir(), 'gbdraw-record-selector-'));
 await writeFile(join(tempRoot, 'package.json'), '{"type":"module"}', 'utf8');
 await cp(join(sourceRoot, 'linear-record-selector.js'), join(tempRoot, 'linear-record-selector.js'));
 await cp(join(sourceRoot, 'record-discovery.js'), join(tempRoot, 'record-discovery.js'));
+await cp(join(sourceRoot, 'record-options.js'), join(tempRoot, 'record-options.js'));
 
 const {
   AUTOMATIC_RECORD_OPTION_LABEL,
@@ -18,6 +19,7 @@ const {
   formatRecordLength
 } = await import(pathToFileURL(join(tempRoot, 'linear-record-selector.js')));
 const {
+  discoverGffFastaRecords,
   discoverSequenceRecords,
   normalizeSequenceRecords
 } = await import(pathToFileURL(join(tempRoot, 'record-discovery.js')));
@@ -48,6 +50,13 @@ assert.deepEqual(duplicateOptions.slice(1), [
   { value: '#1', label: 'RecA (1,234 bp) [#1]', synthetic: false },
   { value: '#2', label: 'RecA (1,100 bp) [#2]', synthetic: false }
 ]);
+assert.deepEqual(
+  buildRecordOptions([
+    { selector: '#1', recordId: 'null', recordLength: 10 },
+    { selector: '#2', recordId: '#named', recordLength: 20 }
+  ]).slice(1).map((option) => option.value),
+  ['#1', '#2']
+);
 
 const unmatchedOptions = buildRecordOptions(records, 'LegacyRec');
 assert.deepEqual(unmatchedOptions[1], {
@@ -101,6 +110,31 @@ assert.deepEqual(unlinkedPaths, ['/records.fa']);
 assert.equal(destroyed, true);
 assert.equal(stagedPaths.size, 0);
 
+const pairedPaths = new Set();
+const paired = await discoverGffFastaRecords({
+  gffFile: { name: 'records.gff' },
+  fastaFile: { name: 'records.fa' },
+  pyodide: {
+    globals: {
+      get: (name) => {
+        assert.equal(name, 'list_gff_fasta_records');
+        return () => JSON.stringify({
+          records: [{ selector: '#1', record_id: 'GffOwned', record_length: 25 }]
+        });
+      }
+    },
+    FS: { unlink: (path) => pairedPaths.delete(path) }
+  },
+  writeFileToFs: async (_file, path) => {
+    pairedPaths.add(path);
+    return true;
+  },
+  gffTemporaryPath: '/records.gff',
+  fastaTemporaryPath: '/records.fasta'
+});
+assert.equal(paired[0].recordId, 'GffOwned');
+assert.equal(pairedPaths.size, 0);
+
 const failedPaths = new Set();
 await assert.rejects(
   discoverSequenceRecords({
@@ -130,7 +164,7 @@ const state = {
   linearSeqs: [{ uid: 'row-a', gb: fileA, fasta: null, region_record_id: '' }]
 };
 const pending = new Map();
-const recordReader = ({ file }) => new Promise((resolve) => pending.set(file, resolve));
+const recordReader = ({ primaryFile }) => new Promise((resolve) => pending.set(primaryFile, resolve));
 const controller = createLinearRecordSelector({
   state,
   reactive: (value) => value,

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -123,7 +123,8 @@ state.annotationSets = [{
   annotations: [{
     id: 'window',
     target: { kind: 'coordinateSpan', record: null, start: 1, end: 4, coordinateSpace: 'source', wrapsOrigin: false, outOfBounds: 'clip' },
-    label: 'Window', mark: 'band', lane: null, style: null, legendLabel: null, metadata: {}
+    label: 'Window', mark: 'band', lane: null, style: null, legendLabel: null,
+    metadata: { _gbdraw_web_target_record_key: 'linear-source::#2' }
   }],
   defaultStyle: {
     stroke: '#404040', strokeWidth: 1.5, strokeDasharray: [], lineCap: 'tick', fill: null,
@@ -135,6 +136,11 @@ state.annotationSets = [{
 const annotationCanonical = buildCanonicalSessionRequest({ state, filesData });
 assert.equal(annotationCanonical.renderRequest.diagramOptions.annotations.sets[0].id, 'review');
 assert.equal(projectCanonicalSessionRequest(annotationCanonical).config.annotationSets[0].annotations[0].id, 'window');
+assert.equal(
+  projectCanonicalSessionRequest(annotationCanonical).config.annotationSets[0].annotations[0]
+    .metadata._gbdraw_web_target_record_key,
+  'linear-source::#2'
+);
 state.annotationSets = [];
 
 state.adv.circular_label_placement = 'radial';


### PR DESCRIPTION
Add stable per-annotation target-record selectors. Validate missing and stale targets before rendering. Preserve FASTA record order for GFF+FASTA inputs.