### PR TITLE
Reduce current-session preflight latency

### DIFF
--- a/gbdraw/web/js/app/losat-cache.js
+++ b/gbdraw/web/js/app/losat-cache.js
@@ -244,6 +244,33 @@ export const validateProteinIdentityManifest = (manifest) => {
   return true;
 };
 
+const validatedProteinIdentityIndexes = new WeakMap();
+
+export const buildValidatedProteinIdentityIndex = (manifest) => {
+  if (!validateProteinIdentityManifest(manifest)) return null;
+  const runtimeIdsByInstance = new Map();
+  Object.entries(manifest.recordInstances).forEach(([instanceKey, instance]) => {
+    const runtimeIds = new Set(Object.values(instance.runtimeIds));
+    runtimeIdsByInstance.set(instanceKey, runtimeIds);
+  });
+  const index = Object.freeze({});
+  validatedProteinIdentityIndexes.set(index, {
+    manifest,
+    runtimeIdsByInstance,
+    runtimeHandles: null
+  });
+  return index;
+};
+
+export const releaseValidatedProteinIdentityIndex = (index) => (
+  validatedProteinIdentityIndexes.delete(index)
+);
+
+const indexedProteinIdentity = (manifest, index) => {
+  const validated = index && validatedProteinIdentityIndexes.get(index);
+  return validated?.manifest === manifest ? validated : null;
+};
+
 export const mergeProteinIdentityManifests = (manifests) => {
   const merged = emptyProteinIdentityManifest();
   (Array.isArray(manifests) ? manifests : []).forEach((manifest) => {
@@ -260,10 +287,16 @@ export const mergeProteinIdentityManifests = (manifests) => {
   return merged;
 };
 
-export const validateProteinRawEntryReferences = (entry, manifest) => {
-  if (!isProteinRawLosatCacheEntry(entry) || !validateProteinIdentityManifest(manifest)) {
+export const validateProteinRawEntryReferences = (
+  entry,
+  manifest,
+  { identityIndex = null } = {}
+) => {
+  if (!isProteinRawLosatCacheEntry(entry)) {
     return false;
   }
+  const indexedIdentity = indexedProteinIdentity(manifest, identityIndex);
+  if (!indexedIdentity && !validateProteinIdentityManifest(manifest)) return false;
   const queryInstance = manifest.recordInstances[entry.queryRecordInstanceKey];
   const subjectInstance = manifest.recordInstances[entry.subjectRecordInstanceKey];
   if (!queryInstance || !subjectInstance) return false;
@@ -277,8 +310,10 @@ export const validateProteinRawEntryReferences = (entry, manifest) => {
   ) return false;
   return rawProteinTextMatchesBindings(
     entry.text,
-    new Set(Object.values(queryInstance.runtimeIds)),
-    new Set(Object.values(subjectInstance.runtimeIds))
+    indexedIdentity?.runtimeIdsByInstance.get(entry.queryRecordInstanceKey)
+      || new Set(Object.values(queryInstance.runtimeIds)),
+    indexedIdentity?.runtimeIdsByInstance.get(entry.subjectRecordInstanceKey)
+      || new Set(Object.values(subjectInstance.runtimeIds))
   );
 };
 
@@ -446,15 +481,22 @@ const isStrictEmptyDerivedResult = (entry) => {
   return true;
 };
 
-export const validateDerivedProteinReferences = (entry, manifest) => {
-  if (
-    !isLosatDerivedCacheEntry(entry, { allowLegacy: false }) ||
-    !validateProteinIdentityManifest(manifest)
-  ) return false;
-  const runtimeHandles = new Set();
-  Object.values(manifest.recordInstances).forEach((instance) => {
-    Object.values(instance.runtimeIds || {}).forEach((handle) => runtimeHandles.add(handle));
-  });
+export const validateDerivedProteinReferences = (
+  entry,
+  manifest,
+  { identityIndex = null } = {}
+) => {
+  if (!isLosatDerivedCacheEntry(entry, { allowLegacy: false })) return false;
+  const indexedIdentity = indexedProteinIdentity(manifest, identityIndex);
+  if (!indexedIdentity && !validateProteinIdentityManifest(manifest)) return false;
+  let runtimeHandles = indexedIdentity?.runtimeHandles || null;
+  if (!runtimeHandles) {
+    runtimeHandles = new Set();
+    Object.values(manifest.recordInstances).forEach((instance) => {
+      Object.values(instance.runtimeIds || {}).forEach((handle) => runtimeHandles.add(handle));
+    });
+    if (indexedIdentity) indexedIdentity.runtimeHandles = runtimeHandles;
+  }
   const hasForbiddenLegacyReference = (value) => (
     LEGACY_PROTEIN_REFERENCE_RE.test(value) ||
     LONG_TRANSPORT_ID_RE.test(value) ||

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -142,14 +142,14 @@ import {
 } from '../app/legend-layout/composition-actions.js';
 import {
   LOSAT_DERIVED_CACHE_SCHEMA,
+  buildValidatedProteinIdentityIndex,
   classifyRawLosatCacheEntry,
   createLegacyProteinCandidateEnvelope,
   emptyProteinIdentityManifest,
   isCurrentRawLosatCacheEntry,
   isLosatDerivedCacheEntry,
   normalizeLegacyProteinCandidateEnvelope,
-  proteinRuntimeIdSets,
-  rawProteinTextMatchesBindings,
+  releaseValidatedProteinIdentityIndex,
   serializableLegacyProteinCandidateEnvelope,
   validateDerivedProteinReferences,
   validateProteinRawEntryReferences,
@@ -1218,39 +1218,43 @@ export const validateSessionLosatArtifacts = (data, sourceSessionVersion) => {
   rejectInvalidLosatCacheKeys(rawEntries, 'LOSAT', { requireKey: true });
   rejectInvalidLosatCacheKeys(derivedEntries, 'derived LOSATP');
 
-  if (!validateProteinIdentityManifest(manifest)) {
+  if (sourceSessionVersion === SESSION_VERSION) {
+    recordStructuralMetric('currentSessionPreflightProteinManifestValidationCount');
+  }
+  const identityIndex = buildValidatedProteinIdentityIndex(manifest);
+  if (!identityIndex) {
     throw new Error(
       `Session version ${sourceSessionVersion} requires a valid schema-2 protein manifest.`
     );
   }
-  for (const entry of rawEntries) {
-    const classification = classifyRawLosatCacheEntry(entry);
-    if (!['protein-current', 'nucleotide-current'].includes(classification)) {
-      throw new Error(
-        `Session version ${sourceSessionVersion} contains a non-current raw LOSAT entry.`
-      );
+  let invalidDerivedEntry = false;
+  try {
+    for (const entry of rawEntries) {
+      const classification = classifyRawLosatCacheEntry(entry);
+      if (!['protein-current', 'nucleotide-current'].includes(classification)) {
+        throw new Error(
+          `Session version ${sourceSessionVersion} contains a non-current raw LOSAT entry.`
+        );
+      }
+      if (classification !== 'protein-current') continue;
+      if (sourceSessionVersion === SESSION_VERSION) {
+        recordStructuralMetric('currentSessionPreflightProteinRawTextValidationCount');
+      }
+      if (
+        !validateProteinRawEntryReferences(entry, manifest, { identityIndex })
+      ) {
+        throw new Error(
+          `Session version ${sourceSessionVersion} contains an unresolved protein raw entry.`
+        );
+      }
     }
-    if (classification !== 'protein-current') continue;
-    const ids = proteinRuntimeIdSets(
-      manifest,
-      entry.queryRecordInstanceKey,
-      entry.subjectRecordInstanceKey
+    invalidDerivedEntry = derivedEntries.some(
+      (entry) => !validateDerivedProteinReferences(entry, manifest, { identityIndex })
     );
-    if (
-      !validateProteinRawEntryReferences(entry, manifest) ||
-      !ids ||
-      !rawProteinTextMatchesBindings(entry.text, ids.query, ids.subject)
-    ) {
-      throw new Error(
-        `Session version ${sourceSessionVersion} contains an unresolved protein raw entry.`
-      );
-    }
+  } finally {
+    releaseValidatedProteinIdentityIndex(identityIndex);
   }
-  if (
-    derivedEntries.some(
-      (entry) => !validateDerivedProteinReferences(entry, manifest)
-    )
-  ) {
+  if (invalidDerivedEntry) {
     throw new Error(
       `Session version ${sourceSessionVersion} contains an invalid derived LOSATP entry.`
     );
@@ -1565,14 +1569,22 @@ const preflightSessionImport = (rawData) => {
     if (!isPlainObject(rawData) || rawData.format !== 'gbdraw-session') {
       throw new Error('Invalid session file.');
     }
+    recordSessionLifecycleEvent('session-authority-validation-start');
     adoptedSession = adoptCurrentSessionDocument(rawData, SESSION_VERSION);
+    recordSessionLifecycleEvent('session-authority-validation-end');
+    recordSessionLifecycleEvent('feature-catalog-validation-start');
     validatedFeatureCatalog = validateCurrentWriterFeatureCatalog(rawData, {
       adopt: true
     });
+    recordSessionLifecycleEvent('feature-catalog-validation-end');
+    recordSessionLifecycleEvent('editor-state-normalization-start');
     normalizedEditorState = normalizeEditorStateData(rawData.editorState, {
       featureCatalog: validatedFeatureCatalog
     });
+    recordSessionLifecycleEvent('editor-state-normalization-end');
+    recordSessionLifecycleEvent('resource-table-adoption-start');
     currentResourceTable = adoptCurrentSessionResources(rawData.resources);
+    recordSessionLifecycleEvent('resource-table-adoption-end');
     normalizedData = rawData;
   } else {
     validateSessionAuthorityInventory(rawData, sourceSessionVersion);
@@ -1586,7 +1598,9 @@ const preflightSessionImport = (rawData) => {
   )
     ? promoteGallerySessionToCurrent(normalizedData)
     : normalizedData;
+  if (currentSession) recordSessionLifecycleEvent('losat-artifact-validation-start');
   validateSessionLosatArtifacts(promotedData, sourceSessionVersion);
+  if (currentSession) recordSessionLifecycleEvent('losat-artifact-validation-end');
   const data = currentSession
     ? promotedData
     : migrateSessionDataToCurrent(promotedData, sourceSessionVersion);
@@ -1596,6 +1610,7 @@ const preflightSessionImport = (rawData) => {
         sourceSessionVersion
       )
     : data.config;
+  if (currentSession) recordSessionLifecycleEvent('canonical-request-projection-start');
   const canonicalProjection = sourceSessionVersion >= 31
     ? projectCanonicalSessionRequest({
         renderRequest: data.renderRequest,
@@ -1613,6 +1628,7 @@ const preflightSessionImport = (rawData) => {
         adoptCanonicalPayloads: currentSession
       })
     : null;
+  if (currentSession) recordSessionLifecycleEvent('canonical-request-projection-end');
   let restoredConfig = canonicalProjection
     ? {
         ...restoreStoredNonCanonicalConfig(
@@ -1652,11 +1668,13 @@ const preflightSessionImport = (rawData) => {
     }
   }
   if (canonicalProjection && sourceSessionVersion === SESSION_VERSION) {
+    recordSessionLifecycleEvent('current-draft-validation-start');
     validateCurrentWriterActiveDraft({
       mode: canonicalProjection.mode,
       projectedConfig: canonicalProjection.config,
       storedConfig: runtimeStoredConfig
     });
+    recordSessionLifecycleEvent('current-draft-validation-end');
     restoredConfig = overlayCurrentWriterDraftConfig(
       restoredConfig,
       runtimeStoredConfig
@@ -1682,6 +1700,7 @@ const preflightSessionImport = (rawData) => {
         : null
     });
   }
+  if (currentSession) recordSessionLifecycleEvent('artifact-projection-start');
   const projectionResult = canonicalProjection
     ? (() => {
         const artifactState = projectArtifactState(data);
@@ -1708,6 +1727,7 @@ const preflightSessionImport = (rawData) => {
         };
       })()
     : null;
+  if (currentSession) recordSessionLifecycleEvent('artifact-projection-end');
   return {
     data,
     sourceSessionVersion,

--- a/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
+++ b/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
@@ -160,6 +160,23 @@ const probeSnapshot = (page) => page.evaluate(() => ({
   resultCount: window.__GBDRAW_APP__?.results?.length || 0
 }));
 
+const phaseDuration = (events, startName, endName) => {
+  const start = events.find(({ name }) => name === startName);
+  const end = events.find(({ name }) => name === endName);
+  return start && end ? end.timestamp - start.timestamp : null;
+};
+
+const PREFLIGHT_SUBPHASES = Object.freeze({
+  sessionAuthorityValidationMs: 'session-authority-validation',
+  featureCatalogValidationMs: 'feature-catalog-validation',
+  editorStateNormalizationMs: 'editor-state-normalization',
+  resourceTableAdoptionMs: 'resource-table-adoption',
+  losatArtifactValidationMs: 'losat-artifact-validation',
+  canonicalRequestProjectionMs: 'canonical-request-projection',
+  currentDraftValidationMs: 'current-draft-validation',
+  artifactProjectionMs: 'artifact-projection'
+});
+
 const loadSyntheticSession = (page, variant = 'normal') => page.evaluate(
   async ({ filename, requestedVariant }) => {
     const response = await fetch(`/gbdraw/web/gallery/sessions/${filename}`);
@@ -212,6 +229,17 @@ const lifecycleTiming = (snapshot) => {
   const preview = snapshot.lifecycle.find(({ name }) => name === 'firstCommittedPreview');
   const ready = snapshot.lifecycle.find(({ name }) => name === 'interactiveReady');
   return {
+    currentSessionPreflightMs: phaseDuration(
+      snapshot.lifecycle,
+      'current-session-preflight-start',
+      'current-session-preflight-end'
+    ),
+    preflightSubphases: Object.fromEntries(
+      Object.entries(PREFLIGHT_SUBPHASES).map(([metric, event]) => [
+        metric,
+        phaseDuration(snapshot.lifecycle, `${event}-start`, `${event}-end`)
+      ])
+    ),
     firstPreviewMs: preview && selected ? preview.timestamp - selected.timestamp : null,
     interactiveReadyMs: ready && selected ? ready.timestamp - selected.timestamp : null,
     ready
@@ -283,6 +311,14 @@ test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, 
 
   const snapshot = await probeSnapshot(page);
   const timing = lifecycleTiming(snapshot);
+  const preflightStructural = {
+    proteinManifestFullValidationCount: Number(
+      snapshot.hookMetrics.currentSessionPreflightProteinManifestValidationCount || 0
+    ),
+    proteinRawTextValidationCount: Number(
+      snapshot.hookMetrics.currentSessionPreflightProteinRawTextValidationCount || 0
+    )
+  };
   expect(snapshot.savedPreviewVisible).toBe(true);
   expect(snapshot.resultCount).toBe(1);
   expect(snapshot.structural).toEqual(ZERO_PREVIEW_METRICS);
@@ -292,11 +328,23 @@ test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, 
   });
   expect(timing.firstPreviewMs).toBeGreaterThan(0);
   expect(timing.interactiveReadyMs).toBeGreaterThanOrEqual(timing.firstPreviewMs);
+  expect(timing.currentSessionPreflightMs).toBeLessThan(30_000);
+  expect(preflightStructural.proteinManifestFullValidationCount).toBe(1);
+  expect(preflightStructural.proteinRawTextValidationCount).toBeGreaterThan(0);
 
   await testInfo.attach('vibrio-lazy-session-metrics.json', {
-    body: Buffer.from(JSON.stringify({ structural: snapshot.structural, timing }, null, 2)),
+    body: Buffer.from(JSON.stringify({
+      structural: snapshot.structural,
+      preflightStructural,
+      timing
+    }, null, 2)),
     contentType: 'application/json'
   });
+  console.log(`Vibrio lazy-session evidence: ${JSON.stringify({
+    structural: snapshot.structural,
+    preflightStructural,
+    timing
+  })}`);
 });
 
 test('Generate materializes only required resources and reuses one Worker', async ({ page }) => {

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -301,12 +301,22 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   const previewMetrics = Object.fromEntries(
     PREVIEW_ZERO_METRICS.map((name) => [name, Number(loadProbe.metrics[name] || 0)])
   );
+  const preflightStructural = {
+    proteinManifestFullValidationCount: Number(
+      loadProbe.metrics.currentSessionPreflightProteinManifestValidationCount || 0
+    ),
+    proteinRawTextValidationCount: Number(
+      loadProbe.metrics.currentSessionPreflightProteinRawTextValidationCount || 0
+    )
+  };
   expect(loaded.previewVisible).toBe(true);
   expect(loaded.resultCount).toBe(1);
   expect(ready).toMatchObject({ status: 'success', degradedRecovery: false });
   expect(previewMetrics).toEqual(Object.fromEntries(
     PREVIEW_ZERO_METRICS.map((name) => [name, 0])
   ));
+  expect(preflightStructural.proteinManifestFullValidationCount).toBe(1);
+  expect(preflightStructural.proteinRawTextValidationCount).toBeGreaterThan(0);
 
   await page.evaluate(() => window.__GBDRAW_VIBRIO_GENERATE_PROBE__.reset());
   const first = await invokeGeneration(page, terminal, runnerEvidence, terminalSignal);
@@ -424,6 +434,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   const report = {
     load: {
       previewMetrics,
+      preflightStructural,
       timings: loadTimings(loadProbe.lifecycle)
     },
     generations: {

--- a/tests/web/losat-cache.test.mjs
+++ b/tests/web/losat-cache.test.mjs
@@ -104,6 +104,8 @@ assert.equal(
   'branch-internal protein raw schema 3 must not be accepted'
 );
 assert.equal(cache.validateProteinIdentityManifest(manifest), true);
+const identityIndex = cache.buildValidatedProteinIdentityIndex(manifest);
+assert.ok(identityIndex, 'a valid manifest must produce a reusable identity index');
 const canonicalJson = (value) => {
   if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
   if (value && typeof value === 'object') {
@@ -148,6 +150,12 @@ assert.equal(
   'branch-internal top-level manifest schema 1 must not be accepted'
 );
 assert.equal(cache.validateProteinRawEntryReferences(proteinEntry, manifest), true);
+assert.equal(
+  cache.validateProteinRawEntryReferences(proteinEntry, manifest, { identityIndex }),
+  true,
+  'raw cache validation must accept the reusable identity index'
+);
+assert.equal(cache.releaseValidatedProteinIdentityIndex(identityIndex), true);
 const queryRuntimeIds = new Set([runtimeA]);
 const subjectRuntimeIds = new Set([runtimeB]);
 assert.equal(


### PR DESCRIPTION
## Summary

- Reuse one validated protein identity index across current-session LOSAT checks.
- Validate each raw LOSAT payload once and release the index before commit.
- Add preflight subphase timings and structural assertions to the Vibrio contracts.

## Results

The real Vibrio current-session preflight fell from 14.1 seconds to 1.5 seconds.
LOSAT artifact validation fell from 13.2 seconds to 0.7 seconds.

Manifest validation passes dropped from 119 to 1, and raw LOSAT text passes
dropped from 118 to 59.

Preview restoration still performs no resource decoding, file copying, or Worker
startup. Both Generate cycles succeed and reuse staged resources.

## Verification

- Required Node Web tests
- Current-session lazy-materialization Playwright contract
- Full Vibrio generation contract
- Python Web feature/request tests
- Ruff and git diff checks