### PR TITLE
Make large Web sessions and renders memory-safe

### DIFF
--- a/gbdraw/web/js/app/annotations.js
+++ b/gbdraw/web/js/app/annotations.js
@@ -5,6 +5,7 @@ import {
   createAnnotationRecordSelector,
   reconcileAnnotationRecordBindings
 } from './annotations/record-selector.js';
+import { readFileText } from '../services/file-content-cache.js';
 
 export const createAnnotationEditor = ({ state, getRecordCatalog }) => {
   const recordSelector = createAnnotationRecordSelector({ getCatalog: getRecordCatalog });
@@ -73,7 +74,7 @@ export const createAnnotationEditor = ({ state, getRecordCatalog }) => {
   const importAnnotationTableFile = async (event) => {
     const file = event?.target?.files?.[0];
     if (!file) return;
-    importAnnotationTable(await file.text());
+    importAnnotationTable(await readFileText(file));
     event.target.value = '';
   };
   return {

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -31,6 +31,7 @@ import { copyTextToClipboard } from '../utils/clipboard.js';
 import { downloadTextFile } from '../services/text-download.js';
 import { resetLayoutState, resetSettings as resetSettingsState } from '../services/reset.js';
 import { disposeDiagramGenerationWorker } from '../services/diagram-generation.js';
+import { recordSessionLifecycleEvent } from '../services/runtime-test-hooks.js';
 import { createPanZoom, createSidebarResize, setupGlobalUiEvents } from './ui.js';
 import { colorValueMode, toNativeColorInputValue } from './color-utils.js';
 import { createFeatureEditor } from './feature-editor.js';
@@ -1933,7 +1934,9 @@ export const createAppSetup = () => {
       if (result?.status === 'ok') {
         await synchronizeLoadedSessionLegendEntries();
       }
+      recordSessionLifecycleEvent('history-baseline-start');
       await history.captureBaseline('Loaded session');
+      recordSessionLifecycleEvent('history-baseline-end');
     }
     return result;
   };

--- a/gbdraw/web/js/app/feature-editor/label-actions.js
+++ b/gbdraw/web/js/app/feature-editor/label-actions.js
@@ -8,6 +8,7 @@ import {
 import { FEATURE_SELECTOR, getFeatureIdentity } from './svg-actions.js';
 import { serializeCleanSvg } from '../../services/svg-serialization.js';
 import { downloadTextFile } from '../../services/text-download.js';
+import { readFileText } from '../../services/file-content-cache.js';
 import { COMPARISON_LEGEND_SELECTOR } from '../legend/utils.js';
 
 export const EXCLUDED_GROUP_SELECTOR = [
@@ -957,7 +958,7 @@ export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
     if (!file) return;
 
     try {
-      const text = await file.text();
+      const text = await readFileText(file);
       const rows = parseLabelOverrideTsv(text);
 
       if (!svgContainer.value) {

--- a/gbdraw/web/js/app/match-sequences.js
+++ b/gbdraw/web/js/app/match-sequences.js
@@ -3,6 +3,7 @@ import {
   orderedConservationSources,
   orderedOptionalConservationFiles
 } from './conservation-series.js';
+import { readFileText } from '../services/file-content-cache.js';
 
 const IUPAC_COMPLEMENT = Object.freeze({
   A: 'T', C: 'G', G: 'C', T: 'A', U: 'A',
@@ -838,8 +839,8 @@ const materializeLinearSequenceRecord = (record, sequenceState) => {
 };
 
 const readInputSequenceRecords = async (file, inputType) => {
-  if (!file || typeof file.text !== 'function') return [];
-  return parseInputSequenceRecords(await file.text(), inputType);
+  if (!file) return [];
+  return parseInputSequenceRecords(await readFileText(file), inputType);
 };
 
 /**

--- a/gbdraw/web/js/app/python-helpers.js
+++ b/gbdraw/web/js/app/python-helpers.js
@@ -11,7 +11,7 @@ from gbdraw.web_support.feature_metadata import (
     extract_features_from_genbank_json,
     extract_features_from_gff_fasta_json,
 )
-from gbdraw.web_support.request_render import render_embedded_canonical_web_request
+from gbdraw.web_support.request_render import render_staged_canonical_web_request
 from gbdraw.session_request_codec import encode_canonical_typed_resource
 
 _WEB_LOSATP_FILTERED_HIT_CACHE = {}
@@ -75,24 +75,35 @@ def _is_blank_or_js_nullish(value):
     except Exception:
         return False
 
-def run_canonical_request_wrapper(request_json, resources_json, workspace):
+def run_canonical_request_wrapper(request_json, resource_paths_json, workspace):
     try:
         payload = json.loads(str(request_json))
-        resources = json.loads(str(resources_json))
-        result = render_embedded_canonical_web_request(
+        resource_paths = json.loads(str(resource_paths_json))
+        result = render_staged_canonical_web_request(
             payload,
-            resources=resources,
+            resource_paths=resource_paths,
             workspace=str(workspace),
         )
-        return json.dumps(result)
+        for item in result.get("results", []):
+            content = item.get("content")
+            if isinstance(content, str):
+                item["content"] = content.encode("utf-8")
+        metadata = result.get("metadata")
+        if isinstance(metadata, dict):
+            result["metadata"] = json.dumps(
+                metadata,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        return result
     except Exception as e:
-        return json.dumps({
+        return {
             "error": {
                 "type": e.__class__.__name__,
                 "message": str(e) if str(e) else "Unhandled exception",
                 "traceback": traceback.format_exc(),
             }
-        })
+        }
 
 def extract_first_fasta(path, fmt, region_spec=None, record_selector=None, reverse_flag=None):
     """Extract the first record as FASTA for LOSAT input."""

--- a/gbdraw/web/js/app/record-discovery.js
+++ b/gbdraw/web/js/app/record-discovery.js
@@ -2,7 +2,11 @@ import {
   DIAGRAM_HELPER_OPERATIONS,
   runDiagramHelperOperation
 } from '../services/diagram-generation.js';
-import { cloneFileBytesForTransfer } from '../services/file-content-cache.js';
+import {
+  cloneFileBytesForTransfer,
+  getSessionResourceSource,
+  readFileText
+} from '../services/file-content-cache.js';
 
 const normalizeRecordLength = (value) => {
   const numeric = Number(value);
@@ -74,6 +78,12 @@ export const parseSequenceRecordText = (text, format) => {
   throw new Error(`Unsupported format: ${String(format)}.`);
 };
 
+const defaultTextReader = (file) => (
+  typeof file?.text === 'function' || getSessionResourceSource(file)
+    ? () => readFileText(file)
+    : null
+);
+
 export const discoverSequenceRecords = async ({
   file,
   format,
@@ -83,7 +93,7 @@ export const discoverSequenceRecords = async ({
   if (!file) throw new Error('A sequence file is required.');
   const readSourceText = typeof readText === 'function'
     ? () => readText(file)
-    : (typeof file.text === 'function' ? () => file.text() : null);
+    : defaultTextReader(file);
   if (readSourceText) {
     try {
       return parseSequenceRecordText(await readSourceText(), format);
@@ -110,7 +120,7 @@ export const discoverGffFastaRecords = async ({
   if (!gffFile || !fastaFile) throw new Error('GFF3 and FASTA files are required.');
   const readSourceText = typeof readText === 'function'
     ? () => readText(fastaFile)
-    : (typeof fastaFile.text === 'function' ? () => fastaFile.text() : null);
+    : defaultTextReader(fastaFile);
   if (readSourceText) {
     try {
       return parseSequenceRecordText(await readSourceText(), 'fasta');

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -111,6 +111,10 @@ import {
   prepareCandidateRenderCommit,
   prepareReflowResultCommit
 } from './candidate-render.js';
+import {
+  recordSessionLifecycleEvent,
+  recordStructuralMetric
+} from '../services/runtime-test-hooks.js';
 
 const DEFAULT_CIRCULAR_CONSERVATION_BLAST_FILTERS = Object.freeze(
   comparisonFiltersForMode('circular')
@@ -917,6 +921,9 @@ export const createRunAnalysis = ({
   let activeLosatAbortController = null;
   let latestCliHelperFiles = [];
   let latestCliHelperArchiveName = 'out-cli-files.zip';
+  const cloneCliHelperFiles = (files) => (
+    (Array.isArray(files) ? files : []).map((file) => ({ ...file }))
+  );
   const recordDiscoverySuppressed = () => Boolean(
     semanticFileWatchersSuppressed?.value ||
     sessionImportRollbackInProgress?.value
@@ -945,7 +952,9 @@ export const createRunAnalysis = ({
         if (!entry) return null;
         return {
           name: String(helper?.name || entry.name || 'helper.tsv'),
-          data: entry.data
+          ...(typeof entry.buildData === 'function'
+            ? { buildData: entry.buildData }
+            : { data: entry.data })
         };
       })
       .filter(Boolean);
@@ -961,14 +970,21 @@ export const createRunAnalysis = ({
       alert('No CLI helper files are available for the latest run.');
       return;
     }
-    const totalChars = latestCliHelperFiles.reduce((sum, file) => sum + String(file.data ?? '').length, 0);
+    const materializedFiles = latestCliHelperFiles.map((file) => ({
+      name: file.name,
+      data: typeof file.buildData === 'function' ? file.buildData() : file.data
+    }));
+    const totalChars = materializedFiles.reduce(
+      (sum, file) => sum + String(file.data ?? '').length,
+      0
+    );
     if (totalChars > 50 * 1024 * 1024) {
       const proceed = confirm(
         `CLI helper file export will download about ${(totalChars / (1024 * 1024)).toFixed(1)} MB. Continue?`
       );
       if (!proceed) return;
     }
-    downloadBlob(createZipBlob(latestCliHelperFiles), latestCliHelperArchiveName);
+    downloadBlob(createZipBlob(materializedFiles), latestCliHelperArchiveName);
   };
 
   const extractCircularTrackSlotError = (err) => {
@@ -1467,6 +1483,7 @@ export const createRunAnalysis = ({
     comparisonPlanSnapshot = null
   } = {}) => {
     const isReflow = runMode === 'reflow';
+    if (!isReflow) recordSessionLifecycleEvent('generate-start');
     const activeComparisonPlanSnapshot = mode.value === 'linear'
       ? (
           comparisonPlanSnapshot || resolveLinearComparisonPlan({
@@ -1606,7 +1623,7 @@ export const createRunAnalysis = ({
           resultGenerationKey: resultGenerationKey?.value ?? 0,
           resultPanelTab: resultPanelTab.value,
           errorLog: cloneJsonValue(errorLog.value, null),
-          latestCliHelperFiles: cloneJsonValue(latestCliHelperFiles, []),
+          latestCliHelperFiles: cloneCliHelperFiles(latestCliHelperFiles),
           latestCliHelperArchiveName,
           matchSequenceSources: matchSequenceRegistry?.values?.() || [],
           editableLabels: cloneJsonValue(editableLabels.value || [], []),
@@ -1644,7 +1661,7 @@ export const createRunAnalysis = ({
       }
       resultPanelTab.value = manualCancelSnapshot.resultPanelTab;
       errorLog.value = cloneJsonValue(manualCancelSnapshot.errorLog, null);
-      latestCliHelperFiles = cloneJsonValue(manualCancelSnapshot.latestCliHelperFiles, []);
+      latestCliHelperFiles = cloneCliHelperFiles(manualCancelSnapshot.latestCliHelperFiles);
       latestCliHelperArchiveName = manualCancelSnapshot.latestCliHelperArchiveName;
       matchSequenceRegistry?.reset?.(manualCancelSnapshot.matchSequenceSources);
       editableLabels.value = cloneJsonValue(manualCancelSnapshot.editableLabels, []);
@@ -1795,6 +1812,25 @@ export const createRunAnalysis = ({
           name: displayName,
           slot: String(slot || '').trim(),
           data: String(data ?? '')
+        });
+      };
+      const recordDeferredGeneratedCliFile = (
+        path,
+        buildData,
+        { name = '', slot = '' } = {}
+      ) => {
+        const normalizedPath = String(path || '').trim();
+        if (!normalizedPath) return;
+        if (typeof buildData !== 'function') {
+          throw new TypeError('A deferred CLI helper file requires a builder.');
+        }
+        const displayName = String(name || getPayloadName(normalizedPath)).trim()
+          || getPayloadName(normalizedPath);
+        generatedCliFileMap.set(normalizedPath, {
+          path: normalizedPath,
+          name: displayName,
+          slot: String(slot || '').trim(),
+          buildData
         });
       };
       const stageTextFile = (
@@ -3846,10 +3882,12 @@ export const createRunAnalysis = ({
       if (typeof serializeCanonicalFiles !== 'function') {
         throw new Error('Canonical input serialization is unavailable.');
       }
+      recordSessionLifecycleEvent('serialize-canonical-files-start');
       const serializedFiles = await serializeCanonicalFiles(
         activeComparisonPlanSnapshot,
         linearRecordCatalog
       );
+      recordSessionLifecycleEvent('serialize-canonical-files-end');
       throwIfGenerationCanceled();
       const canonicalCircularConservation = resolvedCircularConservation.map((entry) => ({
         ...entry,
@@ -3862,6 +3900,36 @@ export const createRunAnalysis = ({
         resolvedComparisons,
         resolvedCircularConservation: canonicalCircularConservation
       });
+      const canonicalResourceEntries = Object.values(canonical.resources || {});
+      const canonicalResourceCount = canonicalResourceEntries.length;
+      const canonicalResourceDeclaredBytes = canonicalResourceEntries.reduce(
+        (total, resource) => total + (Number(resource?.size) || 0),
+        0
+      );
+      const canonicalResourceBase64Characters = canonicalResourceEntries.reduce(
+        (total, resource) => total + (
+          resource?.encoding === 'base64' && typeof resource?.data === 'string'
+            ? resource.data.length
+            : 0
+        ),
+        0
+      );
+      recordSessionLifecycleEvent('canonical-request-built');
+      recordSessionLifecycleEvent('canonical-resource-count', {
+        value: canonicalResourceCount
+      });
+      recordSessionLifecycleEvent('canonical-resource-declared-bytes', {
+        value: canonicalResourceDeclaredBytes
+      });
+      recordSessionLifecycleEvent('canonical-resource-base64-characters', {
+        value: canonicalResourceBase64Characters
+      });
+      recordStructuralMetric('canonicalResourceCount', canonicalResourceCount);
+      recordStructuralMetric('canonicalResourceDeclaredBytes', canonicalResourceDeclaredBytes);
+      recordStructuralMetric(
+        'canonicalResourceBase64Characters',
+        canonicalResourceBase64Characters
+      );
       if (!Number.isInteger(canonicalSessionVersion)) {
         throw new Error('Canonical session version is unavailable.');
       }
@@ -3869,7 +3937,9 @@ export const createRunAnalysis = ({
       const canonicalReplayName = makeSafeFilename(
         `${normalizedOutputPrefix || 'out'}.gbdraw-session.json`
       );
-      const canonicalReplayText = JSON.stringify({
+      const buildCanonicalReplayText = () => {
+        recordSessionLifecycleEvent('canonical-replay-json-start');
+        const replayText = JSON.stringify({
           format: 'gbdraw-session',
           version: canonicalSessionVersion,
           createdAt: manualRunStartedAtIso || new Date().toISOString(),
@@ -3879,12 +3949,19 @@ export const createRunAnalysis = ({
           losatDerivedCache: { entries: [] },
           proteinIdentityManifest: emptyProteinIdentityManifest()
         });
+        recordStructuralMetric('canonicalReplayFullSerializationCount');
+        recordSessionLifecycleEvent('canonical-replay-json-end');
+        recordSessionLifecycleEvent('canonical-replay-json-characters', {
+          value: replayText.length
+        });
+        return replayText;
+      };
       registerRunInfoFile(canonicalReplayPath, {
         name: canonicalReplayName,
         slot: 'generatedFiles.canonical_render_session',
         kind: 'generated'
       });
-      recordGeneratedCliFile(canonicalReplayPath, canonicalReplayText, {
+      recordDeferredGeneratedCliFile(canonicalReplayPath, buildCanonicalReplayText, {
         name: canonicalReplayName,
         slot: 'generatedFiles.canonical_render_session'
       });
@@ -4065,7 +4142,7 @@ export const createRunAnalysis = ({
             normalizeCircularPlotTitlePosition(adv.plot_title_position);
         }
         lastRunInfo.value = candidateRunInfo;
-        latestCliHelperFiles = cloneJsonValue(candidateCliHelpers?.files, []);
+        latestCliHelperFiles = cloneCliHelperFiles(candidateCliHelpers?.files);
         latestCliHelperArchiveName =
           candidateCliHelpers?.archiveName || 'out-cli-files.zip';
         resultPanelTab.value = 'preview';

--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -26,10 +26,13 @@ import { isCommittedSvgResultMounted } from '../services/svg-result-ingestion.js
 export const runRecordDiscoveryWatcher = async ({
   rollbackInProgress,
   semanticWatchersSuppressed,
+  sessionResourceDiscoveryDeferred,
   refresh
 }) => {
   const suppress = Boolean(
-    rollbackInProgress?.value || semanticWatchersSuppressed?.value
+    rollbackInProgress?.value
+    || semanticWatchersSuppressed?.value
+    || sessionResourceDiscoveryDeferred?.value
   );
   await refresh({ suppress });
   return !suppress;
@@ -112,6 +115,7 @@ export const setupWatchers = ({
     pendingPaletteName,
     fileLegendCaptions,
     semanticFileWatchersSuppressed,
+    sessionResourceDiscoveryDeferred,
     sessionImportRollbackInProgress,
     manualPriorityRules,
     manualWhitelist,
@@ -637,6 +641,7 @@ export const setupWatchers = ({
       await runRecordDiscoveryWatcher({
         rollbackInProgress: sessionImportRollbackInProgress,
         semanticWatchersSuppressed: semanticFileWatchersSuppressed,
+        sessionResourceDiscoveryDeferred,
         refresh: ({ suppress }) => refreshCircularRecordOrder({ suppress })
       });
     }
@@ -657,6 +662,7 @@ export const setupWatchers = ({
       await runRecordDiscoveryWatcher({
         rollbackInProgress: sessionImportRollbackInProgress,
         semanticWatchersSuppressed: semanticFileWatchersSuppressed,
+        sessionResourceDiscoveryDeferred,
         refresh: refreshLinearRecordSelectors
       });
     },

--- a/gbdraw/web/js/services/byte-utils.js
+++ b/gbdraw/web/js/services/byte-utils.js
@@ -1,0 +1,72 @@
+const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+const isBase64Whitespace = (character) => (
+  character === ' '
+  || character === '\t'
+  || character === '\n'
+  || character === '\f'
+  || character === '\r'
+);
+
+export const asBytes = (value) => (
+  value instanceof Uint8Array ? value : new Uint8Array(value || [])
+);
+
+export const bytesToBase64 = (value) => {
+  const bytes = asBytes(value);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+};
+
+export const base64ToBytes = (value) => {
+  const binary = atob(String(value || ''));
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+};
+
+export const base64DecodedLastByte = (value, byteLength) => {
+  if (!Number.isSafeInteger(byteLength) || byteLength <= 0) return null;
+  const encoded = String(value || '');
+  const terminalSextets = [];
+  // The terminal byte depends only on the final two non-padding sextets and size modulo 3.
+  for (let index = encoded.length - 1; index >= 0 && terminalSextets.length < 2; index -= 1) {
+    const character = encoded[index];
+    if (character === '=' || isBase64Whitespace(character)) continue;
+    const sextet = BASE64_ALPHABET.indexOf(character);
+    if (sextet < 0) return null;
+    terminalSextets.push(sextet);
+  }
+  if (terminalSextets.length < 2) return null;
+
+  const finalSextet = terminalSextets[0];
+  const penultimateSextet = terminalSextets[1];
+  if (byteLength % 3 === 1) {
+    return (penultimateSextet << 2) | (finalSextet >> 4);
+  }
+  if (byteLength % 3 === 2) {
+    return ((penultimateSextet & 0x0F) << 4) | (finalSextet >> 2);
+  }
+  return ((penultimateSextet & 0x03) << 6) | finalSextet;
+};
+
+export const textToBytes = (value) => new TextEncoder().encode(String(value));
+
+export const bytesToText = (value, options) => (
+  new TextDecoder('utf-8', options).decode(asBytes(value))
+);
+
+export const textToBase64 = (value) => bytesToBase64(textToBytes(value));
+
+export const sha256Hex = async (value) => {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('SHA-256 file identity requires Web Crypto.');
+  }
+  const bytes = asBytes(value);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+};

--- a/gbdraw/web/js/services/canonical-resource-references.js
+++ b/gbdraw/web/js/services/canonical-resource-references.js
@@ -1,0 +1,29 @@
+const RESOURCE_REFERENCE_FIELDS = new Set([
+  'resourceId',
+  'gffResourceId',
+  'fastaResourceId'
+]);
+
+export const isCanonicalResourceReferenceField = (field) => (
+  RESOURCE_REFERENCE_FIELDS.has(field)
+);
+
+export const collectCanonicalResourceIds = (value, target = new Set()) => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectCanonicalResourceIds(item, target));
+    return target;
+  }
+  if (!value || typeof value !== 'object') return target;
+  Object.entries(value).forEach(([key, item]) => {
+    if (
+      isCanonicalResourceReferenceField(key)
+      && typeof item === 'string'
+      && item.trim()
+    ) {
+      target.add(item.trim());
+      return;
+    }
+    collectCanonicalResourceIds(item, target);
+  });
+  return target;
+};

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -92,6 +92,10 @@ import {
 } from '../app/linear-comparisons.js';
 import { buildSessionResources as assembleSessionResources } from './session-resources.js';
 import { base64ToBytes, bytesToBase64, readFileBytes } from './file-content-cache.js';
+import {
+  adoptCurrentSessionResources,
+  isSessionResourceFileView
+} from './session-resource-backing.js';
 import { normalizeLogicalResults } from './result-normalization.js';
 import {
   ingestSvgResults,
@@ -99,6 +103,7 @@ import {
 } from './svg-result-ingestion.js';
 import {
   featureStateFromCatalog,
+  isAdoptedFeatureCatalog,
   validateFeatureCatalog
 } from './feature-catalog.js';
 import {
@@ -151,11 +156,18 @@ import {
   normalizeFeatureRenderingMap
 } from '../utils/feature-rendering.js';
 import {
+  adoptCurrentSessionDocument,
+  adoptRuntimeCanonicalSession,
+  isAdoptedCanonicalSession,
   projectArtifactState,
   projectDocumentMetadata,
   projectWebOnlyEditorMetadata,
   validateSessionAuthorityInventory
 } from './session-authority.js';
+import {
+  recordSessionLifecycleEvent,
+  recordStructuralMetric
+} from './runtime-test-hooks.js';
 import {
   migratePersistedCircularMultiRecordSizeMode,
   migratePersistedLinearLabelPlacement,
@@ -874,6 +886,9 @@ const normalizeDepthTracks = (tracks, legacyAdv = {}) => {
 let lastSessionFilename = null;
 let preservedCliOptions = null;
 let committedCanonicalSession = null;
+let activeSessionResourceTable = null;
+let adoptedProteinIdentityManifest = null;
+const adoptedLosatCacheValues = new WeakSet();
 
 const cloneCanonicalSession = (canonical) => {
   if (
@@ -1007,7 +1022,7 @@ const defaultEditorStateData = () => ({
   featureCatalog: null
 });
 
-export const buildEditorStateData = () => ({
+export const buildEditorStateData = ({ preserveAdoptedCatalog = false } = {}) => ({
   legend: {
     entries: cloneJsonArray(state.legendEntries.value),
     deletedEntries: cloneJsonArray(state.deletedLegendEntries.value),
@@ -1026,10 +1041,13 @@ export const buildEditorStateData = () => ({
     color: state.originalSvgStroke.value?.color ?? null,
     width: state.originalSvgStroke.value?.width ?? null
   },
-  featureCatalog: cloneJsonValue(state.featureCatalog?.value, null)
+  featureCatalog: preserveAdoptedCatalog
+    && isAdoptedFeatureCatalog(state.featureCatalog?.value)
+    ? state.featureCatalog.value
+    : cloneJsonValue(state.featureCatalog?.value, null)
 });
 
-const normalizeEditorStateData = (editorState = {}) => {
+const normalizeEditorStateData = (editorState = {}, { featureCatalog = undefined } = {}) => {
   const defaults = defaultEditorStateData();
   const source = isPlainObject(editorState) ? editorState : {};
   const legend = isPlainObject(source.legend) ? source.legend : {};
@@ -1057,9 +1075,11 @@ const normalizeEditorStateData = (editorState = {}) => {
         ? normalizeStrokeWidth(originalSvgStroke.width)
         : defaults.originalSvgStroke.width
     },
-    featureCatalog: isPlainObject(source.featureCatalog)
-      ? cloneJsonData(source.featureCatalog)
-      : null
+    featureCatalog: featureCatalog !== undefined
+      ? featureCatalog
+      : isPlainObject(source.featureCatalog)
+        ? cloneJsonData(source.featureCatalog)
+        : null
   };
 };
 
@@ -1070,10 +1090,15 @@ const replacePlainObject = (target, source) => {
   });
 };
 
-export const applyEditorStateData = (editorState = {}, { trusted = false } = {}) => {
-  const normalized = trusted
-    ? cloneJsonData(editorState)
-    : normalizeEditorStateData(editorState);
+export const applyEditorStateData = (
+  editorState = {},
+  { trusted = false, normalized: alreadyNormalized = false, adoptCatalog = false } = {}
+) => {
+  const normalized = alreadyNormalized
+    ? editorState
+    : trusted
+      ? cloneJsonData(editorState)
+      : normalizeEditorStateData(editorState);
 
   state.legendEntries.value = normalized.legend.entries;
   state.deletedLegendEntries.value = normalized.legend.deletedEntries;
@@ -1085,7 +1110,9 @@ export const applyEditorStateData = (editorState = {}, { trusted = false } = {})
   replacePlainObject(state.featureStrokeOverrides, normalized.featureStrokes.overrides);
   state.originalSvgStroke.value = normalized.originalSvgStroke;
   if (state.featureCatalog) {
-    state.featureCatalog.value = cloneJsonValue(normalized.featureCatalog, null);
+    state.featureCatalog.value = adoptCatalog
+      ? normalized.featureCatalog
+      : cloneJsonValue(normalized.featureCatalog, null);
   }
 };
 
@@ -1506,7 +1533,7 @@ export const validateCurrentWriterActiveDraft = ({
   }
 };
 
-const validateCurrentWriterFeatureCatalog = (data) => {
+const validateCurrentWriterFeatureCatalog = (data, { adopt = false } = {}) => {
   const results = normalizeLogicalResults(
     (Array.isArray(data.results) ? data.results : []).map((result, index) => ({
       name: result?.name || `Result ${index + 1}`,
@@ -1514,50 +1541,81 @@ const validateCurrentWriterFeatureCatalog = (data) => {
     }))
   );
   const catalog = data.editorState?.featureCatalog ?? null;
-  if (catalog === null) return;
-  data.editorState.featureCatalog = validateFeatureCatalog(catalog, results);
+  if (catalog === null) return null;
+  return validateFeatureCatalog(catalog, results, { adopt });
 };
 
 const preflightSessionImport = (rawData) => {
-  const sourceSessionVersion = rawData.version;
-  validateSessionAuthorityInventory(rawData, sourceSessionVersion);
-  const normalizedData = normalizeSessionData(rawData);
-  if (sourceSessionVersion === SESSION_VERSION) {
-    validateCurrentWriterFeatureCatalog(normalizedData);
+  const sourceSessionVersion = rawData?.version;
+  const currentSession = sourceSessionVersion === SESSION_VERSION;
+  let adoptedSession = null;
+  let currentResourceTable = null;
+  let validatedFeatureCatalog = null;
+  let normalizedEditorState = null;
+  let normalizedData;
+
+  if (currentSession) {
+    if (!isPlainObject(rawData) || rawData.format !== 'gbdraw-session') {
+      throw new Error('Invalid session file.');
+    }
+    adoptedSession = adoptCurrentSessionDocument(rawData, SESSION_VERSION);
+    validatedFeatureCatalog = validateCurrentWriterFeatureCatalog(rawData, {
+      adopt: true
+    });
+    normalizedEditorState = normalizeEditorStateData(rawData.editorState, {
+      featureCatalog: validatedFeatureCatalog
+    });
+    currentResourceTable = adoptCurrentSessionResources(rawData.resources);
+    normalizedData = rawData;
+  } else {
+    validateSessionAuthorityInventory(rawData, sourceSessionVersion);
+    normalizedData = normalizeSessionData(rawData);
+    migrateImportedLinearTrackSlots(normalizedData.config, sourceSessionVersion);
   }
-  migrateImportedLinearTrackSlots(normalizedData.config, sourceSessionVersion);
-  const promotedData = (
+
+  const promotedData = !currentSession && (
     sourceSessionVersion >= 31 &&
     Number(normalizedData.renderRequest?.schema) === 2
-    )
+  )
     ? promoteGallerySessionToCurrent(normalizedData)
     : normalizedData;
   validateSessionLosatArtifacts(promotedData, sourceSessionVersion);
-  const data = migrateSessionDataToCurrent(promotedData, sourceSessionVersion);
+  const data = currentSession
+    ? promotedData
+    : migrateSessionDataToCurrent(promotedData, sourceSessionVersion);
+  const runtimeStoredConfig = currentSession
+    ? migrateImportedLinearTrackSlots(
+        migrateImportedCircularTrackSlots(data.config),
+        sourceSessionVersion
+      )
+    : data.config;
   const canonicalProjection = sourceSessionVersion >= 31
     ? projectCanonicalSessionRequest({
         renderRequest: data.renderRequest,
         resources: data.resources,
         webFiles: data.webFiles,
         legacyFiles: data.files,
-        storedConfig: data.config,
+        storedConfig: runtimeStoredConfig,
         fileBindings: data.cliInvocation?.fileBindings,
         linearTrackSlotSchemaVersion: sourceSessionVersion <= LEGACY_LINEAR_TRACK_SLOT_SESSION_VERSION
           ? LEGACY_LINEAR_TRACK_SLOT_SCHEMA_VERSION
           : LINEAR_TRACK_SLOT_SCHEMA_VERSION,
-        repairInvalidComparisonHeight: sourceSessionVersion >= 31 && sourceSessionVersion <= 33
+        repairInvalidComparisonHeight: sourceSessionVersion >= 31 && sourceSessionVersion <= 33,
+        sessionResourceTable: currentResourceTable,
+        deferResourceContent: currentSession,
+        adoptCanonicalPayloads: currentSession
       })
     : null;
   let restoredConfig = canonicalProjection
     ? {
         ...restoreStoredNonCanonicalConfig(
           canonicalProjection.config,
-          data.config,
+          runtimeStoredConfig,
           { hasCanonicalProteinPipeline: Boolean(canonicalProjection.pipelineState) }
         ),
         rules: applySpecificRuleProvenance(
           canonicalProjection.config.rules,
-          data.config?.rules
+          runtimeStoredConfig?.rules
         )
       }
     : data.config;
@@ -1590,9 +1648,12 @@ const preflightSessionImport = (rawData) => {
     validateCurrentWriterActiveDraft({
       mode: canonicalProjection.mode,
       projectedConfig: canonicalProjection.config,
-      storedConfig: data.config
+      storedConfig: runtimeStoredConfig
     });
-    restoredConfig = overlayCurrentWriterDraftConfig(restoredConfig, data.config);
+    restoredConfig = overlayCurrentWriterDraftConfig(
+      restoredConfig,
+      runtimeStoredConfig
+    );
   }
   if (!canonicalProjection && restoredConfig) {
     hydrateMissingMultiRecordPositionsFromCliInvocation(restoredConfig, data.cliInvocation);
@@ -1617,6 +1678,7 @@ const preflightSessionImport = (rawData) => {
   const projectionResult = canonicalProjection
     ? (() => {
         const artifactState = projectArtifactState(data);
+        if (currentSession) artifactState.editorState = normalizedEditorState;
         if (canonicalProjection.pipelineState) {
           artifactState.orthogroupState = {
             ...(artifactState.orthogroupState || {}),
@@ -1634,7 +1696,8 @@ const preflightSessionImport = (rawData) => {
           },
           editorMetadata: projectWebOnlyEditorMetadata(data),
           artifactState,
-          restoredFiles: canonicalProjection.files
+          restoredFiles: canonicalProjection.files,
+          validatedFeatureCatalog
         };
       })()
     : null;
@@ -1643,7 +1706,9 @@ const preflightSessionImport = (rawData) => {
     sourceSessionVersion,
     canonicalProjection,
     restoredConfig,
-    projectionResult
+    projectionResult,
+    adoptedCanonicalSession: adoptedSession?.canonical || null,
+    currentResourceTable
   };
 };
 
@@ -2192,6 +2257,7 @@ const deserializeFile = (entry) => {
   if (Array.isArray(entry)) {
     return entry.map((item) => deserializeFile(item));
   }
+  if (isSessionResourceFileView(entry)) return entry;
   if (
     !entry ||
     !Object.prototype.hasOwnProperty.call(entry, 'data') ||
@@ -2200,6 +2266,7 @@ const deserializeFile = (entry) => {
   ) return null;
   if (isEncodedDepthFileEntry(entry)) {
     const text = decodeDepthText(entry.data);
+    recordStructuralMetric('fileConstructionCount');
     return new File([text], entry.name || 'depth.tsv', {
       type: entry.type || 'text/tab-separated-values',
       lastModified: entry.lastModified ?? Date.now()
@@ -2207,6 +2274,9 @@ const deserializeFile = (entry) => {
   }
   if (typeof entry.data !== 'string') return null;
   const bytes = base64ToBytes(entry.data);
+  recordStructuralMetric('base64DecodeCount');
+  recordStructuralMetric('decodedByteCount', bytes.byteLength);
+  recordStructuralMetric('fileConstructionCount');
   return new File([bytes], entry.name || 'file', {
     type: entry.type || 'application/octet-stream',
     lastModified: entry.lastModified ?? Date.now()
@@ -2303,7 +2373,7 @@ const serializeLosatCache = () => {
   const seen = new Set();
 
   const buildEntry = (key, cached, infoEntry = {}) => ({
-    ...cloneJsonData(cached),
+    ...(adoptedLosatCacheValues.has(cached) ? cached : cloneJsonData(cached)),
     key: String(key),
     filename: String(infoEntry.filename || ''),
     display: Boolean(infoEntry.display),
@@ -2331,7 +2401,11 @@ const serializeLosatCache = () => {
   return entries;
 };
 
-const applyLosatCache = (entries, legacyEnvelope = null) => {
+const applyLosatCache = (
+  entries,
+  legacyEnvelope = null,
+  { adoptCurrent = false } = {}
+) => {
   const map = new Map();
   const info = [];
   const legacyEntries = [];
@@ -2350,12 +2424,23 @@ const applyLosatCache = (entries, legacyEnvelope = null) => {
       ) {
         return;
       }
-      const restored = cloneJsonData(entry);
-      delete restored.key;
-      delete restored.filename;
-      delete restored.display;
-      [...LOSAT_CACHE_INFO_STRING_FIELDS, ...LOSAT_CACHE_INFO_INTEGER_FIELDS]
-        .forEach((field) => delete restored[field]);
+      const excludedFields = new Set([
+        'key',
+        'filename',
+        'display',
+        ...LOSAT_CACHE_INFO_STRING_FIELDS,
+        ...LOSAT_CACHE_INFO_INTEGER_FIELDS
+      ]);
+      const restored = adoptCurrent
+        ? Object.fromEntries(
+            Object.entries(entry).filter(([field]) => !excludedFields.has(field))
+          )
+        : cloneJsonData(entry);
+      if (!adoptCurrent) {
+        excludedFields.forEach((field) => delete restored[field]);
+      } else {
+        adoptedLosatCacheValues.add(restored);
+      }
       map.set(entry.key, restored);
       if (entry.display === false) return;
       info.push({
@@ -2400,7 +2485,11 @@ const normalizeLegacyDerivedEvidence = (value, fallbackEntries = []) => ({
     .map((entry) => cloneJsonData(entry))
 });
 
-const applyLosatDerivedCache = (entries, legacyEvidence = null) => {
+const applyLosatDerivedCache = (
+  entries,
+  legacyEvidence = null,
+  { adoptCurrent = false } = {}
+) => {
   const map = new Map();
   const legacyEntries = [];
 
@@ -2417,7 +2506,7 @@ const applyLosatDerivedCache = (entries, legacyEvidence = null) => {
         idEncoding: 'runtime-handle-v1',
         key: entry.key,
         mode: String(entry.mode || ''),
-        payload: cloneJsonData(entry.payload)
+        payload: adoptCurrent ? entry.payload : cloneJsonData(entry.payload)
       });
     });
   }
@@ -2430,10 +2519,16 @@ const applyLosatDerivedCache = (entries, legacyEvidence = null) => {
   );
 };
 
-const applyProteinIdentityManifest = (manifest) => {
-  state.proteinIdentityManifest.value = validateProteinIdentityManifest(manifest)
-    ? cloneJsonData(manifest)
-    : emptyProteinIdentityManifest();
+const applyProteinIdentityManifest = (manifest, { adoptCurrent = false } = {}) => {
+  if (!validateProteinIdentityManifest(manifest)) {
+    state.proteinIdentityManifest.value = emptyProteinIdentityManifest();
+    adoptedProteinIdentityManifest = null;
+    return;
+  }
+  state.proteinIdentityManifest.value = adoptCurrent
+    ? manifest
+    : cloneJsonData(manifest);
+  adoptedProteinIdentityManifest = adoptCurrent ? manifest : null;
 };
 
 export const applyOrthogroupStateData = (orthogroupState = {}) => {
@@ -2678,22 +2773,38 @@ export const buildSessionResources = (sourceState, committedRequest) => (
   assembleSessionResources(sourceState, committedRequest)
 );
 
-const deserializeCanonicalComparisons = (comparisons) => (
+const deserializeCanonicalComparisons = (
+  comparisons,
+  { adoptCanonicalPayloads = false } = {}
+) => (
   Array.isArray(comparisons)
     ? comparisons.map((comparison) => (
         isResourceBackedCanonicalComparison(comparison)
           ? mapResourceBackedCanonicalComparison(comparison, deserializeFile)
-          : cloneJsonData(comparison)
+          : adoptCanonicalPayloads ? comparison : cloneJsonData(comparison)
       ))
     : []
 );
 
 export const adoptCanonicalRenderArtifacts = (canonical) => {
-  const projection = projectCanonicalSessionRequest(canonical);
-  const nextCommittedCanonicalSession = cloneCanonicalSession(canonical);
+  const preserveAdoptedResources = isAdoptedCanonicalSession(canonical);
+  const sessionResourceTable = preserveAdoptedResources
+    ? adoptCurrentSessionResources(canonical?.resources)
+    : null;
+  const projection = projectCanonicalSessionRequest({
+    ...canonical,
+    sessionResourceTable,
+    deferResourceContent: preserveAdoptedResources,
+    adoptCanonicalPayloads: preserveAdoptedResources
+  });
+  const nextCommittedCanonicalSession = preserveAdoptedResources
+    ? adoptRuntimeCanonicalSession(canonical)
+    : cloneCanonicalSession(canonical);
+  activeSessionResourceTable = sessionResourceTable;
   if (projection.mode === 'linear') {
     const nextComparisons = deserializeCanonicalComparisons(
-      projection.files.linearCanonicalComparisons
+      projection.files.linearCanonicalComparisons,
+      { adoptCanonicalPayloads: preserveAdoptedResources }
     );
     state.files.linearCanonicalComparisons = nextComparisons;
     committedCanonicalSession = nextCommittedCanonicalSession;
@@ -2746,7 +2857,7 @@ export const adoptCanonicalRenderArtifacts = (canonical) => {
   committedCanonicalSession = nextCommittedCanonicalSession;
 };
 
-const applyFiles = (filesData) => {
+const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
   state.matchSequenceRegistry?.reset?.();
   state.files.c_gb = null;
   state.files.c_gff = null;
@@ -2791,7 +2902,8 @@ const applyFiles = (filesData) => {
     ? filesData.c_conservation_sequence_sources.map((entry) => deserializeFile(entry))
     : [];
   state.files.linearCanonicalComparisons = deserializeCanonicalComparisons(
-    filesData.linearCanonicalComparisons
+    filesData.linearCanonicalComparisons,
+    { adoptCanonicalPayloads }
   );
   state.files.d_color = deserializeFile(filesData.d_color);
   state.files.t_color = deserializeFile(filesData.t_color);
@@ -3136,11 +3248,17 @@ const captureSessionImportSnapshot = () => ({
   runState: buildRunStateData(),
   losatCache: new Map(state.losatCache.value),
   losatDerivedCache: new Map(state.losatDerivedCache.value),
-  proteinIdentityManifest: cloneJsonData(state.proteinIdentityManifest.value),
+  proteinIdentityManifest: state.proteinIdentityManifest.value === adoptedProteinIdentityManifest
+    ? state.proteinIdentityManifest.value
+    : cloneJsonData(state.proteinIdentityManifest.value),
+  adoptedProteinIdentityManifest,
   legacyProteinRawCandidates: cloneJsonData(state.legacyProteinRawCandidates.value),
   legacyProteinDerivedEvidence: cloneJsonData(state.legacyProteinDerivedEvidence.value),
   losatCacheInfo: cloneJsonData(state.losatCacheInfo.value),
-  committedCanonicalSession: cloneCanonicalSession(committedCanonicalSession),
+  committedCanonicalSession: isAdoptedCanonicalSession(committedCanonicalSession)
+    ? committedCanonicalSession
+    : cloneCanonicalSession(committedCanonicalSession),
+  activeSessionResourceTable,
   errorLog: state.errorLog.value,
   resultPanelTab: state.resultPanelTab.value,
   transients: captureSessionImportTransientState()
@@ -3158,11 +3276,17 @@ const restoreSessionImportSnapshot = async (snapshot) => {
     restoreLiveFileState(snapshot.files);
     state.losatCache.value = new Map(snapshot.losatCache);
     state.losatDerivedCache.value = new Map(snapshot.losatDerivedCache);
-    state.proteinIdentityManifest.value = cloneJsonData(snapshot.proteinIdentityManifest);
+    adoptedProteinIdentityManifest = snapshot.adoptedProteinIdentityManifest;
+    state.proteinIdentityManifest.value = snapshot.proteinIdentityManifest === adoptedProteinIdentityManifest
+      ? snapshot.proteinIdentityManifest
+      : cloneJsonData(snapshot.proteinIdentityManifest);
     state.legacyProteinRawCandidates.value = cloneJsonData(snapshot.legacyProteinRawCandidates);
     state.legacyProteinDerivedEvidence.value = cloneJsonData(snapshot.legacyProteinDerivedEvidence);
     state.losatCacheInfo.value = cloneJsonData(snapshot.losatCacheInfo);
-    committedCanonicalSession = cloneCanonicalSession(snapshot.committedCanonicalSession);
+    committedCanonicalSession = isAdoptedCanonicalSession(snapshot.committedCanonicalSession)
+      ? snapshot.committedCanonicalSession
+      : cloneCanonicalSession(snapshot.committedCanonicalSession);
+    activeSessionResourceTable = snapshot.activeSessionResourceTable;
     state.skipCaptureBaseConfig.value = true;
     state.skipPositionReapply.value = true;
     applyResultsData(snapshot.results, snapshot.ui);
@@ -3190,6 +3314,9 @@ const resetSessionBaseline = () => {
   activePreviewRuntime?.clearActiveRuntime?.();
   preservedCliOptions = null;
   committedCanonicalSession = null;
+  activeSessionResourceTable = null;
+  adoptedProteinIdentityManifest = null;
+  state.sessionResourceDiscoveryDeferred.value = false;
   resetSettingsState(state);
   resetLayoutState(state);
   resetRightDrawerState(state);
@@ -3566,15 +3693,17 @@ export const exportSession = async (
   }
 
   const logicalResults = serializeResults();
-  const editorState = buildEditorStateData();
+  const editorState = buildEditorStateData({ preserveAdoptedCatalog: true });
   if (logicalResults.length > 0) {
     if (!editorState.featureCatalog) {
       throw new Error(SESSION_FEATURE_CATALOG_SAVE_ERROR);
     }
     try {
+      const adoptedCatalog = isAdoptedFeatureCatalog(editorState.featureCatalog);
       editorState.featureCatalog = validateFeatureCatalog(
         editorState.featureCatalog,
-        logicalResults
+        logicalResults,
+        { adopt: adoptedCatalog }
       );
     } catch (error) {
       console.warn('Session feature catalog validation failed.', error);
@@ -3594,10 +3723,18 @@ export const exportSession = async (
     storedConfig.adv,
     normalizedArrowGeometryState(storedConfig.adv)
   );
-  let committed = cloneCanonicalSession(committedCanonicalSession);
+  let committed = isAdoptedCanonicalSession(committedCanonicalSession)
+    ? committedCanonicalSession
+    : cloneCanonicalSession(committedCanonicalSession);
   if (committed) {
     try {
-      const projected = projectCanonicalSessionRequest(committed);
+      const adoptedCommitted = isAdoptedCanonicalSession(committed);
+      const projected = projectCanonicalSessionRequest({
+        ...committed,
+        sessionResourceTable: adoptedCommitted ? activeSessionResourceTable : null,
+        deferResourceContent: adoptedCommitted,
+        adoptCanonicalPayloads: adoptedCommitted
+      });
       validateCurrentWriterActiveDraft({
         mode: projected.mode,
         projectedConfig: projected.config,
@@ -3700,7 +3837,11 @@ export const exportSession = async (
       entries: []
     },
     proteinIdentityManifest: validateProteinIdentityManifest(state.proteinIdentityManifest.value)
-      ? cloneJsonData(state.proteinIdentityManifest.value)
+      ? (
+          state.proteinIdentityManifest.value === adoptedProteinIdentityManifest
+            ? state.proteinIdentityManifest.value
+            : cloneJsonData(state.proteinIdentityManifest.value)
+        )
       : emptyProteinIdentityManifest(),
     cliInvocation: exportableCliInvocation
   };
@@ -3732,6 +3873,7 @@ export const exportSession = async (
 export const importSession = async (e, options = {}) => {
   const file = e.target.files[0];
   if (!file) return { status: 'skipped' };
+  recordSessionLifecycleEvent('sessionSelection');
 
   const semanticFileWatchersSuppressedBeforeImport = Boolean(
     state.semanticFileWatchersSuppressed.value
@@ -3761,9 +3903,12 @@ export const importSession = async (e, options = {}) => {
       sourceSessionVersion,
       canonicalProjection,
       restoredConfig,
-      projectionResult
+      projectionResult,
+      adoptedCanonicalSession,
+      currentResourceTable
     } = preflight;
     const canonicalSession = Boolean(projectionResult);
+    const currentSchemaSession = sourceSessionVersion === SESSION_VERSION;
     rollbackSnapshot = captureSessionImportSnapshot();
     if (typeof rollbackStateExtension?.capture === 'function') {
       rollbackExtensionSnapshot = rollbackStateExtension.capture();
@@ -3771,6 +3916,11 @@ export const importSession = async (e, options = {}) => {
     commitStarted = true;
     state.semanticFileWatchersSuppressed.value = true;
     resetSessionBaseline();
+    state.sessionResourceDiscoveryDeferred.value = currentSchemaSession;
+    if (currentSchemaSession) {
+      committedCanonicalSession = adoptedCanonicalSession;
+      activeSessionResourceTable = currentResourceTable;
+    }
     const ui = canonicalSession
       ? {
           ...projectionResult.editorMetadata.ui,
@@ -3827,19 +3977,25 @@ export const importSession = async (e, options = {}) => {
     restoreLayoutPreferences(ui, { preserveActive: Boolean(canonicalSession) });
 
     const { collapsedLinearSeqs } = applyFiles(
-      canonicalSession ? projectionResult.restoredFiles : data.files
+      canonicalSession ? projectionResult.restoredFiles : data.files,
+      { adoptCanonicalPayloads: currentSchemaSession }
     );
     reconcileDepthTrackStateAfterSessionFiles();
     if (canonicalSession) {
       applyLosatCache(
         projectionResult.artifactState.losatCache?.entries,
-        projectionResult.artifactState.legacyArtifacts?.proteinRawCandidates
+        projectionResult.artifactState.legacyArtifacts?.proteinRawCandidates,
+        { adoptCurrent: currentSchemaSession }
       );
       applyLosatDerivedCache(
         projectionResult.artifactState.losatDerivedCache?.entries,
-        projectionResult.artifactState.legacyArtifacts?.proteinDerivedEvidence
+        projectionResult.artifactState.legacyArtifacts?.proteinDerivedEvidence,
+        { adoptCurrent: currentSchemaSession }
       );
-      applyProteinIdentityManifest(projectionResult.artifactState.proteinIdentityManifest);
+      applyProteinIdentityManifest(
+        projectionResult.artifactState.proteinIdentityManifest,
+        { adoptCurrent: currentSchemaSession }
+      );
     } else {
       applyLosatCache(
         data.losatCache?.entries,
@@ -3871,33 +4027,23 @@ export const importSession = async (e, options = {}) => {
       ? projectionResult.artifactState.editorState
       : data.editorState;
     let currentCatalogFeatureState = null;
-    let validatedSessionCatalog = null;
+    let validatedSessionCatalog = currentSchemaSession
+      ? projectionResult?.validatedFeatureCatalog || null
+      : null;
     let restoredEditorState = storedEditorState;
-    if (sourceSessionVersion === SESSION_VERSION) {
-      if (storedEditorState?.featureCatalog) {
-        try {
-          validatedSessionCatalog = validateFeatureCatalog(
-            storedEditorState.featureCatalog,
-            logicalImportedResults
-          );
-          currentCatalogFeatureState = featureStateFromCatalog(
-            validatedSessionCatalog,
-            { mode: state.mode.value }
-          );
-        } catch (catalogError) {
-          console.warn('Session feature catalog is unavailable or incompatible.', catalogError);
-        }
-      }
-      restoredEditorState = {
-        ...(isPlainObject(storedEditorState) ? storedEditorState : {}),
-        featureCatalog: validatedSessionCatalog
-      };
+    if (currentSchemaSession && validatedSessionCatalog) {
+      currentCatalogFeatureState = featureStateFromCatalog(
+        validatedSessionCatalog,
+        { mode: state.mode.value }
+      );
     }
 
     const artifactFeatureState = canonicalSession
-      ? cloneJsonData(projectionResult.artifactState.features)
+      ? currentSchemaSession
+        ? { ...projectionResult.artifactState.features }
+        : cloneJsonData(projectionResult.artifactState.features)
       : {};
-    if (sourceSessionVersion === SESSION_VERSION) {
+    if (currentSchemaSession) {
       [
         'extractedFeatures',
         'biologicalFeatures',
@@ -3913,10 +4059,10 @@ export const importSession = async (e, options = {}) => {
         }
       : (data.features || {});
     applyFeatureStateData(features);
-    if (sourceSessionVersion === SESSION_VERSION && currentCatalogFeatureState) {
+    if (currentSchemaSession && currentCatalogFeatureState) {
       synchronizeRestoredFeatureSummaryStatus({ generationId: 'session-load' });
     }
-    const catalogSequenceSources = sourceSessionVersion === SESSION_VERSION
+    const catalogSequenceSources = currentSchemaSession
       ? (currentCatalogFeatureState?.sequenceSources || [])
       : [];
     const comparisonSourceAvailability = state.mode.value === 'circular'
@@ -3926,7 +4072,7 @@ export const importSession = async (e, options = {}) => {
         })
       : undefined;
     const catalogSequenceSourceCoverage = (
-      sourceSessionVersion === SESSION_VERSION
+      currentSchemaSession
       && validatedSessionCatalog
     )
       ? analyzeCatalogSequenceSourceCoverage({
@@ -3939,7 +4085,8 @@ export const importSession = async (e, options = {}) => {
     const missingCatalogSequenceSources = sourceSessionVersion !== SESSION_VERSION
       || !catalogSequenceSourceCoverage?.complete;
     let restoredFileSequenceSources = [];
-    if (missingCatalogSequenceSources) {
+    if (missingCatalogSequenceSources && !currentSchemaSession) {
+      recordStructuralMetric('sourceRecoveryCount');
       try {
         restoredFileSequenceSources = await buildRestoredMatchSequenceSources({
           mode: state.mode.value,
@@ -3982,7 +4129,10 @@ export const importSession = async (e, options = {}) => {
               {}
         }
     );
-    applyEditorStateData(restoredEditorState);
+    applyEditorStateData(restoredEditorState, {
+      normalized: currentSchemaSession,
+      adoptCatalog: currentSchemaSession
+    });
 
     const restoredFeatureState = currentCatalogFeatureState || features || {};
     const transformRestoredSessionSvg = (svg, { applyStrokes = true } = {}) => {
@@ -4042,7 +4192,32 @@ export const importSession = async (e, options = {}) => {
     state.skipCaptureBaseConfig.value = true;
     state.skipPositionReapply.value = true;
     applyResultsData(committedImportedResults, ui);
+    recordSessionLifecycleEvent('firstCommittedPreview', {
+      resultCount: state.results.value.length
+    });
     await nextTick();
+
+    let currentRecoveryError = null;
+    if (currentSchemaSession && missingCatalogSequenceSources) {
+      recordStructuralMetric('sourceRecoveryCount');
+      try {
+        restoredFileSequenceSources = await buildRestoredMatchSequenceSources({
+          mode: state.mode.value,
+          cInputType: state.cInputType.value,
+          lInputType: state.lInputType.value,
+          files: state.files,
+          linearSeqs: state.linearSeqs,
+          circularConservation: state.circularConservation
+        });
+        state.matchSequenceRegistry?.reset?.([
+          ...catalogSequenceSources,
+          ...restoredFileSequenceSources
+        ]);
+      } catch (sequenceError) {
+        currentRecoveryError = sequenceError;
+        console.warn('Session preview loaded, but match sequence recovery failed.', sequenceError);
+      }
+    }
 
     if (typeof options?.afterLoad === 'function') {
       await options.afterLoad({ data, ui });
@@ -4073,9 +4248,21 @@ export const importSession = async (e, options = {}) => {
     state.semanticFileWatchersSuppressed.value =
       semanticFileWatchersSuppressedBeforeImport;
     await nextTick();
-    committedCanonicalSession = cloneCanonicalSession(data);
+    state.sessionResourceDiscoveryDeferred.value = false;
+    if (!currentSchemaSession) {
+      committedCanonicalSession = cloneCanonicalSession(data);
+      activeSessionResourceTable = null;
+    }
+    recordSessionLifecycleEvent('interactiveReady', {
+      status: 'success',
+      degradedRecovery: Boolean(currentRecoveryError)
+    });
     alert('Session loaded successfully!');
-    return { status: 'ok', data };
+    return {
+      status: 'ok',
+      data,
+      degradedRecovery: Boolean(currentRecoveryError)
+    };
   } catch (err) {
     console.error(err);
     if (commitStarted && rollbackSnapshot) {
@@ -4089,9 +4276,14 @@ export const importSession = async (e, options = {}) => {
       }
     }
     const message = err?.message || 'Invalid JSON structure.';
+    recordSessionLifecycleEvent('interactiveReady', {
+      status: 'error',
+      error: message
+    });
     alert(`Failed to load session: ${message}`);
     return { status: 'error', error: err };
   } finally {
+    state.sessionResourceDiscoveryDeferred.value = false;
     state.semanticFileWatchersSuppressed.value =
       semanticFileWatchersSuppressedBeforeImport;
     e.target.value = '';

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -91,13 +91,19 @@ import {
   resolveLinearComparisonPlan
 } from '../app/linear-comparisons.js';
 import { buildSessionResources as assembleSessionResources } from './session-resources.js';
-import { base64ToBytes, bytesToBase64, readFileBytes } from './file-content-cache.js';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  getSessionResourceSource,
+  readFileBytes
+} from './file-content-cache.js';
 import {
   adoptCurrentSessionResources,
   isSessionResourceFileView
 } from './session-resource-backing.js';
 import { normalizeLogicalResults } from './result-normalization.js';
 import {
+  ingestCatalogBackedSvgResults,
   ingestSvgResults,
   isCommittedSvgResult
 } from './svg-result-ingestion.js';
@@ -168,6 +174,7 @@ import {
   recordSessionLifecycleEvent,
   recordStructuralMetric
 } from './runtime-test-hooks.js';
+import { setResourcePayloadOwner } from './resource-payload-owner.js';
 import {
   migratePersistedCircularMultiRecordSizeMode,
   migratePersistedLinearLabelPlacement,
@@ -2234,10 +2241,28 @@ const restorePaletteStateFromSession = (ui = {}) => {
   }
 };
 
+const serializedFileDescriptors = new WeakMap();
+
 const serializeFile = async (file) => {
   if (!file) return null;
+  const source = getSessionResourceSource(file);
+  if (source?.descriptor) {
+    setResourcePayloadOwner(source.descriptor, file);
+    return source.descriptor;
+  }
+  const cached = serializedFileDescriptors.get(file);
+  if (cached) return cached;
   const bytes = await readFileBytes(file);
-  return {
+  recordStructuralMetric('resourceReencodeCount', 1, {
+    resourceName: String(file.name || 'file')
+  });
+  recordStructuralMetric('base64EncodeCount', 1, {
+    resourceName: String(file.name || 'file')
+  });
+  recordStructuralMetric('encodedByteCount', bytes.byteLength, {
+    resourceName: String(file.name || 'file')
+  });
+  const descriptor = {
     name: file.name || 'file',
     type: file.type || '',
     size: bytes.byteLength,
@@ -2245,6 +2270,9 @@ const serializeFile = async (file) => {
     encoding: 'base64',
     data: bytesToBase64(bytes)
   };
+  setResourcePayloadOwner(descriptor, file);
+  serializedFileDescriptors.set(file, descriptor);
+  return descriptor;
 };
 
 const serializeFileValue = async (value) => (
@@ -3884,20 +3912,26 @@ export const importSession = async (e, options = {}) => {
   let commitStarted = false;
 
   try {
+    recordSessionLifecycleEvent('gzip-to-text-start');
     const text = await readSessionText(file);
+    recordSessionLifecycleEvent('gzip-to-text-end', { characters: text.length });
+    recordSessionLifecycleEvent('json-parse-start');
     let data = JSON.parse(text, (key, value) => {
       if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
         return undefined;
       }
       return value;
     });
+    recordSessionLifecycleEvent('json-parse-end');
     if (isLegacyConfigPayload(data)) {
       applyLegacyConfigPayload(data);
       alert('Legacy configuration loaded. Save as a session to use the current format.');
       return { status: 'legacy' };
     }
 
+    recordSessionLifecycleEvent('current-session-preflight-start');
     const preflight = preflightSessionImport(data);
+    recordSessionLifecycleEvent('current-session-preflight-end');
     data = preflight.data;
     const {
       sourceSessionVersion,
@@ -4171,7 +4205,12 @@ export const importSession = async (e, options = {}) => {
       return legendGroupsChanged || compositionChanged || strokeCount > 0;
     };
 
-    const committedImportedResults = validatedSessionCatalog
+    recordSessionLifecycleEvent('svg-admission-start');
+    const committedImportedResults = currentSchemaSession && validatedSessionCatalog
+      ? ingestCatalogBackedSvgResults(logicalImportedResults, {
+          catalogItems: validatedSessionCatalog.items
+        })
+      : validatedSessionCatalog
       ? prepareCandidateRenderCommit({
           results: logicalImportedResults,
           catalog: validatedSessionCatalog,
@@ -4187,15 +4226,18 @@ export const importSession = async (e, options = {}) => {
       : ingestSvgResults(logicalImportedResults, {
           transformSvg: transformRestoredSessionSvg
         });
+    recordSessionLifecycleEvent('svg-admission-end');
 
     await nextTick();
     state.skipCaptureBaseConfig.value = true;
     state.skipPositionReapply.value = true;
+    recordSessionLifecycleEvent('preview-mount-start');
     applyResultsData(committedImportedResults, ui);
     recordSessionLifecycleEvent('firstCommittedPreview', {
       resultCount: state.results.value.length
     });
     await nextTick();
+    recordSessionLifecycleEvent('preview-mount-end');
 
     let currentRecoveryError = null;
     if (currentSchemaSession && missingCatalogSequenceSources) {

--- a/gbdraw/web/js/services/diagram-generation.js
+++ b/gbdraw/web/js/services/diagram-generation.js
@@ -5,6 +5,7 @@ import {
   DIAGRAM_HELPER_OPERATION_NAMES,
   DIAGRAM_HELPER_OPERATIONS
 } from './diagram-worker-protocol.js';
+import { recordStructuralMetric } from './runtime-test-hooks.js';
 
 export { DIAGRAM_HELPER_OPERATIONS } from './diagram-worker-protocol.js';
 
@@ -84,6 +85,7 @@ export const deserializeWorkerError = (
 const getWorker = () => {
   if (!worker) {
     worker = new Worker(resolveWorkerUrl(), { type: 'module' });
+    recordStructuralMetric('workerConstructionCount');
     workerInitialized = false;
   }
   return worker;
@@ -179,6 +181,7 @@ const ensureWorkerInitialized = () => {
   currentWorker.addEventListener('error', handleError);
   currentWorker.addEventListener('messageerror', handleMessageError);
   initState = { promise, reject: rejectInit, cleanup };
+  recordStructuralMetric('workerInitializationCount');
   currentWorker.postMessage(buildInitPayload(id));
 
   return promise;

--- a/gbdraw/web/js/services/diagram-generation.js
+++ b/gbdraw/web/js/services/diagram-generation.js
@@ -5,7 +5,12 @@ import {
   DIAGRAM_HELPER_OPERATION_NAMES,
   DIAGRAM_HELPER_OPERATIONS
 } from './diagram-worker-protocol.js';
-import { recordStructuralMetric } from './runtime-test-hooks.js';
+import {
+  recordSessionLifecycleEvent,
+  recordStructuralMetric,
+  runtimeTestHooksEnabled
+} from './runtime-test-hooks.js';
+import { createDiagramResourceTransport } from './diagram-resource-staging.js';
 
 export { DIAGRAM_HELPER_OPERATIONS } from './diagram-worker-protocol.js';
 
@@ -20,9 +25,63 @@ export class DiagramGenerationCanceledError extends Error {
 export const isDiagramGenerationCanceled = (error) =>
   Boolean(error?.canceled || error?.name === 'DiagramGenerationCanceledError');
 
+const decodeGenerationResultContent = (result, resultIndex) => {
+  if (!result || typeof result !== 'object' || typeof result.content === 'string') {
+    return result;
+  }
+  const bytes = result.content instanceof ArrayBuffer
+    ? new Uint8Array(result.content)
+    : ArrayBuffer.isView(result.content)
+      ? new Uint8Array(
+          result.content.buffer,
+          result.content.byteOffset,
+          result.content.byteLength
+        )
+      : null;
+  if (!bytes) return result;
+  recordSessionLifecycleEvent('result-binary-decode-start', {
+    resultIndex,
+    bytes: bytes.byteLength
+  });
+  const content = new TextDecoder().decode(bytes);
+  recordStructuralMetric('resultBinaryDecodeCount', 1, { resultIndex });
+  recordStructuralMetric('resultBinaryDecodedBytes', bytes.byteLength, { resultIndex });
+  recordSessionLifecycleEvent('result-binary-decode-end', {
+    resultIndex,
+    bytes: bytes.byteLength,
+    characters: content.length
+  });
+  return { ...result, content };
+};
+
+const decodeGenerationResults = (results) => (
+  Array.isArray(results)
+    ? results.map(decodeGenerationResultContent)
+    : results
+);
+
+const decodeGenerationMetadata = (metadata) => {
+  const bytes = metadata instanceof ArrayBuffer
+    ? new Uint8Array(metadata)
+    : ArrayBuffer.isView(metadata)
+      ? new Uint8Array(metadata.buffer, metadata.byteOffset, metadata.byteLength)
+      : null;
+  if (!bytes) return metadata;
+  recordSessionLifecycleEvent('result-metadata-binary-decode-start', {
+    bytes: bytes.byteLength
+  });
+  const decoded = JSON.parse(new TextDecoder().decode(bytes));
+  recordStructuralMetric('resultMetadataBinaryDecodeCount');
+  recordStructuralMetric('resultMetadataBinaryDecodedBytes', bytes.byteLength);
+  recordSessionLifecycleEvent('result-metadata-binary-decode-end', {
+    bytes: bytes.byteLength
+  });
+  return decoded;
+};
+
 export const normalizeGenerationResponse = (payload) => {
   if (Array.isArray(payload)) {
-    return { results: payload, metadata: {} };
+    return { results: decodeGenerationResults(payload), metadata: {} };
   }
   if (!payload || typeof payload !== 'object') {
     return { results: [], metadata: {} };
@@ -30,13 +89,16 @@ export const normalizeGenerationResponse = (payload) => {
   if (payload.error) {
     return { results: payload, metadata: {} };
   }
-  const results = Array.isArray(payload.results) ? payload.results : [];
+  const results = Array.isArray(payload.results)
+    ? decodeGenerationResults(payload.results)
+    : [];
+  const decodedMetadata = decodeGenerationMetadata(payload.metadata);
   const metadata = (
-    payload.metadata &&
-    typeof payload.metadata === 'object' &&
-    !Array.isArray(payload.metadata)
+    decodedMetadata &&
+    typeof decodedMetadata === 'object' &&
+    !Array.isArray(decodedMetadata)
   )
-    ? payload.metadata
+    ? decodedMetadata
     : {};
   return { results, metadata };
 };
@@ -51,6 +113,7 @@ let activeRequest = null;
 const activeFeatureRequests = new Set();
 const activeHelperRequests = new Set();
 let nextRequestId = 1;
+const resourceTransport = createDiagramResourceTransport();
 
 const diagramHelperOperationNames = new Set(DIAGRAM_HELPER_OPERATION_NAMES);
 
@@ -122,6 +185,7 @@ const terminateWorker = (error = null) => {
   }
   workerInitialized = false;
   workerCapabilities = null;
+  resourceTransport.reset();
 };
 
 const ensureWorkerInitialized = () => {
@@ -191,7 +255,10 @@ export const getDiagramGenerationWorkerCapabilities = () => workerCapabilities;
 
 const collectTransferList = (payload) => {
   const buffers = new Set();
-  (payload?.files || []).forEach((file) => {
+  [
+    ...(payload?.files || []),
+    ...(payload?.stagedResources || [])
+  ].forEach((file) => {
     if (file?.bytes instanceof ArrayBuffer) {
       buffers.add(file.bytes);
     }
@@ -234,6 +301,13 @@ export const runDiagramGeneration = (payload = {}) => {
     try {
       const currentWorker = await ensureWorkerInitialized();
       if (request.settled || activeRequest !== request) return;
+      const preparedResources = await resourceTransport.prepare(payload);
+      if (request.settled || activeRequest !== request) return;
+      const workerPayload = {
+        request: payload.request,
+        resourceManifest: preparedResources.resourceManifest,
+        stagedResources: preparedResources.stagedResources
+      };
 
       const cleanup = () => {
         currentWorker.removeEventListener('message', handleMessage);
@@ -245,38 +319,58 @@ export const runDiagramGeneration = (payload = {}) => {
         settleActiveRequest(request, () => rejectRequest(error));
       };
 
+      const failWorker = (error) => {
+        fail(error);
+        if (worker === currentWorker) terminateWorker(error);
+      };
+
       function handleMessage(event) {
         const data = event.data || {};
+        if (data.type === 'test-lifecycle' && data.requestId === requestId) {
+          recordSessionLifecycleEvent(data.event?.name, data.event);
+          return;
+        }
         if (data.type !== 'run' || data.requestId !== requestId) return;
         if (data.ok) {
+          let normalized;
+          try {
+            normalized = normalizeGenerationResponse(data.results);
+          } catch (error) {
+            failWorker(error);
+            return;
+          }
+          preparedResources.commit();
           settleActiveRequest(request, () => {
-            resolveRequest({ requestId, ...normalizeGenerationResponse(data.results) });
+            resolveRequest({ requestId, ...normalized });
           });
           return;
         }
-        fail(deserializeWorkerError(data.error, 'Diagram generation failed'));
+        failWorker(deserializeWorkerError(data.error, 'Diagram generation failed'));
       }
 
       function handleError(event) {
-        fail(new Error(event.message || 'Diagram generation worker error'));
+        failWorker(new Error(event.message || 'Diagram generation worker error'));
       }
 
       function handleMessageError() {
-        fail(new Error('Diagram generation worker message could not be decoded'));
+        failWorker(new Error('Diagram generation worker message could not be decoded'));
       }
 
       request.cleanup = cleanup;
       currentWorker.addEventListener('message', handleMessage);
       currentWorker.addEventListener('error', handleError);
       currentWorker.addEventListener('messageerror', handleMessageError);
+      recordSessionLifecycleEvent('worker-post-start', { requestId });
       currentWorker.postMessage(
         {
           type: 'run',
           requestId,
-          payload
+          payload: workerPayload,
+          testLifecycleEnabled: runtimeTestHooksEnabled()
         },
-        collectTransferList(payload)
+        collectTransferList(workerPayload)
       );
+      recordSessionLifecycleEvent('worker-post-end', { requestId });
     } catch (error) {
       if (request.settled || activeRequest !== request) return;
       settleActiveRequest(request, () => rejectRequest(error));

--- a/gbdraw/web/js/services/diagram-resource-staging.js
+++ b/gbdraw/web/js/services/diagram-resource-staging.js
@@ -1,0 +1,150 @@
+import { collectCanonicalResourceIds } from './canonical-resource-references.js';
+import { decodeDepthText, isEncodedDepthFileEntry } from './depth-file-codec.js';
+import { takeFileBytesForTransfer } from './file-content-cache.js';
+import { getResourcePayloadOwner } from './resource-payload-owner.js';
+import {
+  recordSessionLifecycleEvent,
+  recordStructuralMetric
+} from './runtime-test-hooks.js';
+
+const BASE64_CHUNK_CHARACTERS = 1024 * 1024;
+
+const decodeBase64ForTransfer = (encoded, declaredSize, resourceId) => {
+  const source = String(encoded || '');
+  if (source.length % 4 !== 0 || /\s/.test(source)) {
+    throw new Error(`Canonical resource ${resourceId} contains invalid base64 data.`);
+  }
+  const bytes = new Uint8Array(declaredSize);
+  let byteOffset = 0;
+  for (let offset = 0; offset < source.length; offset += BASE64_CHUNK_CHARACTERS) {
+    const chunk = atob(source.slice(offset, offset + BASE64_CHUNK_CHARACTERS));
+    if (byteOffset + chunk.length > bytes.byteLength) {
+      throw new Error(`Canonical resource ${resourceId} exceeds its declared byte size.`);
+    }
+    for (let index = 0; index < chunk.length; index += 1) {
+      bytes[byteOffset + index] = chunk.charCodeAt(index);
+    }
+    byteOffset += chunk.length;
+  }
+  if (byteOffset !== declaredSize) {
+    throw new Error(`Canonical resource ${resourceId} byte size does not match its descriptor.`);
+  }
+  return bytes.buffer;
+};
+
+const validateResourceDescriptor = (resourceId, descriptor) => {
+  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+    throw new Error(`Canonical render resource ${resourceId} must be an object.`);
+  }
+  if (!Number.isSafeInteger(descriptor.size) || descriptor.size < 0) {
+    throw new Error(`Canonical render resource ${resourceId} has an invalid byte size.`);
+  }
+  if (
+    descriptor.encoding !== 'base64'
+    && !isEncodedDepthFileEntry(descriptor)
+  ) {
+    throw new Error(`Canonical render resource ${resourceId} has an unsupported encoding.`);
+  }
+  return descriptor;
+};
+
+const descriptorTransferBuffer = async (resourceId, descriptor, owner) => {
+  if (owner && owner !== descriptor) {
+    return takeFileBytesForTransfer(owner);
+  }
+  if (isEncodedDepthFileEntry(descriptor)) {
+    const bytes = new TextEncoder().encode(decodeDepthText(descriptor.data));
+    recordStructuralMetric('decodedByteCount', bytes.byteLength, { resourceId });
+    return bytes.buffer;
+  }
+  recordStructuralMetric('base64DecodeCount', 1, { resourceId });
+  const buffer = decodeBase64ForTransfer(descriptor.data, descriptor.size, resourceId);
+  recordStructuralMetric('decodedByteCount', buffer.byteLength, { resourceId });
+  return buffer;
+};
+
+export const createDiagramResourceTransport = () => {
+  let cachedResources = new Map();
+  let nextCacheToken = 1;
+
+  const reset = () => {
+    cachedResources = new Map();
+    nextCacheToken = 1;
+  };
+
+  const prepare = async ({ request, resources } = {}) => {
+    const referencedIds = Array.from(collectCanonicalResourceIds(request));
+    const resourceManifest = [];
+    const stagedResources = [];
+    const nextCachedResources = new Map();
+    let referencedDeclaredBytes = 0;
+    let bytesTransferred = 0;
+    let materializationCount = 0;
+
+    recordSessionLifecycleEvent('resource-stage-start', {
+      referencedResourceCount: referencedIds.length
+    });
+    for (const resourceId of referencedIds) {
+      const descriptor = validateResourceDescriptor(resourceId, resources?.[resourceId]);
+      const owner = getResourcePayloadOwner(descriptor);
+      const payloadIdentity = owner === descriptor ? descriptor.data : owner;
+      const previous = cachedResources.get(resourceId);
+      const cacheHit = Boolean(
+        previous
+        && previous.owner === owner
+        && previous.payloadIdentity === payloadIdentity
+        && previous.size === descriptor.size
+      );
+      const cacheToken = cacheHit
+        ? previous.cacheToken
+        : `render-resource-${nextCacheToken++}`;
+      referencedDeclaredBytes += descriptor.size;
+      resourceManifest.push({
+        resourceId,
+        cacheToken,
+        name: String(descriptor.name || `${resourceId}.bin`),
+        kind: String(descriptor.kind || 'web-file'),
+        type: String(descriptor.type || 'application/octet-stream'),
+        size: descriptor.size,
+        lastModified: Number(descriptor.lastModified) || 0
+      });
+      nextCachedResources.set(resourceId, {
+        cacheToken,
+        owner,
+        payloadIdentity,
+        size: descriptor.size
+      });
+      if (cacheHit) {
+        recordStructuralMetric('workerResourceCacheHitCount', 1, { resourceId });
+        continue;
+      }
+
+      const bytes = await descriptorTransferBuffer(resourceId, descriptor, owner);
+      if (!(bytes instanceof ArrayBuffer) || bytes.byteLength !== descriptor.size) {
+        throw new Error(`Canonical render resource ${resourceId} byte size does not match.`);
+      }
+      materializationCount += 1;
+      bytesTransferred += bytes.byteLength;
+      recordStructuralMetric('resourceMaterializationCount', 1, { resourceId });
+      recordStructuralMetric('transferredResourceBytes', bytes.byteLength, { resourceId });
+      stagedResources.push({ resourceId, cacheToken, bytes });
+    }
+    recordSessionLifecycleEvent('resource-stage-end', {
+      referencedResourceCount: referencedIds.length,
+      referencedDeclaredBytes,
+      bytesTransferred,
+      materializationCount
+    });
+
+    return {
+      resourceManifest,
+      stagedResources,
+      nextCachedResources,
+      commit() {
+        cachedResources = nextCachedResources;
+      }
+    };
+  };
+
+  return { prepare, reset };
+};

--- a/gbdraw/web/js/services/feature-catalog.js
+++ b/gbdraw/web/js/services/feature-catalog.js
@@ -7,6 +7,7 @@ const FEATURE_CATALOG_RELOAD_MESSAGE =
   'The diagram engine returned incompatible feature metadata. Reload the page and Generate again.';
 
 export const FEATURE_CATALOG_SCHEMA = 3;
+const adoptedFeatureCatalogs = new WeakSet();
 
 const isObject = (value) => (
   value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -334,19 +335,24 @@ const validateCatalogItem = (item, result, resultIndex) => {
   requireArray(item.annotations);
 };
 
-export const validateFeatureCatalog = (catalog, results) => {
+export const validateFeatureCatalog = (catalog, results, { adopt = false } = {}) => {
   const logicalResults = requireArray(results);
   if (!isObject(catalog) || catalog.schema !== FEATURE_CATALOG_SCHEMA) {
     throw catalogError();
   }
-  const validated = cloneJson(catalog);
+  const validated = adopt ? catalog : cloneJson(catalog);
   const items = requireArray(validated.items);
   if (items.length !== logicalResults.length) throw catalogError();
   items.forEach((item, resultIndex) => {
     validateCatalogItem(item, logicalResults[resultIndex], resultIndex);
   });
+  if (adopt) adoptedFeatureCatalogs.add(validated);
   return validated;
 };
+
+export const isAdoptedFeatureCatalog = (catalog) => (
+  Boolean(catalog) && adoptedFeatureCatalogs.has(catalog)
+);
 
 const selectorForFeature = (feature, stableId) => {
   if (isObject(feature.selector)) return cloneJson(feature.selector);

--- a/gbdraw/web/js/services/file-content-cache.js
+++ b/gbdraw/web/js/services/file-content-cache.js
@@ -1,5 +1,6 @@
 import {
   isSessionResourceFileView,
+  releaseSessionResourceContent,
   readSessionResourceBytes,
   readSessionResourceText,
   sessionResourceSource
@@ -71,6 +72,24 @@ export const readFileText = async (file) => {
 };
 
 export const getSessionResourceSource = (file) => sessionResourceSource(file);
+
+export const releaseFileContentCache = (file) => {
+  const key = asCacheKey(file);
+  if (!key) return false;
+  const deleted = fileByteCache.delete(key);
+  return releaseSessionResourceContent(file) || deleted;
+};
+
+export const takeFileBytesForTransfer = async (file) => {
+  const bytes = await readFileBytes(file);
+  const buffer = (
+    bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+      ? bytes.buffer
+      : bytes.slice().buffer
+  );
+  releaseFileContentCache(file);
+  return buffer;
+};
 
 export const cloneFileBytesForTransfer = async (file) => {
   const bytes = await readFileBytes(file);

--- a/gbdraw/web/js/services/file-content-cache.js
+++ b/gbdraw/web/js/services/file-content-cache.js
@@ -1,5 +1,12 @@
 const fileByteCache = new WeakMap();
 
+import {
+  isSessionResourceFileView,
+  readSessionResourceBytes,
+  readSessionResourceText,
+  sessionResourceSource
+} from './session-resource-backing.js';
+
 const asBytes = (value) => (
   value instanceof Uint8Array ? value : new Uint8Array(value || [])
 );
@@ -10,25 +17,40 @@ const asCacheKey = (file) => (
 
 export const readFileBytes = async (file) => {
   const key = asCacheKey(file);
-  if (!key || typeof file.arrayBuffer !== 'function') {
+  const lazyBytes = key && isSessionResourceFileView(file)
+    ? readSessionResourceBytes(file)
+    : null;
+  if (!key || (!lazyBytes && typeof file.arrayBuffer !== 'function')) {
     throw new TypeError('A File-like object with arrayBuffer() is required.');
   }
   let pending = fileByteCache.get(key);
   if (!pending) {
     pending = Promise.resolve()
-      .then(() => file.arrayBuffer())
+      .then(() => lazyBytes || file.arrayBuffer())
       .then((buffer) => new Uint8Array(buffer));
     fileByteCache.set(key, pending);
-    pending.catch(() => {
-      if (fileByteCache.get(key) === pending) fileByteCache.delete(key);
-    });
+    if (!lazyBytes) {
+      pending.catch(() => {
+        if (fileByteCache.get(key) === pending) fileByteCache.delete(key);
+      });
+    }
   }
   return pending;
 };
 
-export const readFileText = async (file) => (
-  bytesToText(await readFileBytes(file))
-);
+export const readFileText = async (file) => {
+  const lazyText = isSessionResourceFileView(file)
+    ? readSessionResourceText(file)
+    : null;
+  if (lazyText) return lazyText;
+  if (typeof file?.arrayBuffer === 'function') {
+    return bytesToText(await readFileBytes(file));
+  }
+  if (typeof file?.text === 'function') return file.text();
+  throw new TypeError('A File-like object with arrayBuffer() or text() is required.');
+};
+
+export const getSessionResourceSource = (file) => sessionResourceSource(file);
 
 export const cloneFileBytesForTransfer = async (file) => {
   const bytes = await readFileBytes(file);

--- a/gbdraw/web/js/services/file-content-cache.js
+++ b/gbdraw/web/js/services/file-content-cache.js
@@ -1,41 +1,61 @@
-const fileByteCache = new WeakMap();
-
 import {
   isSessionResourceFileView,
   readSessionResourceBytes,
   readSessionResourceText,
   sessionResourceSource
 } from './session-resource-backing.js';
+import {
+  asBytes,
+  base64ToBytes,
+  bytesToBase64,
+  bytesToText,
+  sha256Hex,
+  textToBase64,
+  textToBytes
+} from './byte-utils.js';
 
-const asBytes = (value) => (
-  value instanceof Uint8Array ? value : new Uint8Array(value || [])
-);
+export {
+  base64ToBytes,
+  bytesToBase64,
+  bytesToText,
+  sha256Hex,
+  textToBase64,
+  textToBytes
+};
+
+const fileByteCache = new WeakMap();
 
 const asCacheKey = (file) => (
   file && (typeof file === 'object' || typeof file === 'function') ? file : null
 );
 
-export const readFileBytes = async (file) => {
-  const key = asCacheKey(file);
-  const lazyBytes = key && isSessionResourceFileView(file)
-    ? readSessionResourceBytes(file)
-    : null;
-  if (!key || (!lazyBytes && typeof file.arrayBuffer !== 'function')) {
-    throw new TypeError('A File-like object with arrayBuffer() is required.');
-  }
-  let pending = fileByteCache.get(key);
-  if (!pending) {
-    pending = Promise.resolve()
-      .then(() => lazyBytes || file.arrayBuffer())
-      .then((buffer) => new Uint8Array(buffer));
-    fileByteCache.set(key, pending);
-    if (!lazyBytes) {
-      pending.catch(() => {
-        if (fileByteCache.get(key) === pending) fileByteCache.delete(key);
-      });
+export const readFileBytes = (file) => {
+  try {
+    const key = asCacheKey(file);
+    const lazyBytes = key && isSessionResourceFileView(file)
+      ? readSessionResourceBytes(file)
+      : null;
+    if (!key || (!lazyBytes && typeof file.arrayBuffer !== 'function')) {
+      return Promise.reject(new TypeError(
+        'A File-like object with arrayBuffer() is required.'
+      ));
     }
+    let pending = fileByteCache.get(key);
+    if (!pending) {
+      pending = lazyBytes || Promise.resolve()
+        .then(() => file.arrayBuffer())
+        .then(asBytes);
+      fileByteCache.set(key, pending);
+      if (!lazyBytes) {
+        pending.catch(() => {
+          if (fileByteCache.get(key) === pending) fileByteCache.delete(key);
+        });
+      }
+    }
+    return pending;
+  } catch (error) {
+    return Promise.reject(error);
   }
-  return pending;
 };
 
 export const readFileText = async (file) => {
@@ -55,38 +75,4 @@ export const getSessionResourceSource = (file) => sessionResourceSource(file);
 export const cloneFileBytesForTransfer = async (file) => {
   const bytes = await readFileBytes(file);
   return bytes.slice().buffer;
-};
-
-export const bytesToBase64 = (value) => {
-  const bytes = asBytes(value);
-  let binary = '';
-  const chunkSize = 0x8000;
-  for (let index = 0; index < bytes.length; index += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
-  }
-  return btoa(binary);
-};
-
-export const base64ToBytes = (value) => {
-  const binary = atob(String(value || ''));
-  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
-};
-
-export const textToBytes = (value) => new TextEncoder().encode(String(value));
-
-export const bytesToText = (value, options) => (
-  new TextDecoder('utf-8', options).decode(asBytes(value))
-);
-
-export const textToBase64 = (value) => bytesToBase64(textToBytes(value));
-
-export const sha256Hex = async (value) => {
-  if (!globalThis.crypto?.subtle) {
-    throw new Error('SHA-256 file identity requires Web Crypto.');
-  }
-  const bytes = asBytes(value);
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
 };

--- a/gbdraw/web/js/services/resource-payload-owner.js
+++ b/gbdraw/web/js/services/resource-payload-owner.js
@@ -1,0 +1,17 @@
+const payloadOwners = new WeakMap();
+
+const objectKey = (value) => (
+  value && (typeof value === 'object' || typeof value === 'function') ? value : null
+);
+
+export const setResourcePayloadOwner = (descriptor, owner) => {
+  const descriptorKey = objectKey(descriptor);
+  const ownerKey = objectKey(owner);
+  if (descriptorKey && ownerKey) payloadOwners.set(descriptorKey, ownerKey);
+  return descriptor;
+};
+
+export const getResourcePayloadOwner = (descriptor) => {
+  const key = objectKey(descriptor);
+  return (key && payloadOwners.get(key)) || key;
+};

--- a/gbdraw/web/js/services/runtime-test-hooks.js
+++ b/gbdraw/web/js/services/runtime-test-hooks.js
@@ -1,5 +1,7 @@
 const testHooks = () => globalThis.__GBDRAW_TEST_HOOKS__;
 
+export const runtimeTestHooksEnabled = () => Boolean(testHooks());
+
 export const recordStructuralMetric = (name, value = 1, detail = {}) => {
   const callback = testHooks()?.onStructuralMetric;
   if (typeof callback !== 'function') return;

--- a/gbdraw/web/js/services/runtime-test-hooks.js
+++ b/gbdraw/web/js/services/runtime-test-hooks.js
@@ -1,0 +1,21 @@
+const testHooks = () => globalThis.__GBDRAW_TEST_HOOKS__;
+
+export const recordStructuralMetric = (name, value = 1, detail = {}) => {
+  const callback = testHooks()?.onStructuralMetric;
+  if (typeof callback !== 'function') return;
+  callback({
+    name: String(name || ''),
+    value: Number(value) || 0,
+    ...(detail && typeof detail === 'object' ? detail : {})
+  });
+};
+
+export const recordSessionLifecycleEvent = (name, detail = {}) => {
+  const callback = testHooks()?.onSessionLifecycleEvent;
+  if (typeof callback !== 'function') return;
+  callback({
+    name: String(name || ''),
+    timestamp: globalThis.performance?.now?.() ?? Date.now(),
+    ...(detail && typeof detail === 'object' ? detail : {})
+  });
+};

--- a/gbdraw/web/js/services/session-authority.js
+++ b/gbdraw/web/js/services/session-authority.js
@@ -74,6 +74,9 @@ const isPlainObject = (value) => (
   value !== null && typeof value === 'object' && !Array.isArray(value)
 );
 
+const adoptedCurrentDocuments = new WeakSet();
+const adoptedCanonicalOwners = new WeakSet();
+
 const CURRENT_WRITER_FORBIDDEN_FEATURE_FIELDS = Object.freeze([
   'extractedFeatures',
   'biologicalFeatures',
@@ -369,6 +372,44 @@ export const validateSessionAuthorityInventory = (sessionData, version) => {
     throw new Error(`Session contains unclassified top-level field(s): ${unknown.join(', ')}`);
   }
 };
+
+export const adoptRuntimeCanonicalSession = (canonical) => {
+  if (
+    !isPlainObject(canonical)
+    || !isPlainObject(canonical.renderRequest)
+    || !isPlainObject(canonical.resources)
+    || (
+      canonical.webFiles !== undefined
+      && !isPlainObject(canonical.webFiles)
+    )
+  ) {
+    throw new Error('A canonical render request is required for adoptive ownership.');
+  }
+  adoptedCanonicalOwners.add(canonical);
+  return canonical;
+};
+
+export const adoptCurrentSessionDocument = (sessionData, currentVersion) => {
+  validateSessionAuthorityInventory(sessionData, currentVersion);
+  if (sessionData.version !== currentVersion) {
+    throw new Error('Only the current session schema can use adoptive ownership.');
+  }
+  const canonical = adoptRuntimeCanonicalSession({
+    renderRequest: sessionData.renderRequest,
+    resources: sessionData.resources,
+    webFiles: isPlainObject(sessionData.webFiles) ? sessionData.webFiles : {}
+  });
+  adoptedCurrentDocuments.add(sessionData);
+  return { document: sessionData, canonical };
+};
+
+export const isAdoptedCurrentSessionDocument = (value) => (
+  Boolean(value) && adoptedCurrentDocuments.has(value)
+);
+
+export const isAdoptedCanonicalSession = (value) => (
+  Boolean(value) && adoptedCanonicalOwners.has(value)
+);
 
 export const projectWebOnlyEditorMetadata = (sessionData) => ({
   ui: copyFields(sessionData?.ui, WEB_EDITOR_UI_FIELDS)

--- a/gbdraw/web/js/services/session-feature-metadata.js
+++ b/gbdraw/web/js/services/session-feature-metadata.js
@@ -98,6 +98,37 @@ export const addRenderedIdentity = (collection, identity) => {
   collection.totalRenderedCount = collection.renderedIds.size;
 };
 
+export const collectRenderedFeatureIdentitiesFromCatalogItem = (item) => {
+  const collection = createRenderedIdentityCollection();
+  const recordIndexByKey = new Map(
+    (Array.isArray(item?.recordKeys) ? item.recordKeys : []).map(
+      (recordKey, recordIndex) => [String(recordKey || '').trim(), recordIndex]
+    )
+  );
+  const biologicalByKey = new Map();
+  (Array.isArray(item?.biologicalFeatures) ? item.biologicalFeatures : []).forEach(
+    (feature) => {
+      const recordKey = String(feature?.recordKey || '').trim();
+      const featureId = String(feature?.biologicalFeatureId || '').trim();
+      if (recordKey && featureId) biologicalByKey.set(`${recordKey}\u0000${featureId}`, feature);
+    }
+  );
+  (Array.isArray(item?.features) ? item.features : []).forEach((feature) => {
+    const recordKey = String(feature?.recordKey || '').trim();
+    const featureId = String(feature?.biologicalFeatureId || '').trim();
+    const biological = biologicalByKey.get(`${recordKey}\u0000${featureId}`) || {};
+    const renderedId = String(feature?.svgId || '').trim();
+    addRenderedIdentity(collection, {
+      renderedId,
+      stableId: biological.stableFeatureId || featureId || renderedId,
+      recordIndex: recordIndexByKey.get(recordKey),
+      recordId: biological.record_id || biological.recordId || recordKey,
+      elementId: renderedId
+    });
+  });
+  return collection;
+};
+
 /**
  * Build feature identity metadata from the sanitized, detached ingress root.
  * This function never parses SVG text; the ingestion owner supplies the one root.

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -93,6 +93,11 @@ import {
   textToBase64,
   textToBytes
 } from './file-content-cache.js';
+import {
+  adoptedSessionResourceDescriptor,
+  createCombinedSessionResourceFileView,
+  createSessionResourceFileView
+} from './session-resource-backing.js';
 
 export const CANONICAL_REQUEST_SCHEMA = 5;
 const SUPPORTED_CANONICAL_REQUEST_SCHEMAS = new Set([
@@ -2015,29 +2020,35 @@ const resourceAsLegacyFile = (resources, resourceId) => {
   return file;
 };
 
-const webBindingAsLegacyFile = (resources, binding) => {
+const webBindingAsLegacyFile = (resources, binding, resolveResourceFile = null) => {
   if (binding === null || binding === undefined) return null;
   if (!binding || typeof binding !== 'object' || Array.isArray(binding)) {
     throw new Error('Web file bindings must be objects or null.');
   }
   const resourceId = String(binding.resourceId || '').trim();
   if (!resourceId) throw new Error('A Web file binding requires a resourceId.');
-  const file = resourceAsLegacyFile(resources, resourceId);
-  return {
-    ...file,
-    name: normalizeOriginalResourceName(binding.name) || file.name,
+  const metadata = {
+    name: normalizeOriginalResourceName(binding.name),
     type: String(binding.type || ''),
     lastModified: Number(binding.lastModified) || 0
   };
+  if (resolveResourceFile) return resolveResourceFile(resourceId, metadata);
+  const file = resourceAsLegacyFile(resources, resourceId);
+  return { ...file, ...metadata, name: metadata.name || file.name };
 };
 
-const webBindingValueAsLegacyFile = (resources, value) => (
+const webBindingValueAsLegacyFile = (resources, value, resolveResourceFile = null) => (
   Array.isArray(value)
-    ? value.map((item) => webBindingValueAsLegacyFile(resources, item))
-    : webBindingAsLegacyFile(resources, value)
+    ? value.map((item) => webBindingValueAsLegacyFile(resources, item, resolveResourceFile))
+    : webBindingAsLegacyFile(resources, value, resolveResourceFile)
 );
 
-const applyWebFileBindings = (files, webMetadata, resources) => {
+const applyWebFileBindings = (
+  files,
+  webMetadata,
+  resources,
+  { resolveResourceFile = null, adoptCanonicalPayloads = false } = {}
+) => {
   const bindings = webMetadata?.bindings;
   if (bindings === undefined || bindings === null) return files;
   if (!bindings || typeof bindings !== 'object' || Array.isArray(bindings)) {
@@ -2063,7 +2074,11 @@ const applyWebFileBindings = (files, webMetadata, resources) => {
     'qualifier_priority'
   ].forEach((field) => {
     if (!Object.prototype.hasOwnProperty.call(bindings, field)) return;
-    restored[field] = webBindingValueAsLegacyFile(resources, bindings[field]);
+    restored[field] = webBindingValueAsLegacyFile(
+      resources,
+      bindings[field],
+      resolveResourceFile
+    );
   });
   restored.c_conservation_blasts_source =
     bindings.c_conservation_blasts_source === 'losat-cache' ? 'losat-cache' : null;
@@ -2071,11 +2086,11 @@ const applyWebFileBindings = (files, webMetadata, resources) => {
   if (Array.isArray(bindings.linearSeqs)) {
     restored.linearSeqs = bindings.linearSeqs.map((sequence, index) => ({
       uid: String(sequence?.uid || `canonical-seq-${index + 1}`),
-      gb: webBindingValueAsLegacyFile(resources, sequence?.gb),
-      gff: webBindingValueAsLegacyFile(resources, sequence?.gff),
-      fasta: webBindingValueAsLegacyFile(resources, sequence?.fasta),
-      depth: webBindingValueAsLegacyFile(resources, sequence?.depth),
-      blast: webBindingValueAsLegacyFile(resources, sequence?.blast),
+      gb: webBindingValueAsLegacyFile(resources, sequence?.gb, resolveResourceFile),
+      gff: webBindingValueAsLegacyFile(resources, sequence?.gff, resolveResourceFile),
+      fasta: webBindingValueAsLegacyFile(resources, sequence?.fasta, resolveResourceFile),
+      depth: webBindingValueAsLegacyFile(resources, sequence?.depth, resolveResourceFile),
+      blast: webBindingValueAsLegacyFile(resources, sequence?.blast, resolveResourceFile),
       losat_gencode: optionalPositiveInteger(sequence?.losat_gencode) || 1,
       losat_filename: String(sequence?.losat_filename || ''),
       definition: String(sequence?.definition || ''),
@@ -2088,18 +2103,18 @@ const applyWebFileBindings = (files, webMetadata, resources) => {
   }
   if (Array.isArray(bindings.linearComparisons)) {
     restored.linearComparisons = bindings.linearComparisons.map((comparison, index) => ({
-      ...cloneCanonicalJsonValue(comparison),
+      ...(adoptCanonicalPayloads ? comparison : cloneCanonicalJsonValue(comparison)),
       id: String(comparison?.id || `linear-comparison-restored-${index + 1}`),
       queryUid: String(comparison?.queryUid || ''),
       subjectUid: String(comparison?.subjectUid || ''),
       source: String(comparison?.source || 'upload'),
-      file: webBindingValueAsLegacyFile(resources, comparison?.file)
+      file: webBindingValueAsLegacyFile(resources, comparison?.file, resolveResourceFile)
     }));
   }
   if (Array.isArray(bindings.linearCanonicalComparisons)) {
     restored.linearCanonicalComparisons = bindings.linearCanonicalComparisons.map((comparison) => ({
-      ...cloneCanonicalJsonValue(comparison),
-      file: webBindingValueAsLegacyFile(resources, comparison?.file)
+      ...(adoptCanonicalPayloads ? comparison : cloneCanonicalJsonValue(comparison)),
+      file: webBindingValueAsLegacyFile(resources, comparison?.file, resolveResourceFile)
     }));
   }
   return restored;
@@ -2109,7 +2124,10 @@ const cloneCanonicalJsonValue = (value) => (
   value === undefined ? undefined : JSON.parse(JSON.stringify(value))
 );
 
-const projectGeneratedProteinPipeline = (comparison) => {
+const projectGeneratedProteinPipeline = (
+  comparison,
+  { adoptCanonicalPayloads = false } = {}
+) => {
   if (
     !comparison ||
     comparison.kind !== 'generatedProteinComparison' ||
@@ -2121,7 +2139,9 @@ const projectGeneratedProteinPipeline = (comparison) => {
   const parameters = settings.collinearityParams?.parameters || {};
   const mode = String(comparison.mode || 'orthogroup');
   return {
-    generatedProteinComparison: cloneCanonicalJsonValue(comparison),
+    generatedProteinComparison: adoptCanonicalPayloads
+      ? comparison
+      : cloneCanonicalJsonValue(comparison),
     selectedOrthogroupAlignmentFeature:
       String(settings.alignOrthogroupFeature || '').trim(),
     config: {
@@ -2186,7 +2206,12 @@ const requireExactCanonicalFields = (value, required, fieldName) => {
   }
 };
 
-const canonicalDepthResourceFile = (ref, resources, fieldName) => {
+const canonicalDepthResourceFile = (
+  ref,
+  resources,
+  fieldName,
+  resolveResourceFile = null
+) => {
   if (!ref || typeof ref !== 'object' || Array.isArray(ref)) {
     throw new Error(`${fieldName} must be a canonical resource reference.`);
   }
@@ -2198,7 +2223,9 @@ const canonicalDepthResourceFile = (ref, resources, fieldName) => {
     throw new Error(`${fieldName}.resourceId must be a non-empty string.`);
   }
   const resourceId = ref.resourceId.trim();
-  return resourceAsLegacyFile(resources, resourceId);
+  return resolveResourceFile
+    ? resolveResourceFile(resourceId)
+    : resourceAsLegacyFile(resources, resourceId);
 };
 
 const canonicalDepthNumber = (value, fieldName) => {
@@ -2221,7 +2248,8 @@ const projectCanonicalDepthTracks = ({
   options,
   records,
   resources,
-  mode
+  mode,
+  resolveResourceFile = null
 }) => {
   const canonicalPresent = hasOptionValue(options.depthTracks);
   const legacyFields = LEGACY_DEPTH_OPTION_FIELDS.filter(
@@ -2280,7 +2308,8 @@ const projectCanonicalDepthTracks = ({
         : canonicalDepthResourceFile(
           ref,
           resources,
-          `${fieldName}.source${Array.isArray(track.source) ? `[${recordIndex}]` : ''}`
+          `${fieldName}.source${Array.isArray(track.source) ? `[${recordIndex}]` : ''}`,
+          resolveResourceFile
         );
     });
     if (mode === 'circular' && track.height !== null) {
@@ -2556,7 +2585,12 @@ const projectLegacyCanonicalCircularSlot = (slot) => {
   return migrateLegacyCircularTrackSlot(projected);
 };
 
-const combineCircularGenbankResources = (resources, records, originalName = '') => {
+const combineCircularGenbankResources = (
+  resources,
+  records,
+  originalName = '',
+  { resolveResourceFile = null, sessionResourceTable = null } = {}
+) => {
   const resourceIds = [];
   const seen = new Set();
   records.forEach((record) => {
@@ -2568,7 +2602,23 @@ const combineCircularGenbankResources = (resources, records, originalName = '') 
   });
   if (resourceIds.length === 0) return null;
 
-  const files = resourceIds.map((resourceId) => resourceAsLegacyFile(resources, resourceId));
+  if (sessionResourceTable) {
+    return createCombinedSessionResourceFileView(
+      sessionResourceTable,
+      resourceIds,
+      {
+        name: normalizeOriginalResourceName(originalName)
+          || 'canonical-circular-records.gb',
+        type: 'text/plain'
+      }
+    );
+  }
+
+  const files = resourceIds.map((resourceId) => (
+    resolveResourceFile
+      ? resolveResourceFile(resourceId)
+      : resourceAsLegacyFile(resources, resourceId)
+  ));
   if (files.length === 1) return files[0];
   const chunks = files.map((file) => {
     if (file.encoding && file.encoding !== 'base64') {
@@ -2720,7 +2770,10 @@ export const projectCanonicalSessionRequest = ({
   storedConfig = null,
   fileBindings = [],
   linearTrackSlotSchemaVersion = LINEAR_TRACK_SLOT_SCHEMA_VERSION,
-  repairInvalidComparisonHeight = false
+  repairInvalidComparisonHeight = false,
+  sessionResourceTable = null,
+  deferResourceContent = false,
+  adoptCanonicalPayloads = false
 }) => {
   if (!renderRequest || !SUPPORTED_CANONICAL_REQUEST_SCHEMAS.has(renderRequest.schema)) {
     throw new Error('Unsupported canonical renderRequest schema.');
@@ -2736,11 +2789,39 @@ export const projectCanonicalSessionRequest = ({
     ? webFiles
     : {};
   const storedResourceOriginalNames = webMetadata.resourceOriginalNames;
-  const resources = resourcesWithOriginalNames(canonicalResources, {
+  const originalNameHints = {
     ...legacyResourceOriginalNames({ renderRequest, legacyFiles, fileBindings }),
     ...(storedResourceOriginalNames && typeof storedResourceOriginalNames === 'object' &&
       !Array.isArray(storedResourceOriginalNames) ? storedResourceOriginalNames : {})
-  });
+  };
+  const resources = sessionResourceTable
+    ? canonicalResources
+    : resourcesWithOriginalNames(canonicalResources, originalNameHints);
+  const resolveResourceFile = sessionResourceTable
+    ? (resourceId, metadata = {}) => {
+        const descriptor = adoptedSessionResourceDescriptor(
+          sessionResourceTable,
+          resourceId
+        );
+        const storedName = normalizeOriginalResourceName(descriptor.name);
+        const prefix = `${resourceId}-`;
+        let inferredName = storedName;
+        while (inferredName.startsWith(prefix) && inferredName.length > prefix.length) {
+          inferredName = inferredName.slice(prefix.length);
+        }
+        const displayName = normalizeOriginalResourceName(metadata.name)
+          || normalizeOriginalResourceName(originalNameHints[resourceId])
+          || inferredName;
+        return createSessionResourceFileView(
+          sessionResourceTable,
+          resourceId,
+          {
+            ...metadata,
+            ...(displayName ? { name: displayName } : {})
+          }
+        );
+      }
+    : null;
   const legacyCircularInputBinding = (Array.isArray(fileBindings) ? fileBindings : [])
     .find((binding) => /^(?:files\.)?c_gb$/.test(String(binding?.slot || '')));
   const circularInputOriginalName = normalizeOriginalResourceName(
@@ -2763,7 +2844,8 @@ export const projectCanonicalSessionRequest = ({
   const projectedProteinPipeline = projectGeneratedProteinPipeline(
     (renderRequest.comparisons || []).find(
       (comparison) => comparison?.kind === 'generatedProteinComparison'
-    )
+    ),
+    { adoptCanonicalPayloads }
   );
   const comparisonsContainGeneratedProteinPipeline = (
     renderRequest.comparisons || []
@@ -2772,11 +2854,20 @@ export const projectCanonicalSessionRequest = ({
   if (renderRequest.mode === 'circular') {
     const source = records[0]?.source || {};
     if (source.kind === 'genbank') {
-      files.c_gb = combineCircularGenbankResources(resources, records, circularInputOriginalName);
+      files.c_gb = combineCircularGenbankResources(
+        resources,
+        records,
+        circularInputOriginalName,
+        { resolveResourceFile, sessionResourceTable }
+      );
     }
     if (source.kind === 'gffFasta') {
-      files.c_gff = resourceAsLegacyFile(resources, source.gffResourceId);
-      files.c_fasta = resourceAsLegacyFile(resources, source.fastaResourceId);
+      files.c_gff = resolveResourceFile
+        ? resolveResourceFile(source.gffResourceId)
+        : resourceAsLegacyFile(resources, source.gffResourceId);
+      files.c_fasta = resolveResourceFile
+        ? resolveResourceFile(source.fastaResourceId)
+        : resourceAsLegacyFile(resources, source.fastaResourceId);
     }
   } else {
     files.linearSeqs = records.map((record, index) => {
@@ -2787,9 +2878,21 @@ export const projectCanonicalSessionRequest = ({
         savedLinearRecordMetadata[index] || legacyLinearSequences[index] || {};
       return {
         uid: String(record.recordKey || `canonical-seq-${index + 1}`),
-        gb: source.kind === 'genbank' ? resourceAsLegacyFile(resources, source.resourceId) : null,
-        gff: source.kind === 'gffFasta' ? resourceAsLegacyFile(resources, source.gffResourceId) : null,
-        fasta: source.kind === 'gffFasta' ? resourceAsLegacyFile(resources, source.fastaResourceId) : null,
+        gb: source.kind === 'genbank'
+          ? (resolveResourceFile
+              ? resolveResourceFile(source.resourceId)
+              : resourceAsLegacyFile(resources, source.resourceId))
+          : null,
+        gff: source.kind === 'gffFasta'
+          ? (resolveResourceFile
+              ? resolveResourceFile(source.gffResourceId)
+              : resourceAsLegacyFile(resources, source.gffResourceId))
+          : null,
+        fasta: source.kind === 'gffFasta'
+          ? (resolveResourceFile
+              ? resolveResourceFile(source.fastaResourceId)
+              : resourceAsLegacyFile(resources, source.fastaResourceId))
+          : null,
         depth: null,
         blast: null,
         losat_gencode: optionalPositiveInteger(
@@ -2817,7 +2920,9 @@ export const projectCanonicalSessionRequest = ({
         const subjectIndex = Number.isInteger(Number(comparison.subjectRecordIndex))
           ? Number(comparison.subjectRecordIndex)
           : index + 1;
-        const file = resourceAsLegacyFile(resources, comparison.resourceId);
+        const file = resolveResourceFile
+          ? resolveResourceFile(comparison.resourceId)
+          : resourceAsLegacyFile(resources, comparison.resourceId);
         if (files.linearSeqs[queryIndex] && subjectIndex === queryIndex + 1) {
           files.linearSeqs[queryIndex].blast = file;
         }
@@ -2847,7 +2952,9 @@ export const projectCanonicalSessionRequest = ({
           {
             ...mapResourceBackedCanonicalComparison(
               comparison,
-              () => resourceAsLegacyFile(resources, comparison.resourceId)
+              () => resolveResourceFile
+                ? resolveResourceFile(comparison.resourceId)
+                : resourceAsLegacyFile(resources, comparison.resourceId)
             ),
             // This is in-memory projection provenance, not a canonical-schema
             // field. Direct CLI/Python comparison options have no Web pipeline
@@ -2863,7 +2970,7 @@ export const projectCanonicalSessionRequest = ({
       }
       if (comparison?.kind === 'generatedProteinComparison') {
         files.linearCanonicalComparisons.push(
-          cloneCanonicalJsonValue(comparison)
+          adoptCanonicalPayloads ? comparison : cloneCanonicalJsonValue(comparison)
         );
         (Array.isArray(comparison.pairs) ? comparison.pairs : [])
           .forEach((pair, index) => {
@@ -2888,7 +2995,8 @@ export const projectCanonicalSessionRequest = ({
     options,
     records,
     resources,
-    mode: renderRequest.mode
+    mode: renderRequest.mode,
+    resolveResourceFile
   });
   const projectedCircularSizeMode = renderRequest.mode === 'circular'
     ? (
@@ -2914,7 +3022,11 @@ export const projectCanonicalSessionRequest = ({
   if (renderRequest.mode === 'circular' && depthRows.length > 0) {
     files.c_depth = normalizeRecordMajorDepthFileRows(
       canonicalDepth?.fileRows || depthRows.map((row) => row.map((ref) => (
-        ref?.resourceId ? resourceAsLegacyFile(resources, ref.resourceId) : null
+        ref?.resourceId
+          ? (resolveResourceFile
+              ? resolveResourceFile(ref.resourceId)
+              : resourceAsLegacyFile(resources, ref.resourceId))
+          : null
       ))),
       records.length
     );
@@ -2923,47 +3035,81 @@ export const projectCanonicalSessionRequest = ({
     depthRows.forEach((row, index) => {
       if (!files.linearSeqs[index] || !Array.isArray(row)) return;
       const depth = canonicalDepth?.fileRows[index] || row
-        .map((ref) => ref?.resourceId ? resourceAsLegacyFile(resources, ref.resourceId) : null);
+        .map((ref) => ref?.resourceId
+          ? (resolveResourceFile
+              ? resolveResourceFile(ref.resourceId)
+              : resourceAsLegacyFile(resources, ref.resourceId))
+          : null);
       files.linearSeqs[index].depth = depth.length > 1 ? depth : (depth[0] || null);
     });
   }
   const defaultColorsRef = options.colors?.defaultColorsFile || options.colors?.defaultColors;
-  let projectedDefaultColors = {};
+  let projectedDefaultColors = deferResourceContent
+    && storedConfig?.colors
+    && typeof storedConfig.colors === 'object'
+    && !Array.isArray(storedConfig.colors)
+    ? storedConfig.colors
+    : {};
   if (defaultColorsRef?.resourceId) {
-    files.d_color = resourceAsLegacyFile(resources, defaultColorsRef.resourceId);
-    projectedDefaultColors = parseColorTable(
-      resourceTextFromRef(resources, defaultColorsRef)
-    ).colors;
+    files.d_color = resolveResourceFile
+      ? resolveResourceFile(defaultColorsRef.resourceId)
+      : resourceAsLegacyFile(resources, defaultColorsRef.resourceId);
+    if (!deferResourceContent) {
+      projectedDefaultColors = parseColorTable(
+        resourceTextFromRef(resources, defaultColorsRef)
+      ).colors;
+    }
   }
   const colorTableRef = options.colors?.colorTableFile || options.colors?.colorTable;
-  let projectedSpecificRules = [];
+  let projectedSpecificRules = deferResourceContent && Array.isArray(storedConfig?.rules)
+    ? storedConfig.rules
+    : [];
   if (colorTableRef?.resourceId) {
-    files.t_color = resourceAsLegacyFile(resources, colorTableRef.resourceId);
-    projectedSpecificRules = parseSpecificRules(
-      resourceTextFromRef(resources, colorTableRef)
-    ).rules.map(({ fromFile: _fromFile, ...rule }) => rule);
+    files.t_color = resolveResourceFile
+      ? resolveResourceFile(colorTableRef.resourceId)
+      : resourceAsLegacyFile(resources, colorTableRef.resourceId);
+    if (!deferResourceContent) {
+      projectedSpecificRules = parseSpecificRules(
+        resourceTextFromRef(resources, colorTableRef)
+      ).rules.map(({ fromFile: _fromFile, ...rule }) => rule);
+    }
   }
-  let projectedWhitelist = [];
+  let projectedWhitelist = deferResourceContent && Array.isArray(storedConfig?.whitelist)
+    ? storedConfig.whitelist
+    : [];
   if (options.labelWhitelistFile?.resourceId) {
-    files.whitelist = resourceAsLegacyFile(resources, options.labelWhitelistFile.resourceId);
-    projectedWhitelist = parseWhitelistRules(
-      resourceTextFromRef(resources, options.labelWhitelistFile)
-    ).rules;
+    files.whitelist = resolveResourceFile
+      ? resolveResourceFile(options.labelWhitelistFile.resourceId)
+      : resourceAsLegacyFile(resources, options.labelWhitelistFile.resourceId);
+    if (!deferResourceContent) {
+      projectedWhitelist = parseWhitelistRules(
+        resourceTextFromRef(resources, options.labelWhitelistFile)
+      ).rules;
+    }
   }
   const qualifierPriorityRef = options.qualifierPriorityFile || options.qualifierPriorityTable;
-  let projectedPriorityRules = [];
+  let projectedPriorityRules = deferResourceContent
+    && Array.isArray(storedConfig?.qualifierPriorityRules)
+    ? storedConfig.qualifierPriorityRules
+    : [];
   if (qualifierPriorityRef?.resourceId) {
-    files.qualifier_priority = resourceAsLegacyFile(resources, qualifierPriorityRef.resourceId);
-    projectedPriorityRules = parsePriorityRules(
-      resourceTextFromRef(resources, qualifierPriorityRef)
-    ).rules;
+    files.qualifier_priority = resolveResourceFile
+      ? resolveResourceFile(qualifierPriorityRef.resourceId)
+      : resourceAsLegacyFile(resources, qualifierPriorityRef.resourceId);
+    if (!deferResourceContent) {
+      projectedPriorityRules = parsePriorityRules(
+        resourceTextFromRef(resources, qualifierPriorityRef)
+      ).rules;
+    }
   }
-  const projectedFeatureVisibilityRules = options.featureVisibilityTableFile?.resourceId
+  const projectedFeatureVisibilityRules = !deferResourceContent
+    && options.featureVisibilityTableFile?.resourceId
     ? parseFeatureVisibilityRules(
         resourceTextFromRef(resources, options.featureVisibilityTableFile)
       ).rules
     : [];
-  const projectedLabelOverrideRows = options.labelOverrideFile?.resourceId
+  const projectedLabelOverrideRows = !deferResourceContent
+    && options.labelOverrideFile?.resourceId
     ? parseLabelOverrideTsv(resourceTextFromRef(resources, options.labelOverrideFile)).map((row) => ({
         recordId: row.recordId,
         featureType: row.featureType,
@@ -2974,7 +3120,11 @@ export const projectCanonicalSessionRequest = ({
     : [];
   if (renderRequest.mode === 'circular' && Array.isArray(options.conservationBlastFiles)) {
     files.c_conservation_blasts = options.conservationBlastFiles
-      .map((ref) => ref?.resourceId ? resourceAsLegacyFile(resources, ref.resourceId) : null)
+      .map((ref) => ref?.resourceId
+        ? (resolveResourceFile
+            ? resolveResourceFile(ref.resourceId)
+            : resourceAsLegacyFile(resources, ref.resourceId))
+        : null)
       .filter(Boolean);
     const storedConservationSource = String(
       storedConfig?.circularConservation?.source || ''
@@ -2988,14 +3138,22 @@ export const projectCanonicalSessionRequest = ({
   }
   if (renderRequest.mode === 'circular' && Array.isArray(options.conservationFastaFiles)) {
     files.c_conservation_sequence_sources = options.conservationFastaFiles.map((ref) => (
-      ref?.resourceId ? resourceAsLegacyFile(resources, ref.resourceId) : null
+      ref?.resourceId
+        ? (resolveResourceFile
+            ? resolveResourceFile(ref.resourceId)
+            : resourceAsLegacyFile(resources, ref.resourceId))
+        : null
     ));
   } else if (
     renderRequest.mode === 'circular'
     && Array.isArray(webMetadata.conservationSequenceSources)
   ) {
     files.c_conservation_sequence_sources = webMetadata.conservationSequenceSources.map(
-      (resourceId) => (resourceId ? resourceAsLegacyFile(resources, resourceId) : null)
+      (resourceId) => (resourceId
+        ? (resolveResourceFile
+            ? resolveResourceFile(resourceId)
+            : resourceAsLegacyFile(resources, resourceId))
+        : null)
     );
   }
   if (
@@ -3004,10 +3162,19 @@ export const projectCanonicalSessionRequest = ({
   ) {
     files.c_conservation_fastas = webMetadata.conservationLosatFastaSources
       .map((resourceId) => (
-        resourceId ? resourceAsLegacyFile(resources, resourceId) : null
+        resourceId
+          ? (resolveResourceFile
+              ? resolveResourceFile(resourceId)
+              : resourceAsLegacyFile(resources, resourceId))
+          : null
       ));
   }
-  Object.assign(files, applyWebFileBindings(files, webMetadata, resources));
+  Object.assign(files, applyWebFileBindings(
+    files,
+    webMetadata,
+    resources,
+    { resolveResourceFile, adoptCanonicalPayloads }
+  ));
   const explicitOverrides = Object.fromEntries(
     Object.entries(options.configOverrides || {}).filter(
       ([, value]) => value !== null && value !== undefined

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -98,6 +98,10 @@ import {
   createCombinedSessionResourceFileView,
   createSessionResourceFileView
 } from './session-resource-backing.js';
+import {
+  getResourcePayloadOwner,
+  setResourcePayloadOwner
+} from './resource-payload-owner.js';
 
 export const CANONICAL_REQUEST_SCHEMA = 5;
 const SUPPORTED_CANONICAL_REQUEST_SCHEMAS = new Set([
@@ -347,7 +351,7 @@ const createResourceBuilder = () => {
     const kindResourceIds = fileResourceIds.get(kind) || new WeakMap();
     const existingResourceId = kindResourceIds.get(entry);
     if (existingResourceId) return existingResourceId;
-    resources[resourceId] = {
+    const descriptor = {
       kind,
       name: normalizeResourceName(resourceId, entry.name),
       type: String(entry.type || 'application/octet-stream'),
@@ -356,6 +360,13 @@ const createResourceBuilder = () => {
       encoding: entry.encoding || 'base64',
       data: entry.data
     };
+    if (typeof entry.checksum === 'string' && entry.checksum.trim()) {
+      descriptor.checksum = entry.checksum;
+    }
+    resources[resourceId] = setResourcePayloadOwner(
+      descriptor,
+      getResourcePayloadOwner(entry)
+    );
     kindResourceIds.set(entry, resourceId);
     fileResourceIds.set(kind, kindResourceIds);
     const originalName = normalizeOriginalResourceName(entry.name);

--- a/gbdraw/web/js/services/session-resource-backing.js
+++ b/gbdraw/web/js/services/session-resource-backing.js
@@ -1,0 +1,271 @@
+import {
+  base64ToBytes,
+  bytesToText,
+  sha256Hex,
+  textToBytes
+} from './file-content-cache.js';
+import {
+  decodeDepthText,
+  isEncodedDepthFileEntry
+} from './depth-file-codec.js';
+import { recordStructuralMetric } from './runtime-test-hooks.js';
+
+const tableBackings = new WeakMap();
+const fileViewBackings = new WeakMap();
+
+const normalizedChecksum = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new Error('Session resource checksum must be a string.');
+  }
+  const normalized = value.trim().toLowerCase().replace(/^sha256:/, '');
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    throw new Error('Session resource checksum must be a SHA-256 digest.');
+  }
+  return normalized;
+};
+
+const validateDescriptor = (resourceId, descriptor) => {
+  if (!descriptor || typeof descriptor !== 'object' || Array.isArray(descriptor)) {
+    throw new Error(`Session resource ${resourceId} must be an object.`);
+  }
+  const supportedPayload = descriptor.encoding === 'base64'
+    ? typeof descriptor.data === 'string'
+    : isEncodedDepthFileEntry(descriptor);
+  if (!supportedPayload) {
+    throw new Error(`Session resource ${resourceId} has an unsupported encoded payload.`);
+  }
+  if (!Number.isSafeInteger(descriptor.size) || descriptor.size < 0) {
+    throw new Error(`Session resource ${resourceId} has an invalid declared byte size.`);
+  }
+  if (
+    descriptor.lastModified !== undefined
+    && (!Number.isFinite(descriptor.lastModified) || descriptor.lastModified < 0)
+  ) {
+    throw new Error(`Session resource ${resourceId} has an invalid lastModified value.`);
+  }
+  return {
+    descriptor,
+    resourceId,
+    kind: String(descriptor.kind || 'web-file'),
+    name: String(descriptor.name || 'file'),
+    type: String(descriptor.type || 'application/octet-stream'),
+    encoding: String(descriptor.encoding || ''),
+    size: descriptor.size,
+    lastModified: Number(descriptor.lastModified) || 0,
+    checksum: normalizedChecksum(descriptor.checksum),
+    bytesPromise: null,
+    textPromise: null,
+    filePromise: null,
+    dirty: false
+  };
+};
+
+const requireBacking = (table, resourceId) => {
+  const backings = table && tableBackings.get(table);
+  if (!backings) {
+    throw new TypeError('An adopted current-session resource table is required.');
+  }
+  const normalizedId = String(resourceId || '').trim();
+  const backing = backings.get(normalizedId);
+  if (!backing) throw new Error(`Missing canonical resource: ${normalizedId}`);
+  return backing;
+};
+
+const decodedResourceBytes = (backing) => {
+  if (isEncodedDepthFileEntry(backing.descriptor)) {
+    return textToBytes(decodeDepthText(backing.descriptor.data));
+  }
+  recordStructuralMetric('base64DecodeCount', 1, {
+    resourceId: backing.resourceId,
+    resourceName: backing.name
+  });
+  return base64ToBytes(backing.descriptor.data);
+};
+
+const materializeBytes = (backing) => {
+  if (!backing.bytesPromise) {
+    recordStructuralMetric('resourceByteReadCount', 1, {
+      resourceId: backing.resourceId,
+      resourceName: backing.name
+    });
+    backing.bytesPromise = Promise.resolve().then(async () => {
+      let bytes;
+      try {
+        bytes = decodedResourceBytes(backing);
+      } catch (error) {
+        throw new Error(
+          `Session resource ${backing.resourceId} (${backing.name}) contains invalid encoded data.`,
+          { cause: error }
+        );
+      }
+      recordStructuralMetric('decodedByteCount', bytes.byteLength, {
+        resourceId: backing.resourceId,
+        resourceName: backing.name
+      });
+      if (bytes.byteLength !== backing.size) {
+        throw new Error(
+          `Session resource ${backing.resourceId} (${backing.name}) byte size does not match its descriptor.`
+        );
+      }
+      if (backing.checksum) {
+        const actual = await sha256Hex(bytes);
+        if (actual !== backing.checksum) {
+          throw new Error(
+            `Session resource ${backing.resourceId} (${backing.name}) checksum does not match.`
+          );
+        }
+      }
+      return bytes;
+    });
+  }
+  return backing.bytesPromise;
+};
+
+const materializeText = (backing) => {
+  if (!backing.textPromise) {
+    recordStructuralMetric('resourceTextReadCount', 1, {
+      resourceId: backing.resourceId,
+      resourceName: backing.name
+    });
+    backing.textPromise = materializeBytes(backing).then((bytes) => bytesToText(bytes));
+  }
+  return backing.textPromise;
+};
+
+export const adoptCurrentSessionResources = (resources) => {
+  if (!resources || typeof resources !== 'object' || Array.isArray(resources)) {
+    throw new Error('Current session resources must be an object.');
+  }
+  const backings = new Map();
+  Object.entries(resources).forEach(([rawResourceId, descriptor]) => {
+    const resourceId = String(rawResourceId || '').trim();
+    if (!resourceId || backings.has(resourceId)) {
+      throw new Error('Current session resource IDs must be unique non-empty strings.');
+    }
+    backings.set(resourceId, validateDescriptor(resourceId, descriptor));
+  });
+  const table = Object.freeze({});
+  tableBackings.set(table, backings);
+  return table;
+};
+
+export const adoptedSessionResourceDescriptor = (table, resourceId) => (
+  requireBacking(table, resourceId).descriptor
+);
+
+export const createSessionResourceFileView = (table, resourceId, metadata = {}) => {
+  const backing = requireBacking(table, resourceId);
+  const view = Object.freeze({
+    name: String(metadata.name || backing.name),
+    type: metadata.type === undefined ? backing.type : String(metadata.type || ''),
+    size: backing.size,
+    lastModified: metadata.lastModified === undefined
+      ? backing.lastModified
+      : Number(metadata.lastModified) || 0
+  });
+  fileViewBackings.set(view, backing);
+  return view;
+};
+
+export const createCombinedSessionResourceFileView = (
+  table,
+  resourceIds,
+  metadata = {}
+) => {
+  const backings = (Array.isArray(resourceIds) ? resourceIds : [])
+    .map((resourceId) => requireBacking(table, resourceId));
+  if (backings.length === 0) return null;
+  if (backings.length === 1) {
+    return createSessionResourceFileView(table, backings[0].resourceId, metadata);
+  }
+  const composite = {
+    resourceId: backings.map(({ resourceId }) => resourceId).join('+'),
+    name: String(metadata.name || 'canonical-circular-records.gb'),
+    type: String(metadata.type || 'text/plain'),
+    size: backings.reduce((total, backing) => total + backing.size, 0)
+      + Math.max(0, backings.length - 1),
+    lastModified: metadata.lastModified === undefined
+      ? Math.max(0, ...backings.map((backing) => backing.lastModified))
+      : Number(metadata.lastModified) || 0,
+    checksum: null,
+    descriptor: null,
+    descriptors: backings.map((backing) => ({
+      resourceId: backing.resourceId,
+      descriptor: backing.descriptor
+    })),
+    bytesPromise: null,
+    textPromise: null,
+    filePromise: null,
+    dirty: false
+  };
+  const readParts = () => Promise.all(backings.map((backing) => materializeBytes(backing)))
+    .then((parts) => {
+      const lengths = parts.map((part) => (
+        part.byteLength > 0 && part[part.byteLength - 1] !== 0x0A
+          ? part.byteLength + 1
+          : part.byteLength
+      ));
+      const combined = new Uint8Array(lengths.reduce((total, length) => total + length, 0));
+      let offset = 0;
+      parts.forEach((part, index) => {
+        combined.set(part, offset);
+        offset += part.byteLength;
+        if (lengths[index] > part.byteLength) combined[offset++] = 0x0A;
+      });
+      return combined;
+    });
+  composite.readBytes = () => {
+    if (!composite.bytesPromise) composite.bytesPromise = readParts();
+    return composite.bytesPromise;
+  };
+  composite.readText = () => {
+    if (!composite.textPromise) {
+      recordStructuralMetric('resourceTextReadCount', 1, {
+        resourceId: composite.resourceId,
+        resourceName: composite.name
+      });
+      composite.textPromise = composite.readBytes().then((bytes) => bytesToText(bytes));
+    }
+    return composite.textPromise;
+  };
+  const view = Object.freeze({
+    name: composite.name,
+    type: composite.type,
+    size: composite.size,
+    lastModified: composite.lastModified
+  });
+  fileViewBackings.set(view, composite);
+  return view;
+};
+
+export const isSessionResourceFileView = (file) => Boolean(
+  file && (typeof file === 'object' || typeof file === 'function')
+  && fileViewBackings.has(file)
+);
+
+export const sessionResourceSource = (file) => {
+  const backing = fileViewBackings.get(file);
+  if (!backing || backing.dirty) return null;
+  if (Array.isArray(backing.descriptors)) {
+    return Object.freeze({ descriptors: backing.descriptors });
+  }
+  return Object.freeze({
+    resourceId: backing.resourceId,
+    descriptor: backing.descriptor
+  });
+};
+
+export const readSessionResourceBytes = (file) => {
+  const backing = fileViewBackings.get(file);
+  if (!backing) return null;
+  if (typeof backing.readBytes === 'function') return backing.readBytes();
+  return materializeBytes(backing);
+};
+
+export const readSessionResourceText = (file) => {
+  const backing = fileViewBackings.get(file);
+  if (!backing) return null;
+  if (typeof backing.readText === 'function') return backing.readText();
+  return materializeText(backing);
+};

--- a/gbdraw/web/js/services/session-resource-backing.js
+++ b/gbdraw/web/js/services/session-resource-backing.js
@@ -202,6 +202,7 @@ export const createCombinedSessionResourceFileView = (
       resourceId: backing.resourceId,
       descriptor: backing.descriptor
     })),
+    sourceBackings: backings,
     bytesPromise: null,
     textPromise: null,
     filePromise: null,
@@ -276,4 +277,17 @@ export const readSessionResourceText = (file) => {
   if (!backing) return null;
   if (typeof backing.readText === 'function') return backing.readText();
   return materializeText(backing);
+};
+
+export const releaseSessionResourceContent = (file) => {
+  const backing = fileViewBackings.get(file);
+  if (!backing) return false;
+  const releaseBacking = (candidate) => {
+    candidate.bytesPromise = null;
+    candidate.textPromise = null;
+    candidate.filePromise = null;
+    candidate.sourceBackings?.forEach(releaseBacking);
+  };
+  releaseBacking(backing);
+  return true;
 };

--- a/gbdraw/web/js/services/session-resource-backing.js
+++ b/gbdraw/web/js/services/session-resource-backing.js
@@ -1,9 +1,10 @@
 import {
+  base64DecodedLastByte,
   base64ToBytes,
   bytesToText,
   sha256Hex,
   textToBytes
-} from './file-content-cache.js';
+} from './byte-utils.js';
 import {
   decodeDepthText,
   isEncodedDepthFileEntry
@@ -12,6 +13,7 @@ import { recordStructuralMetric } from './runtime-test-hooks.js';
 
 const tableBackings = new WeakMap();
 const fileViewBackings = new WeakMap();
+const LF_BYTE = 0x0A;
 
 const normalizedChecksum = (value) => {
   if (value === null || value === undefined || value === '') return null;
@@ -179,12 +181,18 @@ export const createCombinedSessionResourceFileView = (
   if (backings.length === 1) {
     return createSessionResourceFileView(table, backings[0].resourceId, metadata);
   }
+  const appendedLineFeeds = backings.reduce((count, backing) => (
+    count + Number(
+      backing.size > 0
+      && base64DecodedLastByte(backing.descriptor.data, backing.size) !== LF_BYTE
+    )
+  ), 0);
   const composite = {
     resourceId: backings.map(({ resourceId }) => resourceId).join('+'),
     name: String(metadata.name || 'canonical-circular-records.gb'),
     type: String(metadata.type || 'text/plain'),
     size: backings.reduce((total, backing) => total + backing.size, 0)
-      + Math.max(0, backings.length - 1),
+      + appendedLineFeeds,
     lastModified: metadata.lastModified === undefined
       ? Math.max(0, ...backings.map((backing) => backing.lastModified))
       : Number(metadata.lastModified) || 0,
@@ -202,7 +210,7 @@ export const createCombinedSessionResourceFileView = (
   const readParts = () => Promise.all(backings.map((backing) => materializeBytes(backing)))
     .then((parts) => {
       const lengths = parts.map((part) => (
-        part.byteLength > 0 && part[part.byteLength - 1] !== 0x0A
+        part.byteLength > 0 && part[part.byteLength - 1] !== LF_BYTE
           ? part.byteLength + 1
           : part.byteLength
       ));
@@ -211,7 +219,7 @@ export const createCombinedSessionResourceFileView = (
       parts.forEach((part, index) => {
         combined.set(part, offset);
         offset += part.byteLength;
-        if (lengths[index] > part.byteLength) combined[offset++] = 0x0A;
+        if (lengths[index] > part.byteLength) combined[offset++] = LF_BYTE;
       });
       return combined;
     });

--- a/gbdraw/web/js/services/session-resources.js
+++ b/gbdraw/web/js/services/session-resources.js
@@ -12,6 +12,10 @@ import {
 } from './depth-file-codec.js';
 import { isAdoptedCanonicalSession } from './session-authority.js';
 import { recordStructuralMetric } from './runtime-test-hooks.js';
+import {
+  collectCanonicalResourceIds,
+  isCanonicalResourceReferenceField
+} from './canonical-resource-references.js';
 
 const resourceBytes = (entry) => {
   if (isEncodedDepthFileEntry(entry)) {
@@ -41,12 +45,6 @@ const bindingForFile = (file, resourceId) => ({
   lastModified: Number(file?.lastModified) || 0
 });
 
-const RESOURCE_REFERENCE_FIELDS = new Set([
-  'resourceId',
-  'gffResourceId',
-  'fastaResourceId'
-]);
-
 const rewriteResourceRefs = (value, aliases) => {
   if (Array.isArray(value)) {
     return value.map((item) => rewriteResourceRefs(item, aliases));
@@ -56,7 +54,7 @@ const rewriteResourceRefs = (value, aliases) => {
     Object.entries(value).map(([key, item]) => [
       key,
       (
-        RESOURCE_REFERENCE_FIELDS.has(key)
+        isCanonicalResourceReferenceField(key)
         && typeof item === 'string'
         && aliases.has(item)
       )
@@ -64,26 +62,6 @@ const rewriteResourceRefs = (value, aliases) => {
         : rewriteResourceRefs(item, aliases)
     ])
   );
-};
-
-const collectResourceRefs = (value, target = new Set()) => {
-  if (Array.isArray(value)) {
-    value.forEach((item) => collectResourceRefs(item, target));
-    return target;
-  }
-  if (!value || typeof value !== 'object') return target;
-  Object.entries(value).forEach(([key, item]) => {
-    if (
-      RESOURCE_REFERENCE_FIELDS.has(key)
-      && typeof item === 'string'
-      && item.trim()
-    ) {
-      target.add(item.trim());
-      return;
-    }
-    collectResourceRefs(item, target);
-  });
-  return target;
 };
 
 const rewriteOriginalNameHints = (webFiles, aliases) => {
@@ -207,7 +185,7 @@ export const buildSessionResources = async (state, committedRequest) => {
     });
   }
 
-  const committedResourceIds = collectResourceRefs(committedRequest.renderRequest);
+  const committedResourceIds = collectCanonicalResourceIds(committedRequest.renderRequest);
   for (const resourceId of committedResourceIds) {
     const entry = committedRequest.resources[resourceId];
     if (!entry) {

--- a/gbdraw/web/js/services/session-resources.js
+++ b/gbdraw/web/js/services/session-resources.js
@@ -1,6 +1,7 @@
 import {
   base64ToBytes,
   bytesToBase64,
+  getSessionResourceSource,
   readFileBytes,
   sha256Hex,
   textToBytes
@@ -9,6 +10,8 @@ import {
   decodeDepthText,
   isEncodedDepthFileEntry
 } from './depth-file-codec.js';
+import { isAdoptedCanonicalSession } from './session-authority.js';
+import { recordStructuralMetric } from './runtime-test-hooks.js';
 
 const resourceBytes = (entry) => {
   if (isEncodedDepthFileEntry(entry)) {
@@ -84,6 +87,19 @@ const collectResourceRefs = (value, target = new Set()) => {
 };
 
 const rewriteOriginalNameHints = (webFiles, aliases) => {
+  const identityAliases = [...aliases].every(([source, target]) => source === target);
+  if (identityAliases) {
+    const rewritten = { ...(webFiles || {}) };
+    delete rewritten.bindings;
+    if (Array.isArray(rewritten.linearRecordMetadata)) {
+      rewritten.linearRecordMetadata = rewritten.linearRecordMetadata.map((entry) => {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return entry;
+        const { losatFilename: _losatFilename, ...metadata } = entry;
+        return metadata;
+      });
+    }
+    return rewritten;
+  }
   const rewritten = rewriteResourceRefs(webFiles || {}, aliases);
   delete rewritten.bindings;
   const hints = webFiles?.resourceOriginalNames;
@@ -126,15 +142,52 @@ export const buildSessionResources = async (state, committedRequest) => {
   const resources = {};
   const aliases = new Map();
   const identityToResourceId = new Map();
+  const reuseEncodedResources = isAdoptedCanonicalSession(committedRequest);
   let nextResourceNumber = 1;
+
+  const nextResourceId = () => {
+    let resourceId;
+    do {
+      resourceId = `resource-${String(nextResourceNumber).padStart(4, '0')}`;
+      nextResourceNumber += 1;
+    } while (Object.prototype.hasOwnProperty.call(resources, resourceId));
+    return resourceId;
+  };
+
+  const adoptEncodedResource = (resourceId, descriptor) => {
+    const normalizedId = String(resourceId || '').trim();
+    if (!normalizedId || !descriptor) {
+      throw new Error('An adopted session resource requires an ID and descriptor.');
+    }
+    const existing = resources[normalizedId];
+    if (existing && existing !== descriptor) {
+      const samePayload = (
+        existing.encoding === descriptor.encoding
+        && existing.data === descriptor.data
+        && Number(existing.size) === Number(descriptor.size)
+      );
+      if (!samePayload) {
+        throw new Error(`Conflicting adopted session resource: ${normalizedId}.`);
+      }
+    }
+    resources[normalizedId] = descriptor;
+    aliases.set(normalizedId, normalizedId);
+    return normalizedId;
+  };
 
   const addBytes = async (bytes, metadata = {}) => {
     const identity = `${bytes.byteLength}:${await sha256Hex(bytes)}`;
     const existing = identityToResourceId.get(identity);
     if (existing) return existing;
 
-    const resourceId = `resource-${String(nextResourceNumber).padStart(4, '0')}`;
-    nextResourceNumber += 1;
+    recordStructuralMetric('base64EncodeCount', 1, {
+      resourceName: String(metadata.name || 'file')
+    });
+    recordStructuralMetric('encodedByteCount', bytes.byteLength, {
+      resourceName: String(metadata.name || 'file')
+    });
+    const encoded = bytesToBase64(bytes);
+    const resourceId = nextResourceId();
     identityToResourceId.set(identity, resourceId);
     resources[resourceId] = {
       kind: String(metadata.kind || 'web-file'),
@@ -143,10 +196,16 @@ export const buildSessionResources = async (state, committedRequest) => {
       size: bytes.byteLength,
       lastModified: Number(metadata.lastModified) || 0,
       encoding: 'base64',
-      data: bytesToBase64(bytes)
+      data: encoded
     };
     return resourceId;
   };
+
+  if (reuseEncodedResources) {
+    Object.entries(committedRequest.resources).forEach(([resourceId, descriptor]) => {
+      adoptEncodedResource(resourceId, descriptor);
+    });
+  }
 
   const committedResourceIds = collectResourceRefs(committedRequest.renderRequest);
   for (const resourceId of committedResourceIds) {
@@ -154,12 +213,25 @@ export const buildSessionResources = async (state, committedRequest) => {
     if (!entry) {
       throw new Error(`Committed render resource is missing: ${resourceId}.`);
     }
-    const nextId = await addBytes(resourceBytes(entry), entry);
+    const nextId = reuseEncodedResources
+      ? adoptEncodedResource(resourceId, entry)
+      : await addBytes(resourceBytes(entry), entry);
     aliases.set(resourceId, nextId);
   }
 
   const bindFile = async (file) => {
     if (!file) return null;
+    const source = getSessionResourceSource(file);
+    if (reuseEncodedResources && source?.resourceId && source?.descriptor) {
+      const resourceId = adoptEncodedResource(source.resourceId, source.descriptor);
+      return bindingForFile(file, resourceId);
+    }
+    if (reuseEncodedResources && Array.isArray(source?.descriptors)) {
+      source.descriptors.forEach(({ resourceId, descriptor }) => {
+        adoptEncodedResource(resourceId, descriptor);
+      });
+      return undefined;
+    }
     const bytes = await readFileBytes(file);
     const resourceId = await addBytes(bytes, {
       kind: 'web-file',
@@ -225,8 +297,12 @@ export const buildSessionResources = async (state, committedRequest) => {
     )
   };
 
+  const identityAliases = [...aliases].every(([source, target]) => source === target);
+
   return {
-    renderRequest: rewriteResourceRefs(committedRequest.renderRequest, aliases),
+    renderRequest: identityAliases
+      ? committedRequest.renderRequest
+      : rewriteResourceRefs(committedRequest.renderRequest, aliases),
     resources,
     webFiles: {
       ...rewriteOriginalNameHints(committedRequest.webFiles, aliases),

--- a/gbdraw/web/js/services/svg-result-ingestion.js
+++ b/gbdraw/web/js/services/svg-result-ingestion.js
@@ -1,7 +1,14 @@
 import { sanitizeSvgContent } from './svg-sanitization.js';
 import { serializeCleanSvg } from './svg-serialization.js';
-import { collectRenderedFeatureIdentitiesFromSvgRoot } from './session-feature-metadata.js';
+import {
+  collectRenderedFeatureIdentitiesFromCatalogItem,
+  collectRenderedFeatureIdentitiesFromSvgRoot
+} from './session-feature-metadata.js';
 import { normalizeSvgResultIds } from './svg-result-normalization.js';
+import {
+  recordSessionLifecycleEvent,
+  recordStructuralMetric
+} from './runtime-test-hooks.js';
 
 // This symbol is intentionally module-private. JSON/session data cannot reproduce it,
 // while ordinary in-memory Result object spreads retain the runtime ownership record.
@@ -40,6 +47,27 @@ const markCommitted = (result, metadata) => {
     metadata
   };
   return result;
+};
+
+const hasSanitizedSvgEnvelope = (content) => {
+  const withoutDeclaration = String(content || '')
+    .trim()
+    .replace(/^<\?xml[^>]*>\s*/i, '');
+  return /^<svg(?:\s|>)/i.test(withoutDeclaration);
+};
+
+const sanitizeSvgResultContent = (result, sanitizer, resultIndex) => {
+  recordSessionLifecycleEvent('result-svg-characters', {
+    resultIndex,
+    value: String(result.content || '').length
+  });
+  recordSessionLifecycleEvent('sanitize-start', { resultIndex });
+  const content = sanitizeSvgContent(result.content, sanitizer);
+  recordSessionLifecycleEvent('sanitize-end', {
+    resultIndex,
+    characters: content.length
+  });
+  return content;
 };
 
 export const isCommittedSvgResult = (result) => Boolean(committedState(result));
@@ -95,21 +123,35 @@ export const ingestSvgResult = (
     throw new Error('The diagram engine returned an invalid SVG Result.');
   }
 
-  const sanitized = sanitizeSvgContent(result.content, sanitizer);
+  const sanitized = sanitizeSvgResultContent(result, sanitizer, resultIndex);
+  recordSessionLifecycleEvent('detached-svg-parse-start', { resultIndex });
   const svg = parseSanitizedSvg(sanitized, parser);
+  recordSessionLifecycleEvent('detached-svg-parse-end', { resultIndex });
   if (typeof transformSvg === 'function') {
     transformSvg(svg, { result, resultIndex });
   }
   normalizeSvgResultIds(svg);
+  recordSessionLifecycleEvent('feature-identity-scan-start', { resultIndex });
   const metadata = Object.freeze({
     renderedFeatureIdentities: collectRenderedFeatureIdentitiesFromSvgRoot(svg)
   });
+  recordSessionLifecycleEvent('feature-identity-scan-end', {
+    resultIndex,
+    count: metadata.renderedFeatureIdentities.totalRenderedCount
+  });
+  recordSessionLifecycleEvent('serialize-clean-svg-start', { resultIndex });
   const content = serializeCleanSvg(svg);
+  recordSessionLifecycleEvent('serialize-clean-svg-end', {
+    resultIndex,
+    characters: content.length
+  });
 
-  return markCommitted({
+  const committed = markCommitted({
     ...result,
     content
   }, metadata);
+  recordSessionLifecycleEvent('result-commit', { resultIndex });
+  return committed;
 };
 
 export const ingestSvgResults = (results, options = {}) => {
@@ -121,4 +163,37 @@ export const ingestSvgResults = (results, options = {}) => {
       ? result
       : ingestSvgResult(result, { ...options, resultIndex })
   ));
+};
+
+export const ingestCatalogBackedSvgResults = (
+  results,
+  {
+    catalogItems = [],
+    sanitizer = globalThis.DOMPurify || globalThis.window?.DOMPurify
+  } = {}
+) => {
+  if (!Array.isArray(results)) {
+    throw new Error('The diagram engine returned an invalid Result list.');
+  }
+  return results.map((result, resultIndex) => {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) {
+      throw new Error('The diagram engine returned an invalid SVG Result.');
+    }
+    const content = sanitizeSvgResultContent(result, sanitizer, resultIndex);
+    if (!hasSanitizedSvgEnvelope(content)) {
+      throw new Error('The diagram engine returned malformed SVG content.');
+    }
+    const catalogItem = catalogItems[resultIndex];
+    if (!catalogItem) {
+      throw new Error('The validated feature catalog is incomplete.');
+    }
+    const renderedFeatureIdentities = collectRenderedFeatureIdentitiesFromCatalogItem(catalogItem);
+    recordStructuralMetric('catalogBackedSvgFastPathCount');
+    const committed = markCommitted({
+      ...result,
+      content
+    }, Object.freeze({ renderedFeatureIdentities }));
+    recordSessionLifecycleEvent('result-commit', { resultIndex });
+    return committed;
+  });
 };

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -41,6 +41,7 @@ const generationCancelRequested = ref(false);
 const errorLog = ref(null);
 const sessionTitle = ref('');
 const semanticFileWatchersSuppressed = ref(false);
+const sessionResourceDiscoveryDeferred = ref(false);
 const sessionImportRollbackInProgress = ref(false);
 
 const results = ref([]);
@@ -927,6 +928,7 @@ export const state = {
   errorLog,
   sessionTitle,
   semanticFileWatchersSuppressed,
+  sessionResourceDiscoveryDeferred,
   sessionImportRollbackInProgress,
   results,
   selectedResultIndex,

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -5,6 +5,37 @@ import { normalizeUserFacingError } from '../services/error-normalization.js';
 let runtimePromise = null;
 let runtime = null;
 let operationQueue = Promise.resolve();
+const RENDER_RESOURCE_CACHE = '/gbdraw-web-render-resource-cache';
+const RENDER_WORKSPACE_MARKER = '.gbdraw-worker-render-workspace';
+const RENDER_RESOURCE_ID_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const RENDER_RESOURCE_TOKEN_RE = /^render-resource-[1-9][0-9]*$/;
+const cachedRenderResources = new Map();
+
+const emitTestLifecycle = (enabled, requestId, name, detail = {}) => {
+  if (!enabled) return;
+  self.postMessage({
+    type: 'test-lifecycle',
+    requestId,
+    event: {
+      name,
+      timestamp: globalThis.performance?.now?.() ?? Date.now(),
+      ...detail
+    }
+  });
+};
+
+export const collectGenerationResultTransferList = (payload) => {
+  const buffers = new Set();
+  const addBuffer = (value) => {
+    if (value instanceof ArrayBuffer) buffers.add(value);
+    else if (ArrayBuffer.isView(value)) buffers.add(value.buffer);
+  };
+  (Array.isArray(payload?.results) ? payload.results : []).forEach((result) => {
+    addBuffer(result?.content);
+  });
+  addBuffer(payload?.metadata);
+  return Array.from(buffers);
+};
 
 export const serializeError = (error) => {
   const normalized = normalizeUserFacingError(error);
@@ -222,6 +253,124 @@ const stageHelperFiles = (pyodide, workspace, files, allowedRoles) => {
     paths.set(role, path);
   });
   return paths;
+};
+
+const ensureRenderResourceCache = (pyodide) => {
+  if (!pyodide.FS.analyzePath(RENDER_RESOURCE_CACHE).exists) {
+    pyodide.FS.mkdir(RENDER_RESOURCE_CACHE);
+  }
+};
+
+const stageRenderResources = async (
+  pyodide,
+  workspace,
+  resourceManifest,
+  stagedResources,
+  testLifecycleEnabled,
+  requestId
+) => {
+  if (!Array.isArray(resourceManifest) || !Array.isArray(stagedResources)) {
+    throw new TypeError('Diagram generation requires a staged resource manifest.');
+  }
+  ensureRenderResourceCache(pyodide);
+  const stagedById = new Map();
+  stagedResources.forEach((entry) => {
+    const resourceId = String(entry?.resourceId || '').trim();
+    if (!RENDER_RESOURCE_ID_RE.test(resourceId) || stagedById.has(resourceId)) {
+      throw new TypeError(`Invalid or duplicate staged render resource '${resourceId}'.`);
+    }
+    if (!RENDER_RESOURCE_TOKEN_RE.test(String(entry?.cacheToken || ''))) {
+      throw new TypeError(`Invalid cache token for staged render resource '${resourceId}'.`);
+    }
+    if (!(entry?.bytes instanceof ArrayBuffer)) {
+      throw new TypeError(`Staged render resource '${resourceId}' requires an ArrayBuffer.`);
+    }
+    stagedById.set(resourceId, entry);
+  });
+
+  const manifestIds = new Set();
+  const resourcePaths = {};
+  const resourcesDirectory = `${workspace}/resources`;
+  pyodide.FS.mkdir(workspace);
+  pyodide.FS.writeFile(`${workspace}/${RENDER_WORKSPACE_MARKER}`, new Uint8Array(0));
+  pyodide.FS.mkdir(resourcesDirectory);
+  for (let index = 0; index < resourceManifest.length; index += 1) {
+    const metadata = resourceManifest[index];
+    const resourceId = String(metadata?.resourceId || '').trim();
+    const cacheToken = String(metadata?.cacheToken || '');
+    const size = Number(metadata?.size);
+    if (!RENDER_RESOURCE_ID_RE.test(resourceId) || manifestIds.has(resourceId)) {
+      throw new TypeError(`Invalid or duplicate render resource '${resourceId}'.`);
+    }
+    if (!RENDER_RESOURCE_TOKEN_RE.test(cacheToken)) {
+      throw new TypeError(`Invalid cache token for render resource '${resourceId}'.`);
+    }
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new TypeError(`Invalid byte size for render resource '${resourceId}'.`);
+    }
+    manifestIds.add(resourceId);
+    let cached = cachedRenderResources.get(resourceId);
+    const staged = stagedById.get(resourceId);
+    if (staged) {
+      if (staged.cacheToken !== cacheToken || staged.bytes.byteLength !== size) {
+        throw new TypeError(`Staged render resource '${resourceId}' does not match its manifest.`);
+      }
+      emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-resource-stage-start', {
+        resourceId,
+        bytes: size
+      });
+      if (cached && pyodide.FS.analyzePath(cached.path).exists) {
+        pyodide.FS.unlink(cached.path);
+      }
+      const cachePath = `${RENDER_RESOURCE_CACHE}/${cacheToken}.bin`;
+      if (pyodide.FS.analyzePath(cachePath).exists) pyodide.FS.unlink(cachePath);
+      if (typeof pyodide.FS.createDataFile !== 'function') {
+        throw new Error('Pyodide render resource ownership transfer is unavailable.');
+      }
+      pyodide.FS.createDataFile(
+        RENDER_RESOURCE_CACHE,
+        `${cacheToken}.bin`,
+        new Uint8Array(staged.bytes),
+        true,
+        true,
+        true
+      );
+      cached = { cacheToken, path: cachePath, size };
+      cachedRenderResources.set(resourceId, cached);
+      staged.bytes = null;
+      stagedById.delete(resourceId);
+      emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-resource-stage-end', {
+        resourceId,
+        bytes: size
+      });
+    }
+    if (
+      !cached
+      || cached.cacheToken !== cacheToken
+      || cached.size !== size
+      || !pyodide.FS.analyzePath(cached.path).exists
+    ) {
+      throw new Error(`Render resource cache miss for '${resourceId}'.`);
+    }
+    const requestPath = `${resourcesDirectory}/${String(index + 1).padStart(4, '0')}.bin`;
+    if (typeof pyodide.FS.symlink !== 'function') {
+      throw new Error('Pyodide render resource symbolic links are unavailable.');
+    }
+    pyodide.FS.symlink(cached.path, requestPath);
+    resourcePaths[resourceId] = requestPath;
+  }
+  stagedById.forEach((_entry, resourceId) => {
+    if (!manifestIds.has(resourceId)) {
+      throw new TypeError(`Unexpected staged render resource '${resourceId}'.`);
+    }
+  });
+  cachedRenderResources.forEach((cached, resourceId) => {
+    if (manifestIds.has(resourceId)) return;
+    if (pyodide.FS.analyzePath(cached.path).exists) pyodide.FS.unlink(cached.path);
+    cachedRenderResources.delete(resourceId);
+  });
+  stagedResources.splice(0);
+  return resourcePaths;
 };
 
 const requireHelperFile = (paths, role, operation) => {
@@ -546,8 +695,10 @@ const runHelperOperation = async ({ operation, payload, requestId } = {}) => {
 
 const runGeneration = async ({
   request,
-  resources,
-  requestId
+  resourceManifest,
+  stagedResources,
+  requestId,
+  testLifecycleEnabled = false
 } = {}) => {
   if (!runtime?.pyodide) {
     throw new Error('Diagram generation worker has not been initialized.');
@@ -555,29 +706,73 @@ const runGeneration = async ({
   if (!request || typeof request !== 'object' || Array.isArray(request)) {
     throw new Error('Diagram generation requires a canonical typed request.');
   }
-  if (!resources || typeof resources !== 'object' || Array.isArray(resources)) {
-    throw new Error('Diagram generation requires canonical request resources.');
-  }
   const { pyodide } = runtime;
   const runWrapper = pyodide.globals.get('run_canonical_request_wrapper');
   const workspace = `/gbdraw-web-render-${Number(requestId) || 0}`;
   let result = null;
+  let resultHandle = null;
   let primaryError = null;
+  let pythonWrapperStarted = false;
   try {
-    const resultJson = runWrapper(
-      JSON.stringify(request),
-      JSON.stringify(resources),
+    const resourcePaths = await stageRenderResources(
+      pyodide,
+      workspace,
+      resourceManifest,
+      stagedResources,
+      testLifecycleEnabled,
+      requestId
+    );
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-request-json-start');
+    const requestJson = JSON.stringify(request);
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-request-json-end', {
+      characters: requestJson.length
+    });
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-resource-manifest-json-start');
+    const resourcePathsJson = JSON.stringify(resourcePaths);
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-resource-manifest-json-end', {
+      characters: resourcePathsJson.length
+    });
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'python-wrapper-start');
+    pythonWrapperStarted = true;
+    resultHandle = runWrapper(
+      requestJson,
+      resourcePathsJson,
       workspace
     );
-    result = JSON.parse(String(resultJson || 'null'));
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'python-wrapper-end');
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'result-object-conversion-start');
+    result = typeof resultHandle?.toJs === 'function'
+      ? resultHandle.toJs({ dict_converter: Object.fromEntries })
+      : resultHandle;
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'result-object-conversion-end');
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'result-transport-ready', {
+      transport: 'transferable-binary',
+      bytes: collectGenerationResultTransferList(result).reduce(
+        (total, buffer) => total + buffer.byteLength,
+        0
+      )
+    });
   } catch (error) {
     primaryError = error;
   }
   let destroyError = null;
   try {
-    runWrapper.destroy?.();
+    resultHandle?.destroy?.();
   } catch (error) {
     destroyError = error;
+  }
+  try {
+    runWrapper.destroy?.();
+  } catch (error) {
+    if (destroyError) {
+      attachCleanupDiagnostic(
+        destroyError,
+        error,
+        'Additional temporary render handle cleanup also failed'
+      );
+    } else {
+      destroyError = error;
+    }
   }
   let workspaceError = null;
   try {
@@ -586,7 +781,9 @@ const runGeneration = async ({
       remainingEntries = pyodide.FS.readdir(workspace).filter(
         (entry) => entry !== '.' && entry !== '..'
       );
-      if (remainingEntries.length === 0) {
+      if (!pythonWrapperStarted) {
+        removeWorkspace(pyodide, workspace);
+      } else if (remainingEntries.length === 0) {
         // Pyodide's MEMFS can retain the now-empty top-level directory after
         // Python shutil.rmtree has removed its contents.
         pyodide.FS.rmdir(workspace);
@@ -599,6 +796,11 @@ const runGeneration = async ({
           ? ` (${remainingEntries.join(', ')})`
           : '')
       );
+      try {
+        removeWorkspace(pyodide, workspace);
+      } catch (_cleanupError) {
+        // Preserve the invariant error assembled above.
+      }
     }
   } catch (error) {
     workspaceError = error;
@@ -735,11 +937,20 @@ const handleWorkerMessage = async (data) => {
       throw new Error(`Unsupported diagram generation worker message type '${type || '(blank)'}'.`);
     }
 
+    emitTestLifecycle(
+      data.testLifecycleEnabled,
+      requestId,
+      'run-message-received'
+    );
     const results = await runGeneration({
       ...(data.payload || {}),
-      requestId
+      requestId,
+      testLifecycleEnabled: data.testLifecycleEnabled
     });
-    self.postMessage({ requestId, type: 'run', ok: true, results });
+    self.postMessage(
+      { requestId, type: 'run', ok: true, results },
+      collectGenerationResultTransferList(results)
+    );
   } catch (error) {
     self.postMessage({
       id,

--- a/gbdraw/web_support/request_render.py
+++ b/gbdraw/web_support/request_render.py
@@ -27,6 +27,8 @@ from gbdraw.web_support.feature_catalog import (
 
 
 _RESOURCE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+_STAGED_WORKSPACE_RE = re.compile(r"^gbdraw-web-render-[1-9][0-9]*$")
+_STAGED_WORKSPACE_MARKER = ".gbdraw-worker-render-workspace"
 
 
 def _attach_exception_note(error: BaseException, note: str) -> None:
@@ -208,7 +210,92 @@ def render_embedded_canonical_web_request(
                     ) from cleanup_error
 
 
+def render_staged_canonical_web_request(
+    payload: Mapping[str, Any],
+    *,
+    resource_paths: Mapping[str, str | Path],
+    workspace: str | Path,
+) -> dict[str, Any]:
+    """Render a browser request from paths staged by the diagram Worker."""
+
+    if not isinstance(resource_paths, Mapping):
+        raise ValidationError("The staged Web render resource map must be an object.")
+    workspace_path = Path(workspace)
+    resource_directory = workspace_path / "resources"
+    cache_directory = workspace_path.parent / "gbdraw-web-render-resource-cache"
+    output_directory = workspace_path / "outputs"
+    owns_workspace = False
+    render_error: BaseException | None = None
+    try:
+        marker_path = workspace_path / _STAGED_WORKSPACE_MARKER
+        if (
+            not _STAGED_WORKSPACE_RE.fullmatch(workspace_path.name)
+            or not workspace_path.is_dir()
+            or not resource_directory.is_dir()
+            or not marker_path.is_file()
+            or marker_path.is_symlink()
+        ):
+            raise ValidationError("The staged Web render workspace is incomplete.")
+        owns_workspace = True
+        workspace_identity = workspace_path.resolve(strict=True)
+        resource_identity = resource_directory.resolve(strict=True)
+        allowed_resource_parents = {resource_identity}
+        if cache_directory.is_dir():
+            allowed_resource_parents.add(cache_directory.resolve(strict=True))
+        validated_paths: dict[str, Path] = {}
+        for resource_id, raw_path in resource_paths.items():
+            if (
+                not isinstance(resource_id, str)
+                or not _RESOURCE_ID_RE.fullmatch(resource_id)
+            ):
+                raise ValidationError(
+                    f"Invalid staged Web render resource ID: {resource_id!r}."
+                )
+            path = Path(raw_path)
+            if path.parent.resolve(strict=True) != resource_identity:
+                raise ValidationError(
+                    f"Staged Web render resource {resource_id!r} is outside its workspace."
+                )
+            resolved = path.resolve(strict=True)
+            if resolved.parent not in allowed_resource_parents or not resolved.is_file():
+                raise ValidationError(
+                    f"Staged Web render resource {resource_id!r} is outside its workspace."
+                )
+            validated_paths[resource_id] = path
+        if output_directory.exists():
+            raise ValidationError("The staged Web render output directory already exists.")
+        output_directory.mkdir()
+        if output_directory.resolve(strict=True).parent != workspace_identity:
+            raise ValidationError("The staged Web render output directory is invalid.")
+        return render_canonical_web_request(
+            payload,
+            resource_paths=validated_paths,
+            output_directory=output_directory,
+        )
+    except BaseException as exc:
+        render_error = exc
+        raise
+    finally:
+        if owns_workspace:
+            try:
+                shutil.rmtree(workspace_path)
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_error:
+                if render_error is not None:
+                    _attach_exception_note(
+                        render_error,
+                        "Temporary staged Web render workspace cleanup also failed: "
+                        f"{cleanup_error}",
+                    )
+                else:
+                    raise ValidationError(
+                        "The temporary staged Web render workspace could not be cleaned up."
+                    ) from cleanup_error
+
+
 __all__ = [
     "render_canonical_web_request",
     "render_embedded_canonical_web_request",
+    "render_staged_canonical_web_request",
 ]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test:playwright": "playwright test",
     "test:web:functional-smoke": "playwright test --config=playwright.functional.config.js",
-    "test:web:perf-smoke": "playwright test --config=playwright.perf.config.js"
+    "test:web:perf-smoke": "playwright test --config=playwright.perf.config.js",
+    "test:web:vibrio-generate": "playwright test --config=playwright.vibrio.config.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/playwright.vibrio.config.js
+++ b/playwright.vibrio.config.js
@@ -1,0 +1,17 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+const baseConfig = require('./playwright.config.js');
+
+module.exports = defineConfig({
+  ...baseConfig,
+  testDir: './tests/web/contracts',
+  testMatch: 'vibrio-full-generation.serial.spec.js',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  timeout: 1_200_000,
+  use: {
+    ...baseConfig.use,
+    trace: 'retain-on-failure'
+  }
+});

--- a/tests/test_pairwise_match_popup.py
+++ b/tests/test_pairwise_match_popup.py
@@ -48,7 +48,12 @@ def test_collinearity_popup_uses_display_ids_and_hides_internal_rows(tmp_path: P
         (WEB_ROOT / "js" / "app" / "match-sequences.js")
         .read_text(encoding="utf-8")
         .replace("./feature-sequence-fasta.js", "./feature-sequence-fasta.mjs")
-        .replace("./conservation-series.js", "./conservation-series.mjs"),
+        .replace("./conservation-series.js", "./conservation-series.mjs")
+        .replace("../services/file-content-cache.js", "./file-content-cache.mjs"),
+        encoding="utf-8",
+    )
+    (tmp_path / "file-content-cache.mjs").write_text(
+        "export const readFileText = (file) => file.text();\n",
         encoding="utf-8",
     )
     losat_normalization_path = tmp_path / "losat-normalization.mjs"

--- a/tests/test_web_feature_metadata.py
+++ b/tests/test_web_feature_metadata.py
@@ -100,12 +100,35 @@ def test_canonical_request_wrapper_rejects_invalid_request_without_monkeypatchin
     original_loader = assemble.load_comparisons
     wrapper = python_helpers_namespace["run_canonical_request_wrapper"]
 
-    payload = json.loads(wrapper("{}", "{}", str(tmp_path / "render")))  # type: ignore[operator]
+    payload = wrapper("{}", "{}", str(tmp_path / "render"))  # type: ignore[operator]
 
     assert payload["error"]["type"]
     assert payload["error"]["message"]
     assert assemble.load_comparisons is original_loader
     assert marker.exists()
+
+
+def test_canonical_request_wrapper_returns_svg_content_as_utf8_bytes(
+    tmp_path: Path,
+    python_helpers_namespace: dict[str, object],
+) -> None:
+    wrapper = python_helpers_namespace["run_canonical_request_wrapper"]
+    original_renderer = python_helpers_namespace["render_staged_canonical_web_request"]
+    python_helpers_namespace["render_staged_canonical_web_request"] = (
+        lambda *_args, **_kwargs: {
+            "results": [{"name": "diagram.svg", "content": "<svg>µ</svg>"}],
+            "metadata": {"featureCatalog": {"schema": 1}},
+        }
+    )
+    try:
+        payload = wrapper("{}", "{}", str(tmp_path / "render"))  # type: ignore[operator]
+    finally:
+        python_helpers_namespace["render_staged_canonical_web_request"] = original_renderer
+
+    assert payload == {
+        "results": [{"name": "diagram.svg", "content": "<svg>µ</svg>".encode()}],
+        "metadata": b'{"featureCatalog":{"schema":1}}',
+    }
 
 
 def test_regenerate_definition_svgs_accepts_nullish_font_sizes(

--- a/tests/test_web_request_render.py
+++ b/tests/test_web_request_render.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+
 from Bio.Seq import Seq
 from Bio.SeqFeature import FeatureLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
@@ -20,6 +22,7 @@ from gbdraw.session import build_session_document
 import gbdraw.web_support.request_render as web_request_render
 from gbdraw.web_support.request_render import (
     render_embedded_canonical_web_request,
+    render_staged_canonical_web_request,
 )
 
 
@@ -47,6 +50,41 @@ def test_embedded_web_request_renders_through_typed_api(tmp_path) -> None:
     assert result["results"][0]["content"].lstrip().startswith("<?xml")
     assert not workspace.exists()
 
+
+def test_staged_web_request_renders_and_cleans_worker_workspace(tmp_path) -> None:
+    record = SeqRecord(Seq("ATGC" * 25), id="staged-web-record")
+    record.annotations["molecule_type"] = "DNA"
+    document = build_session_document(
+        CircularDiagramRequest(
+            records=(RecordInput(source=InMemoryRecordSource(record)),),
+            output=RenderOutputRequest(
+                output_prefix="staged-web-result",
+                formats=("svg",),
+            ),
+        )
+    ).to_dict()
+    workspace = tmp_path / "gbdraw-web-render-1"
+    resources_directory = workspace / "resources"
+    resources_directory.mkdir(parents=True)
+    (workspace / ".gbdraw-worker-render-workspace").touch()
+    resource_paths = {}
+    for index, (resource_id, entry) in enumerate(document["resources"].items(), start=1):
+        path = resources_directory / f"{index:04d}.bin"
+        path.write_bytes(base64.b64decode(entry["data"], validate=True))
+        resource_paths[resource_id] = path
+
+    result = render_staged_canonical_web_request(
+        document["renderRequest"],
+        resource_paths=resource_paths,
+        workspace=workspace,
+    )
+
+    assert [item["name"] for item in result["results"]] == [
+        "staged-web-result.svg"
+    ]
+    assert result["results"][0]["content"].lstrip().startswith("<?xml")
+    assert not workspace.exists()
+
     repeated = render_embedded_canonical_web_request(
         document["renderRequest"],
         resources=document["resources"],
@@ -55,6 +93,52 @@ def test_embedded_web_request_renders_through_typed_api(tmp_path) -> None:
 
     assert repeated["results"] == result["results"]
     assert not workspace.exists()
+
+    linked_workspace = tmp_path / "gbdraw-web-render-2"
+    linked_resources = linked_workspace / "resources"
+    linked_resources.mkdir(parents=True)
+    (linked_workspace / ".gbdraw-worker-render-workspace").touch()
+    cache_directory = tmp_path / "gbdraw-web-render-resource-cache"
+    cache_directory.mkdir()
+    linked_paths = {}
+    cache_paths = []
+    for index, (resource_id, entry) in enumerate(document["resources"].items(), start=1):
+        cache_path = cache_directory / f"render-resource-{index}.bin"
+        cache_path.write_bytes(base64.b64decode(entry["data"], validate=True))
+        linked_path = linked_resources / f"{index:04d}.bin"
+        linked_path.symlink_to(cache_path)
+        linked_paths[resource_id] = linked_path
+        cache_paths.append(cache_path)
+
+    linked = render_staged_canonical_web_request(
+        document["renderRequest"],
+        resource_paths=linked_paths,
+        workspace=linked_workspace,
+    )
+
+    assert linked["results"] == result["results"]
+    assert not linked_workspace.exists()
+    assert all(path.is_file() for path in cache_paths)
+
+
+def test_staged_web_request_preserves_workspace_without_worker_marker(tmp_path) -> None:
+    workspace = tmp_path / "gbdraw-web-render-1"
+    resources_directory = workspace / "resources"
+    resources_directory.mkdir(parents=True)
+    sentinel = workspace / "owner-data.txt"
+    sentinel.write_text("preserve", encoding="utf-8")
+
+    with pytest.raises(
+        ValidationError,
+        match="staged Web render workspace is incomplete",
+    ):
+        render_staged_canonical_web_request(
+            {},
+            resource_paths={},
+            workspace=workspace,
+        )
+
+    assert sentinel.read_text(encoding="utf-8") == "preserve"
 
 
 def test_embedded_web_request_rejects_duplicate_materialized_names(tmp_path) -> None:

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -258,8 +258,12 @@ test('the embedded Python render bridge has no alternate production caller', () 
     new Map([['workers/diagram-generation-worker.js', 1]])
   );
   assert.deepEqual(
-    occurrenceOwners(/\brender_embedded_canonical_web_request\b/g),
+    occurrenceOwners(/\brender_staged_canonical_web_request\b/g),
     new Map([['app/python-helpers.js', 2]])
+  );
+  assert.doesNotMatch(
+    productionSources.get('workers/diagram-generation-worker.js'),
+    /JSON\.stringify\(resources\)/
   );
   assert.deepEqual(
     occurrenceOwners(/\bdef\s+run_canonical_request_wrapper\s*\(/g),

--- a/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
+++ b/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
@@ -1,0 +1,502 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { gunzipSync } = require('node:zlib');
+const {
+  getDiagramWorkerActivity,
+  openApp
+} = require('../helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const webSessionRoot = join(repoRoot, 'gbdraw', 'web', 'gallery', 'sessions');
+const syntheticSourceName = 'HmmtDNA_basic_circular.gbdraw-session.json';
+const syntheticSource = JSON.parse(readFileSync(
+  join(webSessionRoot, syntheticSourceName),
+  'utf8'
+));
+const vibrioSession = join(
+  webSessionRoot,
+  'vibrio-harveyi-group-collinear.gbdraw-session.json.gz'
+);
+const frozenV39Session = join(
+  repoRoot,
+  'tests',
+  'fixtures',
+  'sessions',
+  'BGC0000708-BGC0000713.v39.gbdraw-session.json.gz'
+);
+
+const STRUCTURAL_METRICS = [
+  'base64DecodeCount',
+  'decodedByteCount',
+  'fileConstructionCount',
+  'blobConstructionCount',
+  'resourceTextReadCount',
+  'resourceByteReadCount',
+  'sourceRecoveryCount',
+  'workerConstructionCount',
+  'workerInitializationCount'
+];
+
+const ZERO_PREVIEW_METRICS = Object.fromEntries(
+  STRUCTURAL_METRICS.map((name) => [name, 0])
+);
+
+const installLazySessionProbe = async (page) => page.addInitScript((metricNames) => {
+  const metricMap = () => Object.fromEntries(metricNames.map((name) => [name, 0]));
+  const hookMetrics = metricMap();
+  const nativeMetrics = metricMap();
+  const details = [];
+  const lifecycle = [];
+  const constructedFiles = new WeakSet();
+  const ignoredFiles = new WeakSet();
+
+  const probe = {
+    hookMetrics,
+    nativeMetrics,
+    details,
+    lifecycle,
+    historyLoaded: false,
+    ignoreFile(file) {
+      if (file && typeof file === 'object') ignoredFiles.add(file);
+    },
+    reset() {
+      Object.keys(hookMetrics).forEach((name) => {
+        hookMetrics[name] = 0;
+      });
+      metricNames.forEach((name) => {
+        nativeMetrics[name] = 0;
+      });
+      details.length = 0;
+      lifecycle.length = 0;
+      this.historyLoaded = false;
+    },
+    snapshot() {
+      return {
+        structural: Object.fromEntries(metricNames.map((name) => [
+          name,
+          Math.max(Number(hookMetrics[name] || 0), Number(nativeMetrics[name] || 0))
+        ])),
+        hookMetrics: { ...hookMetrics },
+        nativeMetrics: { ...nativeMetrics },
+        details: details.map((detail) => ({ ...detail })),
+        lifecycle: lifecycle.map((event) => ({ ...event })),
+        historyLoaded: this.historyLoaded
+      };
+    }
+  };
+  window.__GBDRAW_LAZY_SESSION_PROBE__ = probe;
+  window.__GBDRAW_TEST_HOOKS__ = {
+    onStructuralMetric(metric) {
+      const name = String(metric?.name || '');
+      if (!Object.hasOwn(hookMetrics, name)) hookMetrics[name] = 0;
+      hookMetrics[name] += Number(metric.value || 0);
+      details.push({ ...metric, timestamp: performance.now() });
+    },
+    onSessionLifecycleEvent(event) {
+      lifecycle.push({ ...event });
+    }
+  };
+
+  const nativeAtob = window.atob;
+  window.atob = function lazySessionTrackedAtob(value) {
+    const decoded = nativeAtob.call(this, value);
+    nativeMetrics.base64DecodeCount += 1;
+    nativeMetrics.decodedByteCount += decoded.length;
+    return decoded;
+  };
+
+  const NativeBlob = window.Blob;
+  window.Blob = new Proxy(NativeBlob, {
+    construct(target, args) {
+      nativeMetrics.blobConstructionCount += 1;
+      return Reflect.construct(target, args, target);
+    }
+  });
+  const NativeFile = window.File;
+  window.File = new Proxy(NativeFile, {
+    construct(target, args) {
+      nativeMetrics.fileConstructionCount += 1;
+      const file = Reflect.construct(target, args, target);
+      constructedFiles.add(file);
+      return file;
+    }
+  });
+  const nativeArrayBuffer = NativeBlob.prototype.arrayBuffer;
+  NativeBlob.prototype.arrayBuffer = function lazySessionTrackedArrayBuffer(...args) {
+    if (constructedFiles.has(this) && !ignoredFiles.has(this)) {
+      nativeMetrics.resourceByteReadCount += 1;
+    }
+    return nativeArrayBuffer.apply(this, args);
+  };
+  const nativeText = NativeBlob.prototype.text;
+  NativeBlob.prototype.text = function lazySessionTrackedText(...args) {
+    if (constructedFiles.has(this) && !ignoredFiles.has(this)) {
+      nativeMetrics.resourceTextReadCount += 1;
+    }
+    return nativeText.apply(this, args);
+  };
+}, STRUCTURAL_METRICS);
+
+const armHistoryCompletion = (page) => page.evaluate(() => {
+  const history = window.__GBDRAW_HISTORY__;
+  const probe = window.__GBDRAW_LAZY_SESSION_PROBE__;
+  const original = history.captureBaseline;
+  probe.historyLoaded = false;
+  history.captureBaseline = async (label, ...args) => {
+    const result = await original(label, ...args);
+    if (label === 'Loaded session') {
+      probe.historyLoaded = true;
+      history.captureBaseline = original;
+    }
+    return result;
+  };
+});
+
+const probeSnapshot = (page) => page.evaluate(() => ({
+  ...window.__GBDRAW_LAZY_SESSION_PROBE__.snapshot(),
+  savedPreviewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+  selectedResultIndex: window.__GBDRAW_APP__?.selectedResultIndex ?? null,
+  resultCount: window.__GBDRAW_APP__?.results?.length || 0
+}));
+
+const loadSyntheticSession = (page, variant = 'normal') => page.evaluate(
+  async ({ filename, requestedVariant }) => {
+    const response = await fetch(`/gbdraw/web/gallery/sessions/${filename}`);
+    if (!response.ok) throw new Error(`Could not load ${filename}: ${response.status}`);
+    const session = await response.json();
+    session.title = `lazy-${requestedVariant}`;
+    session.resources['unused-lazy-contract'] = {
+      kind: 'web-file',
+      name: 'unused-lazy-contract.txt',
+      type: 'text/plain',
+      size: 7,
+      lastModified: 0,
+      encoding: 'base64',
+      data: btoa('unused\n')
+    };
+    const recordResourceId = session.renderRequest.records[0].source.resourceId;
+    if (requestedVariant === 'invalid-size') {
+      session.resources['unused-lazy-contract'].size = -1;
+    } else if (requestedVariant === 'invalid-base64') {
+      session.resources[recordResourceId].data = '%%%';
+    }
+    const file = new File(
+      [JSON.stringify(session)],
+      `lazy-${requestedVariant}.gbdraw-session.json`,
+      { type: 'application/json' }
+    );
+    const probe = window.__GBDRAW_LAZY_SESSION_PROBE__;
+    probe.ignoreFile(file);
+    probe.reset();
+    const result = await window.__GBDRAW_APP__.importSession({
+      target: { files: [file], value: 'selected' }
+    });
+    return {
+      status: result?.status,
+      degradedRecovery: Boolean(result?.degradedRecovery),
+      message: String(result?.error?.message || '')
+    };
+  },
+  { filename: syntheticSourceName, requestedVariant: variant }
+);
+
+const openInstrumentedApp = async (page) => {
+  page.on('dialog', (dialog) => dialog.accept());
+  await installLazySessionProbe(page);
+  await openApp(page);
+};
+
+const lifecycleTiming = (snapshot) => {
+  const selected = snapshot.lifecycle.find(({ name }) => name === 'sessionSelection');
+  const preview = snapshot.lifecycle.find(({ name }) => name === 'firstCommittedPreview');
+  const ready = snapshot.lifecycle.find(({ name }) => name === 'interactiveReady');
+  return {
+    firstPreviewMs: preview && selected ? preview.timestamp - selected.timestamp : null,
+    interactiveReadyMs: ready && selected ? ready.timestamp - selected.timestamp : null,
+    ready
+  };
+};
+
+test.describe.configure({ mode: 'serial' });
+
+test('synthetic current session restores and exports without materializing resources', async ({
+  page
+}) => {
+  test.setTimeout(180_000);
+  await openInstrumentedApp(page);
+
+  const imported = await loadSyntheticSession(page);
+  expect(imported).toEqual({ status: 'ok', degradedRecovery: false, message: '' });
+  const preview = await probeSnapshot(page);
+  expect(preview.savedPreviewVisible).toBe(true);
+  expect(preview.resultCount).toBe(1);
+  expect(preview.structural).toEqual(ZERO_PREVIEW_METRICS);
+
+  await page.evaluate(() => {
+    window.__GBDRAW_APP__.sessionTitle = 'lazy-unchanged-export';
+  });
+  const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
+  const saved = await page.evaluate(() => window.__GBDRAW_APP__.saveSessionWithTitle());
+  expect(saved.status).toBe('saved');
+  const download = await downloadPromise;
+  const exported = JSON.parse(gunzipSync(readFileSync(await download.path())).toString('utf8'));
+  const afterExport = await probeSnapshot(page);
+
+  expect(afterExport.structural.base64DecodeCount).toBe(0);
+  expect(afterExport.hookMetrics.base64EncodeCount || 0).toBe(0);
+  for (const resourceId of [
+    'record-1-genbank',
+    'colors-default-colors'
+  ]) {
+    expect(exported.resources[resourceId]).toEqual(syntheticSource.resources[resourceId]);
+  }
+  expect(exported.resources['unused-lazy-contract']).toEqual({
+    kind: 'web-file',
+    name: 'unused-lazy-contract.txt',
+    type: 'text/plain',
+    size: 7,
+    lastModified: 0,
+    encoding: 'base64',
+    data: Buffer.from('unused\n').toString('base64')
+  });
+});
+
+test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, testInfo) => {
+  test.setTimeout(180_000);
+  await openInstrumentedApp(page);
+  await page.evaluate(() => window.__GBDRAW_LAZY_SESSION_PROBE__.reset());
+  await armHistoryCompletion(page);
+
+  const input = page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  );
+  await input.setInputFiles(vibrioSession);
+  await page.waitForFunction(
+    () => window.__GBDRAW_LAZY_SESSION_PROBE__?.historyLoaded === true,
+    null,
+    { timeout: 180_000 }
+  );
+  await page.evaluate(() => new Promise((resolve) => (
+    requestAnimationFrame(() => requestAnimationFrame(resolve))
+  )));
+
+  const snapshot = await probeSnapshot(page);
+  const timing = lifecycleTiming(snapshot);
+  expect(snapshot.savedPreviewVisible).toBe(true);
+  expect(snapshot.resultCount).toBe(1);
+  expect(snapshot.structural).toEqual(ZERO_PREVIEW_METRICS);
+  expect(timing.ready).toMatchObject({
+    status: 'success',
+    degradedRecovery: false
+  });
+  expect(timing.firstPreviewMs).toBeGreaterThan(0);
+  expect(timing.interactiveReadyMs).toBeGreaterThanOrEqual(timing.firstPreviewMs);
+
+  await testInfo.attach('vibrio-lazy-session-metrics.json', {
+    body: Buffer.from(JSON.stringify({ structural: snapshot.structural, timing }, null, 2)),
+    contentType: 'application/json'
+  });
+});
+
+test('Generate materializes only required resources and reuses one Worker', async ({ page }) => {
+  test.setTimeout(300_000);
+  await openInstrumentedApp(page);
+  expect(await loadSyntheticSession(page)).toMatchObject({
+    status: 'ok',
+    degradedRecovery: false
+  });
+  const preview = await probeSnapshot(page);
+  expect(preview.structural).toEqual(ZERO_PREVIEW_METRICS);
+
+  const generated = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const first = await app.runAnalysis();
+    const {
+      DIAGRAM_HELPER_OPERATIONS,
+      runDiagramHelperOperation
+    } = await import('/gbdraw/web/js/services/diagram-generation.js');
+    const helper = await runDiagramHelperOperation(
+      DIAGRAM_HELPER_OPERATIONS.MEASURE_LEGEND_TEXT,
+      { caption: 'lazy worker reuse', fontFamily: 'Arial', fontSize: 14 }
+    );
+    const second = await app.runAnalysis();
+    return {
+      first,
+      second,
+      helperWidth: Number(helper?.result?.width || 0),
+      errorSummary: String(app.errorLog?.summary || '')
+    };
+  });
+  expect(generated).toMatchObject({
+    first: { status: 'ok' },
+    second: { status: 'ok' },
+    errorSummary: ''
+  });
+  expect(generated.helperWidth).toBeGreaterThan(0);
+
+  const snapshot = await probeSnapshot(page);
+  const materializedIds = new Set(
+    snapshot.details
+      .filter(({ name }) => name === 'resourceByteReadCount')
+      .map(({ resourceId }) => resourceId)
+  );
+  expect(materializedIds.has('record-1-genbank')).toBe(true);
+  expect(materializedIds.has('unused-lazy-contract')).toBe(false);
+  expect([...materializedIds].every((resourceId) => (
+    ['record-1-genbank', 'colors-default-colors'].includes(resourceId)
+  ))).toBe(true);
+  expect(snapshot.structural.base64DecodeCount).toBe(materializedIds.size);
+
+  const previewEvent = snapshot.lifecycle.find(
+    ({ name }) => name === 'firstCommittedPreview'
+  );
+  const workerInitEvent = snapshot.details.find(
+    ({ name }) => name === 'workerInitializationCount'
+  );
+  expect(previewEvent?.timestamp).toBeLessThan(workerInitEvent?.timestamp);
+  expect(snapshot.structural.workerConstructionCount).toBe(1);
+  expect(snapshot.structural.workerInitializationCount).toBe(1);
+
+  const worker = await getDiagramWorkerActivity(page);
+  expect(worker.constructions).toBe(1);
+  expect(worker.initializations).toBe(1);
+  expect(worker.helpers).toBeGreaterThanOrEqual(1);
+  expect(worker.runs).toBe(2);
+  expect(worker.instances).toHaveLength(1);
+  expect(worker.instances[0].terminated).toBe(false);
+});
+
+test('preflight and lazy-access failures preserve the committed preview', async ({ page }) => {
+  test.setTimeout(180_000);
+  await openInstrumentedApp(page);
+  expect(await loadSyntheticSession(page)).toMatchObject({ status: 'ok' });
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    window.__GBDRAW_LAZY_ROLLBACK_BASELINE__ = {
+      file: app.files.c_gb,
+      content: app.results[app.selectedResultIndex].content,
+      selectedResultIndex: app.selectedResultIndex,
+      undoCount: window.__GBDRAW_HISTORY__.getUndoCount()
+    };
+  });
+
+  const rejected = await loadSyntheticSession(page, 'invalid-size');
+  expect(rejected.status).toBe('error');
+  expect(rejected.message).toMatch(/unused-lazy-contract.*invalid declared byte size/);
+  expect(await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const baseline = window.__GBDRAW_LAZY_ROLLBACK_BASELINE__;
+    return {
+      sameFile: app.files.c_gb === baseline.file,
+      sameContent: app.results[app.selectedResultIndex].content === baseline.content,
+      selectedResultIndex: app.selectedResultIndex,
+      undoCount: window.__GBDRAW_HISTORY__.getUndoCount(),
+      previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg'))
+    };
+  })).toEqual({
+    sameFile: true,
+    sameContent: true,
+    selectedResultIndex: 0,
+    undoCount: 0,
+    previewVisible: true
+  });
+
+  const corrupt = await loadSyntheticSession(page, 'invalid-base64');
+  expect(corrupt).toEqual({ status: 'ok', degradedRecovery: false, message: '' });
+  const beforeAccess = await probeSnapshot(page);
+  expect(beforeAccess.structural).toEqual(ZERO_PREVIEW_METRICS);
+  const access = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const content = app.results[app.selectedResultIndex].content;
+    const { readFileText } = await import('/gbdraw/web/js/services/file-content-cache.js');
+    let first = '';
+    let second = '';
+    try {
+      await readFileText(app.files.c_gb);
+    } catch (error) {
+      first = String(error?.message || error);
+    }
+    try {
+      await readFileText(app.files.c_gb);
+    } catch (error) {
+      second = String(error?.message || error);
+    }
+    return {
+      first,
+      second,
+      sameContent: app.results[app.selectedResultIndex].content === content,
+      previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg'))
+    };
+  });
+  expect(access.first).toMatch(
+    /record-1-genbank \(record-1\.gbk\) contains invalid encoded data/
+  );
+  expect(access.second).toBe(access.first);
+  expect(access.sameContent).toBe(true);
+  expect(access.previewVisible).toBe(true);
+  const afterAccess = await probeSnapshot(page);
+  expect(afterAccess.structural.base64DecodeCount).toBe(1);
+  expect(afterAccess.structural.resourceByteReadCount).toBe(1);
+  expect(afterAccess.structural.workerConstructionCount).toBe(0);
+  expect(afterAccess.structural.workerInitializationCount).toBe(0);
+});
+
+test('a frozen v39 session round-trips through the legacy migration path', async ({ page }) => {
+  test.setTimeout(240_000);
+  await openInstrumentedApp(page);
+  await armHistoryCompletion(page);
+  const input = page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  );
+  await input.setInputFiles(frozenV39Session);
+  await page.waitForFunction(
+    () => window.__GBDRAW_LAZY_SESSION_PROBE__?.historyLoaded === true,
+    null,
+    { timeout: 180_000 }
+  );
+  expect((await probeSnapshot(page)).savedPreviewVisible).toBe(true);
+
+  await page.evaluate(() => {
+    window.__GBDRAW_APP__.sessionTitle = 'legacy-lazy-round-trip';
+  });
+  const regenerated = await page.evaluate(async () => ({
+    result: await window.__GBDRAW_APP__.runAnalysis(),
+    errorLog: window.__GBDRAW_APP__.errorLog
+  }));
+  expect(regenerated.result, JSON.stringify(regenerated.errorLog)).toEqual({ status: 'ok' });
+  const downloadPromise = page.waitForEvent('download', { timeout: 120_000 });
+  const saveOutcome = await page.evaluate(async () => {
+    const result = await window.__GBDRAW_APP__.saveSessionWithTitle();
+    return {
+      result,
+      errorLog: window.__GBDRAW_APP__.errorLog
+    };
+  });
+  expect(saveOutcome.result.status, JSON.stringify(saveOutcome.errorLog)).toBe('saved');
+  const roundTripPath = await (await downloadPromise).path();
+  const roundTrip = JSON.parse(gunzipSync(readFileSync(roundTripPath)).toString('utf8'));
+  expect(roundTrip.version).toBe(40);
+  expect(roundTrip.results).toHaveLength(1);
+  expect(roundTrip.editorState.featureCatalog).toBeTruthy();
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => Boolean(window.__GBDRAW_APP__), null, {
+    timeout: 180_000
+  });
+  await page.evaluate(() => window.__GBDRAW_LAZY_SESSION_PROBE__.reset());
+  await armHistoryCompletion(page);
+  await page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  ).setInputFiles(roundTripPath);
+  await page.waitForFunction(
+    () => window.__GBDRAW_LAZY_SESSION_PROBE__?.historyLoaded === true,
+    null,
+    { timeout: 180_000 }
+  );
+  const restored = await probeSnapshot(page);
+  expect(restored.savedPreviewVisible).toBe(true);
+  expect(restored.resultCount).toBe(1);
+  expect(restored.structural.workerConstructionCount).toBe(0);
+  expect(restored.structural.workerInitializationCount).toBe(0);
+});

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -1,0 +1,462 @@
+const { test, expect } = require('@playwright/test');
+const { join, resolve } = require('node:path');
+const {
+  getDiagramWorkerActivity,
+  openApp
+} = require('../helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const vibrioSession = join(
+  repoRoot,
+  'gbdraw',
+  'web',
+  'gallery',
+  'sessions',
+  'vibrio-harveyi-group-collinear.gbdraw-session.json.gz'
+);
+
+const PREVIEW_ZERO_METRICS = [
+  'base64DecodeCount',
+  'decodedByteCount',
+  'sourceRecoveryCount',
+  'workerConstructionCount',
+  'workerInitializationCount'
+];
+
+const installStructuralProbe = async (page, runnerEvidence) => {
+  await page.exposeFunction('__gbdrawCaptureVibrioEvidence', (entry) => {
+    runnerEvidence.push(entry);
+  });
+  await page.addInitScript(() => {
+    const metrics = {};
+    const details = [];
+    const lifecycle = [];
+    const probe = {
+      metrics,
+      details,
+      lifecycle,
+      reset() {
+        Object.keys(metrics).forEach((name) => delete metrics[name]);
+        details.length = 0;
+        lifecycle.length = 0;
+      },
+      snapshot() {
+        return {
+          metrics: { ...metrics },
+          details: details.map((detail) => ({ ...detail })),
+          lifecycle: lifecycle.map((event) => ({ ...event }))
+        };
+      }
+    };
+    window.__GBDRAW_VIBRIO_GENERATE_PROBE__ = probe;
+    window.__GBDRAW_TEST_HOOKS__ = {
+      onStructuralMetric(metric) {
+        const name = String(metric?.name || '');
+        metrics[name] = Number(metrics[name] || 0) + Number(metric?.value || 0);
+        details.push({ ...metric, timestamp: performance.now() });
+        void window.__gbdrawCaptureVibrioEvidence({ type: 'metric', value: metric });
+      },
+      onSessionLifecycleEvent(event) {
+        lifecycle.push({ ...event });
+        void window.__gbdrawCaptureVibrioEvidence({ type: 'lifecycle', value: event });
+      }
+    };
+  });
+};
+
+const probeSnapshot = (page) => page.evaluate(() => (
+  window.__GBDRAW_VIBRIO_GENERATE_PROBE__.snapshot()
+));
+
+const phaseDuration = (events, startName, endName) => {
+  const start = events.find(({ name }) => name === startName);
+  const end = events.find(({ name }) => name === endName);
+  return start && end ? end.timestamp - start.timestamp : null;
+};
+
+const loadTimings = (events) => {
+  const selection = events.find(({ name }) => name === 'sessionSelection');
+  const preview = events.find(({ name }) => name === 'firstCommittedPreview');
+  const ready = events.find(({ name }) => name === 'interactiveReady');
+  return {
+    gzipToTextMs: phaseDuration(events, 'gzip-to-text-start', 'gzip-to-text-end'),
+    jsonParseMs: phaseDuration(events, 'json-parse-start', 'json-parse-end'),
+    currentSessionPreflightMs: phaseDuration(
+      events,
+      'current-session-preflight-start',
+      'current-session-preflight-end'
+    ),
+    svgAdmissionMs: phaseDuration(events, 'svg-admission-start', 'svg-admission-end'),
+    previewMountMs: phaseDuration(events, 'preview-mount-start', 'preview-mount-end'),
+    historyBaselineMs: phaseDuration(
+      events,
+      'history-baseline-start',
+      'history-baseline-end'
+    ),
+    firstPreviewMs: selection && preview ? preview.timestamp - selection.timestamp : null,
+    interactiveReadyMs: selection && ready ? ready.timestamp - selection.timestamp : null
+  };
+};
+
+const workerErrors = (activity) => (
+  (activity?.instances || []).flatMap((instance) => instance.errors || [])
+);
+
+const workerFailureSettlements = (activity) => (
+  (activity?.instances || []).flatMap((instance) => (
+    (instance.settlements || []).filter(({ type, ok }) => type === 'run' && !ok)
+  ))
+);
+
+const errorText = (diagnostic) => [
+  diagnostic?.evaluationError,
+  diagnostic?.outcome?.thrown,
+  diagnostic?.outcome?.errorSummary,
+  ...(diagnostic?.outcome?.errorDetails || []),
+  ...workerFailureSettlements(diagnostic?.worker).map(({ error }) => error),
+  ...workerErrors(diagnostic?.worker).map(({ message }) => message)
+].filter(Boolean).join('\n');
+
+const classifyGeneration = (diagnostic) => {
+  const message = errorText(diagnostic);
+  if (diagnostic.terminal.contextClosed) return 'browser-context-closure';
+  if (diagnostic.terminal.pageCrashed || /target (?:page )?crashed/i.test(message)) {
+    return 'page-crash';
+  }
+  if (/RangeError|invalid string length|string length overflow/i.test(message)) {
+    return 'range-or-invalid-string-length';
+  }
+  if (/out of memory|memory access out of bounds|Cannot enlarge memory|WebAssembly\.Memory/i.test(message)) {
+    return 'wasm-or-pyodide-out-of-memory';
+  }
+  if (
+    workerErrors(diagnostic.worker).length > 0
+    || workerFailureSettlements(diagnostic.worker).length > 0
+  ) return 'worker-error';
+  if (diagnostic.terminal.pageClosed) return 'page-closure';
+  if (diagnostic.evaluationError || diagnostic.outcome?.thrown) return 'evaluation-error';
+  if (diagnostic.outcome?.status === 'error') return 'returned-application-error';
+  if (diagnostic.outcome?.status === 'ok') return 'success';
+  return 'unknown';
+};
+
+const invokeGeneration = async (page, terminal, runnerEvidence, terminalSignal) => {
+  let outcome = null;
+  let evaluationError = '';
+  const evaluation = page.evaluate(async () => {
+      const app = window.__GBDRAW_APP__;
+      const started = performance.now();
+      try {
+        const result = await app.runAnalysis();
+        const selected = app.results?.[app.selectedResultIndex];
+        return {
+          status: String(result?.status || ''),
+          elapsedMs: performance.now() - started,
+          thrown: '',
+          errorSummary: String(app.errorLog?.summary || ''),
+          errorDetails: Array.isArray(app.errorLog?.details)
+            ? app.errorLog.details.map((detail) => String(detail))
+            : [],
+          resultCount: Array.isArray(app.results) ? app.results.length : 0,
+          generatedSvgCharacters: String(selected?.content || '').length,
+          resultCommitted: String(selected?.content || '').includes('<svg'),
+          previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg'))
+        };
+      } catch (error) {
+        return {
+          status: 'thrown',
+          elapsedMs: performance.now() - started,
+          thrown: `${String(error?.name || 'Error')}: ${String(error?.message || error)}`,
+          errorSummary: String(app?.errorLog?.summary || ''),
+          errorDetails: [],
+          resultCount: Array.isArray(app?.results) ? app.results.length : 0,
+          generatedSvgCharacters: 0,
+          resultCommitted: false,
+          previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg'))
+        };
+      }
+    })
+    .then((value) => ({ type: 'outcome', value }))
+    .catch((error) => ({
+      type: 'evaluation-error',
+      value: `${String(error?.name || 'Error')}: ${String(error?.message || error)}`
+    }));
+  const completion = await Promise.race([
+    evaluation,
+    terminalSignal.then((value) => ({ type: 'terminal', value }))
+  ]);
+  if (completion.type === 'outcome') {
+    outcome = completion.value;
+  } else if (completion.type === 'evaluation-error') {
+    evaluationError = completion.value;
+  } else {
+    evaluationError = `Browser terminal event: ${completion.value}`;
+  }
+
+  let worker = null;
+  if (!page.isClosed() && !terminal.pageCrashed && !terminal.contextClosed) {
+    try {
+      worker = await getDiagramWorkerActivity(page);
+    } catch (error) {
+      evaluationError ||= `${String(error?.name || 'Error')}: ${String(error?.message || error)}`;
+    }
+  }
+  const diagnostic = {
+    outcome,
+    evaluationError,
+    terminal: { ...terminal },
+    worker,
+    lastLifecycle: runnerEvidence.findLast?.(({ type }) => type === 'lifecycle')?.value
+      || [...runnerEvidence].reverse().find(({ type }) => type === 'lifecycle')?.value
+      || null
+  };
+  return { ...diagnostic, classification: classifyGeneration(diagnostic) };
+};
+
+const assertRecoverableErrorState = async (page, diagnostic, originalPreview) => {
+  if (diagnostic.classification !== 'returned-application-error') return null;
+  expect(page.isClosed(), JSON.stringify(diagnostic, null, 2)).toBe(false);
+  const recovery = await page.evaluate(async ({ expectedPreview }) => {
+    const app = window.__GBDRAW_APP__;
+    const selected = app.results?.[app.selectedResultIndex];
+    const {
+      DIAGRAM_HELPER_OPERATIONS,
+      runDiagramHelperOperation
+    } = await import('/gbdraw/web/js/services/diagram-generation.js');
+    const helper = await runDiagramHelperOperation(
+      DIAGRAM_HELPER_OPERATIONS.MEASURE_LEGEND_TEXT,
+      { caption: 'Vibrio recovery probe', fontFamily: 'Arial', fontSize: 14 }
+    );
+    return {
+      appAlive: Boolean(app),
+      previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+      previewPreserved: String(selected?.content || '') === expectedPreview,
+      helperWidth: Number(helper?.result?.width || 0)
+    };
+  }, { expectedPreview: originalPreview });
+  expect(recovery, JSON.stringify(diagnostic, null, 2)).toMatchObject({
+    appAlive: true,
+    previewVisible: true,
+    previewPreserved: true
+  });
+  expect(recovery.helperWidth).toBeGreaterThan(0);
+  return recovery;
+};
+
+test.describe.configure({ mode: 'serial' });
+
+test('real Vibrio preview regenerates twice through staged binary resources', async ({
+  page,
+  context
+}, testInfo) => {
+  const terminal = {
+    pageCrashed: false,
+    pageClosed: false,
+    contextClosed: false
+  };
+  let signalTerminal;
+  const terminalSignal = new Promise((resolveSignal) => {
+    signalTerminal = resolveSignal;
+  });
+  page.on('crash', () => {
+    terminal.pageCrashed = true;
+    signalTerminal('page-crash');
+  });
+  page.on('close', () => {
+    terminal.pageClosed = true;
+    signalTerminal('page-close');
+  });
+  context.on('close', () => {
+    terminal.contextClosed = true;
+    signalTerminal('context-close');
+  });
+  page.on('dialog', (dialog) => dialog.accept());
+  const runnerEvidence = [];
+  await installStructuralProbe(page, runnerEvidence);
+  await openApp(page);
+  await page.evaluate(() => window.__GBDRAW_VIBRIO_GENERATE_PROBE__.reset());
+
+  await page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  ).setInputFiles(vibrioSession);
+  await page.waitForFunction(
+    () => window.__GBDRAW_VIBRIO_GENERATE_PROBE__.lifecycle.some(
+      ({ name }) => name === 'history-baseline-end'
+    ),
+    null,
+    { timeout: 300_000 }
+  );
+
+  const loaded = await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const selected = app.results?.[app.selectedResultIndex];
+    return {
+      originalPreview: String(selected?.content || ''),
+      previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+      resultCount: Array.isArray(app.results) ? app.results.length : 0
+    };
+  });
+  const loadProbe = await probeSnapshot(page);
+  const ready = loadProbe.lifecycle.find(({ name }) => name === 'interactiveReady');
+  const previewMetrics = Object.fromEntries(
+    PREVIEW_ZERO_METRICS.map((name) => [name, Number(loadProbe.metrics[name] || 0)])
+  );
+  expect(loaded.previewVisible).toBe(true);
+  expect(loaded.resultCount).toBe(1);
+  expect(ready).toMatchObject({ status: 'success', degradedRecovery: false });
+  expect(previewMetrics).toEqual(Object.fromEntries(
+    PREVIEW_ZERO_METRICS.map((name) => [name, 0])
+  ));
+
+  await page.evaluate(() => window.__GBDRAW_VIBRIO_GENERATE_PROBE__.reset());
+  const first = await invokeGeneration(page, terminal, runnerEvidence, terminalSignal);
+  const firstProbe = !page.isClosed() && !terminal.pageCrashed
+    ? await probeSnapshot(page)
+    : { metrics: {}, details: [], lifecycle: [] };
+  const firstRecovery = await assertRecoverableErrorState(page, first, loaded.originalPreview);
+  expect(first.classification, JSON.stringify(first, null, 2)).toBe('success');
+  expect(first.outcome).toMatchObject({
+    status: 'ok',
+    resultCommitted: true,
+    previewVisible: true
+  });
+
+  const second = await invokeGeneration(page, terminal, runnerEvidence, terminalSignal);
+  const cumulativeProbe = !page.isClosed() && !terminal.pageCrashed
+    ? await probeSnapshot(page)
+    : { metrics: {}, details: [], lifecycle: [] };
+  const secondRecovery = await assertRecoverableErrorState(page, second, loaded.originalPreview);
+  expect(second.classification, JSON.stringify(second, null, 2)).toBe('success');
+  expect(second.outcome).toMatchObject({
+    status: 'ok',
+    resultCommitted: true,
+    previewVisible: true
+  });
+
+  const activity = second.worker;
+  const runs = activity?.instances?.[0]?.runs || [];
+  const lifecycleNames = cumulativeProbe.lifecycle.map(({ name }) => name);
+  const resultSvgCharacters = cumulativeProbe.lifecycle
+    .filter(({ name }) => name === 'result-svg-characters')
+    .map(({ value }) => Number(value || 0));
+  const structural = {
+    canonicalReplayFullSerializationCount: Number(
+      cumulativeProbe.metrics.canonicalReplayFullSerializationCount || 0
+    ),
+    workerBase64ResourceCloneCount: runs.filter(
+      ({ hasBase64ResourceTable }) => hasBase64ResourceTable
+    ).length,
+    workerBase64ResourceJsonStringifyCount: lifecycleNames.filter(
+      (name) => name.startsWith('worker-resources-json-')
+    ).length,
+    resourceMaterializationCount: Number(
+      cumulativeProbe.metrics.resourceMaterializationCount || 0
+    ),
+    resourceReencodeCount: Number(cumulativeProbe.metrics.resourceReencodeCount || 0),
+    resultBinaryDecodeCount: Number(cumulativeProbe.metrics.resultBinaryDecodeCount || 0),
+    resultBinaryDecodedBytes: Number(cumulativeProbe.metrics.resultBinaryDecodedBytes || 0),
+    resultMetadataBinaryDecodeCount: Number(
+      cumulativeProbe.metrics.resultMetadataBinaryDecodeCount || 0
+    ),
+    resultMetadataBinaryDecodedBytes: Number(
+      cumulativeProbe.metrics.resultMetadataBinaryDecodedBytes || 0
+    )
+  };
+  const resultTransportEvents = cumulativeProbe.lifecycle.filter(
+    ({ name }) => name === 'result-transport-ready'
+  );
+
+  expect(activity.constructions).toBe(1);
+  expect(activity.initializations).toBe(1);
+  expect(activity.runs).toBe(2);
+  expect(activity.instances).toHaveLength(1);
+  expect(activity.instances[0].terminated).toBe(false);
+  expect(workerErrors(activity)).toEqual([]);
+  expect(runs).toHaveLength(2);
+  expect(runs[0].referencedResourceCount).toBeGreaterThan(0);
+  expect(runs[0].referencedDeclaredBytes).toBeGreaterThan(0);
+  expect(runs[0].stagedResourceCount).toBe(runs[0].referencedResourceCount);
+  expect(runs[0].stagedResourceBytes).toBe(runs[0].referencedDeclaredBytes);
+  expect(runs[0].transferredBytes).toBe(runs[0].stagedResourceBytes);
+  expect(runs[1]).toMatchObject({
+    referencedResourceCount: runs[0].referencedResourceCount,
+    referencedDeclaredBytes: runs[0].referencedDeclaredBytes,
+    stagedResourceCount: 0,
+    stagedResourceBytes: 0,
+    transferredBytes: 0,
+    hasBase64ResourceTable: false
+  });
+  expect(structural).toMatchObject({
+    canonicalReplayFullSerializationCount: 0,
+    workerBase64ResourceCloneCount: 0,
+    workerBase64ResourceJsonStringifyCount: 0,
+    resourceMaterializationCount: runs[0].referencedResourceCount,
+    resourceReencodeCount: 0,
+    resultBinaryDecodeCount: 2,
+    resultMetadataBinaryDecodeCount: 2
+  });
+  expect(structural.resultBinaryDecodedBytes).toBeGreaterThan(0);
+  expect(structural.resultMetadataBinaryDecodedBytes).toBeGreaterThan(0);
+  expect(resultTransportEvents).toHaveLength(2);
+  expect(resultTransportEvents.every(
+    ({ transport, bytes }) => transport === 'transferable-binary' && Number(bytes) > 0
+  )).toBe(true);
+  expect(resultSvgCharacters).toHaveLength(2);
+  expect(resultSvgCharacters.every((characters) => characters > 0)).toBe(true);
+
+  const workerPing = await page.evaluate(async () => {
+    const {
+      DIAGRAM_HELPER_OPERATIONS,
+      runDiagramHelperOperation
+    } = await import('/gbdraw/web/js/services/diagram-generation.js');
+    const response = await runDiagramHelperOperation(
+      DIAGRAM_HELPER_OPERATIONS.MEASURE_LEGEND_TEXT,
+      { caption: 'Vibrio worker alive', fontFamily: 'Arial', fontSize: 14 }
+    );
+    return Number(response?.result?.width || 0);
+  });
+  expect(workerPing).toBeGreaterThan(0);
+  const afterPing = await getDiagramWorkerActivity(page);
+  expect(afterPing.constructions).toBe(1);
+  expect(afterPing.initializations).toBe(1);
+  expect(afterPing.instances[0].terminated).toBe(false);
+
+  const report = {
+    load: {
+      previewMetrics,
+      timings: loadTimings(loadProbe.lifecycle)
+    },
+    generations: {
+      first,
+      second,
+      firstRecovery,
+      secondRecovery,
+      referencedResourceCount: runs[0].referencedResourceCount,
+      referencedDeclaredBytes: runs[0].referencedDeclaredBytes,
+      firstTransferredBytes: runs[0].transferredBytes,
+      secondTransferredBytes: runs[1].transferredBytes,
+      resourceMaterializations: structural.resourceMaterializationCount,
+      resourceReencodes: structural.resourceReencodeCount,
+      generatedSvgCharacters: resultSvgCharacters,
+      firstElapsedMs: first.outcome.elapsedMs,
+      secondElapsedMs: second.outcome.elapsedMs,
+      firstProbe
+    },
+    structural,
+    worker: afterPing
+  };
+  await testInfo.attach('vibrio-full-generation-metrics.json', {
+    body: Buffer.from(JSON.stringify(report, null, 2)),
+    contentType: 'application/json'
+  });
+  console.log(`Vibrio full-generation evidence: ${JSON.stringify({
+    loadTimings: report.load.timings,
+    firstGenerateMs: report.generations.firstElapsedMs,
+    secondGenerateMs: report.generations.secondElapsedMs,
+    referencedResourceCount: report.generations.referencedResourceCount,
+    referencedDeclaredBytes: report.generations.referencedDeclaredBytes,
+    firstTransferredBytes: report.generations.firstTransferredBytes,
+    secondTransferredBytes: report.generations.secondTransferredBytes,
+    structural: report.structural
+  })}`);
+});

