### PR TITLE
Record Generate as an immutable artifact replacement

### DIFF
--- a/gbdraw/web/CLAUDE.md
+++ b/gbdraw/web/CLAUDE.md
@@ -82,6 +82,9 @@ During an artifact History transaction, the captured `before` checkpoint is the
 current checkpoint until the `after` capture replaces it. Do not retain an older
 equivalent current checkpoint alongside the transaction copy.
 
+Generate is an already-applied immutable artifact replacement. It must not use
+full checkpoint cloning or signing, and its pre-state is the sole rollback authority.
+
 Keep top-level `create*` entry points in `js/app/*.js`. Put larger,
 single-purpose helpers in the matching subfolder instead of growing another
 general utility module.

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -973,6 +973,9 @@ export const createAppSetup = () => {
     applyIntent: historySnapshots.applyHistoryIntent,
     buildCheckpoint: historySnapshots.buildArtifactCheckpoint,
     applyCheckpoint: historySnapshots.applyArtifactCheckpoint,
+    captureGeneratedArtifactHandle: historySnapshots.captureGeneratedArtifactHandle,
+    restoreGeneratedArtifactHandle: historySnapshots.restoreGeneratedArtifactHandle,
+    compareGeneratedArtifactHandles: historySnapshots.compareGeneratedArtifactHandles,
     signatureFor: historySnapshots.snapshotSignature,
     fileStore: historyFileStore,
     collectCurrentFileIds: historySnapshots.collectCurrentFileIds,
@@ -1829,7 +1832,9 @@ export const createAppSetup = () => {
     downloadLosatPair,
     setLosatPairFilename,
     clearLosatCache,
-    getLosatPairDefaultName
+    getLosatPairDefaultName,
+    captureGeneratedArtifactRuntimeState,
+    restoreGeneratedArtifactRuntimeState
   } = createRunAnalysis({
     state,
     serializeCanonicalFiles: (comparisonPlanSnapshot, linearRecordCatalog = null) => (
@@ -1841,14 +1846,19 @@ export const createAppSetup = () => {
     prepareLinearRecordCatalog,
     canonicalSessionVersion: SESSION_VERSION,
     adoptCanonicalRenderArtifacts,
-    buildGeneratedArtifactSnapshot: historySnapshots.buildGeneratedArtifactSnapshot,
-    applyGeneratedArtifactSnapshot: historySnapshots.applyGeneratedArtifactSnapshot,
+    captureGeneratedArtifactHandle: historySnapshots.captureGeneratedArtifactHandle,
+    restoreGeneratedArtifactHandle: historySnapshots.restoreGeneratedArtifactHandle,
+    setGeneratedArtifactIdentity: historySnapshots.setGeneratedArtifactIdentity,
     resetPreviewViewport,
     validateAnnotationTargets: ({ loadComparison }) => {
       const catalog = getAnnotationRecordCatalog(loadComparison);
       reconcileAnnotationRecordBindings(annotationSets, catalog);
       return validateAnnotationRecordTargets(annotationSets, catalog);
     }
+  });
+  historySnapshots.setGeneratedArtifactRuntimeOwner({
+    capture: captureGeneratedArtifactRuntimeState,
+    restore: restoreGeneratedArtifactRuntimeState
   });
   const resultsManager = createResultsManager({
     state,
@@ -1931,6 +1941,11 @@ export const createAppSetup = () => {
       })
     });
     if (result?.status === 'ok' || result?.status === 'legacy') {
+      historySnapshots.clearGeneratedArtifactIdentity({
+        retainedBytes: result?.status === 'ok'
+          ? Number(result.decompressedCharacters || 0) * 2
+          : 0
+      });
       await nextTick();
       if (result?.status === 'ok') {
         await synchronizeLoadedSessionLegendEntries();
@@ -2202,24 +2217,30 @@ export const createAppSetup = () => {
         : {}
     });
   };
-  const runAnalysis = async () => history.runUndoableCheckpoint('Generate diagram', async () => {
-    cancelDefinitionUpdate();
-    const comparisonPlanSnapshot = mode.value === 'linear'
-      ? linearComparisonResolution.value
-      : null;
+  const runAnalysis = async () => history.runUndoableArtifactReplacement(
+    'Generate diagram',
+    async (generatedArtifactHandle) => {
+      cancelDefinitionUpdate();
+      const comparisonPlanSnapshot = mode.value === 'linear'
+        ? linearComparisonResolution.value
+        : null;
 
-    const result = await runGeneratedDiagramAnalysis(comparisonPlanSnapshot);
-    if (result?.status === 'error' && mode.value === 'linear') {
-      await focusLinearComparisonIssue();
+      const result = await runGeneratedDiagramAnalysis(
+        comparisonPlanSnapshot,
+        generatedArtifactHandle
+      );
+      if (result?.status === 'error' && mode.value === 'linear') {
+        await focusLinearComparisonIssue();
+      }
+      if (result?.status === 'ok') {
+        featureSelection.clearFeatureSelection({ clearStatus: true });
+      }
+      return result;
+    }, {
+      shouldCommit: (result) => result?.status === 'ok',
+      onCheckpointCapture: recordGenerateHistoryCapture
     }
-    if (result?.status === 'ok') {
-      featureSelection.clearFeatureSelection({ clearStatus: true });
-    }
-    return result;
-  }, {
-    shouldCommit: (result) => result?.status === 'ok',
-    onCheckpointCapture: recordGenerateHistoryCapture
-  });
+  );
 
   const cancelGeneration = () => {
     cancelRunAnalysis();

--- a/gbdraw/web/js/app/candidate-render.js
+++ b/gbdraw/web/js/app/candidate-render.js
@@ -28,17 +28,20 @@ const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object || {
 const replaceRuleDerivedFillOverrides = (overrides, features, rules) => {
   const candidates = Array.isArray(features) ? features : [];
   const specificRules = Array.isArray(rules) ? rules : [];
+  const hashRules = [];
+  const qualifierRules = [];
+  specificRules.forEach((rule) => {
+    (text(rule?.qual).toLowerCase() === 'hash' ? hashRules : qualifierRules).push(rule);
+  });
   candidates.forEach((feature) => {
-    for (const rule of specificRules) {
-      if (!ruleMatchesFeature(feature, rule)) continue;
-      const key = featureOverrideKey(feature);
-      if (key) {
-        overrides[key] = {
-          color: rule.color,
-          caption: rule.cap
-        };
-      }
-      break;
+    const rule = hashRules.find((candidate) => ruleMatchesFeature(feature, candidate))
+      || qualifierRules.find((candidate) => ruleMatchesFeature(feature, candidate));
+    const key = rule ? featureOverrideKey(feature) : '';
+    if (key) {
+      overrides[key] = {
+        color: rule.color,
+        caption: rule.cap
+      };
     }
   });
 };

--- a/gbdraw/web/js/app/match-sequences.js
+++ b/gbdraw/web/js/app/match-sequences.js
@@ -136,6 +136,18 @@ export const createSequenceSourceRegistry = (initialSources = []) => {
     (Array.isArray(nextSources) ? nextSources : []).forEach(register);
   };
 
+  // Artifact History only supplies entries previously produced by this registry.
+  // Re-adopt those immutable entries without normalizing or copying large sequence
+  // strings a second time.
+  const resetTrusted = (nextSources = []) => {
+    sources.clear();
+    ambiguousKeys.clear();
+    (Array.isArray(nextSources) ? nextSources : []).forEach((source) => {
+      const key = text(source?.key);
+      if (key) sources.set(key, source);
+    });
+  };
+
   const resolve = (sourceKey, recordId, context = {}) => {
     const expectedSourceIndex = optionalNonnegativeIntegerStatus(context.sourceIndex);
     const expectedRecordIndex = optionalNonnegativeIntegerStatus(context.recordIndex);
@@ -189,7 +201,14 @@ export const createSequenceSourceRegistry = (initialSources = []) => {
   };
 
   (Array.isArray(initialSources) ? initialSources : []).forEach(register);
-  return { sources, register, reset, resolve, values: () => Array.from(sources.values()) };
+  return {
+    sources,
+    register,
+    reset,
+    resetTrusted,
+    resolve,
+    values: () => Array.from(sources.values())
+  };
 };
 
 const sourceIdentity = (source, overrides = {}) => {

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -803,8 +803,9 @@ export const createRunAnalysis = ({
   serializeCanonicalFiles,
   canonicalSessionVersion,
   adoptCanonicalRenderArtifacts,
-  buildGeneratedArtifactSnapshot,
-  applyGeneratedArtifactSnapshot,
+  captureGeneratedArtifactHandle,
+  restoreGeneratedArtifactHandle,
+  setGeneratedArtifactIdentity = null,
   resetPreviewViewport,
   validateAnnotationTargets = null,
   prepareLinearRecordCatalog = null,
@@ -902,10 +903,10 @@ export const createRunAnalysis = ({
     labelReflowLastError
   } = state;
   if (
-    typeof buildGeneratedArtifactSnapshot !== 'function'
-    || typeof applyGeneratedArtifactSnapshot !== 'function'
+    typeof captureGeneratedArtifactHandle !== 'function'
+    || typeof restoreGeneratedArtifactHandle !== 'function'
   ) {
-    throw new Error('createRunAnalysis requires generated artifact snapshot handlers.');
+    throw new Error('createRunAnalysis requires generated artifact handle handlers.');
   }
   const executeLosatJobs = (...args) => {
     const override = globalThis.__GBDRAW_LOSAT_EXECUTOR__;
@@ -924,6 +925,34 @@ export const createRunAnalysis = ({
   const cloneCliHelperFiles = (files) => (
     (Array.isArray(files) ? files : []).map((file) => ({ ...file }))
   );
+  const captureGeneratedArtifactRuntimeState = () => {
+    const helperFiles = cloneCliHelperFiles(latestCliHelperFiles);
+    return {
+      latestCliHelperFiles: helperFiles,
+      latestCliHelperArchiveName,
+      losatTelemetry: cloneJsonValue(globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__, null),
+      retainedBytes: helperFiles.reduce((total, file) => (
+        total
+        + String(file?.name || '').length * 2
+        + String(file?.data || '').length * 2
+        + Math.max(0, Number(file?.retainedBytes) || 0)
+        + 256
+      ), String(latestCliHelperArchiveName || '').length * 2 + 16_384)
+    };
+  };
+  const restoreGeneratedArtifactRuntimeState = (runtimeState = {}, { ui = {} } = {}) => {
+    latestCliHelperFiles = cloneCliHelperFiles(runtimeState?.latestCliHelperFiles);
+    latestCliHelperArchiveName = String(
+      runtimeState?.latestCliHelperArchiveName || 'out-cli-files.zip'
+    );
+    globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__ = cloneJsonValue(
+      runtimeState?.losatTelemetry,
+      null
+    );
+    if (typeof resetPreviewViewport === 'function') {
+      resetPreviewViewport({ pan: ui?.canvasPan });
+    }
+  };
   const recordDiscoverySuppressed = () => Boolean(
     semanticFileWatchersSuppressed?.value ||
     sessionImportRollbackInProgress?.value
@@ -952,6 +981,7 @@ export const createRunAnalysis = ({
         if (!entry) return null;
         return {
           name: String(helper?.name || entry.name || 'helper.tsv'),
+          retainedBytes: Math.max(0, Number(entry.retainedBytes) || 0),
           ...(typeof entry.buildData === 'function'
             ? { buildData: entry.buildData }
             : { data: entry.data })
@@ -1480,7 +1510,8 @@ export const createRunAnalysis = ({
   const runAnalysisInternal = async ({
     runMode = 'manual',
     requestId = 0,
-    comparisonPlanSnapshot = null
+    comparisonPlanSnapshot = null,
+    generatedArtifactHandle = null
   } = {}) => {
     const isReflow = runMode === 'reflow';
     if (!isReflow) {
@@ -1504,6 +1535,20 @@ export const createRunAnalysis = ({
     let keepProcessingStatus = false;
     let generationAbortController = null;
     let generationAbortSignal = null;
+    const committedArtifactHandle = isReflow
+      ? null
+      : (generatedArtifactHandle || await captureGeneratedArtifactHandle());
+    const restoreCommittedArtifact = async () => {
+      if (!committedArtifactHandle) return;
+      await restoreGeneratedArtifactHandle(committedArtifactHandle);
+    };
+    const finishCanceledManualRun = async () => {
+      await restoreCommittedArtifact();
+      errorLog.value = null;
+      processingStatus.value = 'Canceled.';
+      keepProcessingStatus = true;
+      return { status: 'canceled' };
+    };
     const setProcessingStatus = (message) => {
       if (!isReflow) processingStatus.value = String(message || '');
     };
@@ -1551,12 +1596,15 @@ export const createRunAnalysis = ({
           activeLosatAbortController = null;
         }
         generationCancelRequested.value = false;
-        return { status: 'canceled' };
+        return finishCanceledManualRun();
       }
       if (prepared?.error) {
         const message = String(prepared.error);
         if (isReflow) labelReflowLastError.value = message;
-        else errorLog.value = formatJsError(new Error(message));
+        else {
+          await restoreCommittedArtifact();
+          errorLog.value = formatJsError(new Error(message));
+        }
         if (activeLosatAbortController === generationAbortController) {
           activeLosatAbortController = null;
         }
@@ -1590,10 +1638,11 @@ export const createRunAnalysis = ({
             activeLosatAbortController = null;
           }
           generationCancelRequested.value = false;
-          return { status: 'canceled' };
+          return finishCanceledManualRun();
         }
         if (!circularDiscoveryMatchesCurrentInput()) {
           const message = circularRecordDiscovery.error || 'Could not read records from the circular input file(s).';
+          await restoreCommittedArtifact();
           errorLog.value = formatJsError(new Error(message));
           if (activeLosatAbortController === generationAbortController) {
             activeLosatAbortController = null;
@@ -1607,6 +1656,7 @@ export const createRunAnalysis = ({
       if (isReflow) {
         labelReflowLastError.value = depthInputError;
       } else {
+        await restoreCommittedArtifact();
         errorLog.value = formatJsError(new Error(depthInputError));
       }
       if (activeLosatAbortController === generationAbortController) {
@@ -1615,86 +1665,6 @@ export const createRunAnalysis = ({
       return { status: 'error' };
     }
     const previousSelectedResultIndex = selectedResultIndex.value;
-    const manualCancelSnapshot = isReflow
-      ? null
-      : {
-          artifact: buildGeneratedArtifactSnapshot(),
-          resultIdentity: results.value,
-          extractedFeatureIdentity: extractedFeatures.value,
-          biologicalFeatureIdentity: biologicalFeatures?.value,
-          trackSlotResolvedGeometry: cloneJsonValue(trackSlotResolvedGeometry.value || null, null),
-          resultGenerationKey: resultGenerationKey?.value ?? 0,
-          resultPanelTab: resultPanelTab.value,
-          errorLog: cloneJsonValue(errorLog.value, null),
-          latestCliHelperFiles: cloneCliHelperFiles(latestCliHelperFiles),
-          latestCliHelperArchiveName,
-          matchSequenceSources: matchSequenceRegistry?.values?.() || [],
-          editableLabels: cloneJsonValue(editableLabels.value || [], []),
-          labelTextScopeDialog: cloneJsonValue(labelTextScopeDialog, {}),
-          featureEditorStatus: cloneJsonValue(featureEditorStatus || {}, {}),
-          featureExtractionPending: featureExtractionPending.value,
-          featureExtractionError: featureExtractionError.value,
-          labelOverrideBuildWarning: labelOverrideBuildWarning.value,
-          proteinIdentityManifest: proteinIdentityManifest.value,
-          legacyProteinRawCandidates: legacyProteinRawCandidates.value,
-          legacyProteinDerivedEvidence: legacyProteinDerivedEvidence.value,
-          losatCache: Array.from(losatCache.value || new Map()),
-          losatDerivedCache: Array.from(losatDerivedCache.value || new Map()),
-          losatCacheInfo: losatCacheInfo.value,
-          collinearGroups: collinearGroups.value,
-          losatTelemetry: cloneJsonValue(
-            globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__,
-            null
-          )
-        };
-    const restoreManualCancelSnapshot = () => {
-      if (!manualCancelSnapshot) return;
-      applyGeneratedArtifactSnapshot(manualCancelSnapshot.artifact, { restoreResults: false });
-      results.value = manualCancelSnapshot.resultIdentity;
-      extractedFeatures.value = manualCancelSnapshot.extractedFeatureIdentity;
-      if (biologicalFeatures) {
-        biologicalFeatures.value = manualCancelSnapshot.biologicalFeatureIdentity;
-      }
-      trackSlotResolvedGeometry.value = manualCancelSnapshot.trackSlotResolvedGeometry;
-      if (typeof resetPreviewViewport === 'function') {
-        resetPreviewViewport({ pan: manualCancelSnapshot.artifact.ui?.canvasPan });
-      }
-      if (resultGenerationKey) {
-        resultGenerationKey.value = manualCancelSnapshot.resultGenerationKey;
-      }
-      resultPanelTab.value = manualCancelSnapshot.resultPanelTab;
-      errorLog.value = cloneJsonValue(manualCancelSnapshot.errorLog, null);
-      latestCliHelperFiles = cloneCliHelperFiles(manualCancelSnapshot.latestCliHelperFiles);
-      latestCliHelperArchiveName = manualCancelSnapshot.latestCliHelperArchiveName;
-      matchSequenceRegistry?.reset?.(manualCancelSnapshot.matchSequenceSources);
-      editableLabels.value = cloneJsonValue(manualCancelSnapshot.editableLabels, []);
-      Object.assign(
-        labelTextScopeDialog,
-        cloneJsonValue(manualCancelSnapshot.labelTextScopeDialog, {})
-      );
-      setFeatureEditorStatus(cloneJsonValue(manualCancelSnapshot.featureEditorStatus, {}));
-      featureExtractionPending.value = manualCancelSnapshot.featureExtractionPending;
-      featureExtractionError.value = manualCancelSnapshot.featureExtractionError;
-      labelOverrideBuildWarning.value = manualCancelSnapshot.labelOverrideBuildWarning;
-      proteinIdentityManifest.value = manualCancelSnapshot.proteinIdentityManifest;
-      legacyProteinRawCandidates.value = manualCancelSnapshot.legacyProteinRawCandidates;
-      legacyProteinDerivedEvidence.value = manualCancelSnapshot.legacyProteinDerivedEvidence;
-      losatCache.value = new Map(manualCancelSnapshot.losatCache);
-      losatDerivedCache.value = new Map(manualCancelSnapshot.losatDerivedCache);
-      losatCacheInfo.value = manualCancelSnapshot.losatCacheInfo;
-      collinearGroups.value = manualCancelSnapshot.collinearGroups;
-      globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__ = cloneJsonValue(
-        manualCancelSnapshot.losatTelemetry,
-        null
-      );
-    };
-    const finishCanceledManualRun = () => {
-      restoreManualCancelSnapshot();
-      errorLog.value = null;
-      processingStatus.value = 'Canceled.';
-      keepProcessingStatus = true;
-      return { status: 'canceled' };
-    };
     const editableLabelsSnapshot = Array.isArray(editableLabels.value)
       ? editableLabels.value.map((entry) => ({ ...entry }))
       : [];
@@ -1820,7 +1790,7 @@ export const createRunAnalysis = ({
       const recordDeferredGeneratedCliFile = (
         path,
         buildData,
-        { name = '', slot = '' } = {}
+        { name = '', slot = '', retainedBytes = 0 } = {}
       ) => {
         const normalizedPath = String(path || '').trim();
         if (!normalizedPath) return;
@@ -1833,6 +1803,7 @@ export const createRunAnalysis = ({
           path: normalizedPath,
           name: displayName,
           slot: String(slot || '').trim(),
+          retainedBytes: Math.max(0, Number(retainedBytes) || 0),
           buildData
         });
       };
@@ -3980,7 +3951,11 @@ export const createRunAnalysis = ({
       });
       recordDeferredGeneratedCliFile(canonicalReplayPath, buildCanonicalReplayText, {
         name: canonicalReplayName,
-        slot: 'generatedFiles.canonical_render_session'
+        slot: 'generatedFiles.canonical_render_session',
+        retainedBytes:
+          canonicalResourceDeclaredBytes
+          + canonicalResourceBase64Characters * 2
+          + 65_536
       });
       const gbdrawStartedAt = getNow();
       const generationResponse = await runDiagramGeneration({
@@ -4003,7 +3978,7 @@ export const createRunAnalysis = ({
           labelReflowLastError.value = formatPythonError(res.error)?.summary || 'Auto reflow failed';
           return { status: 'error' };
         }
-        restoreManualCancelSnapshot();
+        await restoreCommittedArtifact();
         errorLog.value = formatPythonError(res.error);
         return { status: 'error' };
       }
@@ -4015,7 +3990,7 @@ export const createRunAnalysis = ({
         if (!isReflow && generationCancelRequested.value) {
           return finishCanceledManualRun();
         }
-        if (!isReflow) restoreManualCancelSnapshot();
+        if (!isReflow) await restoreCommittedArtifact();
         return { status: 'stale' };
       }
 
@@ -4034,7 +4009,7 @@ export const createRunAnalysis = ({
       if (!isReflow) recordSessionLifecycleEvent('candidate-result-validation-start');
       const candidateCatalog = isReflow
         ? null
-        : validateFeatureCatalog(generationMetadata.featureCatalog, res);
+        : validateFeatureCatalog(generationMetadata.featureCatalog, res, { adopt: true });
       if (!isReflow) recordSessionLifecycleEvent('candidate-result-validation-end');
       recordSessionLifecycleEvent('result-admission-start');
       const candidateCommit = isReflow
@@ -4060,7 +4035,7 @@ export const createRunAnalysis = ({
               featureStrokeOverrides,
               legendStrokeOverrides,
               manualSpecificRules,
-              legacyFeatures: manualCancelSnapshot?.artifact?.features?.extractedFeatures || [],
+              legacyFeatures: committedArtifactHandle?.features?.extractedFeatures || [],
               suppressPairwiseIdentityLegend
             })
           );
@@ -4073,7 +4048,7 @@ export const createRunAnalysis = ({
         ) {
           return finishCanceledManualRun();
         }
-        if (!isReflow) restoreManualCancelSnapshot();
+        if (!isReflow) await restoreCommittedArtifact();
         return { status: 'stale' };
       }
 
@@ -4185,6 +4160,11 @@ export const createRunAnalysis = ({
       if (!isReflow && typeof adoptCanonicalRenderArtifacts === 'function') {
         adoptCanonicalRenderArtifacts(canonical);
       }
+      if (!isReflow && typeof setGeneratedArtifactIdentity === 'function') {
+        setGeneratedArtifactIdentity(generationResponse.artifactIdentity, {
+          results: candidateCommit.results
+        });
+      }
       return { status: 'ok' };
     } catch (e) {
       if (!legacyPromotionCommitted) {
@@ -4204,7 +4184,7 @@ export const createRunAnalysis = ({
         labelReflowLastError.value = formatJsError(e)?.summary || 'Auto reflow failed';
         return { status: 'error' };
       }
-      restoreManualCancelSnapshot();
+      await restoreCommittedArtifact();
       errorLog.value = formatJsError(e);
       return { status: 'error' };
     } finally {
@@ -4221,9 +4201,13 @@ export const createRunAnalysis = ({
     }
   };
 
-  const runAnalysis = async (comparisonPlanSnapshot = null) => runAnalysisInternal({
+  const runAnalysis = async (
+    comparisonPlanSnapshot = null,
+    generatedArtifactHandle = null
+  ) => runAnalysisInternal({
     runMode: 'manual',
-    comparisonPlanSnapshot
+    comparisonPlanSnapshot,
+    generatedArtifactHandle
   });
 
   const cancelRunAnalysis = () => {
@@ -4302,6 +4286,8 @@ export const createRunAnalysis = ({
   return {
     runAnalysis,
     cancelRunAnalysis,
+    captureGeneratedArtifactRuntimeState,
+    restoreGeneratedArtifactRuntimeState,
     runLabelReflow,
     refreshCircularRecordOrder,
     downloadCliHelperFiles,

--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -78,6 +78,7 @@ export const setupWatchers = ({
     skipCaptureBaseConfig,
     skipPositionReapply,
     skipExtractOnSvgChange,
+    trustedArtifactRestoreInProgress,
     svgContainer,
     layoutPreferences,
     suppressCircularMultiRecordDefaults,
@@ -355,10 +356,11 @@ export const setupWatchers = ({
         previewRuntime?.clearActiveRuntime?.();
       }
 
-      if (!skipExtractOnSvgChange.value) {
+      if (!skipExtractOnSvgChange.value && !trustedArtifactRestoreInProgress.value) {
         measureTiming(timingEntries, 'watch(svgContent) extractLegendEntries', extractLegendEntries);
       }
       const shouldBindComposition = Boolean(
+        !trustedArtifactRestoreInProgress.value &&
         svg && (
           !isIncrementalEdit ||
           svg.getAttribute(COMPOSITION_SCHEMA_ATTRIBUTE) !== null ||
@@ -380,7 +382,7 @@ export const setupWatchers = ({
       measureTiming(timingEntries, 'watch(svgContent) setupLegendDrag', setupLegendDrag);
       measureTiming(timingEntries, 'watch(svgContent) setupDiagramDrag', () => setupDiagramDrag(isIncrementalEdit));
       measureTiming(timingEntries, 'watch(svgContent) attachSvgFeatureHandlers', attachSvgFeatureHandlers);
-      if (shouldSyncLabelEditor()) {
+      if (!trustedArtifactRestoreInProgress.value && shouldSyncLabelEditor()) {
         measureTiming(timingEntries, 'watch(svgContent) syncLabelEditor', syncLabelEditor);
       }
 
@@ -410,7 +412,7 @@ export const setupWatchers = ({
   );
 
   watch(extractedFeatures, () => {
-    if (semanticFileWatchersSuppressed.value) return;
+    if (semanticFileWatchersSuppressed.value || trustedArtifactRestoreInProgress.value) return;
     refreshFeatureVisibilitySelectorCache();
     if (!svgContent.value) return;
     nextTick(() => {
@@ -423,7 +425,10 @@ export const setupWatchers = ({
     });
   });
 
-  watch(featureSelectorSafetyScope, refreshFeatureVisibilitySelectorCache, { immediate: true });
+  watch(featureSelectorSafetyScope, () => {
+    if (trustedArtifactRestoreInProgress.value) return;
+    refreshFeatureVisibilitySelectorCache();
+  }, { immediate: true });
 
   watch(
     [labelTextFeatureOverrides, labelTextBulkOverrides, labelVisibilityOverrides],

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -4323,6 +4323,7 @@ export const importSession = async (e, options = {}) => {
     return {
       status: 'ok',
       data,
+      decompressedCharacters: text.length,
       degradedRecovery: Boolean(currentRecoveryError)
     };
   } catch (err) {

--- a/gbdraw/web/js/services/diagram-generation.js
+++ b/gbdraw/web/js/services/diagram-generation.js
@@ -79,15 +79,40 @@ const decodeGenerationMetadata = (metadata) => {
   return decoded;
 };
 
+const normalizeGeneratedArtifactIdentity = (identity) => {
+  const fingerprint = String(identity?.fingerprint || '').toLowerCase();
+  if (
+    identity?.schema !== 1
+    || identity?.algorithm !== 'SHA-256'
+    || !/^[0-9a-f]{64}$/.test(fingerprint)
+  ) return null;
+  const retainedBytes = Number(identity.retainedBytes);
+  const resultBytes = Number(identity.resultBytes);
+  const metadataBytes = Number(identity.metadataBytes);
+  if (
+    !Number.isSafeInteger(retainedBytes) || retainedBytes < 0
+    || !Number.isSafeInteger(resultBytes) || resultBytes < 0
+    || !Number.isSafeInteger(metadataBytes) || metadataBytes < 0
+  ) return null;
+  return Object.freeze({
+    schema: 1,
+    algorithm: 'SHA-256',
+    fingerprint,
+    retainedBytes,
+    resultBytes,
+    metadataBytes
+  });
+};
+
 export const normalizeGenerationResponse = (payload) => {
   if (Array.isArray(payload)) {
-    return { results: decodeGenerationResults(payload), metadata: {} };
+    return { results: decodeGenerationResults(payload), metadata: {}, artifactIdentity: null };
   }
   if (!payload || typeof payload !== 'object') {
-    return { results: [], metadata: {} };
+    return { results: [], metadata: {}, artifactIdentity: null };
   }
   if (payload.error) {
-    return { results: payload, metadata: {} };
+    return { results: payload, metadata: {}, artifactIdentity: null };
   }
   const results = Array.isArray(payload.results)
     ? decodeGenerationResults(payload.results)
@@ -100,7 +125,11 @@ export const normalizeGenerationResponse = (payload) => {
   )
     ? decodedMetadata
     : {};
-  return { results, metadata };
+  return {
+    results,
+    metadata,
+    artifactIdentity: normalizeGeneratedArtifactIdentity(payload.artifactIdentity)
+  };
 };
 
 const resolveWorkerUrl = () => new URL('../workers/diagram-generation-worker.js', import.meta.url).toString();
@@ -332,7 +361,7 @@ export const runDiagramGeneration = (payload = {}) => {
         if (worker === currentWorker) terminateWorker(error);
       };
 
-      function handleMessage(event) {
+      async function handleMessage(event) {
         const data = event.data || {};
         if (data.type === 'test-lifecycle' && data.requestId === requestId) {
           recordSessionLifecycleEvent(data.event?.name, data.event);
@@ -340,6 +369,18 @@ export const runDiagramGeneration = (payload = {}) => {
         }
         if (data.type !== 'run' || data.requestId !== requestId) return;
         if (data.ok) {
+          const beforeResponse = runtimeTestHooksEnabled()
+            ? globalThis.__GBDRAW_TEST_HOOKS__?.beforeDiagramGenerationResponse
+            : null;
+          if (typeof beforeResponse === 'function') {
+            try {
+              await beforeResponse({ requestId });
+            } catch (error) {
+              failWorker(error);
+              return;
+            }
+            if (request.settled || activeRequest !== request) return;
+          }
           let normalized;
           try {
             normalized = normalizeGenerationResponse(data.results);

--- a/gbdraw/web/js/services/history-snapshot.js
+++ b/gbdraw/web/js/services/history-snapshot.js
@@ -204,6 +204,18 @@ const getRef = (target, fallback = null) => (
     : fallback
 );
 
+const setGeneratedArtifactRef = (target, value) => {
+  if (target && typeof target === 'object' && 'value' in target) target.value = value;
+};
+
+const getGeneratedArtifactRef = (target, fallback = null) => (
+  target && typeof target === 'object' && 'value' in target ? target.value : fallback
+);
+
+const artifactOwnedValue = (value) => (
+  typeof globalThis.Vue?.toRaw === 'function' ? globalThis.Vue.toRaw(value) : value
+);
+
 const buildDraftIntentData = (state) => ({
   selectedAnnotation: cloneJsonData(getRef(state.selectedAnnotation, null)),
   selectedSpecificPreset: String(getRef(state.selectedSpecificPreset, '') || ''),
@@ -642,10 +654,580 @@ export const createHistorySnapshotService = ({
   }
 
   let afterApplyHistoryIntent = null;
+  let generatedArtifactRuntimeOwner = null;
+  let currentGeneratedArtifactIdentity = null;
+  let currentGeneratedArtifactRetainedBytes = 0;
+  let generatedArtifactRestoreDepth = 0;
+  let restoreSemanticSuppressionBaseline = false;
+  let restoreTrustedStateBaseline = false;
 
   const setAfterApplyHistoryIntent = (callback) => {
     afterApplyHistoryIntent = typeof callback === 'function' ? callback : null;
   };
+
+  const setGeneratedArtifactRuntimeOwner = (owner) => {
+    generatedArtifactRuntimeOwner = (
+      owner
+      && typeof owner.capture === 'function'
+      && typeof owner.restore === 'function'
+    ) ? owner : null;
+  };
+
+  const artifactOwnerReferences = (results) => Object.freeze({
+    results: Object.freeze(
+      (Array.isArray(results) ? results : []).map(artifactOwnedValue)
+    ),
+    featureCatalog: artifactOwnedValue(getGeneratedArtifactRef(state.featureCatalog, null)),
+    extractedFeatures: artifactOwnedValue(getGeneratedArtifactRef(state.extractedFeatures, null)),
+    biologicalFeatures: artifactOwnedValue(getGeneratedArtifactRef(state.biologicalFeatures, null)),
+    featureSelectorSafetyScope: artifactOwnedValue(
+      getGeneratedArtifactRef(state.featureSelectorSafetyScope, null)
+    ),
+    orthogroups: artifactOwnedValue(getGeneratedArtifactRef(state.orthogroups, null)),
+    featureOrthogroupIndex: artifactOwnedValue(
+      getGeneratedArtifactRef(state.featureOrthogroupIndex, null)
+    ),
+    collinearGroups: artifactOwnedValue(getGeneratedArtifactRef(state.collinearGroups, null)),
+    trackSlotResolvedGeometry: artifactOwnedValue(
+      getGeneratedArtifactRef(state.trackSlotResolvedGeometry, null)
+    ),
+    proteinIdentityManifest: artifactOwnedValue(
+      getGeneratedArtifactRef(state.proteinIdentityManifest, null)
+    ),
+    legacyProteinRawCandidates: artifactOwnedValue(
+      getGeneratedArtifactRef(state.legacyProteinRawCandidates, null)
+    ),
+    legacyProteinDerivedEvidence: artifactOwnedValue(
+      getGeneratedArtifactRef(state.legacyProteinDerivedEvidence, null)
+    )
+  });
+
+  const setGeneratedArtifactIdentity = (identity, { results = null } = {}) => {
+    const fingerprint = String(identity?.fingerprint || '').toLowerCase();
+    if (
+      identity?.schema !== 1
+      || identity?.algorithm !== 'SHA-256'
+      || !/^[0-9a-f]{64}$/.test(fingerprint)
+    ) {
+      currentGeneratedArtifactIdentity = null;
+      currentGeneratedArtifactRetainedBytes = 0;
+      return false;
+    }
+    const committedResults = Array.isArray(results)
+      ? results
+      : getGeneratedArtifactRef(state.results, []);
+    currentGeneratedArtifactIdentity = Object.freeze({
+      schema: 1,
+      algorithm: 'SHA-256',
+      fingerprint,
+      ownerReferences: artifactOwnerReferences(committedResults)
+    });
+    currentGeneratedArtifactRetainedBytes = Math.max(
+      0,
+      Number(identity.retainedBytes) || 0
+    );
+    return true;
+  };
+
+  const clearGeneratedArtifactIdentity = ({ retainedBytes = 0 } = {}) => {
+    currentGeneratedArtifactIdentity = null;
+    currentGeneratedArtifactRetainedBytes = Math.max(0, Number(retainedBytes) || 0);
+  };
+
+  const currentArtifactMatchesIdentity = (results, identity) => {
+    const expected = identity?.ownerReferences;
+    if (!expected || expected.results.length !== results.length) return false;
+    if (!expected.results.every((result, index) => (
+      result === artifactOwnedValue(results[index])
+    ))) return false;
+    return (
+      expected.featureCatalog === artifactOwnedValue(
+        getGeneratedArtifactRef(state.featureCatalog, null)
+      )
+      && expected.extractedFeatures === artifactOwnedValue(
+        getGeneratedArtifactRef(state.extractedFeatures, null)
+      )
+      && expected.biologicalFeatures === artifactOwnedValue(
+        getGeneratedArtifactRef(state.biologicalFeatures, null)
+      )
+      && expected.featureSelectorSafetyScope
+        === artifactOwnedValue(getGeneratedArtifactRef(state.featureSelectorSafetyScope, null))
+      && expected.orthogroups === artifactOwnedValue(
+        getGeneratedArtifactRef(state.orthogroups, null)
+      )
+      && expected.featureOrthogroupIndex
+        === artifactOwnedValue(getGeneratedArtifactRef(state.featureOrthogroupIndex, null))
+      && expected.collinearGroups === artifactOwnedValue(
+        getGeneratedArtifactRef(state.collinearGroups, null)
+      )
+      && expected.trackSlotResolvedGeometry
+        === artifactOwnedValue(getGeneratedArtifactRef(state.trackSlotResolvedGeometry, null))
+      && expected.proteinIdentityManifest
+        === artifactOwnedValue(getGeneratedArtifactRef(state.proteinIdentityManifest, null))
+      && expected.legacyProteinRawCandidates
+        === artifactOwnedValue(getGeneratedArtifactRef(state.legacyProteinRawCandidates, null))
+      && expected.legacyProteinDerivedEvidence
+        === artifactOwnedValue(getGeneratedArtifactRef(state.legacyProteinDerivedEvidence, null))
+    );
+  };
+
+  const copyMapEntries = (map) => {
+    const ownedMap = artifactOwnedValue(map);
+    return Object.freeze(
+      Array.from(ownedMap instanceof Map ? ownedMap : new Map(), ([key, value]) => (
+        Object.freeze([key, artifactOwnedValue(value)])
+      ))
+    );
+  };
+
+  const copyObjectEntries = (value) => Object.freeze(
+    Object.entries(value && typeof value === 'object' ? value : {}).map(([key, entry]) => (
+      Object.freeze([key, artifactOwnedValue(entry)])
+    ))
+  );
+
+  const estimateCacheEntries = (entries) => entries.reduce((total, pair) => {
+    const entry = pair?.[1];
+    const rawTextBytes = typeof entry?.text === 'string' ? entry.text.length * 2 : 0;
+    const declaredBytes = Number(entry?.retainedBytes || entry?.byteLength || entry?.size) || 0;
+    const complexFloor = entry && typeof entry === 'object' ? 4096 : 128;
+    return total + Math.max(rawTextBytes, declaredBytes, complexFloor);
+  }, 0);
+
+  const compactGeneratedArtifactSignature = (handle) => JSON.stringify({
+    ui: handle.ui,
+    featureEdits: {
+      selectedFeatureRecordIdx: handle.features.selectedFeatureRecordIdx,
+      featureRecordIds: handle.features.featureRecordIds,
+      featureColorOverrides: handle.features.featureColorOverrides,
+      featureVisibilityManualRules: handle.features.featureVisibilityManualRules,
+      featureVisibilityOverrides: handle.features.featureVisibilityOverrides,
+      labelTextFeatureOverrides: handle.features.labelTextFeatureOverrides,
+      labelOverrideRows: handle.features.labelOverrideRows,
+      labelTextBulkOverrides: handle.features.labelTextBulkOverrides,
+      labelTextFeatureOverrideSources: handle.features.labelTextFeatureOverrideSources,
+      labelVisibilityOverrides: handle.features.labelVisibilityOverrides,
+      labelOverrideContextKey: handle.features.labelOverrideContextKey
+    },
+    editor: {
+      legend: handle.editorState.legend,
+      featureStrokes: handle.editorState.featureStrokes,
+      originalSvgStroke: handle.editorState.originalSvgStroke
+    },
+    orthogroupEdits: {
+      selectedOrthogroupId: handle.orthogroupState.selectedOrthogroupId,
+      selectedOrthogroupAlignmentFeature:
+        handle.orthogroupState.selectedOrthogroupAlignmentFeature,
+      orthogroupNameOverrides: handle.orthogroupState.orthogroupNameOverrides,
+      orthogroupDescriptionOverrides:
+        handle.orthogroupState.orthogroupDescriptionOverrides
+    },
+    presentation: {
+      resultPanelTab: handle.resultPanelTab
+    },
+    cacheEntries: {
+      raw: handle.losatCache.map(([key, value]) => [
+        String(key),
+        String(value?.kind || ''),
+        String(value?.program || ''),
+        String(value?.flow || ''),
+        String(value?.queryCanonicalHash || ''),
+        String(value?.subjectCanonicalHash || ''),
+        String(value?.text || '').length
+      ]),
+      derived: handle.losatDerivedCache.map(([key, value]) => [
+        String(key),
+        String(value?.kind || ''),
+        String(value?.mode || '')
+      ]),
+      display: handle.losatCacheInfo
+    },
+    matchSequences: handle.matchSequenceSources.map((source) => [
+      String(source?.key || ''),
+      String(source?.recordId || ''),
+      String(source?.origin || ''),
+      Number(source?.recordIndex ?? -1),
+      Number(source?.sourceIndex ?? -1),
+      String(source?.sequence || '').length
+    ])
+  });
+
+  const captureGeneratedArtifactHandle = () => {
+    // Vue exposes these owners through reactive proxies. History retains their
+    // raw committed values only after the production mutation audit established
+    // replacement/copy-on-write ownership for every heavy domain below.
+    const results = Object.freeze(
+      [...(getGeneratedArtifactRef(state.results, []) || [])].map(artifactOwnedValue)
+    );
+    const ui = typeof buildUiStateData === 'function'
+      ? buildUiStateData({ includePreviewNavigation: true })
+      : buildFallbackUiStateData(state);
+    const features = {
+      extractedFeatures: artifactOwnedValue(
+        getGeneratedArtifactRef(state.extractedFeatures, [])
+      ),
+      biologicalFeatures: artifactOwnedValue(
+        getGeneratedArtifactRef(state.biologicalFeatures, [])
+      ),
+      featureSelectorSafetyScope: artifactOwnedValue(
+        getGeneratedArtifactRef(state.featureSelectorSafetyScope, [])
+      ),
+      featureRecordIds: Object.freeze([
+        ...(getGeneratedArtifactRef(state.featureRecordIds, []) || [])
+      ]),
+      featureVisibilitySelectorCache: copyObjectEntries(
+        state.featureVisibilitySelectorCache
+      ),
+      selectedFeatureRecordIdx: getGeneratedArtifactRef(state.selectedFeatureRecordIdx, 0),
+      featureColorOverrides: clonePlainObject(state.featureColorOverrides),
+      featureVisibilityManualRules: cloneFeatureVisibilityRules(
+        state.featureVisibilityManualRules
+      ),
+      featureVisibilityOverrides: cloneFeatureVisibilityOverrides(
+        state.featureVisibilityOverrides
+      ),
+      labelTextFeatureOverrides: clonePlainObject(state.labelTextFeatureOverrides),
+      labelOverrideRows: cloneJsonData(
+        getGeneratedArtifactRef(state.canonicalLabelOverrideRows, [])
+      ) || [],
+      labelTextBulkOverrides: clonePlainObject(state.labelTextBulkOverrides),
+      labelTextFeatureOverrideSources: clonePlainObject(
+        state.labelTextFeatureOverrideSources
+      ),
+      labelVisibilityOverrides: clonePlainObject(state.labelVisibilityOverrides),
+      labelOverrideContextKey: String(
+        getGeneratedArtifactRef(state.labelOverrideContextKey, '') || ''
+      )
+    };
+    const editorState = {
+      legend: {
+        entries: cloneJsonData(getGeneratedArtifactRef(state.legendEntries, [])) || [],
+        deletedEntries: cloneJsonData(
+          getGeneratedArtifactRef(state.deletedLegendEntries, [])
+        ) || [],
+        originalOrder: cloneJsonData(
+          getGeneratedArtifactRef(state.originalLegendOrder, [])
+        ) || [],
+        originalColors: clonePlainObject(
+          getGeneratedArtifactRef(state.originalLegendColors, {})
+        ),
+        colorOverrides: clonePlainObject(state.legendColorOverrides),
+        strokeOverrides: clonePlainObject(state.legendStrokeOverrides),
+        addedCaptions: Array.from(
+          getGeneratedArtifactRef(state.addedLegendCaptions, new Set()) || []
+        )
+      },
+      featureStrokes: { overrides: clonePlainObject(state.featureStrokeOverrides) },
+      originalSvgStroke: cloneJsonData(
+        getGeneratedArtifactRef(state.originalSvgStroke, null)
+      ) || {
+        color: null,
+        width: null
+      },
+      featureCatalog: artifactOwnedValue(
+        getGeneratedArtifactRef(state.featureCatalog, null)
+      )
+    };
+    const orthogroupState = {
+      groups: artifactOwnedValue(getGeneratedArtifactRef(state.orthogroups, [])),
+      featureIndex: artifactOwnedValue(
+        getGeneratedArtifactRef(state.featureOrthogroupIndex, new Map())
+      ),
+      selectedOrthogroupId: String(
+        getGeneratedArtifactRef(state.selectedOrthogroupId, '') || ''
+      ),
+      selectedOrthogroupAlignmentFeature: String(
+        getGeneratedArtifactRef(state.selectedOrthogroupAlignmentFeature, '') || ''
+      ),
+      orthogroupNameOverrides: clonePlainObject(state.orthogroupNameOverrides),
+      orthogroupDescriptionOverrides: clonePlainObject(
+        state.orthogroupDescriptionOverrides
+      )
+    };
+    const runState = typeof buildRunStateData === 'function'
+      ? buildRunStateData()
+      : {
+          lastRunInfo: cloneJsonData(getGeneratedArtifactRef(state.lastRunInfo, null)),
+          pairwiseMatchFactors: clonePlainObject(
+            getGeneratedArtifactRef(state.pairwiseMatchFactors, {})
+          )
+        };
+    const losatCache = copyMapEntries(
+      getGeneratedArtifactRef(state.losatCache, new Map())
+    );
+    const losatDerivedCache = copyMapEntries(
+      getGeneratedArtifactRef(state.losatDerivedCache, new Map())
+    );
+    const handle = {
+      kind: 'GeneratedArtifactHandle',
+      ui,
+      results,
+      features,
+      editorState,
+      orthogroupState,
+      runState,
+      trackSlotResolvedGeometry: artifactOwnedValue(
+        getGeneratedArtifactRef(state.trackSlotResolvedGeometry, null)
+      ),
+      resultGenerationKey: getGeneratedArtifactRef(state.resultGenerationKey, 0),
+      resultPanelTab: getGeneratedArtifactRef(state.resultPanelTab, 'preview'),
+      errorLog: cloneJsonData(getGeneratedArtifactRef(state.errorLog, null)),
+      editableLabels: cloneJsonData(
+        getGeneratedArtifactRef(state.editableLabels, [])
+      ) || [],
+      labelTextScopeDialog: cloneJsonData(state.labelTextScopeDialog || {}) || {},
+      featureEditorStatus: cloneJsonData(state.featureEditorStatus || {}) || {},
+      featureExtractionPending: Boolean(
+        getGeneratedArtifactRef(state.featureExtractionPending, false)
+      ),
+      featureExtractionError: getGeneratedArtifactRef(state.featureExtractionError, null),
+      labelOverrideBuildWarning: String(
+        getGeneratedArtifactRef(state.labelOverrideBuildWarning, '') || ''
+      ),
+      proteinIdentityManifest: artifactOwnedValue(
+        getGeneratedArtifactRef(state.proteinIdentityManifest, null)
+      ),
+      legacyProteinRawCandidates: artifactOwnedValue(
+        getGeneratedArtifactRef(state.legacyProteinRawCandidates, null)
+      ),
+      legacyProteinDerivedEvidence: artifactOwnedValue(
+        getGeneratedArtifactRef(state.legacyProteinDerivedEvidence, null)
+      ),
+      losatCache,
+      losatDerivedCache,
+      losatCacheInfo: cloneJsonData(
+        getGeneratedArtifactRef(state.losatCacheInfo, [])
+      ) || [],
+      collinearGroups: artifactOwnedValue(
+        getGeneratedArtifactRef(state.collinearGroups, [])
+      ),
+      matchSequenceSources: Object.freeze([
+        ...(state.matchSequenceRegistry?.values?.() || [])
+      ]),
+      runtimeState: generatedArtifactRuntimeOwner?.capture?.() || null,
+      transportIdentity: null,
+      baseRetainedBytes: currentGeneratedArtifactRetainedBytes,
+      fileIds: Object.freeze([...collectCurrentFileIds(state, fileStore)])
+    };
+    const compactSignature = compactGeneratedArtifactSignature(handle);
+    const transportIdentity = currentArtifactMatchesIdentity(
+      results,
+      currentGeneratedArtifactIdentity
+    ) ? currentGeneratedArtifactIdentity : null;
+    handle.transportIdentity = transportIdentity;
+    const resultUtf16Bytes = results.reduce(
+      (total, result) => total + String(result?.content || '').length * 2,
+      0
+    );
+    const derivedCollectionBytes = (
+      (Array.isArray(features.extractedFeatures) ? features.extractedFeatures.length : 0) * 512
+      + (Array.isArray(features.biologicalFeatures) ? features.biologicalFeatures.length : 0) * 512
+      + features.featureVisibilitySelectorCache.length * 512
+      + (Array.isArray(orthogroupState.groups) ? orthogroupState.groups.length : 0) * 1024
+      + (Array.isArray(handle.collinearGroups) ? handle.collinearGroups.length : 0) * 1024
+      + handle.matchSequenceSources.reduce(
+          (total, source) => total + String(source?.sequence || '').length * 2 + 256,
+          0
+        )
+    );
+    handle.identity = Object.freeze({
+      fingerprint: transportIdentity?.fingerprint || '',
+      compactSignature
+    });
+    handle.retainedBytes = currentGeneratedArtifactRetainedBytes
+      + resultUtf16Bytes + derivedCollectionBytes + estimateCacheEntries(losatCache)
+      + estimateCacheEntries(losatDerivedCache)
+      + Math.max(0, Number(handle.runtimeState?.retainedBytes) || 0)
+      + compactSignature.length * 2;
+    return Object.freeze(handle);
+  };
+
+  const restoreGeneratedArtifactHandle = async (handle) => {
+    if (!handle || handle.kind !== 'GeneratedArtifactHandle') return false;
+    if (generatedArtifactRestoreDepth === 0) {
+      restoreSemanticSuppressionBaseline = Boolean(
+        getGeneratedArtifactRef(state.semanticFileWatchersSuppressed, false)
+      );
+      restoreTrustedStateBaseline = Boolean(
+        getGeneratedArtifactRef(state.trustedArtifactRestoreInProgress, false)
+      );
+    }
+    generatedArtifactRestoreDepth += 1;
+    setGeneratedArtifactRef(state.semanticFileWatchersSuppressed, true);
+    setGeneratedArtifactRef(state.trustedArtifactRestoreInProgress, true);
+    try {
+      closeTransientState(state);
+      const ui = handle.ui || {};
+      if (ui.mode) {
+        setGeneratedArtifactRef(state.mode, ui.mode === 'linear' ? 'linear' : 'circular');
+      }
+      if (ui.cInputType) setGeneratedArtifactRef(state.cInputType, ui.cInputType);
+      if (ui.lInputType) setGeneratedArtifactRef(state.lInputType, ui.lInputType);
+      await nextTick();
+
+      if (state.skipCaptureBaseConfig) state.skipCaptureBaseConfig.value = true;
+      if (state.skipPositionReapply) state.skipPositionReapply.value = true;
+      setGeneratedArtifactRef(state.results, [...handle.results]);
+      setGeneratedArtifactRef(
+        state.selectedResultIndex,
+        handle.results.length > 0
+          ? Math.max(0, Math.min(Number(ui.selectedResultIndex) || 0, handle.results.length - 1))
+          : 0
+      );
+
+      if (typeof applyFeatureStateData === 'function') {
+        applyFeatureStateData(handle.features || {});
+      } else {
+        applyFallbackFeatureStateData(state, handle.features || {});
+      }
+      replacePlainObject(
+        state.featureVisibilitySelectorCache,
+        Object.fromEntries(handle.features?.featureVisibilitySelectorCache || [])
+      );
+      setGeneratedArtifactRef(state.orthogroups, handle.orthogroupState?.groups || []);
+      setGeneratedArtifactRef(
+        state.featureOrthogroupIndex,
+        handle.orthogroupState?.featureIndex || new Map()
+      );
+      setGeneratedArtifactRef(
+        state.selectedOrthogroupId,
+        String(handle.orthogroupState?.selectedOrthogroupId || '')
+      );
+      setGeneratedArtifactRef(
+        state.selectedOrthogroupAlignmentFeature,
+        String(handle.orthogroupState?.selectedOrthogroupAlignmentFeature || '')
+      );
+      replacePlainObject(
+        state.orthogroupNameOverrides,
+        clonePlainObject(handle.orthogroupState?.orthogroupNameOverrides)
+      );
+      replacePlainObject(
+        state.orthogroupDescriptionOverrides,
+        clonePlainObject(handle.orthogroupState?.orthogroupDescriptionOverrides)
+      );
+
+      const trustedEditorState = {
+        ...cloneJsonData({
+          legend: handle.editorState?.legend || {},
+          featureStrokes: handle.editorState?.featureStrokes || {},
+          originalSvgStroke: handle.editorState?.originalSvgStroke || {}
+        }),
+        featureCatalog: handle.editorState?.featureCatalog || null
+      };
+      if (typeof applyEditorStateData === 'function') {
+        applyEditorStateData(trustedEditorState, {
+          normalized: true,
+          adoptCatalog: true
+        });
+      } else {
+        applyEditorIntentData(state, trustedEditorState);
+        setGeneratedArtifactRef(state.featureCatalog, trustedEditorState.featureCatalog);
+      }
+      if (typeof applyRunStateData === 'function') {
+        applyRunStateData(handle.runState || {});
+      } else {
+        setGeneratedArtifactRef(
+          state.lastRunInfo,
+          cloneJsonData(handle.runState?.lastRunInfo) || null
+        );
+        setGeneratedArtifactRef(
+          state.pairwiseMatchFactors,
+          clonePlainObject(handle.runState?.pairwiseMatchFactors)
+        );
+      }
+
+      setGeneratedArtifactRef(
+        state.trackSlotResolvedGeometry,
+        handle.trackSlotResolvedGeometry ?? null
+      );
+      setGeneratedArtifactRef(state.resultGenerationKey, handle.resultGenerationKey ?? 0);
+      setGeneratedArtifactRef(state.resultPanelTab, handle.resultPanelTab || 'preview');
+      setGeneratedArtifactRef(state.errorLog, cloneJsonData(handle.errorLog));
+      setGeneratedArtifactRef(
+        state.editableLabels,
+        cloneJsonData(handle.editableLabels) || []
+      );
+      if (state.labelTextScopeDialog) {
+        Object.assign(
+          state.labelTextScopeDialog,
+          cloneJsonData(handle.labelTextScopeDialog) || {}
+        );
+      }
+      if (state.featureEditorStatus) {
+        Object.assign(
+          state.featureEditorStatus,
+          cloneJsonData(handle.featureEditorStatus) || {}
+        );
+      }
+      setGeneratedArtifactRef(
+        state.featureExtractionPending,
+        Boolean(handle.featureExtractionPending)
+      );
+      setGeneratedArtifactRef(
+        state.featureExtractionError,
+        handle.featureExtractionError ?? null
+      );
+      setGeneratedArtifactRef(
+        state.labelOverrideBuildWarning,
+        handle.labelOverrideBuildWarning || ''
+      );
+      setGeneratedArtifactRef(state.proteinIdentityManifest, handle.proteinIdentityManifest);
+      setGeneratedArtifactRef(
+        state.legacyProteinRawCandidates,
+        handle.legacyProteinRawCandidates
+      );
+      setGeneratedArtifactRef(
+        state.legacyProteinDerivedEvidence,
+        handle.legacyProteinDerivedEvidence
+      );
+      setGeneratedArtifactRef(state.losatCache, new Map(handle.losatCache || []));
+      setGeneratedArtifactRef(
+        state.losatDerivedCache,
+        new Map(handle.losatDerivedCache || [])
+      );
+      setGeneratedArtifactRef(
+        state.losatCacheInfo,
+        cloneJsonData(handle.losatCacheInfo) || []
+      );
+      setGeneratedArtifactRef(state.collinearGroups, handle.collinearGroups || []);
+      if (typeof state.matchSequenceRegistry?.resetTrusted === 'function') {
+        state.matchSequenceRegistry.resetTrusted(handle.matchSequenceSources || []);
+      } else {
+        state.matchSequenceRegistry?.reset?.(handle.matchSequenceSources || []);
+      }
+
+      if (typeof applyUiStateData === 'function') {
+        applyUiStateData(ui);
+      } else {
+        applyFallbackUiStateData(state, ui);
+      }
+      await generatedArtifactRuntimeOwner?.restore?.(handle.runtimeState, { ui });
+      currentGeneratedArtifactIdentity = handle.transportIdentity || null;
+      currentGeneratedArtifactRetainedBytes = Number(handle.baseRetainedBytes) || 0;
+      await nextTick();
+      // The SVG watcher schedules its trusted mount work on a nested nextTick.
+      await nextTick();
+      return true;
+    } finally {
+      generatedArtifactRestoreDepth = Math.max(0, generatedArtifactRestoreDepth - 1);
+      if (generatedArtifactRestoreDepth === 0) {
+        setGeneratedArtifactRef(
+          state.trustedArtifactRestoreInProgress,
+          restoreTrustedStateBaseline
+        );
+        setGeneratedArtifactRef(
+          state.semanticFileWatchersSuppressed,
+          restoreSemanticSuppressionBaseline
+        );
+      }
+    }
+  };
+
+  const compareGeneratedArtifactHandles = (before, after) => Boolean(
+    before?.identity?.fingerprint
+    && before.identity.fingerprint === after?.identity?.fingerprint
+    && before.identity.compactSignature === after?.identity?.compactSignature
+  );
 
   const buildGeneratedArtifactSnapshot = ({ includePreviewNavigation = true } = {}) => {
     const ui = typeof buildUiStateData === 'function'
@@ -938,9 +1520,15 @@ export const createHistorySnapshotService = ({
     applyGeneratedArtifactSnapshot,
     applyHistoryIntent,
     buildArtifactCheckpoint,
+    captureGeneratedArtifactHandle,
+    clearGeneratedArtifactIdentity,
     collectCurrentFileIds: () => collectCurrentFileIds(state, fileStore),
+    compareGeneratedArtifactHandles,
     buildGeneratedArtifactSnapshot,
     buildHistoryIntent,
+    restoreGeneratedArtifactHandle,
+    setGeneratedArtifactIdentity,
+    setGeneratedArtifactRuntimeOwner,
     setAfterApplyHistoryIntent,
     snapshotSignature
   };

--- a/gbdraw/web/js/services/history.js
+++ b/gbdraw/web/js/services/history.js
@@ -114,6 +114,9 @@ export const createHistoryManager = ({
   applyIntent,
   buildCheckpoint,
   applyCheckpoint,
+  captureGeneratedArtifactHandle = null,
+  restoreGeneratedArtifactHandle = null,
+  compareGeneratedArtifactHandles = null,
   signatureFor = (value) => JSON.stringify(value),
   fileStore = null,
   collectCurrentFileIds = null,
@@ -148,7 +151,14 @@ export const createHistoryManager = ({
     artifactCheckpointSignatureComputations: 0,
     byteEstimateComputations: 0,
     historySvgBytes: 0,
-    checkpointEstimatedBytes: 0
+    checkpointEstimatedBytes: 0,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0,
+    manualCancelFullArtifactSnapshotBuildCount: 0,
+    artifactHandleBeforeBuildCount: 0,
+    artifactHandleAfterBuildCount: 0,
+    artifactFingerprintComparisonCount: 0,
+    artifactReplacementHistoryEntryCount: 0
   };
   let currentIntent = null;
   let currentIntentSignature = '';
@@ -263,6 +273,11 @@ export const createHistoryManager = ({
   const setCurrentCheckpoint = ({ checkpoint, signature }) => {
     currentCheckpoint = checkpoint;
     currentCheckpointSignature = signature;
+  };
+
+  const clearCurrentCheckpoint = () => {
+    currentCheckpoint = null;
+    currentCheckpointSignature = '';
   };
 
   const entryFileIds = (entry) => (
@@ -556,6 +571,191 @@ export const createHistoryManager = ({
       : execute(transaction);
   };
 
+  const finishArtifactHandleCapture = (handle, phase) => {
+    if (!handle || typeof handle !== 'object') {
+      throw new Error('Generated artifact capture did not return a handle.');
+    }
+    const retainedBytes = Number(handle.retainedBytes);
+    if (!Number.isFinite(retainedBytes) || retainedBytes < 0) {
+      throw new Error('Generated artifact handle has an invalid retained-byte estimate.');
+    }
+    emitHistoryDiagnostic({
+      type: 'capture',
+      scope: 'artifact-replacement',
+      phase,
+      bytes: retainedBytes
+    });
+    return handle;
+  };
+
+  const captureArtifactHandle = (phase) => {
+    if (typeof captureGeneratedArtifactHandle !== 'function') {
+      throw new Error('Generated artifact replacement requires a capture owner.');
+    }
+    capturing.value = true;
+    if (phase === 'before') diagnostics.artifactHandleBeforeBuildCount += 1;
+    else diagnostics.artifactHandleAfterBuildCount += 1;
+    try {
+      const handle = captureGeneratedArtifactHandle({ phase });
+      if (isPromiseLike(handle)) {
+        return Promise.resolve(handle)
+          .then((captured) => finishArtifactHandleCapture(captured, phase))
+          .finally(() => {
+            capturing.value = false;
+          });
+      }
+      const captured = finishArtifactHandleCapture(handle, phase);
+      capturing.value = false;
+      return captured;
+    } catch (error) {
+      capturing.value = false;
+      throw error;
+    }
+  };
+
+  const beginArtifactReplacement = async (label = 'Generate diagram', options = {}) => {
+    if (restoring.value || capturing.value) return null;
+    if (activeTransaction && !activeTransaction.closed) {
+      const pendingIntent = activeTransaction;
+      const previousDeferred = Boolean(pendingIntent.deferAdapterCommit);
+      pendingIntent.deferAdapterCommit = true;
+      try {
+        await commit(pendingIntent);
+      } catch (error) {
+        if (!pendingIntent.closed) pendingIntent.deferAdapterCommit = previousDeferred;
+        throw error;
+      }
+    }
+    notifyCheckpointCapture(options, 'before-start');
+    const before = await captureArtifactHandle('before');
+    notifyCheckpointCapture(options, 'before-end');
+    emitHistoryDiagnostic({ type: 'begin', scope: 'artifact-replacement', label });
+    return {
+      label,
+      before,
+      closed: false,
+      source: options.source || ''
+    };
+  };
+
+  const sameArtifactHandles = (before, after) => {
+    diagnostics.artifactFingerprintComparisonCount += 1;
+    const same = typeof compareGeneratedArtifactHandles === 'function'
+      ? Boolean(compareGeneratedArtifactHandles(before, after))
+      : Boolean(
+          before?.identity?.fingerprint
+          && before.identity.fingerprint === after?.identity?.fingerprint
+          && before.identity.compactSignature === after?.identity?.compactSignature
+        );
+    emitHistoryDiagnostic({
+      type: 'compare',
+      scope: 'artifact-replacement',
+      equal: same
+    });
+    return same;
+  };
+
+  const artifactHandleFileIds = (handle) => new Set(handle?.fileIds || []);
+
+  const commitAppliedArtifactReplacement = async (transaction, options = {}) => {
+    if (!transaction || transaction.closed) return false;
+    notifyCheckpointCapture(options, 'after-start');
+    const after = await captureArtifactHandle('after');
+    const intent = await captureIntent();
+    transaction.closed = true;
+    setCurrentIntent(intent);
+    clearCurrentCheckpoint();
+
+    if (sameArtifactHandles(transaction.before, after)) {
+      emitHistoryDiagnostic({
+        type: 'commit',
+        scope: 'artifact-replacement',
+        label: transaction.label,
+        created: false
+      });
+      releaseUnreferencedFiles();
+      touch();
+      notifyCheckpointCapture(options, 'after-end');
+      return false;
+    }
+
+    const fileIds = artifactHandleFileIds(transaction.before);
+    artifactHandleFileIds(after).forEach((id) => fileIds.add(id));
+    const entry = {
+      type: 'artifact-replacement',
+      label: transaction.label || options.label || 'Generate diagram',
+      before: transaction.before,
+      after,
+      byteSize: Math.max(
+        1,
+        (Number(transaction.before.retainedBytes) || 0) + (Number(after.retainedBytes) || 0)
+      ),
+      fileIds
+    };
+    diagnostics.byteEstimateComputations += 1;
+    diagnostics.artifactReplacementHistoryEntryCount += 1;
+    emitHistoryDiagnostic({
+      type: 'size',
+      scope: 'artifact-replacement',
+      bytes: entry.byteSize
+    });
+    pushUndoEntry(entry);
+    clearRedo();
+    enforceLimits();
+    touch();
+    emitHistoryDiagnostic({
+      type: 'commit',
+      scope: 'artifact-replacement',
+      label: entry.label,
+      created: true,
+      bytes: entry.byteSize
+    });
+    notifyCheckpointCapture(options, 'after-end');
+    return true;
+  };
+
+  const restoreArtifactHandle = async (handle) => {
+    if (typeof restoreGeneratedArtifactHandle !== 'function') {
+      throw new Error('Generated artifact replacement requires a restore owner.');
+    }
+    restoring.value = true;
+    try {
+      await restoreGeneratedArtifactHandle(handle);
+    } finally {
+      restoring.value = false;
+    }
+    clearCurrentCheckpoint();
+    await refreshCurrentIntent();
+  };
+
+  const runUndoableArtifactReplacement = async (label, fn, options = {}) => {
+    if (typeof fn !== 'function') return undefined;
+    if (restoring.value || capturing.value) return fn(null);
+    const transaction = await beginArtifactReplacement(label, options);
+    try {
+      const result = await fn(transaction?.before || null);
+      if (
+        typeof options.shouldCommit === 'function'
+        && !options.shouldCommit(result)
+      ) {
+        if (transaction) transaction.closed = true;
+        await refreshCurrentIntent();
+        releaseUnreferencedFiles();
+        touch();
+        return result;
+      }
+      await commitAppliedArtifactReplacement(transaction, options);
+      return result;
+    } catch (error) {
+      if (transaction) {
+        transaction.closed = true;
+        await restoreArtifactHandle(transaction.before);
+      }
+      releaseUnreferencedFiles();
+      throw error;
+    }
+  };
+
   const normalizeCommand = (label, command) => {
     if (!command || typeof command !== 'object' || command.noop) return null;
     if (typeof command.apply !== 'function') {
@@ -644,6 +844,10 @@ export const createHistoryManager = ({
     await refreshCurrentIntent();
   };
 
+  const applyArtifactReplacementEntry = async (handle) => {
+    await restoreArtifactHandle(handle);
+  };
+
   const applyCommandWithFlag = async (entry, direction) => {
     restoring.value = true;
     try {
@@ -666,6 +870,8 @@ export const createHistoryManager = ({
       await refreshCurrentIntent();
     } else if (entry.type === 'checkpoint') {
       await applyCheckpointEntry(entry.before);
+    } else if (entry.type === 'artifact-replacement') {
+      await applyArtifactReplacementEntry(entry.before);
     } else {
       await applyIntentEntry(entry, 'undo');
     }
@@ -688,6 +894,8 @@ export const createHistoryManager = ({
       await refreshCurrentIntent();
     } else if (entry.type === 'checkpoint') {
       await applyCheckpointEntry(entry.after);
+    } else if (entry.type === 'artifact-replacement') {
+      await applyArtifactReplacementEntry(entry.after);
     } else {
       await applyIntentEntry(entry, 'redo');
     }
@@ -705,12 +913,14 @@ export const createHistoryManager = ({
 
   return {
     begin,
+    beginArtifactReplacement,
     beginCheckpoint,
     cancel,
     captureBaseline,
     canRedo,
     canUndo,
     commit,
+    commitAppliedArtifactReplacement,
     commitCheckpoint,
     getCurrentCheckpoint: () => currentCheckpoint,
     getCurrentCheckpointSignature: () => currentCheckpointSignature,
@@ -727,6 +937,7 @@ export const createHistoryManager = ({
     capturing,
     revision,
     runUndoable,
+    runUndoableArtifactReplacement,
     runUndoableCheckpoint,
     runUndoableCommand,
     undo,

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -781,6 +781,10 @@ const skipPositionReapply = ref(false);
 // This prevents race condition where watcher overwrites correct legend state
 const skipExtractOnSvgChange = ref(false);
 
+// Trusted Artifact History restores already-validated generated owners directly.
+// Watchers still mount the SVG and handlers, but must not rebuild metadata from it.
+const trustedArtifactRestoreInProgress = ref(false);
+
 const featureKeys = [
   'assembly_gap',
   'C_region',
@@ -1132,6 +1136,7 @@ export const state = {
   skipCaptureBaseConfig,
   skipPositionReapply,
   skipExtractOnSvgChange,
+  trustedArtifactRestoreInProgress,
   normalizePaletteColors,
   normalizePaletteDefinitions,
   featureKeys,

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -37,6 +37,78 @@ export const collectGenerationResultTransferList = (payload) => {
   return Array.from(buffers);
 };
 
+const bytesForDigest = (value) => {
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return null;
+};
+
+const hexDigest = async (bytes) => {
+  const digest = new Uint8Array(await globalThis.crypto.subtle.digest('SHA-256', bytes));
+  return Array.from(digest, (value) => value.toString(16).padStart(2, '0')).join('');
+};
+
+/**
+ * Build a private identity from the buffers that are already being transferred.
+ * SVG and metadata payloads are never re-encoded or concatenated here. Each large
+ * buffer is hashed independently and only the compact digest manifest is encoded
+ * for the final ordered digest.
+ */
+export const buildGeneratedArtifactTransportIdentity = async (payload) => {
+  const results = Array.isArray(payload?.results) ? payload.results : [];
+  const encoder = new TextEncoder();
+  const resultManifest = [];
+  let resultBytes = 0;
+  let resultNameBytes = 0;
+
+  for (let index = 0; index < results.length; index += 1) {
+    const result = results[index] || {};
+    const nameBytes = encoder.encode(String(result.name || ''));
+    const contentBytes = bytesForDigest(result.content);
+    if (!contentBytes) {
+      throw new Error('Generated SVG content was not encoded for Worker transport.');
+    }
+    resultBytes += contentBytes.byteLength;
+    resultNameBytes += nameBytes.byteLength;
+    resultManifest.push({
+      index,
+      nameBytes: nameBytes.byteLength,
+      nameSha256: await hexDigest(nameBytes),
+      contentBytes: contentBytes.byteLength,
+      contentSha256: await hexDigest(contentBytes)
+    });
+  }
+
+  const metadataBytes = bytesForDigest(payload?.metadata);
+  if (!metadataBytes) {
+    throw new Error('Generated metadata was not encoded for Worker transport.');
+  }
+  const manifest = {
+    schema: 1,
+    results: resultManifest,
+    metadata: {
+      bytes: metadataBytes.byteLength,
+      sha256: await hexDigest(metadataBytes)
+    }
+  };
+  const fingerprint = await hexDigest(encoder.encode(JSON.stringify(manifest)));
+  return Object.freeze({
+    schema: 1,
+    algorithm: 'SHA-256',
+    fingerprint,
+    resultBytes,
+    resultNameBytes,
+    metadataBytes: metadataBytes.byteLength,
+    // Parsed metadata retains strings and object structure in addition to the
+    // transferred UTF-8 representation. Two bytes per source byte is a bounded,
+    // deliberately conservative owner estimate; Result UTF-16 strings are added
+    // separately by the main-thread handle.
+    retainedBytes: resultBytes + resultNameBytes + metadataBytes.byteLength * 2
+  });
+};
+
 export const serializeError = (error) => {
   const normalized = normalizeUserFacingError(error);
   return {
@@ -852,12 +924,21 @@ const runGeneration = async ({
     workspaceError = error;
   }
   emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-cleanup-end');
-  return resolveGenerationCleanupOutcome({
+  const outcome = resolveGenerationCleanupOutcome({
     result,
     primaryError,
     destroyError,
     workspaceError
   });
+  if (!outcome?.error) {
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-artifact-identity-start');
+    outcome.artifactIdentity = await buildGeneratedArtifactTransportIdentity(outcome);
+    emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-artifact-identity-end', {
+      fingerprint: outcome.artifactIdentity.fingerprint,
+      retainedBytes: outcome.artifactIdentity.retainedBytes
+    });
+  }
+  return outcome;
 };
 
 const runFeatureExtraction = async ({

--- a/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
+++ b/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
@@ -461,6 +461,8 @@ test('Generate materializes only required resources and reuses one Worker', asyn
       return { length: normalized.length, hash: hash >>> 0 };
     };
     const snapshotResultState = () => ({
+      mode: app.mode,
+      generatedMode: app.generatedMode,
       names: app.results.map((result) => String(result?.name || '')),
       svgIdentities: app.results.map((result) => svgIdentity(result?.content)),
       selectedResultIndex: app.selectedResultIndex,
@@ -468,13 +470,30 @@ test('Generate materializes only required resources and reuses one Worker', asyn
       featureCount: app.extractedFeatures.length,
       orthogroupCount: app.orthogroups.length
     });
+    const historyDelta = (before, after) => Object.fromEntries([
+      'artifactCheckpointBuilds',
+      'artifactCheckpointSignatureComputations',
+      'historySvgBytes',
+      'checkpointEstimatedBytes',
+      'generatedArtifactFullCloneCount',
+      'generatedArtifactFullSerializationCount',
+      'manualCancelFullArtifactSnapshotBuildCount',
+      'artifactHandleBeforeBuildCount',
+      'artifactHandleAfterBuildCount',
+      'artifactFingerprintComparisonCount',
+      'artifactReplacementHistoryEntryCount'
+    ].map((name) => [name, Number(after[name] || 0) - Number(before[name] || 0)]));
     const loaded = snapshotResultState();
+    const beforeFirst = history.getDiagnostics();
     const first = await app.runAnalysis();
+    const afterFirst = history.getDiagnostics();
     const generatedState = snapshotResultState();
     const firstUndoCount = history.getUndoCount();
     const firstRedoCount = history.getRedoCount();
+    const firstUndoLabel = history.undoLabel();
     const undone = await history.undo();
     const restoredLoadedState = snapshotResultState();
+    const redoLabelAfterUndo = history.redoLabel();
     const redone = await history.redo();
     const restoredGeneratedState = snapshotResultState();
     const {
@@ -485,7 +504,32 @@ test('Generate materializes only required resources and reuses one Worker', asyn
       DIAGRAM_HELPER_OPERATIONS.MEASURE_LEGEND_TEXT,
       { caption: 'lazy worker reuse', fontFamily: 'Arial', fontSize: 14 }
     );
+    const beforeSecond = history.getDiagnostics();
+    const undoCountBeforeSecond = history.getUndoCount();
+    const redoCountBeforeSecond = history.getRedoCount();
     const second = await app.runAnalysis();
+    const afterSecond = history.getDiagnostics();
+    const undoCountAfterSecond = history.getUndoCount();
+    const redoCountAfterSecond = history.getRedoCount();
+    const generateProbe = window.__GBDRAW_LAZY_SESSION_PROBE__.snapshot();
+    const editableFeature = app.extractedFeatures.find((feature) => (
+      app.canEditFeatureColor(feature)
+    ));
+    if (!editableFeature) {
+      throw new Error('The synthetic session has no editable feature for mutation isolation.');
+    }
+    const currentColor = String(app.getFeatureColorValue(editableFeature) || '').toLowerCase();
+    const mutationColor = currentColor === '#123456' ? '#654321' : '#123456';
+    const editApplied = await app.setFeatureColorValue(editableFeature, mutationColor);
+    const editedState = snapshotResultState();
+    const undoEdit = await history.undo();
+    const afterUndoEdit = snapshotResultState();
+    const undoGenerate = await history.undo();
+    const afterUndoGenerate = snapshotResultState();
+    const redoGenerate = await history.redo();
+    const afterRedoGenerate = snapshotResultState();
+    const redoEdit = await history.redo();
+    const afterRedoEdit = snapshotResultState();
     return {
       first,
       second,
@@ -493,10 +537,31 @@ test('Generate materializes only required resources and reuses one Worker', asyn
       generatedState,
       firstUndoCount,
       firstRedoCount,
+      firstUndoLabel,
+      redoLabelAfterUndo,
       undone,
       restoredLoadedState,
       redone,
       restoredGeneratedState,
+      firstHistory: historyDelta(beforeFirst, afterFirst),
+      secondHistory: historyDelta(beforeSecond, afterSecond),
+      undoCountBeforeSecond,
+      redoCountBeforeSecond,
+      undoCountAfterSecond,
+      redoCountAfterSecond,
+      generateProbe,
+      mutationIsolation: {
+        editApplied,
+        editedState,
+        undoEdit,
+        afterUndoEdit,
+        undoGenerate,
+        afterUndoGenerate,
+        redoGenerate,
+        afterRedoGenerate,
+        redoEdit,
+        afterRedoEdit
+      },
       helperWidth: Number(helper?.result?.width || 0),
       errorSummary: String(app.errorLog?.summary || '')
     };
@@ -509,16 +574,55 @@ test('Generate materializes only required resources and reuses one Worker', asyn
   expect(generated.helperWidth).toBeGreaterThan(0);
   expect(generated.firstUndoCount).toBe(1);
   expect(generated.firstRedoCount).toBe(0);
+  expect(generated.firstUndoLabel).toBe('Generate diagram');
   expect(generated.undone).toBe(true);
-  expect(generated.restoredLoadedState).toEqual(generated.loaded);
+  expect(generated.restoredLoadedState, JSON.stringify(generated, null, 2)).toEqual(
+    generated.loaded
+  );
   expect(generated.redone).toBe(true);
+  expect(generated.redoLabelAfterUndo).toBe('Generate diagram');
   expect(generated.restoredGeneratedState).toEqual(generated.generatedState);
   expect(generated.restoredGeneratedState.selectedResultIndex).toBeGreaterThanOrEqual(0);
   expect(generated.restoredGeneratedState.selectedResultIndex).toBeLessThan(
     generated.restoredGeneratedState.resultCount
   );
+  expect(generated.firstHistory).toEqual({
+    artifactCheckpointBuilds: 0,
+    artifactCheckpointSignatureComputations: 0,
+    historySvgBytes: 0,
+    checkpointEstimatedBytes: 0,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0,
+    manualCancelFullArtifactSnapshotBuildCount: 0,
+    artifactHandleBeforeBuildCount: 1,
+    artifactHandleAfterBuildCount: 1,
+    artifactFingerprintComparisonCount: 1,
+    artifactReplacementHistoryEntryCount: 1
+  });
+  expect(generated.secondHistory).toEqual({
+    ...generated.firstHistory,
+    artifactReplacementHistoryEntryCount: 0
+  });
+  expect(generated.undoCountAfterSecond).toBe(generated.undoCountBeforeSecond);
+  expect(generated.redoCountAfterSecond).toBe(generated.redoCountBeforeSecond);
+  expect(generated.mutationIsolation.editApplied).toBe(true);
+  expect(generated.mutationIsolation.editedState.svgIdentities).not.toEqual(
+    generated.generatedState.svgIdentities
+  );
+  expect(generated.mutationIsolation.undoEdit).toBe(true);
+  expect(generated.mutationIsolation.afterUndoEdit.resultCount).toBe(
+    generated.generatedState.resultCount
+  );
+  expect(generated.mutationIsolation.undoGenerate).toBe(true);
+  expect(generated.mutationIsolation.afterUndoGenerate).toEqual(generated.loaded);
+  expect(generated.mutationIsolation.redoGenerate).toBe(true);
+  expect(generated.mutationIsolation.afterRedoGenerate).toEqual(generated.generatedState);
+  expect(generated.mutationIsolation.redoEdit).toBe(true);
+  expect(generated.mutationIsolation.afterRedoEdit.resultCount).toBe(
+    generated.mutationIsolation.editedState.resultCount
+  );
 
-  const snapshot = await probeSnapshot(page);
+  const snapshot = generated.generateProbe;
   const materializedIds = new Set(
     snapshot.details
       .filter(({ name }) => name === 'resourceByteReadCount')
@@ -529,7 +633,12 @@ test('Generate materializes only required resources and reuses one Worker', asyn
   expect([...materializedIds].every((resourceId) => (
     ['record-1-genbank', 'colors-default-colors'].includes(resourceId)
   ))).toBe(true);
-  expect(snapshot.structural.base64DecodeCount).toBe(materializedIds.size);
+  expect(snapshot.structural.base64DecodeCount).toBe(
+    snapshot.structural.resourceByteReadCount
+  );
+  expect(snapshot.structural.base64DecodeCount).toBeGreaterThanOrEqual(
+    materializedIds.size
+  );
 
   const previewEvent = snapshot.lifecycle.find(
     ({ name }) => name === 'firstCommittedPreview'
@@ -548,6 +657,151 @@ test('Generate materializes only required resources and reuses one Worker', asyn
   expect(worker.runs).toBe(2);
   expect(worker.instances).toHaveLength(1);
   expect(worker.instances[0].terminated).toBe(false);
+});
+
+test('the real Cancel control restores the committed artifact and leaves no History entry', async ({
+  page
+}) => {
+  test.setTimeout(300_000);
+  await openInstrumentedApp(page);
+  await armHistoryCompletion(page);
+  expect(await loadSyntheticSession(page)).toMatchObject({
+    status: 'ok',
+    degradedRecovery: false
+  });
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    window.__GBDRAW_CANCEL_BASELINE__ = {
+      content: String(app.results?.[app.selectedResultIndex]?.content || ''),
+      resultCount: app.results.length,
+      selectedResultIndex: app.selectedResultIndex,
+      featureCount: app.extractedFeatures.length,
+      orthogroupCount: app.orthogroups.length,
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount(),
+      diagnostics: history.getDiagnostics()
+    };
+    window.__GBDRAW_CANCEL_BASELINE_REFS__ = {
+      result: app.results?.[app.selectedResultIndex] || null,
+      extractedFeatures: app.extractedFeatures,
+      orthogroups: app.orthogroups
+    };
+    let releaseResponse;
+    const responseGate = new Promise((resolve) => {
+      releaseResponse = resolve;
+    });
+    window.__GBDRAW_CANCEL_RESPONSE_STARTED__ = false;
+    window.__GBDRAW_RELEASE_CANCEL_RESPONSE__ = releaseResponse;
+    window.__GBDRAW_TEST_HOOKS__.beforeDiagramGenerationResponse = () => {
+      window.__GBDRAW_CANCEL_RESPONSE_STARTED__ = true;
+      return responseGate;
+    };
+    window.__GBDRAW_CANCEL_RUN__ = app.runAnalysis();
+  });
+
+  await page.waitForFunction(
+    () => window.__GBDRAW_CANCEL_RESPONSE_STARTED__ === true,
+    null,
+    { timeout: 240_000 }
+  );
+  await page.getByRole('button', { name: /Cancel$/ }).click();
+  const canceled = await page.evaluate(async () => {
+    const result = await window.__GBDRAW_CANCEL_RUN__;
+    window.__GBDRAW_RELEASE_CANCEL_RESPONSE__?.();
+    delete window.__GBDRAW_TEST_HOOKS__.beforeDiagramGenerationResponse;
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    const baseline = window.__GBDRAW_CANCEL_BASELINE__;
+    const baselineRefs = window.__GBDRAW_CANCEL_BASELINE_REFS__;
+    const after = history.getDiagnostics();
+    const delta = Object.fromEntries([
+      'artifactCheckpointBuilds',
+      'artifactCheckpointSignatureComputations',
+      'historySvgBytes',
+      'checkpointEstimatedBytes',
+      'generatedArtifactFullCloneCount',
+      'generatedArtifactFullSerializationCount',
+      'manualCancelFullArtifactSnapshotBuildCount',
+      'artifactHandleBeforeBuildCount',
+      'artifactHandleAfterBuildCount',
+      'artifactFingerprintComparisonCount',
+      'artifactReplacementHistoryEntryCount'
+    ].map((name) => [
+      name,
+      Number(after[name] || 0) - Number(baseline.diagnostics[name] || 0)
+    ]));
+    return {
+      result,
+      contentRestored:
+        String(app.results?.[app.selectedResultIndex]?.content || '') === baseline.content,
+      resultCount: app.results.length,
+      selectedResultIndex: app.selectedResultIndex,
+      featureCount: app.extractedFeatures.length,
+      orthogroupCount: app.orthogroups.length,
+      baselineFeatureCount: baseline.featureCount,
+      baselineOrthogroupCount: baseline.orthogroupCount,
+      sameResultObject:
+        app.results?.[app.selectedResultIndex] === baselineRefs.result,
+      sameExtractedFeatureOwner: app.extractedFeatures === baselineRefs.extractedFeatures,
+      sameOrthogroupOwner: app.orthogroups === baselineRefs.orthogroups,
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount(),
+      processing: app.processing,
+      diagnostics: delta
+    };
+  });
+  expect(canceled).toMatchObject({
+    result: { status: 'canceled' },
+    contentRestored: true,
+    resultCount: 1,
+    selectedResultIndex: 0,
+    sameResultObject: true,
+    sameExtractedFeatureOwner: true,
+    sameOrthogroupOwner: true,
+    undoCount: 0,
+    redoCount: 0,
+    processing: false,
+    diagnostics: {
+      artifactCheckpointBuilds: 0,
+      artifactCheckpointSignatureComputations: 0,
+      historySvgBytes: 0,
+      checkpointEstimatedBytes: 0,
+      generatedArtifactFullCloneCount: 0,
+      generatedArtifactFullSerializationCount: 0,
+      manualCancelFullArtifactSnapshotBuildCount: 0,
+      artifactHandleBeforeBuildCount: 1,
+      artifactHandleAfterBuildCount: 0,
+      artifactFingerprintComparisonCount: 0,
+      artifactReplacementHistoryEntryCount: 0
+    }
+  });
+  expect(canceled.featureCount).toBe(canceled.baselineFeatureCount);
+  expect(canceled.featureCount).toBeGreaterThan(0);
+  expect(canceled.orthogroupCount).toBe(canceled.baselineOrthogroupCount);
+
+  const canceledWorker = await getDiagramWorkerActivity(page);
+  expect(canceledWorker.runs).toBe(1);
+  expect(canceledWorker.instances[0].terminated).toBe(true);
+
+  const retry = await page.evaluate(async () => ({
+    result: await window.__GBDRAW_APP__.runAnalysis(),
+    undoCount: window.__GBDRAW_HISTORY__.getUndoCount(),
+    redoCount: window.__GBDRAW_HISTORY__.getRedoCount(),
+    previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+    errorSummary: String(window.__GBDRAW_APP__.errorLog?.summary || '')
+  }));
+  expect(retry).toMatchObject({
+    result: { status: 'ok' },
+    undoCount: 1,
+    redoCount: 0,
+    previewVisible: true,
+    errorSummary: ''
+  });
+  const afterRetryWorker = await getDiagramWorkerActivity(page);
+  expect(afterRetryWorker.constructions).toBe(2);
+  expect(afterRetryWorker.instances[1].terminated).toBe(false);
 });
 
 test('preflight and lazy-access failures preserve the committed preview', async ({ page }) => {

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -108,7 +108,14 @@ const HISTORY_DIAGNOSTIC_FIELDS = [
   'intentBuilds',
   'intentSignatureComputations',
   'historySvgBytes',
-  'checkpointEstimatedBytes'
+  'checkpointEstimatedBytes',
+  'generatedArtifactFullCloneCount',
+  'generatedArtifactFullSerializationCount',
+  'manualCancelFullArtifactSnapshotBuildCount',
+  'artifactHandleBeforeBuildCount',
+  'artifactHandleAfterBuildCount',
+  'artifactFingerprintComparisonCount',
+  'artifactReplacementHistoryEntryCount'
 ];
 
 const historyStructuralDelta = (events, startName, endName) => {
@@ -148,6 +155,16 @@ const generationPhaseAttribution = (outcome, probe) => {
     events,
     'serialize-canonical-files-start',
     'serialize-canonical-files-end'
+  );
+  const historyBeforeStructural = historyStructuralDelta(
+    events,
+    'generate-history-before-start',
+    'generate-history-before-end'
+  );
+  const historyAfterStructural = historyStructuralDelta(
+    events,
+    'generate-history-after-start',
+    'generate-history-after-end'
   );
   return {
     warmGenerateMs: Number(outcome?.elapsedMs || 0),
@@ -248,6 +265,11 @@ const generationPhaseAttribution = (outcome, probe) => {
       'worker-cleanup-start',
       'worker-cleanup-end'
     ),
+    workerArtifactIdentityMs: durationOrZero(
+      events,
+      'worker-artifact-identity-start',
+      'worker-artifact-identity-end'
+    ),
     resultTransportDecodeMs,
     candidateResultValidationMs: durationOrZero(
       events,
@@ -289,16 +311,12 @@ const generationPhaseAttribution = (outcome, probe) => {
       'generate-history-after-start',
       'generate-history-after-end'
     ),
-    historyBeforeStructural: historyStructuralDelta(
-      events,
-      'generate-history-before-start',
-      'generate-history-before-end'
-    ),
-    historyAfterStructural: historyStructuralDelta(
-      events,
-      'generate-history-after-start',
-      'generate-history-after-end'
-    )
+    historyBeforeStructural,
+    historyAfterStructural,
+    historyStructural: Object.fromEntries(HISTORY_DIAGNOSTIC_FIELDS.map((name) => [
+      name,
+      Number(historyBeforeStructural[name] || 0) + Number(historyAfterStructural[name] || 0)
+    ]))
   };
 };
 
@@ -373,10 +391,28 @@ const invokeGeneration = async (page, terminal, runnerEvidence, terminalSignal) 
   let evaluationError = '';
   const evaluation = page.evaluate(async () => {
       const app = window.__GBDRAW_APP__;
+      const history = window.__GBDRAW_HISTORY__;
+      const diagnosticFields = [
+        'artifactCheckpointBuilds',
+        'artifactCheckpointSignatureComputations',
+        'historySvgBytes',
+        'checkpointEstimatedBytes',
+        'generatedArtifactFullCloneCount',
+        'generatedArtifactFullSerializationCount',
+        'manualCancelFullArtifactSnapshotBuildCount',
+        'artifactHandleBeforeBuildCount',
+        'artifactHandleAfterBuildCount',
+        'artifactFingerprintComparisonCount',
+        'artifactReplacementHistoryEntryCount'
+      ];
+      const historyBefore = history.getDiagnostics();
+      const undoCountBefore = history.getUndoCount();
+      const redoCountBefore = history.getRedoCount();
       const started = performance.now();
       try {
         const result = await app.runAnalysis();
         const selected = app.results?.[app.selectedResultIndex];
+        const historyAfter = history.getDiagnostics();
         return {
           status: String(result?.status || ''),
           elapsedMs: performance.now() - started,
@@ -388,7 +424,15 @@ const invokeGeneration = async (page, terminal, runnerEvidence, terminalSignal) 
           resultCount: Array.isArray(app.results) ? app.results.length : 0,
           generatedSvgCharacters: String(selected?.content || '').length,
           resultCommitted: String(selected?.content || '').includes('<svg'),
-          previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg'))
+          previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+          undoCountBefore,
+          undoCountAfter: history.getUndoCount(),
+          redoCountBefore,
+          redoCountAfter: history.getRedoCount(),
+          historyStructural: Object.fromEntries(diagnosticFields.map((name) => [
+            name,
+            Number(historyAfter[name] || 0) - Number(historyBefore[name] || 0)
+          ]))
         };
       } catch (error) {
         return {
@@ -588,6 +632,10 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   const resultSvgCharacters = [firstProbe, secondProbe].map((probe) => Number(
     probe.lifecycle.find(({ name }) => name === 'result-svg-characters')?.value || 0
   ));
+  const artifactFingerprints = [firstProbe, secondProbe].map((probe) => String(
+    probe.lifecycle.find(({ name }) => name === 'worker-artifact-identity-end')
+      ?.fingerprint || ''
+  ));
   const firstStructural = {
     canonicalReplayFullSerializationCount: Number(
       firstProbe.metrics.canonicalReplayFullSerializationCount || 0
@@ -683,6 +731,19 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   };
   const firstPhaseAttribution = generationPhaseAttribution(first.outcome, firstProbe);
   const secondPhaseAttribution = generationPhaseAttribution(second.outcome, secondProbe);
+  const expectedWarmGenerateHistory = {
+    artifactCheckpointBuilds: 0,
+    artifactCheckpointSignatureComputations: 0,
+    historySvgBytes: 0,
+    checkpointEstimatedBytes: 0,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0,
+    manualCancelFullArtifactSnapshotBuildCount: 0,
+    artifactHandleBeforeBuildCount: 1,
+    artifactHandleAfterBuildCount: 1,
+    artifactFingerprintComparisonCount: 1,
+    artifactReplacementHistoryEntryCount: 0
+  };
 
   expect(activity.constructions).toBe(1);
   expect(activity.initializations).toBe(1);
@@ -708,6 +769,16 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     workerInitializationMs: 0,
     workerInitializationReused: true,
     newlyStagedResourceBytes: 0
+  });
+  expect(second.outcome.historyStructural).toEqual(expectedWarmGenerateHistory);
+  expect(secondPhaseAttribution.historyStructural).toMatchObject(
+    expectedWarmGenerateHistory
+  );
+  expect(second.outcome.undoCountAfter).toBe(second.outcome.undoCountBefore);
+  expect(second.outcome.redoCountAfter).toBe(second.outcome.redoCountBefore);
+  expect(first.outcome.historyStructural).toMatchObject({
+    ...expectedWarmGenerateHistory,
+    artifactReplacementHistoryEntryCount: 1
   });
   expect(secondStructural.resourceMaterializationCount).toBe(0);
   expect(secondStructural).toMatchObject({
@@ -759,6 +830,10 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   )).toBe(true);
   expect(resultSvgCharacters).toHaveLength(2);
   expect(resultSvgCharacters.every((characters) => characters > 0)).toBe(true);
+  expect(artifactFingerprints).toHaveLength(2);
+  expect(artifactFingerprints.every((fingerprint) => /^[0-9a-f]{64}$/.test(fingerprint)))
+    .toBe(true);
+  expect(artifactFingerprints[1]).toBe(artifactFingerprints[0]);
   expect(generatedFeatureCatalogDigest).toMatchObject({
     schema: 3,
     itemCount: 1
@@ -810,6 +885,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   ).toBe(0);
 
   const outputsExactlyEqual = firstGeneratedSvg === secondGeneratedSvg;
+  expect(outputsExactlyEqual).toBe(true);
   let historyRoundTrip;
   if (outputsExactlyEqual) {
     historyRoundTrip = await page.evaluate((expectedCharacters) => {
@@ -829,8 +905,8 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
       historyEntryCreated: false,
       undoRedoAttempted: false,
       noOpGeneratePreserved: true,
-      undoCountAfter: 0,
-      redoCountAfter: 0
+      undoCountAfter: second.outcome.undoCountAfter,
+      redoCountAfter: second.outcome.redoCountAfter
     });
   } else {
     historyRoundTrip = await page.evaluate(async ({ firstSvg, secondSvg }) => {
@@ -900,7 +976,10 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
       exactBytesEqual: firstGeneratedSvg === secondGeneratedSvg,
       firstCharacters: firstGeneratedSvg.length,
       secondCharacters: secondGeneratedSvg.length,
-      featureCatalog: generatedFeatureCatalogDigest
+      featureCatalog: generatedFeatureCatalogDigest,
+      artifactFingerprints,
+      generatedMetadataFingerprintEqual:
+        artifactFingerprints[0] === artifactFingerprints[1]
     },
     historyRoundTrip,
     structural,

--- a/tests/web/diagram-generation-worker.test.mjs
+++ b/tests/web/diagram-generation-worker.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
 
 globalThis.self = {};
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
 
 const {
+  buildGeneratedArtifactTransportIdentity,
   collectGenerationResultTransferList,
   resolveGenerationCleanupOutcome,
   serializeError
@@ -16,6 +19,37 @@ assert.deepEqual(
     metadata: metadataBytes
   }),
   [svgBytes.buffer, metadataBytes.buffer]
+);
+const firstIdentity = await buildGeneratedArtifactTransportIdentity({
+  results: [{ name: 'out.svg', content: svgBytes }],
+  metadata: metadataBytes
+});
+const sameIdentity = await buildGeneratedArtifactTransportIdentity({
+  results: [{ name: 'out.svg', content: svgBytes }],
+  metadata: metadataBytes
+});
+const changedIdentity = await buildGeneratedArtifactTransportIdentity({
+  results: [{ name: 'changed.svg', content: svgBytes }],
+  metadata: metadataBytes
+});
+const changedContentIdentity = await buildGeneratedArtifactTransportIdentity({
+  results: [{ name: 'out.svg', content: new TextEncoder().encode('<svg>b</svg>') }],
+  metadata: metadataBytes
+});
+const changedMetadataIdentity = await buildGeneratedArtifactTransportIdentity({
+  results: [{ name: 'out.svg', content: svgBytes }],
+  metadata: new TextEncoder().encode('{"featureCatalog":{"schema":4}}')
+});
+assert.match(firstIdentity.fingerprint, /^[0-9a-f]{64}$/);
+assert.equal(firstIdentity.fingerprint, sameIdentity.fingerprint);
+assert.notEqual(firstIdentity.fingerprint, changedIdentity.fingerprint);
+assert.notEqual(firstIdentity.fingerprint, changedContentIdentity.fingerprint);
+assert.notEqual(firstIdentity.fingerprint, changedMetadataIdentity.fingerprint);
+assert.equal(
+  firstIdentity.retainedBytes,
+  svgBytes.byteLength
+    + metadataBytes.byteLength * 2
+    + new TextEncoder().encode('out.svg').byteLength
 );
 
 const pythonPayload = {

--- a/tests/web/history.test.mjs
+++ b/tests/web/history.test.mjs
@@ -328,6 +328,189 @@ const createLayoutPreferences = () => ({
 }
 
 {
+  let setting = 'loaded-setting';
+  let artifact = {
+    id: 'loaded',
+    identity: { fingerprint: '', compactSignature: 'loaded' },
+    retainedBytes: 128,
+    fileIds: new Set()
+  };
+  let workerCalls = 0;
+  const restored = [];
+  const history = createHistoryManager({
+    buildIntent: async () => ({ setting }),
+    applyIntent: async (intent) => {
+      setting = intent.setting;
+    },
+    buildCheckpoint: () => {
+      throw new Error('Generate replacement must not build a checkpoint.');
+    },
+    applyCheckpoint: async () => {
+      throw new Error('Generate replacement must not apply a checkpoint.');
+    },
+    captureGeneratedArtifactHandle: () => artifact,
+    restoreGeneratedArtifactHandle: async (handle) => {
+      artifact = handle;
+      restored.push(handle.id);
+    },
+    compareGeneratedArtifactHandles: (before, after) => Boolean(
+      before.identity.fingerprint
+      && before.identity.fingerprint === after.identity.fingerprint
+      && before.identity.compactSignature === after.identity.compactSignature
+    )
+  });
+  const generated = (id, compactSignature = 'stable') => ({
+    id,
+    identity: { fingerprint: id.repeat(64).slice(0, 64), compactSignature },
+    retainedBytes: 256,
+    fileIds: new Set()
+  });
+
+  await history.initializeIntentBaseline('Loaded session');
+  const beforeFirst = history.getDiagnostics();
+  await history.runUndoableArtifactReplacement('Generate A', async (before) => {
+    assert.equal(before.id, 'loaded');
+    workerCalls += 1;
+    artifact = generated('a');
+    return { status: 'ok' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  const afterFirst = history.getDiagnostics();
+  assert.equal(history.getUndoCount(), 1);
+  assert.equal(afterFirst.artifactHandleBeforeBuildCount - beforeFirst.artifactHandleBeforeBuildCount, 1);
+  assert.equal(afterFirst.artifactHandleAfterBuildCount - beforeFirst.artifactHandleAfterBuildCount, 1);
+  assert.equal(afterFirst.artifactFingerprintComparisonCount - beforeFirst.artifactFingerprintComparisonCount, 1);
+  assert.equal(afterFirst.artifactReplacementHistoryEntryCount - beforeFirst.artifactReplacementHistoryEntryCount, 1);
+  assert.equal(afterFirst.artifactCheckpointBuilds - beforeFirst.artifactCheckpointBuilds, 0);
+  assert.equal(afterFirst.artifactCheckpointSignatureComputations - beforeFirst.artifactCheckpointSignatureComputations, 0);
+  assert.equal(afterFirst.historySvgBytes - beforeFirst.historySvgBytes, 0);
+  assert.equal(afterFirst.checkpointEstimatedBytes - beforeFirst.checkpointEstimatedBytes, 0);
+  assert.equal(afterFirst.generatedArtifactFullCloneCount - beforeFirst.generatedArtifactFullCloneCount, 0);
+  assert.equal(afterFirst.generatedArtifactFullSerializationCount - beforeFirst.generatedArtifactFullSerializationCount, 0);
+  assert.equal(
+    afterFirst.manualCancelFullArtifactSnapshotBuildCount
+      - beforeFirst.manualCancelFullArtifactSnapshotBuildCount,
+    0
+  );
+
+  await history.undo();
+  assert.equal(artifact.id, 'loaded');
+  await history.redo();
+  assert.equal(artifact.id, 'a');
+  assert.equal(workerCalls, 1, 'Undo/Redo must not invoke generation');
+
+  const beforeUnchanged = history.getDiagnostics();
+  const undoCountBeforeUnchanged = history.getUndoCount();
+  const redoCountBeforeUnchanged = history.getRedoCount();
+  await history.runUndoableArtifactReplacement('Generate A unchanged', async () => {
+    workerCalls += 1;
+    artifact = generated('a');
+    return { status: 'ok' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  const afterUnchanged = history.getDiagnostics();
+  assert.equal(history.getUndoCount(), undoCountBeforeUnchanged);
+  assert.equal(history.getRedoCount(), redoCountBeforeUnchanged);
+  assert.equal(
+    afterUnchanged.artifactReplacementHistoryEntryCount
+      - beforeUnchanged.artifactReplacementHistoryEntryCount,
+    0
+  );
+  assert.equal(afterUnchanged.artifactHandleBeforeBuildCount - beforeUnchanged.artifactHandleBeforeBuildCount, 1);
+  assert.equal(afterUnchanged.artifactHandleAfterBuildCount - beforeUnchanged.artifactHandleAfterBuildCount, 1);
+  assert.equal(
+    afterUnchanged.artifactFingerprintComparisonCount
+      - beforeUnchanged.artifactFingerprintComparisonCount,
+    1
+  );
+
+  const pendingSetting = await history.begin('Change render setting');
+  setting = 'changed-setting';
+  await history.runUndoableArtifactReplacement('Generate B', async () => {
+    workerCalls += 1;
+    artifact = generated('b');
+    return { status: 'ok' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  assert.equal(pendingSetting.closed, true);
+  assert.equal(pendingSetting.deferAdapterCommit, true);
+  assert.equal(history.undoLabel(), 'Generate B');
+  await history.undo();
+  assert.equal(artifact.id, 'a');
+  assert.equal(setting, 'changed-setting');
+  assert.equal(history.undoLabel(), 'Change render setting');
+  await history.undo();
+  assert.equal(setting, 'loaded-setting');
+  await history.redo();
+  await history.redo();
+  assert.equal(setting, 'changed-setting');
+  assert.equal(artifact.id, 'b');
+
+  await history.runUndoableArtifactReplacement('Generate C', async () => {
+    workerCalls += 1;
+    artifact = generated('c');
+    return { status: 'ok' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  await history.undo();
+  assert.equal(artifact.id, 'b');
+  await history.undo();
+  assert.equal(artifact.id, 'a');
+  await history.redo();
+  assert.equal(artifact.id, 'b');
+  await history.redo();
+  assert.equal(artifact.id, 'c');
+
+  const countBeforeFailure = history.getUndoCount();
+  const failed = await history.runUndoableArtifactReplacement('Failed Generate', async (before) => {
+    artifact = generated('d');
+    artifact = before;
+    return { status: 'error' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  assert.deepEqual(failed, { status: 'error' });
+  assert.equal(artifact.id, 'c');
+  assert.equal(history.getUndoCount(), countBeforeFailure);
+  assert.equal(history.getRedoCount(), 0);
+
+  await assert.rejects(
+    history.runUndoableArtifactReplacement('Thrown Generate', async () => {
+      artifact = generated('d');
+      throw new Error('injected generation failure');
+    }),
+    /injected generation failure/
+  );
+  assert.equal(artifact.id, 'c');
+  assert.equal(restored.at(-1), 'c');
+}
+
+{
+  let artifact = {
+    identity: { fingerprint: 'a'.repeat(64), compactSignature: 'a' },
+    retainedBytes: 80,
+    fileIds: []
+  };
+  const history = createHistoryManager({
+    maxBytes: 100,
+    buildIntent: async () => ({}),
+    applyIntent: async () => {},
+    buildCheckpoint: () => ({}),
+    applyCheckpoint: async () => {},
+    captureGeneratedArtifactHandle: () => artifact,
+    restoreGeneratedArtifactHandle: async (handle) => {
+      artifact = handle;
+    }
+  });
+  await history.initializeIntentBaseline('Loaded session');
+  await history.runUndoableArtifactReplacement('Oversized Generate', async () => {
+    artifact = {
+      identity: { fingerprint: 'b'.repeat(64), compactSignature: 'b' },
+      retainedBytes: 80,
+      fileIds: []
+    };
+    return { status: 'ok' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  assert.equal(history.getDiagnostics().artifactReplacementHistoryEntryCount, 1);
+  assert.equal(history.canUndo(), false);
+  assert.match(history.historyLimitMessage.value, /discarded/);
+}
+
+{
   let value = 0;
   const buildState = async () => ({ value });
   const applyState = async (snapshot) => {
@@ -1438,6 +1621,223 @@ const createLayoutPreferences = () => ({
   });
   await history.undo();
   assert.deepEqual(draftState(), after);
+}
+
+{
+  const fileStore = createHistoryFileStore();
+  const resultA = { name: 'a.svg', content: '<svg id="a" />' };
+  const extractedA = [{ svg_id: 'feature-a', payload: 'x'.repeat(100_000) }];
+  const biologicalA = [{ biological_feature_id: 'bio-a', payload: 'y'.repeat(100_000) }];
+  const catalogA = { schema: 3, items: [{ payload: 'z'.repeat(100_000) }] };
+  const groupsA = [{ id: 'group-a', members: ['feature-a'] }];
+  const state = {
+    files: {},
+    linearSeqs: [],
+    linearComparisonPlan: { mode: 'none', defaultSource: 'losat', edges: [] },
+    mode: ref('circular'),
+    cInputType: ref('gb'),
+    lInputType: ref('gb'),
+    results: ref([resultA]),
+    selectedResultIndex: ref(0),
+    extractedFeatures: ref(extractedA),
+    biologicalFeatures: ref(biologicalA),
+    featureCatalog: ref(catalogA),
+    featureSelectorSafetyScope: ref([]),
+    featureRecordIds: ref(['record-a']),
+    selectedFeatureRecordIdx: ref(0),
+    featureColorOverrides: { 'feature-a': '#112233' },
+    featureVisibilityManualRules: [],
+    featureVisibilityOverrides: {},
+    featureVisibilitySelectorCache: {
+      'feature-a': { qualifier: 'hash', value: 'feature-a' }
+    },
+    labelTextFeatureOverrides: {},
+    canonicalLabelOverrideRows: ref([]),
+    labelTextBulkOverrides: {},
+    labelTextFeatureOverrideSources: {},
+    labelVisibilityOverrides: {},
+    labelOverrideContextKey: ref('context-a'),
+    legendEntries: ref([{ caption: 'A', color: '#112233' }]),
+    deletedLegendEntries: ref([]),
+    originalLegendOrder: ref(['A']),
+    originalLegendColors: ref({ A: '#112233' }),
+    legendColorOverrides: {},
+    legendStrokeOverrides: {},
+    addedLegendCaptions: ref(new Set()),
+    featureStrokeOverrides: {},
+    originalSvgStroke: ref({ color: '#000000', width: 1 }),
+    orthogroups: ref(groupsA),
+    featureOrthogroupIndex: ref(new Map([['feature-a', 'group-a']])),
+    selectedOrthogroupId: ref('group-a'),
+    selectedOrthogroupAlignmentFeature: ref('feature-a'),
+    orthogroupNameOverrides: {},
+    orthogroupDescriptionOverrides: {},
+    collinearGroups: ref([]),
+    lastRunInfo: ref({ resultCount: 1 }),
+    pairwiseMatchFactors: ref({}),
+    trackSlotResolvedGeometry: ref({ schema: 1 }),
+    resultGenerationKey: ref(1),
+    resultPanelTab: ref('preview'),
+    errorLog: ref(null),
+    editableLabels: ref([]),
+    labelTextScopeDialog: {},
+    featureEditorStatus: { status: 'summary-ready', summaryCount: 1 },
+    featureExtractionPending: ref(false),
+    featureExtractionError: ref(null),
+    labelOverrideBuildWarning: ref(''),
+    proteinIdentityManifest: ref({ schema: 1, records: [] }),
+    legacyProteinRawCandidates: ref({ schema: 1, entries: [] }),
+    legacyProteinDerivedEvidence: ref({ schema: 1, entries: [] }),
+    losatCache: ref(new Map([['raw-a', { text: 'row\n' }]])),
+    losatDerivedCache: ref(new Map()),
+    losatCacheInfo: ref([{ key: 'raw-a' }]),
+    matchSequenceRegistry: {
+      current: [{ key: 'record-a', recordId: 'record-a', aliases: [], sequence: 'ACGT' }],
+      values() { return this.current; },
+      reset(sources) { this.current = sources.map((source) => ({ ...source })); },
+      resetTrusted(sources) { this.current = [...sources]; }
+    },
+    skipCaptureBaseConfig: ref(false),
+    skipPositionReapply: ref(false),
+    skipExtractOnSvgChange: ref(false),
+    trustedArtifactRestoreInProgress: ref(false),
+    semanticFileWatchersSuppressed: ref(false)
+  };
+  let resultAdmissionCalls = 0;
+  const snapshots = createHistorySnapshotService({
+    state,
+    fileStore,
+    nextTick: async () => {},
+    buildUiStateData: () => ({
+      mode: state.mode.value,
+      cInputType: state.cInputType.value,
+      lInputType: state.lInputType.value,
+      selectedResultIndex: state.selectedResultIndex.value,
+      appliedPaletteName: 'default',
+      appliedPaletteColors: {}
+    }),
+    applyUiStateData: (ui) => {
+      state.mode.value = ui.mode;
+      state.selectedResultIndex.value = ui.selectedResultIndex;
+    },
+    serializeResults: () => {
+      throw new Error('Generated Artifact Handles must not serialize Results.');
+    },
+    applyResultsData: () => {
+      resultAdmissionCalls += 1;
+      throw new Error('Trusted artifact restore must not use Result admission.');
+    },
+    applyFeatureStateData: (features) => {
+      state.extractedFeatures.value = features.extractedFeatures;
+      state.biologicalFeatures.value = features.biologicalFeatures;
+      state.featureSelectorSafetyScope.value = features.featureSelectorSafetyScope;
+      state.featureRecordIds.value = features.featureRecordIds;
+      state.selectedFeatureRecordIdx.value = features.selectedFeatureRecordIdx;
+      Object.assign(state.featureColorOverrides, features.featureColorOverrides);
+    },
+    applyEditorStateData: (editorState, options) => {
+      assert.equal(options.normalized, true);
+      assert.equal(options.adoptCatalog, true);
+      state.legendEntries.value = editorState.legend.entries;
+      state.featureCatalog.value = editorState.featureCatalog;
+    },
+    buildRunStateData: () => ({
+      lastRunInfo: structuredClone(state.lastRunInfo.value),
+      pairwiseMatchFactors: structuredClone(state.pairwiseMatchFactors.value)
+    }),
+    applyRunStateData: (runState) => {
+      state.lastRunInfo.value = structuredClone(runState.lastRunInfo);
+      state.pairwiseMatchFactors.value = structuredClone(runState.pairwiseMatchFactors);
+    }
+  });
+  snapshots.setGeneratedArtifactIdentity({
+    schema: 1,
+    algorithm: 'SHA-256',
+    fingerprint: 'a'.repeat(64),
+    retainedBytes: 400_000
+  }, { results: state.results.value });
+
+  const handleA = snapshots.captureGeneratedArtifactHandle();
+  assert.equal(Object.isFrozen(handleA), true);
+  assert.equal(Object.isFrozen(handleA.results), true);
+  assert.notEqual(handleA.results, state.results.value);
+  assert.equal(handleA.results[0], resultA);
+  assert.equal(handleA.features.extractedFeatures, extractedA);
+  assert.equal(handleA.features.biologicalFeatures, biologicalA);
+  assert.equal(handleA.editorState.featureCatalog, catalogA);
+  assert.equal(handleA.orthogroupState.groups, groupsA);
+  assert.equal(
+    Object.fromEntries(handleA.features.featureVisibilitySelectorCache)['feature-a'].value,
+    'feature-a'
+  );
+  assert.ok(handleA.retainedBytes >= 400_000);
+
+  state.results.value[0] = { name: 'a.svg', content: '<svg id="b" />' };
+  const invalidatedIdentityHandle = snapshots.captureGeneratedArtifactHandle();
+  assert.equal(
+    invalidatedIdentityHandle.identity.fingerprint,
+    '',
+    'Replacing a Result object must invalidate its Worker-byte identity even at equal length.'
+  );
+  state.results.value[0] = { name: 'edited.svg', content: '<svg id="edited" />' };
+  state.featureColorOverrides['feature-a'] = '#abcdef';
+  state.featureVisibilitySelectorCache['feature-a'] = {
+    qualifier: 'hash',
+    value: 'edited-feature'
+  };
+  state.legendEntries.value[0].caption = 'Edited current legend';
+  state.extractedFeatures.value = [{ svg_id: 'feature-b' }];
+  state.biologicalFeatures.value = [{ biological_feature_id: 'bio-b' }];
+  state.featureCatalog.value = { schema: 3, items: [] };
+  state.orthogroups.value = [{ id: 'group-b' }];
+  snapshots.setGeneratedArtifactIdentity({
+    schema: 1,
+    algorithm: 'SHA-256',
+    fingerprint: 'b'.repeat(64),
+    retainedBytes: 1024
+  }, { results: state.results.value });
+  const handleB = snapshots.captureGeneratedArtifactHandle();
+
+  assert.equal(handleA.results[0], resultA);
+  assert.equal(handleA.features.featureColorOverrides['feature-a'], '#112233');
+  assert.equal(handleA.editorState.legend.entries[0].caption, 'A');
+  assert.equal(
+    Object.fromEntries(handleA.features.featureVisibilitySelectorCache)['feature-a'].value,
+    'feature-a'
+  );
+  assert.equal(handleB.results[0].name, 'edited.svg');
+
+  await snapshots.restoreGeneratedArtifactHandle(handleA);
+  assert.equal(resultAdmissionCalls, 0);
+  assert.equal(state.results.value[0], resultA);
+  assert.equal(state.extractedFeatures.value, extractedA);
+  assert.equal(state.biologicalFeatures.value, biologicalA);
+  assert.equal(state.featureCatalog.value, catalogA);
+  assert.equal(state.orthogroups.value, groupsA);
+  assert.equal(state.featureColorOverrides['feature-a'], '#112233');
+  assert.equal(state.legendEntries.value[0].caption, 'A');
+  assert.equal(state.featureVisibilitySelectorCache['feature-a'].value, 'feature-a');
+  const recapturedA = snapshots.captureGeneratedArtifactHandle();
+  assert.equal(recapturedA.identity.fingerprint, 'a'.repeat(64));
+  assert.equal(recapturedA.retainedBytes, handleA.retainedBytes);
+
+  state.results.value[0] = { ...state.results.value[0], content: '<svg id="normal-edit" />' };
+  state.featureColorOverrides['feature-a'] = '#ffffff';
+  state.legendEntries.value[0].caption = 'Normal supported edit';
+  assert.equal(handleA.results[0].content, '<svg id="a" />');
+  assert.equal(handleA.features.featureColorOverrides['feature-a'], '#112233');
+  assert.equal(handleA.editorState.legend.entries[0].caption, 'A');
+
+  await snapshots.restoreGeneratedArtifactHandle(handleB);
+  assert.equal(state.results.value[0].name, 'edited.svg');
+  assert.equal(state.extractedFeatures.value[0].svg_id, 'feature-b');
+
+  await Promise.all([
+    snapshots.restoreGeneratedArtifactHandle(handleA),
+    snapshots.restoreGeneratedArtifactHandle(handleB)
+  ]);
+  assert.equal(state.trustedArtifactRestoreInProgress.value, false);
+  assert.equal(state.semanticFileWatchersSuppressed.value, false);
 }
 
 console.log('history tests passed');

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -193,9 +193,17 @@ const artifactSnapshots = createHistorySnapshotService({
   buildRunStateData,
   applyRunStateData
 });
-const generatedArtifactSnapshotOptions = {
-  buildGeneratedArtifactSnapshot: artifactSnapshots.buildGeneratedArtifactSnapshot,
-  applyGeneratedArtifactSnapshot: artifactSnapshots.applyGeneratedArtifactSnapshot
+const generatedArtifactHandleOptions = {
+  captureGeneratedArtifactHandle: artifactSnapshots.captureGeneratedArtifactHandle,
+  restoreGeneratedArtifactHandle: artifactSnapshots.restoreGeneratedArtifactHandle,
+  setGeneratedArtifactIdentity: artifactSnapshots.setGeneratedArtifactIdentity
+};
+const wireGeneratedArtifactRuntimeOwner = (runner) => {
+  artifactSnapshots.setGeneratedArtifactRuntimeOwner({
+    capture: runner.captureGeneratedArtifactRuntimeState,
+    restore: runner.restoreGeneratedArtifactRuntimeState
+  });
+  return runner;
 };
 
 const result = (name, marker) => ({
@@ -353,8 +361,8 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   let failArtifactAdoption = false;
   let cancelDuringCandidate = false;
   let runner;
-  runner = createRunAnalysis({
-    ...generatedArtifactSnapshotOptions,
+  runner = wireGeneratedArtifactRuntimeOwner(createRunAnalysis({
+    ...generatedArtifactHandleOptions,
     state,
     serializeCanonicalFiles: () => serializeActiveRenderFiles(state.mode.value, state),
     canonicalSessionVersion: SESSION_VERSION,
@@ -384,7 +392,7 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
       state.canvasPan.y = Number(pan?.y) || 0;
       if (!pan) state.zoom.value = 1;
     }
-  });
+  }));
 
   const committedResult = result('audit-simple.svg', 'committed');
   const committedCatalog = validCatalog(committedResult.name);
@@ -470,7 +478,9 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   assert.deepEqual(await runner.runAnalysis(), { status: 'canceled' });
   cancelDuringCandidate = false;
   assert.deepEqual(committedFeatureState(), canceledState);
-  assert.equal(state.results.value, canceledResultIdentity);
+  assert.notEqual(state.results.value, canceledResultIdentity);
+  assert.deepEqual(state.results.value, canceledResultIdentity);
+  assert.equal(state.results.value[0], canceledResultIdentity[0]);
   assert.equal(state.extractedFeatures.value, committedExtractedFeatureIdentity);
   assert.equal(state.biologicalFeatures.value, committedBiologicalFeatureIdentity);
   assert.equal(state.processingStatus.value, 'Canceled.');
@@ -828,8 +838,8 @@ test('Linear mode none ignores dormant comparison state while active depth and a
     throw new Error('mode none must not execute LOSAT');
   };
 
-  const runner = createRunAnalysis({
-    ...generatedArtifactSnapshotOptions,
+  const runner = wireGeneratedArtifactRuntimeOwner(createRunAnalysis({
+    ...generatedArtifactHandleOptions,
     state,
     serializeCanonicalFiles: (snapshot, recordCatalog) => {
       serializeCalls += 1;
@@ -861,7 +871,7 @@ test('Linear mode none ignores dormant comparison state while active depth and a
       state.canvasPan.y = Number(pan?.y) || 0;
       if (!pan) state.zoom.value = 1;
     }
-  });
+  }));
 
   const linearResult = result('linear-none.svg', 'linear-none');
   workerResponses.push(response(linearResult, validCatalog(linearResult.name)));
@@ -956,7 +966,9 @@ test('Linear mode none ignores dormant comparison state while active depth and a
   await runner.cancelRunAnalysis();
   releaseRecordCatalog({ catalog: preparedRecordCatalog, error: '' });
   assert.deepEqual(await canceledRun, { status: 'canceled' });
-  assert.equal(state.results.value, committedResults);
+  assert.notEqual(state.results.value, committedResults);
+  assert.deepEqual(state.results.value, committedResults);
+  assert.equal(state.results.value[0], committedResults[0]);
   assert.equal(state.processing.value, false);
   assert.equal(state.generationCancelRequested.value, false);
   assert.equal(serializeCalls, 1);

--- a/tests/web/session-feature-metadata.test.mjs
+++ b/tests/web/session-feature-metadata.test.mjs
@@ -144,14 +144,22 @@ const { normalizeGenerationResponse } = await import(pathToFileURL(join(tempDir,
 
 {
   const legacyResults = [{ name: 'out.svg', content: '<svg />' }];
-  assert.deepEqual(normalizeGenerationResponse(legacyResults), { results: legacyResults, metadata: {} });
+  assert.deepEqual(normalizeGenerationResponse(legacyResults), {
+    results: legacyResults,
+    metadata: {},
+    artifactIdentity: null
+  });
   const metadata = { trackSlotGeometry: { schema: 1, mode: 'linear', records: [] } };
   assert.deepEqual(
     normalizeGenerationResponse({ results: legacyResults, metadata }),
-    { results: legacyResults, metadata }
+    { results: legacyResults, metadata, artifactIdentity: null }
   );
   const errorPayload = { error: { type: 'OutputError', message: 'No output files generated.' } };
-  assert.deepEqual(normalizeGenerationResponse(errorPayload), { results: errorPayload, metadata: {} });
+  assert.deepEqual(normalizeGenerationResponse(errorPayload), {
+    results: errorPayload,
+    metadata: {},
+    artifactIdentity: null
+  });
   const binarySvg = new TextEncoder().encode('<svg>µ</svg>');
   assert.deepEqual(
     normalizeGenerationResponse({
@@ -160,7 +168,8 @@ const { normalizeGenerationResponse } = await import(pathToFileURL(join(tempDir,
     }),
     {
       results: [{ name: 'binary.svg', content: '<svg>µ</svg>' }],
-      metadata
+      metadata,
+      artifactIdentity: null
     }
   );
 }


### PR DESCRIPTION
Replace Generate’s duplicate checkpoint/cancel-snapshot ownership with reference-owned GeneratedArtifactHandles and a private Worker SHA-256 identity. Record one already-applied History replacement only for changed artifacts, with direct trusted Undo/Redo and bounded memory accounting. Add structural, chain, mutation, failure, real-cancel, compatibility, and Vibrio performance coverage.