### PR TITLE
Fix Web sequence-source coverage CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
     branches: ["main"]
   workflow_dispatch:
 
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   core:
     name: Core (Python ${{ matrix.python-version }})
@@ -125,9 +129,9 @@ jobs:
       - name: Run Web JavaScript tests
         run: |
           node --test tests/web/*.test.mjs
+          node --test --test-concurrency=1 tests/web/contracts/vibrio-sequence-source-coverage.test.mjs
           node tests/web/session-request.test.mjs --project-session gbdraw/web/gallery/sessions/hepatoplasmataceae_orthogroup.gbdraw-session.json.gz
           node tests/web/session-request.test.mjs --project-session gbdraw/web/gallery/sessions/tobacco-chloroplast.gbdraw-session.json
-          node tests/web/session-request.test.mjs --project-session gbdraw/web/gallery/sessions/vibrio-harveyi-group-collinear.gbdraw-session.json.gz
 
       - name: Run Python browser tests
         run: >-

--- a/gbdraw/web/js/app/match-sequences.js
+++ b/gbdraw/web/js/app/match-sequences.js
@@ -344,15 +344,6 @@ export const analyzeCatalogSequenceSourceCoverage = ({
     }
   });
 
-  const comparisonSourceIndexes = new Set(
-    sourceEntries
-      .map(({ source }) => sourceIdentity(source))
-      .filter((identity) => (
-        identity.origin === 'homology-comparison'
-        && identity.sourceIndex !== null
-      ))
-      .map((identity) => identity.sourceIndex)
-  );
   const requirements = new Map();
   const failedRequirementKeys = new Set();
   const failureReasons = new Map();
@@ -472,14 +463,6 @@ export const analyzeCatalogSequenceSourceCoverage = ({
           const expectedOrigin = homology
             ? (role === normalizedReferenceSide ? 'circular-reference' : 'homology-comparison')
             : 'linear-record';
-          if (
-            expectedOrigin === 'homology-comparison'
-            && sourceIndex.valid
-            && sourceIndex.supplied
-            && !comparisonSourceIndexes.has(sourceIndex.value)
-          ) {
-            return;
-          }
           const displayedRecord = recordIndex.value === null
             ? null
             : displayedRecords[recordIndex.value] || null;

--- a/tests/web/contracts/vibrio-sequence-source-coverage.test.mjs
+++ b/tests/web/contracts/vibrio-sequence-source-coverage.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { cp, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+const repoRoot = process.cwd();
+const sourceRoot = join(repoRoot, 'gbdraw', 'web', 'js');
+const tempRoot = await mkdtemp(join(tmpdir(), 'gbdraw-vibrio-coverage-'));
+await cp(sourceRoot, join(tempRoot, 'js'), { recursive: true });
+await writeFile(join(tempRoot, 'package.json'), '{"type":"module"}\n', 'utf8');
+
+const { analyzeCatalogSequenceSourceCoverage } = await import(
+  pathToFileURL(join(tempRoot, 'js', 'app', 'match-sequences.js'))
+);
+const { promoteGallerySessionToCurrent } = await import(
+  pathToFileURL(join(tempRoot, 'js', 'services', 'gallery-session-migration.js'))
+);
+const { projectCanonicalSessionRequest } = await import(
+  pathToFileURL(join(tempRoot, 'js', 'services', 'session-request.js'))
+);
+
+const fixturePath = join(
+  repoRoot,
+  'gbdraw',
+  'web',
+  'gallery',
+  'sessions',
+  'vibrio-harveyi-group-collinear.gbdraw-session.json.gz'
+);
+const fixture = JSON.parse(gunzipSync(await readFile(fixturePath)).toString('utf8'));
+
+test('real Vibrio catalog covers every sequence consumer with a valid sparse catalog', () => {
+  const coverage = analyzeCatalogSequenceSourceCoverage({
+    mode: fixture.renderRequest.mode,
+    catalogFeatureState: fixture.editorState.featureCatalog,
+    renderRequest: fixture.renderRequest
+  });
+
+  assert.equal(coverage.complete, true);
+  assert.deepEqual(coverage.missingConsumers, []);
+  assert.deepEqual(coverage.invalidCatalogSources, []);
+  assert.deepEqual(
+    coverage.resolvedConsumers.map(({ expectedSource }) => expectedSource.recordIndex),
+    [0, 1, 3, 4, 5, 6, 7, 8, 9, 10]
+  );
+  assert.deepEqual(coverage.displayedRecordsWithoutConsumers, [{
+    recordIndex: 2,
+    recordKey: 'record-3'
+  }]);
+});
+
+test('real Vibrio session still projects its embedded records and presentation settings', () => {
+  const projectedSession = projectCanonicalSessionRequest({
+    renderRequest: fixture.renderRequest,
+    resources: fixture.resources,
+    webFiles: fixture.webFiles,
+    legacyFiles: fixture.files,
+    storedConfig: fixture.config,
+    fileBindings: fixture.cliInvocation?.fileBindings,
+    linearTrackSlotSchemaVersion: Number(fixture.version) <= 32 ? 1 : 2
+  });
+
+  assert.equal(projectedSession.files.linearSeqs.length, 11);
+  assert.equal(
+    projectedSession.files.linearSeqs[0].gb.name,
+    'NZ_CP125875.1__GCF_030060435.1_ASM3006043v1_genomic.gbff'
+  );
+  assert.equal(projectedSession.config.adv.block_stroke_width, 0);
+  assert.equal(projectedSession.config.adv.line_stroke_width, 1);
+  assert.equal(projectedSession.config.adv.axis_stroke_width, 2);
+  assert.equal(projectedSession.config.adv.def_font_size, 16);
+  assert.equal(projectedSession.config.filterMode, 'None');
+});
+
+test('real Vibrio Gallery promotion retains its collinearity unit gap', () => {
+  const promoted = promoteGallerySessionToCurrent(fixture);
+  const comparison = promoted.renderRequest.comparisons.find(
+    (candidate) => candidate.kind === 'generatedProteinComparison'
+  );
+
+  assert.equal(
+    comparison.settings.collinearityParams.parameters.maxUnitGap,
+    2
+  );
+});

--- a/tests/web/gallery-session-migration.test.mjs
+++ b/tests/web/gallery-session-migration.test.mjs
@@ -685,16 +685,6 @@ assert.equal(
   'underlay'
 );
 
-const vibrio = await loadSession('vibrio-harveyi-group-collinear.gbdraw-session.json.gz');
-const promotedVibrio = promoteGallerySessionToCurrent(vibrio);
-const promotedVibrioComparison = promotedVibrio.renderRequest.comparisons.find(
-  (comparison) => comparison.kind === 'generatedProteinComparison'
-);
-assert.equal(
-  promotedVibrioComparison.settings.collinearityParams.parameters.maxUnitGap,
-  2
-);
-
 for (const session of [promotedBgc, promotedMajani]) {
   for (const comparison of session.renderRequest.comparisons) {
     if (!comparison.resourceId) continue;

--- a/tests/web/match-sequences.test.mjs
+++ b/tests/web/match-sequences.test.mjs
@@ -4,7 +4,6 @@ import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { gunzipSync } from 'node:zlib';
 
 const tempDir = await mkdtemp(join(tmpdir(), 'gbdraw-match-sequences-'));
 await writeFile(join(tempDir, 'package.json'), '{"type":"module"}\n', 'utf8');
@@ -163,35 +162,6 @@ test('registry validates every supplied source identity field and duplicate key'
   );
 });
 
-test('real Vibrio catalog covers every consumer without a source for its unused record', async () => {
-  const fixture = JSON.parse(gunzipSync(await readFile(
-    'gbdraw/web/gallery/sessions/vibrio-harveyi-group-collinear.gbdraw-session.json.gz'
-  )));
-  const coverage = analyzeCatalogSequenceSourceCoverage({
-    mode: fixture.renderRequest.mode,
-    catalogFeatureState: fixture.editorState.featureCatalog,
-    renderRequest: fixture.renderRequest
-  });
-
-  assert.equal(coverage.complete, true);
-  assert.deepEqual(coverage.consumerCounts, {
-    biologicalFeatures: 49612,
-    matchEndpoints: 1266
-  });
-  assert.equal(coverage.requiredConsumers.length, 10);
-  assert.equal(coverage.resolvedConsumers.length, 10);
-  assert.deepEqual(coverage.missingConsumers, []);
-  assert.deepEqual(coverage.invalidCatalogSources, []);
-  assert.deepEqual(
-    coverage.resolvedConsumers.map(({ expectedSource }) => expectedSource.recordIndex),
-    [0, 1, 3, 4, 5, 6, 7, 8, 9, 10]
-  );
-  assert.deepEqual(coverage.displayedRecordsWithoutConsumers, [{
-    recordIndex: 2,
-    recordKey: 'record-3'
-  }]);
-});
-
 test('coverage reports a match endpoint whose displayed record source is missing', () => {
   const source = {
     key: 'linear:record:0',
@@ -243,6 +213,55 @@ test('coverage reports a match endpoint whose displayed record source is missing
     [{ kind: 'match-endpoint', id: 'match-a-b/subject' }]
   );
   assert.match(coverage.missingConsumers[0].reasons[0], /unavailable/);
+});
+
+test('coverage reports a homology match endpoint whose comparison source is missing', () => {
+  const referenceSource = {
+    key: 'circular:record:0',
+    recordId: 'reference',
+    aliases: ['reference'],
+    sequence: 'AACCGGTT',
+    origin: 'circular-reference',
+    recordIndex: 0
+  };
+  const coverage = analyzeCatalogSequenceSourceCoverage({
+    mode: 'circular',
+    renderRequest: {
+      records: [{ recordKey: 'record-reference' }]
+    },
+    catalogFeatureState: {
+      items: [{
+        recordKeys: ['record-reference'],
+        sequenceSources: [referenceSource],
+        biologicalFeatures: [],
+        comparisonMatches: [{
+          id: 'homology-a',
+          match_kind: 'homology',
+          query_record_id: 'comparison',
+          subject_record_id: 'reference',
+          source_index: '0',
+          reference_side: 'subject'
+        }]
+      }]
+    }
+  });
+
+  assert.equal(coverage.complete, false);
+  assert.deepEqual(coverage.consumerCounts, {
+    biologicalFeatures: 0,
+    matchEndpoints: 2
+  });
+  assert.equal(coverage.resolvedConsumers.length, 1);
+  assert.equal(coverage.missingConsumers.length, 1);
+  assert.equal(
+    coverage.missingConsumers[0].expectedSource.origin,
+    'homology-comparison'
+  );
+  assert.equal(coverage.missingConsumers[0].expectedSource.sourceIndex, 0);
+  assert.deepEqual(
+    coverage.missingConsumers[0].exampleConsumers,
+    [{ kind: 'match-endpoint', id: 'homology-a/query' }]
+  );
 });
 
 test('builds deterministic single and combined FASTA in query-subject order', () => {


### PR DESCRIPTION
Require missing homology match sources to trigger session fallback, isolate all real Vibrio checks in one serial contract, and cancel superseded Tests workflow runs.