### PR TITLE
Avoid full artifact capture for session-load History

### DIFF
--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -975,6 +975,7 @@ export const createAppSetup = () => {
     applyCheckpoint: historySnapshots.applyArtifactCheckpoint,
     signatureFor: historySnapshots.snapshotSignature,
     fileStore: historyFileStore,
+    collectCurrentFileIds: historySnapshots.collectCurrentFileIds,
     makeRef: ref
   });
   window.__GBDRAW_HISTORY__ = history;
@@ -1935,7 +1936,7 @@ export const createAppSetup = () => {
         await synchronizeLoadedSessionLegendEntries();
       }
       recordSessionLifecycleEvent('history-baseline-start');
-      await history.captureBaseline('Loaded session');
+      await history.initializeIntentBaseline('Loaded session');
       recordSessionLifecycleEvent('history-baseline-end');
     }
     return result;
@@ -2208,6 +2209,8 @@ export const createAppSetup = () => {
       featureSelection.clearFeatureSelection({ clearStatus: true });
     }
     return result;
+  }, {
+    shouldCommit: (result) => result?.status === 'ok'
   });
 
   const cancelGeneration = () => {

--- a/gbdraw/web/js/services/history-snapshot.js
+++ b/gbdraw/web/js/services/history-snapshot.js
@@ -502,6 +502,47 @@ const buildIntentFilesData = (state, fileStore) => {
   return files;
 };
 
+const collectCurrentFileIds = (state, fileStore) => {
+  const fileIds = new Set();
+  const register = (value) => {
+    if (Array.isArray(value)) {
+      value.forEach(register);
+      return;
+    }
+    const fileId = fileStore.registerFile(value);
+    if (fileId) fileIds.add(fileId);
+  };
+  const files = state.files || {};
+  [
+    files.c_gb,
+    files.c_gff,
+    files.c_fasta,
+    files.c_depth,
+    files.c_conservation_blasts,
+    files.c_conservation_fastas,
+    files.c_conservation_sequence_sources,
+    files.d_color,
+    files.t_color,
+    files.blacklist,
+    files.whitelist,
+    files.qualifier_priority
+  ].forEach(register);
+  (Array.isArray(files.linearCanonicalComparisons)
+    ? files.linearCanonicalComparisons
+    : []
+  ).forEach((comparison) => register(comparison?.file));
+  Array.from(state.linearSeqs || []).forEach((sequence) => {
+    register(sequence?.gb);
+    register(sequence?.gff);
+    register(sequence?.fasta);
+    register(sequence?.depth);
+  });
+  Array.from(state.linearComparisonPlan?.edges || []).forEach((comparison) => {
+    register(comparison?.file);
+  });
+  return fileIds;
+};
+
 const applyFilesData = (state, filesData, fileStore, normalizeLinearSeqList = null) => {
   if (!state.files) return;
   state.matchSequenceRegistry?.reset?.();
@@ -897,6 +938,7 @@ export const createHistorySnapshotService = ({
     applyGeneratedArtifactSnapshot,
     applyHistoryIntent,
     buildArtifactCheckpoint,
+    collectCurrentFileIds: () => collectCurrentFileIds(state, fileStore),
     buildGeneratedArtifactSnapshot,
     buildHistoryIntent,
     setAfterApplyHistoryIntent,

--- a/gbdraw/web/js/services/history.js
+++ b/gbdraw/web/js/services/history.js
@@ -116,6 +116,7 @@ export const createHistoryManager = ({
   applyCheckpoint,
   signatureFor = (value) => JSON.stringify(value),
   fileStore = null,
+  collectCurrentFileIds = null,
   maxActions = DEFAULT_MAX_ACTIONS,
   maxBytes = DEFAULT_MAX_BYTES,
   makeRef = makeBox
@@ -143,6 +144,8 @@ export const createHistoryManager = ({
     intentBuilds: 0,
     artifactCheckpointBuilds: 0,
     signatureComputations: 0,
+    intentSignatureComputations: 0,
+    artifactCheckpointSignatureComputations: 0,
     byteEstimateComputations: 0,
     historySvgBytes: 0
   };
@@ -160,6 +163,11 @@ export const createHistoryManager = ({
 
   const computeSignature = (value, scope) => {
     diagnostics.signatureComputations += 1;
+    if (scope === 'artifact-checkpoint') {
+      diagnostics.artifactCheckpointSignatureComputations += 1;
+    } else if (String(scope || '').startsWith('intent')) {
+      diagnostics.intentSignatureComputations += 1;
+    }
     const signature = signatureFor(value);
     emitHistoryDiagnostic({ type: 'signature', scope, bytes: String(signature || '').length * 2 });
     return signature;
@@ -172,6 +180,16 @@ export const createHistoryManager = ({
     return bytes;
   };
 
+  const collectIntentFileIds = (intent) => {
+    const fileIds = collectHistoryFileIds(intent, new Set());
+    if (typeof collectCurrentFileIds !== 'function') return fileIds;
+    const currentIds = collectCurrentFileIds();
+    if (currentIds && typeof currentIds[Symbol.iterator] === 'function') {
+      for (const fileId of currentIds) fileIds.add(fileId);
+    }
+    return fileIds;
+  };
+
   const captureIntent = async () => {
     capturing.value = true;
     diagnostics.intentBuilds += 1;
@@ -182,7 +200,7 @@ export const createHistoryManager = ({
       return {
         intent,
         signature,
-        fileIds: collectHistoryFileIds(intent, new Set())
+        fileIds: collectIntentFileIds(intent)
       };
     } finally {
       capturing.value = false;
@@ -327,6 +345,20 @@ export const createHistoryManager = ({
     if (!transaction) return;
     transaction.closed = true;
     if (activeTransaction === transaction) activeTransaction = null;
+  };
+
+  const initializeIntentBaseline = async (_label = 'Intent baseline') => {
+    if (restoring.value) return false;
+    if (activeTransaction && !activeTransaction.closed) cancel(activeTransaction);
+    const intentRecord = await captureIntent();
+    clearStack(undoStack);
+    clearRedo();
+    currentCheckpoint = null;
+    currentCheckpointSignature = '';
+    setCurrentIntent(intentRecord);
+    enforceLimits();
+    touch();
+    return true;
   };
 
   const buildPatchEntry = (transaction, afterRecord, options = {}) => {
@@ -476,10 +508,19 @@ export const createHistoryManager = ({
     const execute = async (tx) => {
       try {
         const result = await fn();
+        if (
+          typeof options.shouldCommit === 'function'
+          && !options.shouldCommit(result)
+        ) {
+          if (tx) tx.closed = true;
+          releaseUnreferencedFiles();
+          return result;
+        }
         await commitCheckpoint(tx, options);
         return result;
       } catch (error) {
         if (tx) tx.closed = true;
+        releaseUnreferencedFiles();
         throw error;
       }
     };
@@ -562,7 +603,7 @@ export const createHistoryManager = ({
     setCurrentIntent({
       intent: nextIntent,
       signature,
-      fileIds: collectHistoryFileIds(nextIntent, new Set())
+      fileIds: collectIntentFileIds(nextIntent)
     });
   };
 
@@ -653,6 +694,7 @@ export const createHistoryManager = ({
     getRedoCount: () => redoStack.length,
     getUndoCount: () => undoStack.length,
     historyLimitMessage,
+    initializeIntentBaseline,
     redo,
     redoLabel,
     restoring,

--- a/tests/web/composition-layout-real.playwright.spec.js
+++ b/tests/web/composition-layout-real.playwright.spec.js
@@ -464,21 +464,21 @@ const reloadSession = async (page, file, mode, legendSide) => {
   await page.waitForFunction(() => window.__GBDRAW_APP__);
   await page.evaluate(() => {
     const history = window.__GBDRAW_HISTORY__;
-    if (!history?.captureBaseline) {
+    if (!history?.initializeIntentBaseline) {
       throw new Error('The session-import history boundary is unavailable.');
     }
-    const originalCaptureBaseline = history.captureBaseline;
+    const originalInitializeIntentBaseline = history.initializeIntentBaseline;
     window.__GBDRAW_SESSION_IMPORT_COMPLETE__ = null;
-    history.captureBaseline = async (label, ...args) => {
+    history.initializeIntentBaseline = async (label, ...args) => {
       try {
-        const result = await originalCaptureBaseline(label, ...args);
+        const result = await originalInitializeIntentBaseline(label, ...args);
         if (label === 'Loaded session') {
-          history.captureBaseline = originalCaptureBaseline;
+          history.initializeIntentBaseline = originalInitializeIntentBaseline;
           window.__GBDRAW_SESSION_IMPORT_COMPLETE__ = { status: 'ok', label };
         }
         return result;
       } catch (error) {
-        history.captureBaseline = originalCaptureBaseline;
+        history.initializeIntentBaseline = originalInitializeIntentBaseline;
         window.__GBDRAW_SESSION_IMPORT_COMPLETE__ = {
           status: 'error',
           message: String(error?.message || error)

--- a/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
+++ b/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
@@ -42,6 +42,17 @@ const ZERO_PREVIEW_METRICS = Object.fromEntries(
   STRUCTURAL_METRICS.map((name) => [name, 0])
 );
 
+const ZERO_ARTIFACT_HISTORY_BASELINE = Object.freeze({
+  artifactCheckpointBuilds: 0,
+  artifactCheckpointSignatureComputations: 0,
+  artifactSvgBytes: 0,
+  intentBuilds: 1,
+  intentSignatureComputations: 1,
+  undoCount: 0,
+  redoCount: 0,
+  currentCheckpointAbsent: true
+});
+
 const installLazySessionProbe = async (page) => page.addInitScript((metricNames) => {
   const metricMap = () => Object.fromEntries(metricNames.map((name) => [name, 0]));
   const hookMetrics = metricMap();
@@ -57,6 +68,7 @@ const installLazySessionProbe = async (page) => page.addInitScript((metricNames)
     details,
     lifecycle,
     historyLoaded: false,
+    historyBaseline: null,
     ignoreFile(file) {
       if (file && typeof file === 'object') ignoredFiles.add(file);
     },
@@ -70,6 +82,7 @@ const installLazySessionProbe = async (page) => page.addInitScript((metricNames)
       details.length = 0;
       lifecycle.length = 0;
       this.historyLoaded = false;
+      this.historyBaseline = null;
     },
     snapshot() {
       return {
@@ -81,7 +94,8 @@ const installLazySessionProbe = async (page) => page.addInitScript((metricNames)
         nativeMetrics: { ...nativeMetrics },
         details: details.map((detail) => ({ ...detail })),
         lifecycle: lifecycle.map((event) => ({ ...event })),
-        historyLoaded: this.historyLoaded
+        historyLoaded: this.historyLoaded,
+        historyBaseline: this.historyBaseline ? { ...this.historyBaseline } : null
       };
     }
   };
@@ -141,15 +155,40 @@ const installLazySessionProbe = async (page) => page.addInitScript((metricNames)
 const armHistoryCompletion = (page) => page.evaluate(() => {
   const history = window.__GBDRAW_HISTORY__;
   const probe = window.__GBDRAW_LAZY_SESSION_PROBE__;
-  const original = history.captureBaseline;
+  if (!history?.initializeIntentBaseline) {
+    throw new Error('The lightweight session-import History boundary is unavailable.');
+  }
+  const original = history.initializeIntentBaseline;
   probe.historyLoaded = false;
-  history.captureBaseline = async (label, ...args) => {
-    const result = await original(label, ...args);
-    if (label === 'Loaded session') {
-      probe.historyLoaded = true;
-      history.captureBaseline = original;
+  probe.historyBaseline = null;
+  history.initializeIntentBaseline = async (label, ...args) => {
+    const before = history.getDiagnostics();
+    try {
+      const result = await original(label, ...args);
+      if (label === 'Loaded session') {
+        const after = history.getDiagnostics();
+        probe.historyBaseline = {
+          artifactCheckpointBuilds:
+            after.artifactCheckpointBuilds - before.artifactCheckpointBuilds,
+          artifactCheckpointSignatureComputations:
+            after.artifactCheckpointSignatureComputations
+              - before.artifactCheckpointSignatureComputations,
+          artifactSvgBytes: after.historySvgBytes - before.historySvgBytes,
+          intentBuilds: after.intentBuilds - before.intentBuilds,
+          intentSignatureComputations:
+            after.intentSignatureComputations - before.intentSignatureComputations,
+          undoCount: history.getUndoCount(),
+          redoCount: history.getRedoCount(),
+          currentCheckpointAbsent: history.getCurrentCheckpoint() === null
+        };
+        probe.historyLoaded = true;
+        history.initializeIntentBaseline = original;
+      }
+      return result;
+    } catch (error) {
+      history.initializeIntentBaseline = original;
+      throw error;
     }
-    return result;
   };
 });
 
@@ -234,6 +273,11 @@ const lifecycleTiming = (snapshot) => {
       'current-session-preflight-start',
       'current-session-preflight-end'
     ),
+    historyBaselineMs: phaseDuration(
+      snapshot.lifecycle,
+      'history-baseline-start',
+      'history-baseline-end'
+    ),
     preflightSubphases: Object.fromEntries(
       Object.entries(PREFLIGHT_SUBPHASES).map(([metric, event]) => [
         metric,
@@ -253,6 +297,7 @@ test('synthetic current session restores and exports without materializing resou
 }) => {
   test.setTimeout(180_000);
   await openInstrumentedApp(page);
+  await armHistoryCompletion(page);
 
   const imported = await loadSyntheticSession(page);
   expect(imported).toEqual({ status: 'ok', degradedRecovery: false, message: '' });
@@ -260,6 +305,42 @@ test('synthetic current session restores and exports without materializing resou
   expect(preview.savedPreviewVisible).toBe(true);
   expect(preview.resultCount).toBe(1);
   expect(preview.structural).toEqual(ZERO_PREVIEW_METRICS);
+  expect(preview.historyBaseline).toEqual(ZERO_ARTIFACT_HISTORY_BASELINE);
+
+  const intentHistory = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    const loadedValue = Boolean(app.form.show_scale);
+    const loadedContent = app.results[app.selectedResultIndex]?.content || '';
+    await history.runUndoable('Change coordinate scale', () => {
+      app.form.show_scale = !loadedValue;
+    });
+    const editedValue = Boolean(app.form.show_scale);
+    const undoResult = await history.undo();
+    const undoValue = Boolean(app.form.show_scale);
+    const redoResult = await history.redo();
+    return {
+      loadedValue,
+      editedValue,
+      undoResult,
+      undoValue,
+      redoResult,
+      redoValue: Boolean(app.form.show_scale),
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount(),
+      previewUnchanged: app.results[app.selectedResultIndex]?.content === loadedContent
+    };
+  });
+  expect(intentHistory).toMatchObject({
+    editedValue: !intentHistory.loadedValue,
+    undoResult: true,
+    undoValue: intentHistory.loadedValue,
+    redoResult: true,
+    redoValue: !intentHistory.loadedValue,
+    undoCount: 1,
+    redoCount: 0,
+    previewUnchanged: true
+  });
 
   await page.evaluate(() => {
     window.__GBDRAW_APP__.sessionTitle = 'lazy-unchanged-export';
@@ -322,6 +403,7 @@ test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, 
   expect(snapshot.savedPreviewVisible).toBe(true);
   expect(snapshot.resultCount).toBe(1);
   expect(snapshot.structural).toEqual(ZERO_PREVIEW_METRICS);
+  expect(snapshot.historyBaseline).toEqual(ZERO_ARTIFACT_HISTORY_BASELINE);
   expect(timing.ready).toMatchObject({
     status: 'success',
     degradedRecovery: false
@@ -329,12 +411,15 @@ test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, 
   expect(timing.firstPreviewMs).toBeGreaterThan(0);
   expect(timing.interactiveReadyMs).toBeGreaterThanOrEqual(timing.firstPreviewMs);
   expect(timing.currentSessionPreflightMs).toBeLessThan(30_000);
+  expect(timing.historyBaselineMs).toBeGreaterThanOrEqual(0);
+  expect(timing.historyBaselineMs).toBeLessThan(30_000);
   expect(preflightStructural.proteinManifestFullValidationCount).toBe(1);
   expect(preflightStructural.proteinRawTextValidationCount).toBeGreaterThan(0);
 
   await testInfo.attach('vibrio-lazy-session-metrics.json', {
     body: Buffer.from(JSON.stringify({
       structural: snapshot.structural,
+      historyBaseline: snapshot.historyBaseline,
       preflightStructural,
       timing
     }, null, 2)),
@@ -342,6 +427,7 @@ test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, 
   });
   console.log(`Vibrio lazy-session evidence: ${JSON.stringify({
     structural: snapshot.structural,
+    historyBaseline: snapshot.historyBaseline,
     preflightStructural,
     timing
   })}`);
@@ -350,16 +436,47 @@ test('real Vibrio preview is lazy and leaves the Worker idle', async ({ page }, 
 test('Generate materializes only required resources and reuses one Worker', async ({ page }) => {
   test.setTimeout(300_000);
   await openInstrumentedApp(page);
+  await armHistoryCompletion(page);
   expect(await loadSyntheticSession(page)).toMatchObject({
     status: 'ok',
     degradedRecovery: false
   });
   const preview = await probeSnapshot(page);
   expect(preview.structural).toEqual(ZERO_PREVIEW_METRICS);
+  expect(preview.historyBaseline).toEqual(ZERO_ARTIFACT_HISTORY_BASELINE);
 
   const generated = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    const svgIdentity = (content) => {
+      const documentElement = new DOMParser()
+        .parseFromString(String(content || ''), 'image/svg+xml')
+        .documentElement;
+      const normalized = new XMLSerializer().serializeToString(documentElement);
+      let hash = 2166136261;
+      for (let index = 0; index < normalized.length; index += 1) {
+        hash ^= normalized.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+      }
+      return { length: normalized.length, hash: hash >>> 0 };
+    };
+    const snapshotResultState = () => ({
+      names: app.results.map((result) => String(result?.name || '')),
+      svgIdentities: app.results.map((result) => svgIdentity(result?.content)),
+      selectedResultIndex: app.selectedResultIndex,
+      resultCount: app.results.length,
+      featureCount: app.extractedFeatures.length,
+      orthogroupCount: app.orthogroups.length
+    });
+    const loaded = snapshotResultState();
     const first = await app.runAnalysis();
+    const generatedState = snapshotResultState();
+    const firstUndoCount = history.getUndoCount();
+    const firstRedoCount = history.getRedoCount();
+    const undone = await history.undo();
+    const restoredLoadedState = snapshotResultState();
+    const redone = await history.redo();
+    const restoredGeneratedState = snapshotResultState();
     const {
       DIAGRAM_HELPER_OPERATIONS,
       runDiagramHelperOperation
@@ -372,6 +489,14 @@ test('Generate materializes only required resources and reuses one Worker', asyn
     return {
       first,
       second,
+      loaded,
+      generatedState,
+      firstUndoCount,
+      firstRedoCount,
+      undone,
+      restoredLoadedState,
+      redone,
+      restoredGeneratedState,
       helperWidth: Number(helper?.result?.width || 0),
       errorSummary: String(app.errorLog?.summary || '')
     };
@@ -382,6 +507,16 @@ test('Generate materializes only required resources and reuses one Worker', asyn
     errorSummary: ''
   });
   expect(generated.helperWidth).toBeGreaterThan(0);
+  expect(generated.firstUndoCount).toBe(1);
+  expect(generated.firstRedoCount).toBe(0);
+  expect(generated.undone).toBe(true);
+  expect(generated.restoredLoadedState).toEqual(generated.loaded);
+  expect(generated.redone).toBe(true);
+  expect(generated.restoredGeneratedState).toEqual(generated.generatedState);
+  expect(generated.restoredGeneratedState.selectedResultIndex).toBeGreaterThanOrEqual(0);
+  expect(generated.restoredGeneratedState.selectedResultIndex).toBeLessThan(
+    generated.restoredGeneratedState.resultCount
+  );
 
   const snapshot = await probeSnapshot(page);
   const materializedIds = new Set(
@@ -488,6 +623,29 @@ test('preflight and lazy-access failures preserve the committed preview', async 
   expect(afterAccess.structural.resourceByteReadCount).toBe(1);
   expect(afterAccess.structural.workerConstructionCount).toBe(0);
   expect(afterAccess.structural.workerInitializationCount).toBe(0);
+
+  const failedGenerate = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    const loadedContent = app.results[app.selectedResultIndex]?.content || '';
+    const result = await app.runAnalysis();
+    return {
+      status: result?.status,
+      previewCommitted: app.results[app.selectedResultIndex]?.content === loadedContent,
+      previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount(),
+      currentCheckpointAbsent: history.getCurrentCheckpoint() === null
+    };
+  });
+  expect(failedGenerate).toEqual({
+    status: 'error',
+    previewCommitted: true,
+    previewVisible: true,
+    undoCount: 0,
+    redoCount: 0,
+    currentCheckpointAbsent: true
+  });
 });
 
 test('a frozen v39 session round-trips through the legacy migration path', async ({ page }) => {

--- a/tests/web/history.test.mjs
+++ b/tests/web/history.test.mjs
@@ -157,6 +157,147 @@ const createLayoutPreferences = () => ({
 }
 
 {
+  let setting = 0;
+  let checkpointBuilds = 0;
+  const history = createHistoryManager({
+    buildIntent: async () => ({ setting }),
+    applyIntent: async (intent) => {
+      setting = intent.setting;
+    },
+    buildCheckpoint: () => {
+      checkpointBuilds += 1;
+      return { setting, artifact: '<svg id="baseline" />' };
+    },
+    applyCheckpoint: async (checkpoint) => {
+      setting = checkpoint.setting;
+    }
+  });
+
+  await history.captureBaseline('full baseline');
+  await history.runUndoable('Set one', () => {
+    setting = 1;
+  });
+  await history.undo();
+  assert.equal(history.getRedoCount(), 1);
+  const pending = await history.begin('Pending edit');
+  setting = 2;
+  const before = history.getDiagnostics();
+
+  await history.initializeIntentBaseline('Loaded session');
+  const after = history.getDiagnostics();
+  assert.equal(pending.closed, true);
+  assert.equal(history.getUndoCount(), 0);
+  assert.equal(history.getRedoCount(), 0);
+  assert.equal(history.canUndo(), false);
+  assert.equal(history.canRedo(), false);
+  assert.equal(history.getCurrentCheckpoint(), null);
+  assert.equal(history.getCurrentCheckpointSignature(), '');
+  assert.equal(after.intentBuilds - before.intentBuilds, 1);
+  assert.equal(after.intentSignatureComputations - before.intentSignatureComputations, 1);
+  assert.equal(after.artifactCheckpointBuilds - before.artifactCheckpointBuilds, 0);
+  assert.equal(
+    after.artifactCheckpointSignatureComputations
+      - before.artifactCheckpointSignatureComputations,
+    0
+  );
+  assert.equal(after.signatureComputations - before.signatureComputations, 1);
+  assert.equal(after.historySvgBytes - before.historySvgBytes, 0);
+  assert.equal(checkpointBuilds, 1);
+
+  await history.runUndoable('Set three', () => {
+    setting = 3;
+  });
+  assert.equal(setting, 3);
+  await history.undo();
+  assert.equal(setting, 2);
+  await history.redo();
+  assert.equal(setting, 3);
+}
+
+{
+  let documentState = {
+    setting: 'loaded',
+    results: [{ name: 'loaded.svg', content: '<svg id="loaded" />' }],
+    selectedResultIndex: 0
+  };
+  let checkpointBuilds = 0;
+  const history = createHistoryManager({
+    buildIntent: async () => ({ setting: documentState.setting }),
+    applyIntent: async (intent) => {
+      documentState.setting = intent.setting;
+    },
+    buildCheckpoint: () => {
+      checkpointBuilds += 1;
+      return structuredClone(documentState);
+    },
+    applyCheckpoint: async (checkpoint) => {
+      documentState = structuredClone(checkpoint);
+    }
+  });
+
+  await history.initializeIntentBaseline('Loaded session');
+  assert.equal(checkpointBuilds, 0);
+  await history.runUndoableCheckpoint('Generate', () => {
+    documentState = {
+      setting: 'generated',
+      results: [
+        { name: 'generated-1.svg', content: '<svg id="generated-1" />' },
+        { name: 'generated-2.svg', content: '<svg id="generated-2" />' }
+      ],
+      selectedResultIndex: 1
+    };
+  });
+  assert.equal(checkpointBuilds, 2);
+  assert.equal(history.getUndoCount(), 1);
+  assert.equal(history.undoLabel(), 'Generate');
+  await history.undo();
+  assert.deepEqual(documentState, {
+    setting: 'loaded',
+    results: [{ name: 'loaded.svg', content: '<svg id="loaded" />' }],
+    selectedResultIndex: 0
+  });
+  await history.redo();
+  assert.equal(documentState.results.length, 2);
+  assert.equal(documentState.results[1].name, 'generated-2.svg');
+  assert.equal(documentState.selectedResultIndex, 1);
+}
+
+{
+  let checkpointBuilds = 0;
+  const history = createHistoryManager({
+    buildIntent: async () => ({ setting: 'loaded' }),
+    applyIntent: async () => {},
+    buildCheckpoint: () => {
+      checkpointBuilds += 1;
+      return { results: [{ content: '<svg id="loaded" />' }] };
+    },
+    applyCheckpoint: async () => {}
+  });
+
+  await history.initializeIntentBaseline('Loaded session');
+  await assert.rejects(
+    history.runUndoableCheckpoint('Failed Generate', async () => {
+      throw new Error('generation failed');
+    }),
+    /generation failed/
+  );
+  assert.equal(history.getUndoCount(), 0);
+  assert.equal(history.getRedoCount(), 0);
+  assert.equal(history.getCurrentCheckpoint(), null);
+
+  const canceled = await history.runUndoableCheckpoint(
+    'Canceled Generate',
+    async () => ({ status: 'canceled' }),
+    { shouldCommit: (result) => result?.status === 'ok' }
+  );
+  assert.deepEqual(canceled, { status: 'canceled' });
+  assert.equal(checkpointBuilds, 2);
+  assert.equal(history.getUndoCount(), 0);
+  assert.equal(history.getRedoCount(), 0);
+  assert.equal(history.getCurrentCheckpoint(), null);
+}
+
+{
   let value = 0;
   const buildState = async () => ({ value });
   const applyState = async (snapshot) => {
@@ -1083,6 +1224,102 @@ const createLayoutPreferences = () => ({
   assert.equal(Object.prototype.hasOwnProperty.call(intent.files, 'linearCanonicalComparisons'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(intent.files, 'c_conservation_sequence_sources'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(intent.files, 'c_conservation_blasts'), false);
+}
+
+{
+  const fileStore = createHistoryFileStore();
+  const circularPrimary = makeFile('circular-primary.gb', 101);
+  const circularDepth = makeFile('circular-depth.tsv', 102);
+  const conservationBlast = makeFile('derived-conservation.tsv', 103);
+  const conservationFasta = makeFile('conservation-subject.fa', 104);
+  const conservationSequenceSource = makeFile('derived-conservation-source.fa', 105);
+  const linearPrimary = makeFile('linear-primary.gb', 106);
+  const linearDepth = makeFile('linear-depth.tsv', 107);
+  const linearComparison = makeFile('linear-comparison.tsv', 108);
+  const canonicalProtein = makeFile('canonical-protein.tsv', 109);
+  const canonicalOrthogroups = makeFile('canonical-orthogroups.json', 110);
+  const canonicalCollinearity = makeFile('canonical-collinearity.json', 111);
+  const unreferenced = makeFile('unreferenced.tmp', 112);
+  const retainedFiles = [
+    circularPrimary,
+    circularDepth,
+    conservationBlast,
+    conservationFasta,
+    conservationSequenceSource,
+    linearPrimary,
+    linearDepth,
+    linearComparison,
+    canonicalProtein,
+    canonicalOrthogroups,
+    canonicalCollinearity
+  ];
+  const retainedIds = retainedFiles.map((file) => fileStore.describeFile(file).fileId);
+  const unreferencedId = fileStore.describeFile(unreferenced).fileId;
+  const state = {
+    files: {
+      c_gb: circularPrimary,
+      c_gff: null,
+      c_fasta: null,
+      c_depth: [circularDepth],
+      c_conservation_blasts: [conservationBlast],
+      c_conservation_blasts_source: 'losat-cache',
+      c_conservation_fastas: [conservationFasta],
+      c_conservation_sequence_sources: [conservationSequenceSource],
+      linearCanonicalComparisons: [
+        { kind: 'precomputedProteinComparison', file: canonicalProtein },
+        { kind: 'orthogroupResult', file: canonicalOrthogroups },
+        { kind: 'collinearityResult', file: canonicalCollinearity }
+      ],
+      d_color: null,
+      t_color: null,
+      blacklist: null,
+      whitelist: null,
+      qualifier_priority: null
+    },
+    linearSeqs: [{
+      uid: 'linear-a',
+      gb: linearPrimary,
+      gff: null,
+      fasta: null,
+      depth: [linearDepth]
+    }],
+    linearComparisonPlan: {
+      mode: 'selected',
+      defaultSource: 'upload',
+      edges: [{ id: 'edge-a-b', file: linearComparison }]
+    }
+  };
+  let setting = 'loaded';
+  let artifactBuilds = 0;
+  const snapshots = createHistorySnapshotService({ state, fileStore });
+  const history = createHistoryManager({
+    fileStore,
+    collectCurrentFileIds: snapshots.collectCurrentFileIds,
+    buildIntent: async () => ({ setting }),
+    applyIntent: async (intent) => {
+      setting = intent.setting;
+    },
+    buildCheckpoint: () => {
+      artifactBuilds += 1;
+      throw new Error('lightweight baseline must not build an artifact checkpoint');
+    },
+    applyCheckpoint: snapshots.applyArtifactCheckpoint
+  });
+
+  await history.initializeIntentBaseline('Loaded session');
+  assert.equal(artifactBuilds, 0);
+  retainedIds.forEach((fileId) => assert.equal(fileStore.has(fileId), true));
+  assert.equal(fileStore.has(unreferencedId), false);
+
+  await history.runUndoable('Change ordinary setting', () => {
+    setting = 'edited';
+  });
+  await history.undo();
+  assert.equal(setting, 'loaded');
+  retainedIds.forEach((fileId) => assert.equal(fileStore.has(fileId), true));
+  await history.redo();
+  assert.equal(setting, 'edited');
+  retainedIds.forEach((fileId) => assert.equal(fileStore.has(fileId), true));
 }
 
 {

--- a/tests/web/webapp-performance.playwright.spec.js
+++ b/tests/web/webapp-performance.playwright.spec.js
@@ -168,21 +168,21 @@ const installBrowserProbe = async (page) => page.evaluate((featureSelector) => {
 const loadWssvSession = async (page) => {
   await page.evaluate(() => {
     const history = window.__GBDRAW_HISTORY__;
-    if (!history?.captureBaseline) {
+    if (!history?.initializeIntentBaseline) {
       throw new Error('The session-import History boundary is unavailable.');
     }
-    const originalCaptureBaseline = history.captureBaseline;
+    const originalInitializeIntentBaseline = history.initializeIntentBaseline;
     window.__GBDRAW_WSSV_IMPORT_COMPLETE__ = null;
-    history.captureBaseline = async (label, ...args) => {
+    history.initializeIntentBaseline = async (label, ...args) => {
       try {
-        const result = await originalCaptureBaseline(label, ...args);
+        const result = await originalInitializeIntentBaseline(label, ...args);
         if (label === 'Loaded session') {
-          history.captureBaseline = originalCaptureBaseline;
+          history.initializeIntentBaseline = originalInitializeIntentBaseline;
           window.__GBDRAW_WSSV_IMPORT_COMPLETE__ = { status: 'ok', label };
         }
         return result;
       } catch (error) {
-        history.captureBaseline = originalCaptureBaseline;
+        history.initializeIntentBaseline = originalInitializeIntentBaseline;
         window.__GBDRAW_WSSV_IMPORT_COMPLETE__ = {
           status: 'error',
           message: String(error?.message || error)


### PR DESCRIPTION
Initialize History from the loaded session’s intent and lightweight file inventory without cloning or signing Results/SVG artifacts. Preserve lazy first-checkpoint capture for Generate, retain all current resource-backed files, and discard failed or canceled Generate checkpoints. Add structural, retention, Undo/Redo, failure, and real-session performance coverage.