--- a/tests/web/depth-track-session.playwright.spec.js
+++ b/tests/web/depth-track-session.playwright.spec.js
@@ -2489,10 +2489,10 @@ test('Circular sparse diagonal depth survives a session round trip and track rem
   await page.waitForFunction(() => {
     const app = window.__GBDRAW_APP__;
     return app.mode === 'circular' &&
-      app.circularRecordList?.length === 2 &&
       Array.isArray(app.files?.c_depth) &&
       app.files.c_depth.length === 2;
   }, null, { timeout: 120000 });
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.circularRecordList?.length)).toBe(0);
 
   const restoredState = await page.evaluate(() => {
     const app = window.__GBDRAW_APP__;
@@ -2514,6 +2514,7 @@ test('Circular sparse diagonal depth survives a session round trip and track rem
     errorSummary: '',
     errorDetails: []
   });
+  await page.waitForFunction(() => window.__GBDRAW_APP__?.circularRecordList?.length === 2);
   const secondResult = await inspectCircularSparseDepthResult(page);
   expect(secondResult.groups).toEqual(firstResult.groups);
   expect(secondResult.depthAFills).toContain('#112233');

--- a/tests/web/diagram-generation-worker.test.mjs
+++ b/tests/web/diagram-generation-worker.test.mjs
@@ -3,9 +3,20 @@ import assert from 'node:assert/strict';
 globalThis.self = {};
 
 const {
+  collectGenerationResultTransferList,
   resolveGenerationCleanupOutcome,
   serializeError
 } = await import('../../gbdraw/web/js/workers/diagram-generation-worker.js');
+
+const svgBytes = new TextEncoder().encode('<svg />');
+const metadataBytes = new TextEncoder().encode('{"featureCatalog":{}}');
+assert.deepEqual(
+  collectGenerationResultTransferList({
+    results: [{ content: svgBytes }, { content: '<svg />' }],
+    metadata: metadataBytes
+  }),
+  [svgBytes.buffer, metadataBytes.buffer]
+);
 
 const pythonPayload = {
   error: {

--- a/tests/web/diagram-resource-staging.test.mjs
+++ b/tests/web/diagram-resource-staging.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const metrics = [];
+const lifecycle = [];
+globalThis.__GBDRAW_TEST_HOOKS__ = {
+  onStructuralMetric: (metric) => metrics.push(metric),
+  onSessionLifecycleEvent: (event) => lifecycle.push(event)
+};
+
+const { createDiagramResourceTransport } = await import(
+  '../../gbdraw/web/js/services/diagram-resource-staging.js'
+);
+
+const descriptor = (text, name = 'record.gb') => ({
+  kind: 'genbank',
+  name,
+  type: 'text/plain',
+  size: Buffer.byteLength(text),
+  lastModified: 1,
+  encoding: 'base64',
+  data: Buffer.from(text).toString('base64')
+});
+
+test('render staging selects references, transfers bytes once, and reuses the cache', async () => {
+  const transport = createDiagramResourceTransport();
+  const record = descriptor('LOCUS record\nORIGIN\n//\n');
+  const unused = descriptor('unused', 'unused.txt');
+  const request = {
+    records: [{ source: { kind: 'genbank', resourceId: 'record-1-genbank' } }],
+    diagramOptions: {}
+  };
+  const resources = {
+    'record-1-genbank': record,
+    'unused-resource': unused
+  };
+
+  const first = await transport.prepare({ request, resources });
+  assert.deepEqual(
+    first.resourceManifest.map(({ resourceId }) => resourceId),
+    ['record-1-genbank']
+  );
+  assert.equal(first.stagedResources.length, 1);
+  assert.equal(
+    Buffer.from(first.stagedResources[0].bytes).toString('utf8'),
+    'LOCUS record\nORIGIN\n//\n'
+  );
+  first.commit();
+
+  const second = await transport.prepare({ request, resources });
+  assert.equal(second.stagedResources.length, 0);
+  assert.equal(
+    second.resourceManifest[0].cacheToken,
+    first.resourceManifest[0].cacheToken
+  );
+  second.commit();
+
+  const replacement = descriptor('LOCUS other!\nORIGIN\n//\n');
+  const third = await transport.prepare({
+    request,
+    resources: { ...resources, 'record-1-genbank': replacement }
+  });
+  assert.equal(third.stagedResources.length, 1);
+  assert.notEqual(
+    third.resourceManifest[0].cacheToken,
+    first.resourceManifest[0].cacheToken
+  );
+
+  assert.equal(
+    metrics.filter(({ name }) => name === 'resourceMaterializationCount').length,
+    2
+  );
+  assert.equal(
+    metrics.filter(({ name }) => name === 'workerResourceCacheHitCount').length,
+    1
+  );
+  assert.equal(
+    lifecycle.filter(({ name }) => name === 'resource-stage-end').length,
+    3
+  );
+});

--- a/tests/web/helpers/app-lifecycle.cjs
+++ b/tests/web/helpers/app-lifecycle.cjs
@@ -56,7 +56,31 @@ const installDiagramWorkerTracking = async (page) => {
           });
           instance.events.push(`helper:request:${String(message.operation || '')}`);
         } else if (message?.type === 'run') {
-          instance.runs.push({ requestId: String(message.requestId ?? '') });
+          const resourceManifest = Array.isArray(message.payload?.resourceManifest)
+            ? message.payload.resourceManifest
+            : [];
+          const stagedResources = Array.isArray(message.payload?.stagedResources)
+            ? message.payload.stagedResources
+            : [];
+          instance.runs.push({
+            requestId: String(message.requestId ?? ''),
+            referencedResourceCount: resourceManifest.length,
+            referencedDeclaredBytes: resourceManifest.reduce(
+              (total, resource) => total + Number(resource?.size || 0),
+              0
+            ),
+            stagedResourceCount: stagedResources.length,
+            stagedResourceBytes: stagedResources.reduce(
+              (total, resource) => total + Number(resource?.bytes?.byteLength || 0),
+              0
+            ),
+            transferCount: transferList.length,
+            transferredBytes: transferList.reduce(
+              (total, item) => total + Number(item?.byteLength || 0),
+              0
+            ),
+            hasBase64ResourceTable: Boolean(message.payload?.resources)
+          });
           instance.events.push('run:request');
         }
       }
@@ -88,6 +112,7 @@ const installDiagramWorkerTracking = async (page) => {
           helpers: [],
           runs: [],
           settlements: [],
+          errors: [],
           events: [],
           terminated: false
         };
@@ -107,6 +132,20 @@ const installDiagramWorkerTracking = async (page) => {
               : ''
           });
           instance.events.push(`${message.type}:${message.ok === true ? 'ok' : 'error'}`);
+        });
+        worker.addEventListener('error', (event) => {
+          instance.errors.push({
+            type: 'error',
+            message: String(event?.message || 'Diagram Worker error')
+          });
+          instance.events.push('worker:error');
+        });
+        worker.addEventListener('messageerror', () => {
+          instance.errors.push({
+            type: 'messageerror',
+            message: 'Diagram Worker message could not be decoded'
+          });
+          instance.events.push('worker:messageerror');
         });
 
         return worker;

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -913,23 +913,16 @@ test('Automatic Linear renders every record from one GenBank source and survives
     session.renderRequest.records.map((record) => record.source.resourceId)
   ).size).toBe(1);
 
-  await page.addInitScript((recordSourceName) => {
-    const nativeArrayBuffer = File.prototype.arrayBuffer;
-    let releaseRecordRead;
-    const recordReadGate = new Promise((resolve) => { releaseRecordRead = resolve; });
-    window.__GBDRAW_RECORD_TEXT_READS__ = 0;
-    window.__GBDRAW_RELEASE_RECORD_TEXT__ = releaseRecordRead;
-    File.prototype.arrayBuffer = async function (...args) {
-      if (this.name !== recordSourceName) return nativeArrayBuffer.apply(this, args);
-      const { state } = await import('./js/state.js');
-      if (state.semanticFileWatchersSuppressed.value) {
-        return nativeArrayBuffer.apply(this, args);
+  await page.addInitScript(() => {
+    window.__GBDRAW_RECORD_RESOURCE_READS__ = 0;
+    window.__GBDRAW_TEST_HOOKS__ = {
+      onStructuralMetric(metric) {
+        if (metric.name === 'resourceByteReadCount') {
+          window.__GBDRAW_RECORD_RESOURCE_READS__ += metric.value;
+        }
       }
-      window.__GBDRAW_RECORD_TEXT_READS__ += 1;
-      await recordReadGate;
-      return nativeArrayBuffer.apply(this, args);
     };
-  }, sourceName);
+  });
   await page.reload({ waitUntil: 'domcontentloaded' });
   await waitForAppShell(page);
   const dialogPromise = page.waitForEvent('dialog', { timeout: 120000 });
@@ -937,21 +930,23 @@ test('Automatic Linear renders every record from one GenBank source and survives
   const dialog = await dialogPromise;
   expect(dialog.message()).toBe('Session loaded successfully!');
   await dialog.accept();
-  await page.waitForFunction(() => window.__GBDRAW_RECORD_TEXT_READS__ === 1);
+  expect(await page.evaluate(() => window.__GBDRAW_RECORD_RESOURCE_READS__)).toBe(0);
 
-  await page.evaluate(async () => {
-    const { state } = await import('./js/state.js');
-    state.labelReflowForceRequestReason.value = 'multi-record-session-reflow';
-    state.labelReflowForceRequestSeq.value += 1;
-    await window.Vue.nextTick();
+  await page.evaluate(() => {
+    window.__GBDRAW_AUTOMATIC_RELOAD_RUN__ = { done: false, error: '' };
+    window.__GBDRAW_APP__.runAnalysis().then(() => {
+      window.__GBDRAW_AUTOMATIC_RELOAD_RUN__.done = true;
+    }).catch((error) => {
+      Object.assign(window.__GBDRAW_AUTOMATIC_RELOAD_RUN__, {
+        done: true,
+        error: error?.message || String(error)
+      });
+    });
   });
-  await expect.poll(() => page.evaluate(() => window.__GBDRAW_RECORD_TEXT_READS__)).toBe(1);
-  expect(await page.evaluate(async () => {
-    const { state } = await import('./js/state.js');
-    return [window.__GBDRAW_DIAGRAM_RUNS__.length, state.labelReflowLastError.value];
-  })).toEqual([0, null]);
-  await page.evaluate(() => window.__GBDRAW_RELEASE_RECORD_TEXT__());
-  await page.waitForFunction(() => window.__GBDRAW_DIAGRAM_RUNS__.length === 1);
+  await page.waitForFunction(() => window.__GBDRAW_AUTOMATIC_RELOAD_RUN__?.done === true);
+  expect(await page.evaluate(() => window.__GBDRAW_AUTOMATIC_RELOAD_RUN__.error)).toBe('');
+  expect(await page.evaluate(() => window.__GBDRAW_RECORD_RESOURCE_READS__)).toBe(1);
+  expect(await page.evaluate(() => window.__GBDRAW_DIAGRAM_RUNS__.length)).toBe(1);
 
   const restored = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;

--- a/tests/web/losat-cache-migration.playwright.spec.js
+++ b/tests/web/losat-cache-migration.playwright.spec.js
@@ -213,9 +213,10 @@ const installUserUploadedTsv = async (page) => page.evaluate(
 
 const readFirstUploadedTsv = async (page) => page.evaluate(async () => {
   const file = window.__GBDRAW_APP__.linearComparisonPlan.edges[0]?.file;
+  const { readFileBytes } = await import('/gbdraw/web/js/services/file-content-cache.js');
   return {
     name: file?.name || '',
-    bytes: file ? Array.from(new Uint8Array(await file.arrayBuffer())) : []
+    bytes: file ? Array.from(await readFileBytes(file)) : []
   };
 });
 

--- a/tests/web/losat-cache-migration.playwright.spec.js
+++ b/tests/web/losat-cache-migration.playwright.spec.js
@@ -442,9 +442,9 @@ const failRendererAfterMigration = async (page) => page.evaluate(async () => {
       !rendererFailureInjected &&
       message?.type === 'run' &&
       message?.payload?.request?.schema === CANONICAL_REQUEST_SCHEMA &&
-      message?.payload?.resources &&
-      typeof message.payload.resources === 'object' &&
-      !Array.isArray(message.payload.resources)
+      Array.isArray(message?.payload?.resourceManifest) &&
+      Array.isArray(message?.payload?.stagedResources) &&
+      !Object.hasOwn(message.payload, 'resources')
     ) {
       rendererFailureInjected = true;
       message.payload.request = null;

--- a/tests/web/match-sequences.test.mjs
+++ b/tests/web/match-sequences.test.mjs
@@ -1,35 +1,42 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const tempDir = await mkdtemp(join(tmpdir(), 'gbdraw-match-sequences-'));
 await writeFile(join(tempDir, 'package.json'), '{"type":"module"}\n', 'utf8');
+await mkdir(join(tempDir, 'app'));
+await mkdir(join(tempDir, 'services'));
 await writeFile(
-  join(tempDir, 'feature-utils.js'),
+  join(tempDir, 'app', 'feature-utils.js'),
   await readFile('gbdraw/web/js/app/feature-utils.js', 'utf8'),
   'utf8'
 );
 await writeFile(
-  join(tempDir, 'feature-sequence-fasta.js'),
+  join(tempDir, 'app', 'feature-sequence-fasta.js'),
   await readFile('gbdraw/web/js/app/feature-sequence-fasta.js', 'utf8'),
   'utf8'
 );
 await writeFile(
-  join(tempDir, 'color-utils.js'),
+  join(tempDir, 'app', 'color-utils.js'),
   await readFile('gbdraw/web/js/app/color-utils.js', 'utf8'),
   'utf8'
 );
 await writeFile(
-  join(tempDir, 'conservation-series.js'),
+  join(tempDir, 'app', 'conservation-series.js'),
   await readFile('gbdraw/web/js/app/conservation-series.js', 'utf8'),
   'utf8'
 );
 await writeFile(
-  join(tempDir, 'match-sequences.js'),
+  join(tempDir, 'app', 'match-sequences.js'),
   await readFile('gbdraw/web/js/app/match-sequences.js', 'utf8'),
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'services', 'file-content-cache.js'),
+  'export const readFileText = (file) => file.text();\n',
   'utf8'
 );
 
@@ -41,7 +48,7 @@ const {
   extractMatchedSpan,
   resolveCircularComparisonSequenceAvailability,
   reverseComplementNucleotide
-} = await import(pathToFileURL(join(tempDir, 'match-sequences.js')));
+} = await import(pathToFileURL(join(tempDir, 'app', 'match-sequences.js')));
 
 const textFile = (value) => ({ text: async () => value });
 const namedTextFile = (name, value) => ({ name, text: async () => value });

--- a/tests/web/preview-runtime.test.mjs
+++ b/tests/web/preview-runtime.test.mjs
@@ -8,6 +8,7 @@ const repoRoot = process.cwd();
 const sourcePath = join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'preview-runtime.js');
 const featureDomSourcePath = join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'feature-dom.js');
 const serviceNames = [
+  'runtime-test-hooks.js',
   'session-feature-metadata.js',
   'svg-result-normalization.js',
   'svg-result-ingestion.js',

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -13,7 +13,22 @@ globalThis.window = {
   },
   DOMPurify: { sanitize: (value) => value }
 };
-globalThis.document = {};
+let downloadedBlob = null;
+let downloadedFilename = '';
+globalThis.document = {
+  body: { appendChild: (node) => { node.parentNode = globalThis.document.body; } },
+  createElement: () => ({
+    addEventListener() {},
+    click() { downloadedFilename = this.download; },
+    parentNode: null
+  }),
+  removeChild() {}
+};
+URL.createObjectURL = (blob) => {
+  downloadedBlob = blob;
+  return 'blob:audit-download';
+};
+URL.revokeObjectURL = () => {};
 installFakeSvgDom();
 globalThis.alert = () => {};
 globalThis.confirm = () => true;
@@ -225,6 +240,27 @@ const response = (logicalResult, featureCatalog) => ({
   metadata: featureCatalog === undefined ? {} : { featureCatalog }
 });
 
+const storedZipEntries = async (blob) => {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const decoder = new TextDecoder();
+  const entries = [];
+  let offset = 0;
+  while (offset + 30 <= bytes.byteLength && view.getUint32(offset, true) === 0x04034B50) {
+    const size = view.getUint32(offset + 18, true);
+    const nameLength = view.getUint16(offset + 26, true);
+    const extraLength = view.getUint16(offset + 28, true);
+    const nameStart = offset + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    entries.push({
+      name: decoder.decode(bytes.subarray(nameStart, nameStart + nameLength)),
+      text: decoder.decode(bytes.subarray(dataStart, dataStart + size))
+    });
+    offset = dataStart + size;
+  }
+  return entries;
+};
+
 const committedFeatureState = () => structuredClone({
   results: state.results.value,
   selectedResultIndex: state.selectedResultIndex.value,
@@ -249,6 +285,14 @@ const committedFeatureState = () => structuredClone({
 });
 
 test('audit-5 owner: direct simple createRunAnalysis path is worker-only and catalog-transactional', async () => {
+  const structuralMetrics = {};
+  globalThis.__GBDRAW_TEST_HOOKS__ = {
+    onStructuralMetric(metric) {
+      structuralMetrics[metric.name] = (
+        Number(structuralMetrics[metric.name] || 0) + Number(metric.value || 0)
+      );
+    }
+  };
   const primary = new AuditFile(['LOCUS audit\nORIGIN\n//\n'], 'active.gb', {
     type: 'text/plain',
     lastModified: 7
@@ -355,6 +399,23 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   assert.deepEqual(state.featureCatalog.value, committedCatalog);
   assert.equal(state.extractedFeatures.value.length, 1);
   assert.equal(state.biologicalFeatures.value.length, 1);
+  assert.equal(structuralMetrics.canonicalReplayFullSerializationCount || 0, 0);
+  runner.downloadCliHelperFiles();
+  assert.equal(structuralMetrics.canonicalReplayFullSerializationCount, 1);
+  assert.equal(downloadedFilename, 'audit-simple-cli-files.zip');
+  const helperEntries = await storedZipEntries(downloadedBlob);
+  const replayEntry = helperEntries.find(({ name }) => name.endsWith('.gbdraw-session.json'));
+  assert.ok(replayEntry);
+  const replay = JSON.parse(replayEntry.text);
+  assert.equal(replay.format, 'gbdraw-session');
+  assert.equal(replay.version, SESSION_VERSION);
+  assert.equal(replay.renderRequest.schema, 5);
+  assert.ok(Object.keys(replay.resources).length > 0);
+
+  const firstRunPayload = workerMessages.find(({ type }) => type === 'run').payload;
+  assert.equal(Object.hasOwn(firstRunPayload, 'resources'), false);
+  assert.ok(firstRunPayload.resourceManifest.length > 0);
+  assert.ok(firstRunPayload.stagedResources.every(({ bytes }) => bytes instanceof ArrayBuffer));
 
   const committedState = committedFeatureState();
   const committedExtractedFeatureIdentity = state.extractedFeatures.value;
@@ -432,7 +493,7 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   const readyResult = result('ready.svg', 'ready');
   workerResponses.push(response(readyResult, validCatalog(readyResult.name)));
   assert.deepEqual(await runner.runAnalysis(), { status: 'ok' });
-  assert.equal(activePrimaryReads, 1);
+  assert.equal(activePrimaryReads, 2);
 
   Object.assign(state.circularRecordDiscovery, {
     status: 'idle',
@@ -868,7 +929,7 @@ test('Linear mode none ignores dormant comparison state while active depth and a
   assert.equal(payload.request.diagramOptions.annotations.sets[0].id, 'active-annotation');
   assert.equal(payload.request.diagramOptions.depthTracks.length, 1);
   assert.equal(
-    Object.values(payload.resources).some((resource) => (
+    payload.resourceManifest.some((resource) => (
       String(resource?.kind || '').includes('comparison')
     )),
     false

--- a/tests/web/session-definition-rehydration.test.mjs
+++ b/tests/web/session-definition-rehydration.test.mjs
@@ -31,7 +31,9 @@ const imported = await importSession({
 });
 
 assert.equal(imported.status, 'ok');
-assert.ok(state.files.c_gb instanceof File);
+assert.equal(state.files.c_gb instanceof File, false);
+assert.equal(typeof state.files.c_gb.arrayBuffer, 'undefined');
+assert.ok(Object.isFrozen(state.files.c_gb));
 assert.ok(state.extractedFeatures.value.length > 0);
 assert.equal(state.featureEditorStatus.status, 'summary-ready');
 assert.equal(state.featureEditorStatus.summaryCount, state.extractedFeatures.value.length);

--- a/tests/web/session-feature-metadata.test.mjs
+++ b/tests/web/session-feature-metadata.test.mjs
@@ -22,6 +22,18 @@ await copyModule('gbdraw/web/js/app/session-feature-metadata.js', 'app/session-f
 await copyModule('gbdraw/web/js/app/feature-metadata-extraction.js', 'app/feature-metadata-extraction.js');
 await copyModule('gbdraw/web/js/app/losat-normalization.js', 'app/losat-normalization.js');
 await copyModule('gbdraw/web/js/services/diagram-generation.js', 'services/diagram-generation.js');
+await copyModule(
+  'gbdraw/web/js/services/diagram-resource-staging.js',
+  'services/diagram-resource-staging.js'
+);
+await copyModule(
+  'gbdraw/web/js/services/canonical-resource-references.js',
+  'services/canonical-resource-references.js'
+);
+await copyModule(
+  'gbdraw/web/js/services/resource-payload-owner.js',
+  'services/resource-payload-owner.js'
+);
 await copyModule('gbdraw/web/js/services/diagram-worker-protocol.js', 'services/diagram-worker-protocol.js');
 await copyModule('gbdraw/web/js/services/error-normalization.js', 'services/error-normalization.js');
 await copyModule('gbdraw/web/js/services/byte-utils.js', 'services/byte-utils.js');
@@ -140,6 +152,17 @@ const { normalizeGenerationResponse } = await import(pathToFileURL(join(tempDir,
   );
   const errorPayload = { error: { type: 'OutputError', message: 'No output files generated.' } };
   assert.deepEqual(normalizeGenerationResponse(errorPayload), { results: errorPayload, metadata: {} });
+  const binarySvg = new TextEncoder().encode('<svg>µ</svg>');
+  assert.deepEqual(
+    normalizeGenerationResponse({
+      results: [{ name: 'binary.svg', content: binarySvg }],
+      metadata: new TextEncoder().encode(JSON.stringify(metadata))
+    }),
+    {
+      results: [{ name: 'binary.svg', content: '<svg>µ</svg>' }],
+      metadata
+    }
+  );
 }
 
 const parseAttributes = (source) => {

--- a/tests/web/session-feature-metadata.test.mjs
+++ b/tests/web/session-feature-metadata.test.mjs
@@ -24,6 +24,7 @@ await copyModule('gbdraw/web/js/app/losat-normalization.js', 'app/losat-normaliz
 await copyModule('gbdraw/web/js/services/diagram-generation.js', 'services/diagram-generation.js');
 await copyModule('gbdraw/web/js/services/diagram-worker-protocol.js', 'services/diagram-worker-protocol.js');
 await copyModule('gbdraw/web/js/services/error-normalization.js', 'services/error-normalization.js');
+await copyModule('gbdraw/web/js/services/byte-utils.js', 'services/byte-utils.js');
 await copyModule('gbdraw/web/js/services/file-content-cache.js', 'services/file-content-cache.js');
 await copyModule('gbdraw/web/js/services/depth-file-codec.js', 'services/depth-file-codec.js');
 await copyModule('gbdraw/web/js/services/json-clone.js', 'services/json-clone.js');

--- a/tests/web/session-feature-metadata.test.mjs
+++ b/tests/web/session-feature-metadata.test.mjs
@@ -25,6 +25,7 @@ await copyModule('gbdraw/web/js/services/diagram-generation.js', 'services/diagr
 await copyModule('gbdraw/web/js/services/diagram-worker-protocol.js', 'services/diagram-worker-protocol.js');
 await copyModule('gbdraw/web/js/services/error-normalization.js', 'services/error-normalization.js');
 await copyModule('gbdraw/web/js/services/file-content-cache.js', 'services/file-content-cache.js');
+await copyModule('gbdraw/web/js/services/depth-file-codec.js', 'services/depth-file-codec.js');
 await copyModule('gbdraw/web/js/services/json-clone.js', 'services/json-clone.js');
 await copyModule('gbdraw/web/js/services/feature-identity.js', 'services/feature-identity.js');
 await copyModule(
@@ -33,6 +34,11 @@ await copyModule(
 );
 await copyModule('gbdraw/web/js/services/pyodide-assets.js', 'services/pyodide-assets.js');
 await copyModule('gbdraw/web/js/services/runtime-capabilities.js', 'services/runtime-capabilities.js');
+await copyModule('gbdraw/web/js/services/runtime-test-hooks.js', 'services/runtime-test-hooks.js');
+await copyModule(
+  'gbdraw/web/js/services/session-resource-backing.js',
+  'services/session-resource-backing.js'
+);
 await copyModule('gbdraw/web/js/services/session-feature-metadata.js', 'services/session-feature-metadata.js');
 await copyModule('gbdraw/web/js/services/svg-result-ingestion.js', 'services/svg-result-ingestion.js');
 await copyModule('gbdraw/web/js/services/svg-result-normalization.js', 'services/svg-result-normalization.js');

--- a/tests/web/session-losat-cache-validation.test.mjs
+++ b/tests/web/session-losat-cache-validation.test.mjs
@@ -18,6 +18,16 @@ installFakeSvgDom();
 let restoredPrimaryTextReads = 0;
 let restoredPrimaryArrayBufferReads = 0;
 const restoredTextReadsByName = new Map();
+globalThis.__GBDRAW_TEST_HOOKS__ = {
+  onStructuralMetric({ name, resourceName }) {
+    if (name !== 'resourceTextReadCount') return;
+    restoredPrimaryTextReads += 1;
+    restoredTextReadsByName.set(
+      resourceName,
+      (restoredTextReadsByName.get(resourceName) || 0) + 1
+    );
+  }
+};
 globalThis.File = class File extends Blob {
   constructor(parts, name, options = {}) {
     super(parts, options);

--- a/tests/web/session-resource-backing.test.mjs
+++ b/tests/web/session-resource-backing.test.mjs
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import { File } from 'node:buffer';
+import { createHash, webcrypto } from 'node:crypto';
+import test from 'node:test';
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const metrics = [];
+globalThis.__GBDRAW_TEST_HOOKS__ = {
+  onStructuralMetric(metric) {
+    metrics.push({ ...metric });
+  }
+};
+
+const {
+  adoptCurrentSessionResources,
+  createSessionResourceFileView,
+  readSessionResourceBytes,
+  readSessionResourceText
+} = await import('../../gbdraw/web/js/services/session-resource-backing.js');
+const {
+  readFileBytes,
+  readFileText
+} = await import('../../gbdraw/web/js/services/file-content-cache.js');
+const { adoptRuntimeCanonicalSession } = await import(
+  '../../gbdraw/web/js/services/session-authority.js'
+);
+const { buildSessionResources } = await import(
+  '../../gbdraw/web/js/services/session-resources.js'
+);
+
+const encodedDescriptor = (name, text, overrides = {}) => {
+  const bytes = new TextEncoder().encode(text);
+  return {
+    kind: 'genbank',
+    name,
+    type: 'text/plain',
+    size: bytes.byteLength,
+    lastModified: 7,
+    encoding: 'base64',
+    data: Buffer.from(bytes).toString('base64'),
+    ...overrides
+  };
+};
+
+const metricTotal = (name, resourceId = null) => metrics
+  .filter((metric) => (
+    metric.name === name
+    && (resourceId === null || metric.resourceId === resourceId)
+  ))
+  .reduce((total, metric) => total + metric.value, 0);
+
+const resetMetrics = () => metrics.splice(0);
+
+test('current-session file views materialize one requested resource once', async () => {
+  const alphaText = 'alpha resource\n';
+  const checksum = createHash('sha256').update(alphaText).digest('hex');
+  const resources = {
+    alpha: encodedDescriptor('alpha.gbk', alphaText, {
+      checksum: `sha256:${checksum}`
+    }),
+    beta: encodedDescriptor('beta.gbk', 'beta resource\n')
+  };
+  resetMetrics();
+  const table = adoptCurrentSessionResources(resources);
+  const alpha = createSessionResourceFileView(table, 'alpha', {
+    name: 'display-alpha.gbk',
+    type: 'application/genbank',
+    lastModified: 99
+  });
+  const beta = createSessionResourceFileView(table, 'beta');
+
+  assert.deepEqual(alpha, {
+    name: 'display-alpha.gbk',
+    type: 'application/genbank',
+    size: new TextEncoder().encode(alphaText).byteLength,
+    lastModified: 99
+  });
+  assert.equal(Object.isFrozen(alpha), true);
+  assert.equal(Object.hasOwn(alpha, 'data'), false);
+  assert.equal(Object.hasOwn(alpha, 'resourceId'), false);
+  assert.equal(metrics.length, 0, 'adoption and metadata projection stay lazy');
+
+  const directBytes = readSessionResourceBytes(alpha);
+  assert.strictEqual(
+    readSessionResourceBytes(alpha),
+    directBytes,
+    'concurrent backing reads share one Promise'
+  );
+  const [bytesA, bytesB, textA, textB, directText] = await Promise.all([
+    readFileBytes(alpha),
+    readFileBytes(alpha),
+    readFileText(alpha),
+    readFileText(alpha),
+    readSessionResourceText(alpha)
+  ]);
+
+  assert.strictEqual(bytesA, bytesB);
+  assert.equal(new TextDecoder().decode(bytesA), alphaText);
+  assert.equal(textA, alphaText);
+  assert.equal(textB, alphaText);
+  assert.equal(directText, alphaText);
+  assert.equal(metricTotal('base64DecodeCount', 'alpha'), 1);
+  assert.equal(metricTotal('decodedByteCount', 'alpha'), alpha.size);
+  assert.equal(metricTotal('resourceByteReadCount', 'alpha'), 1);
+  assert.equal(metricTotal('resourceTextReadCount', 'alpha'), 1);
+  assert.equal(metricTotal('base64DecodeCount', 'beta'), 0);
+  assert.equal(metricTotal('resourceByteReadCount', 'beta'), 0);
+  assert.equal(await readFileText(beta), 'beta resource\n');
+  assert.equal(metricTotal('base64DecodeCount', 'beta'), 1);
+});
+
+test('lazy resource failures identify the resource and remain cached', async () => {
+  const cases = [
+    {
+      id: 'invalid-base64',
+      descriptor: encodedDescriptor('invalid.gbk', 'unused', { data: '%%%' }),
+      message: /invalid-base64 \(invalid\.gbk\) contains invalid encoded data/
+    },
+    {
+      id: 'wrong-size',
+      descriptor: encodedDescriptor('wrong-size.gbk', 'size', { size: 99 }),
+      message: /wrong-size \(wrong-size\.gbk\) byte size does not match/
+    },
+    {
+      id: 'wrong-checksum',
+      descriptor: encodedDescriptor('wrong-checksum.gbk', 'checksum', {
+        checksum: '0'.repeat(64)
+      }),
+      message: /wrong-checksum \(wrong-checksum\.gbk\) checksum does not match/
+    }
+  ];
+
+  for (const { id, descriptor, message } of cases) {
+    resetMetrics();
+    const table = adoptCurrentSessionResources({ [id]: descriptor });
+    const view = createSessionResourceFileView(table, id);
+    const first = readSessionResourceBytes(view);
+    const second = readSessionResourceBytes(view);
+    assert.strictEqual(second, first);
+    await assert.rejects(first, message);
+    await assert.rejects(readFileText(view), message);
+    assert.equal(metricTotal('base64DecodeCount', id), 1);
+    assert.equal(metricTotal('resourceByteReadCount', id), 1);
+  }
+});
+
+test('ordinary uploaded File objects keep the native read behavior', async () => {
+  const file = new File(['native upload'], 'native.txt', { type: 'text/plain' });
+  let reads = 0;
+  const nativeArrayBuffer = file.arrayBuffer.bind(file);
+  file.arrayBuffer = async () => {
+    reads += 1;
+    return nativeArrayBuffer();
+  };
+
+  assert.equal(await readFileText(file), 'native upload');
+  assert.equal(new TextDecoder().decode(await readFileBytes(file)), 'native upload');
+  assert.equal(reads, 1);
+});
+
+test('adopted export reuses descriptors and encodes only a replacement', async () => {
+  const resources = {
+    alpha: encodedDescriptor('alpha.gbk', 'alpha\n'),
+    beta: encodedDescriptor('beta.gbk', 'beta\n'),
+    unused: encodedDescriptor('unused.txt', 'unused\n')
+  };
+  const committed = adoptRuntimeCanonicalSession({
+    renderRequest: {
+      schema: 5,
+      mode: 'linear',
+      records: [
+        {
+          recordKey: 'alpha-record',
+          source: { kind: 'genbank', resourceId: 'alpha' }
+        },
+        {
+          recordKey: 'beta-record',
+          source: { kind: 'genbank', resourceId: 'beta' }
+        }
+      ],
+      diagramOptions: {},
+      layout: {},
+      comparisons: [],
+      output: { prefix: 'lazy-export', formats: ['svg'], overwrite: false }
+    },
+    resources,
+    webFiles: {}
+  });
+  const table = adoptCurrentSessionResources(resources);
+  const alpha = createSessionResourceFileView(table, 'alpha');
+  const beta = createSessionResourceFileView(table, 'beta');
+  const state = {
+    files: {},
+    linearSeqs: [
+      { uid: 'alpha-record', gb: alpha, losat_gencode: 1 },
+      { uid: 'beta-record', gb: beta, losat_gencode: 1 }
+    ],
+    linearComparisonPlan: { edges: [] }
+  };
+
+  resetMetrics();
+  const unchanged = await buildSessionResources(state, committed);
+  assert.equal(metricTotal('base64DecodeCount'), 0);
+  assert.equal(metricTotal('base64EncodeCount'), 0);
+  assert.strictEqual(unchanged.resources.alpha, resources.alpha);
+  assert.strictEqual(unchanged.resources.beta, resources.beta);
+  assert.strictEqual(unchanged.resources.unused, resources.unused);
+  assert.deepEqual(unchanged.resources, resources);
+
+  assert.equal(await readFileText(alpha), 'alpha\n');
+  resetMetrics();
+  const materializedButUnchanged = await buildSessionResources(state, committed);
+  assert.equal(metricTotal('base64DecodeCount'), 0);
+  assert.equal(metricTotal('base64EncodeCount'), 0);
+  assert.strictEqual(materializedButUnchanged.resources.alpha, resources.alpha);
+
+  const replacement = new File(['replacement beta\n'], 'beta.gbk', {
+    type: 'text/plain',
+    lastModified: 8
+  });
+  state.linearSeqs[1].gb = replacement;
+  resetMetrics();
+  const changed = await buildSessionResources(state, committed);
+  const changedId = changed.webFiles.bindings.linearSeqs[1].gb.resourceId;
+  assert.equal(metricTotal('base64DecodeCount'), 0);
+  assert.equal(metricTotal('base64EncodeCount'), 1);
+  assert.equal(metricTotal('encodedByteCount'), replacement.size);
+  assert.equal(changed.webFiles.bindings.linearSeqs[0].gb.resourceId, 'alpha');
+  assert.notEqual(changedId, 'beta');
+  assert.strictEqual(changed.resources.alpha, resources.alpha);
+  assert.strictEqual(changed.resources.beta, resources.beta);
+  assert.equal(
+    Buffer.from(changed.resources[changedId].data, 'base64').toString('utf8'),
+    'replacement beta\n'
+  );
+});

--- a/tests/web/session-resource-backing.test.mjs
+++ b/tests/web/session-resource-backing.test.mjs
@@ -14,6 +14,7 @@ globalThis.__GBDRAW_TEST_HOOKS__ = {
 
 const {
   adoptCurrentSessionResources,
+  createCombinedSessionResourceFileView,
   createSessionResourceFileView,
   readSessionResourceBytes,
   readSessionResourceText
@@ -87,15 +88,33 @@ test('current-session file views materialize one requested resource once', async
     directBytes,
     'concurrent backing reads share one Promise'
   );
-  const [bytesA, bytesB, textA, textB, directText] = await Promise.all([
+  const genericBytes = readFileBytes(alpha);
+  assert.strictEqual(
+    genericBytes,
+    directBytes,
+    'the generic cache retains the backing Promise rather than a copied byte array'
+  );
+  assert.strictEqual(
     readFileBytes(alpha),
+    genericBytes,
+    'concurrent generic reads share the cached Promise'
+  );
+  const [directValue, bytesA, bytesB, textA, textB, directText] = await Promise.all([
+    directBytes,
+    genericBytes,
     readFileBytes(alpha),
     readFileText(alpha),
     readFileText(alpha),
     readSessionResourceText(alpha)
   ]);
 
+  assert.strictEqual(bytesA, directValue);
   assert.strictEqual(bytesA, bytesB);
+  assert.strictEqual(
+    await readFileBytes(alpha),
+    directValue,
+    'the generic cache does not retain a second Uint8Array'
+  );
   assert.equal(new TextDecoder().decode(bytesA), alphaText);
   assert.equal(textA, alphaText);
   assert.equal(textB, alphaText);
@@ -108,6 +127,72 @@ test('current-session file views materialize one requested resource once', async
   assert.equal(metricTotal('resourceByteReadCount', 'beta'), 0);
   assert.equal(await readFileText(beta), 'beta resource\n');
   assert.equal(metricTotal('base64DecodeCount', 'beta'), 1);
+});
+
+test('combined file views report exact canonical byte sizes without preview decoding', async () => {
+  const cases = [
+    {
+      name: 'both resources end with LF',
+      parts: ['a\n', 'ab\n'],
+      expected: 'a\nab\n'
+    },
+    {
+      name: 'neither resource ends with LF',
+      parts: ['a', 'abc'],
+      expected: 'a\nabc\n'
+    },
+    {
+      name: 'one resource ends with LF',
+      parts: ['alpha\n', 'be'],
+      expected: 'alpha\nbe\n'
+    }
+  ];
+
+  for (const { name, parts, expected } of cases) {
+    resetMetrics();
+    const resources = Object.fromEntries(parts.map((text, index) => [
+      `part-${index + 1}`,
+      encodedDescriptor(`part-${index + 1}.gbk`, text)
+    ]));
+    const table = adoptCurrentSessionResources(resources);
+    const view = createCombinedSessionResourceFileView(table, Object.keys(resources));
+    const expectedBytes = new TextEncoder().encode(expected);
+
+    assert.equal(metrics.length, 0, `${name}: metadata projection stays lazy`);
+    assert.equal(view.size, expectedBytes.byteLength, `${name}: declared size is exact`);
+
+    const backingRead = readSessionResourceBytes(view);
+    assert.strictEqual(
+      readSessionResourceBytes(view),
+      backingRead,
+      `${name}: concurrent combined backing reads share one Promise`
+    );
+    const genericRead = readFileBytes(view);
+    assert.strictEqual(
+      genericRead,
+      backingRead,
+      `${name}: generic and combined boundaries share one Promise`
+    );
+    assert.strictEqual(readFileBytes(view), genericRead);
+
+    const [backingBytes, genericBytes] = await Promise.all([backingRead, genericRead]);
+    assert.strictEqual(
+      genericBytes,
+      backingBytes,
+      `${name}: generic and combined boundaries share one Uint8Array`
+    );
+    assert.equal(view.size, genericBytes.byteLength, `${name}: materialized size is exact`);
+    assert.equal(new TextDecoder().decode(genericBytes), expected);
+
+    Object.keys(resources).forEach((resourceId) => {
+      assert.equal(metricTotal('base64DecodeCount', resourceId), 1);
+      assert.equal(metricTotal('resourceByteReadCount', resourceId), 1);
+      assert.equal(
+        metricTotal('decodedByteCount', resourceId),
+        resources[resourceId].size
+      );
+    });
+  }
 });
 
 test('lazy resource failures identify the resource and remain cached', async () => {

--- a/tests/web/svg-result-ingestion.test.mjs
+++ b/tests/web/svg-result-ingestion.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   getCommittedSvgContent,
   getCommittedSvgResultMetadata,
+  ingestCatalogBackedSvgResults,
   ingestSvgResult,
   ingestSvgResults,
   isCommittedSvgResult,
@@ -11,7 +12,6 @@ import {
   markCommittedSvgResultUnmounted
 } from '../../gbdraw/web/js/services/svg-result-ingestion.js';
 import { normalizeLogicalResults } from '../../gbdraw/web/js/services/result-normalization.js';
-
 class FakeDomParser {
   static calls = 0;
 
@@ -119,6 +119,63 @@ test('a malformed sanitized document never becomes committed', () => {
       {
         sanitizer: { sanitize: (content) => content },
         parser: FakeDomParser
+      }
+    ),
+    /malformed SVG/
+  );
+});
+
+test('a validated catalog commits sanitized saved SVG without a detached parse or scan', () => {
+  const catalogItem = {
+    recordKeys: ['record-a'],
+    biologicalFeatures: [{
+      recordKey: 'record-a',
+      biologicalFeatureId: 'stable-a',
+      record_id: 'public-record-a'
+    }],
+    features: [{
+      recordKey: 'record-a',
+      biologicalFeatureId: 'stable-a',
+      svgId: 'rendered-a'
+    }]
+  };
+  let sanitizeCalls = 0;
+  const beforeParserCalls = FakeDomParser.calls;
+  const committed = ingestCatalogBackedSvgResults([{
+    name: 'saved.svg',
+    content: '<?xml version="1.0"?><svg><script>bad()</script><path id="rendered-a"/></svg>'
+  }], {
+    catalogItems: [catalogItem],
+    sanitizer: {
+      sanitize(content) {
+        sanitizeCalls += 1;
+        return content.replace(/^<\?xml[^>]*>/, '').replace(/<script>[\s\S]*?<\/script>/, '');
+      }
+    }
+  })[0];
+
+  assert.equal(sanitizeCalls, 1);
+  assert.equal(FakeDomParser.calls, beforeParserCalls);
+  assert.equal(isCommittedSvgResult(committed), true);
+  assert.equal(committed.content, '<svg><path id="rendered-a"/></svg>');
+  assert.deepEqual(
+    getCommittedSvgResultMetadata(committed).renderedFeatureIdentities.byRenderedId
+      .get('rendered-a'),
+    {
+      renderedId: 'rendered-a',
+      stableId: 'stable-a',
+      recordIndex: 0,
+      recordId: 'public-record-a',
+      elementId: 'rendered-a'
+    }
+  );
+
+  assert.throws(
+    () => ingestCatalogBackedSvgResults(
+      [{ name: 'bad.svg', content: 'not svg' }],
+      {
+        catalogItems: [catalogItem],
+        sanitizer: { sanitize: (content) => content }
       }
     ),
     /malformed SVG/

--- a/tests/web/svg-result-ingestion.test.mjs
+++ b/tests/web/svg-result-ingestion.test.mjs
@@ -149,7 +149,15 @@ test('a validated catalog commits sanitized saved SVG without a detached parse o
     sanitizer: {
       sanitize(content) {
         sanitizeCalls += 1;
-        return content.replace(/^<\?xml[^>]*>/, '').replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
+        let sanitized = content;
+        let previous;
+        do {
+          previous = sanitized;
+          sanitized = sanitized
+            .replace(/^<\?xml[^>]*>/, '')
+            .replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
+        } while (sanitized !== previous);
+        return sanitized;
       }
     }
   })[0];

--- a/tests/web/svg-result-ingestion.test.mjs
+++ b/tests/web/svg-result-ingestion.test.mjs
@@ -149,7 +149,7 @@ test('a validated catalog commits sanitized saved SVG without a detached parse o
     sanitizer: {
       sanitize(content) {
         sanitizeCalls += 1;
-        return content.replace(/^<\?xml[^>]*>/, '').replace(/<script>[\s\S]*?<\/script>/, '');
+        return content.replace(/^<\?xml[^>]*>/, '').replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
       }
     }
   })[0];

--- a/tests/web/webapp-performance.playwright.spec.js
+++ b/tests/web/webapp-performance.playwright.spec.js
@@ -262,8 +262,14 @@ test('WSSV restore and ordinary edits keep History and SVG work bounded', async 
   await assertSessionLoadLeftWorkerIdle(page);
   const restoreProbe = await getProbeSnapshot(page);
   expect(restoreProbe.sanitizeCalls, 'WSSV must cross one sanitizer boundary').toHaveLength(1);
-  expect(restoreProbe.parseCalls, 'WSSV must cross one full SVG parse boundary').toHaveLength(1);
-  expect(restoreProbe.serializeCalls.length, 'WSSV commit may serialize at most once').toBeLessThanOrEqual(1);
+  expect(
+    restoreProbe.parseCalls,
+    'validated current-session catalogs must avoid a detached SVG parse'
+  ).toHaveLength(0);
+  expect(
+    restoreProbe.serializeCalls,
+    'validated current-session catalogs must avoid reserializing the saved SVG'
+  ).toHaveLength(0);
   expect(restoreProbe.resultContentUpdates, 'WSSV must have one final Result commit').toHaveLength(1);
   expect(restoreProbe.previewMounts, 'the committed WSSV Result must mount once').toHaveLength(1);
   expect(restoreProbe.featureIndexBuilds, 'the feature DOM index must be built once per root').toHaveLength(1);


### PR DESCRIPTION
## Summary

Make current Web sessions and large browser renders memory-safe at the
real V. harveyi Gallery scale.

This PR restores reliable session loading and repeated Generate Diagram
operations. It does not yet restore the former few-second latency.

## Root cause

Large renders amplified memory through both sides of the Worker boundary:

- base64 resource tables were copied into replay JSON;
- the table was structured-cloned into the Worker and stringified again;
- Python parsed and decoded the same resources;
- the large SVG and feature metadata result was serialized as one JSON string
  and parsed again on the JavaScript side.

The historical commits examined did not contain a successful real
V. harveyi Generate baseline, so this PR does not claim to identify the first
commit where Generate began failing.

## Changes

- lazily adopt validated current-session resources;
- stage only resources referenced by the canonical request;
- transfer resource bytes with transferable ArrayBuffers;
- reuse staged resources in the persistent diagram Worker;
- pass validated workspace paths to Python instead of a base64 resource table;
- return SVG and feature metadata as transferable UTF-8 binary;
- generate the full replay session only when the CLI helper is downloaded;
- use the validated feature catalog to avoid redundant saved-SVG parse,
  feature scan, and serialization work;
- add a serial real V. harveyi load and two-render acceptance contract.

The session format, Gallery artifacts, reference SVGs, and SESSION_VERSION
are unchanged.

## Validation

Real V. harveyi:

- first preview: 23.09 s
- interactive-ready: 23.50 s
- Generate 1: 70.14 s
- Generate 2: 67.02 s
- first resource transfer: 71,480,904 bytes
- second resource transfer: 0 bytes
- Worker construction and initialization: once
- full replay JSON generation during render: zero
- base64 Worker clone/stringify: zero

The session loads, generates, and generates again without a page crash.

## Remaining work

- current-session preflight still takes about 15 s;
- History baseline still takes about 4.5 s;
- Generate remains about 67–70 s;
- the outer session is still one JSON document and therefore has a finite
  practical memory limit.

Those performance improvements are intentionally deferred to separate PRs.