### PR TITLE
Reuse prepared biological inputs across warm Generates

### DIFF
--- a/gbdraw/api/prepared.py
+++ b/gbdraw/api/prepared.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Mapping
+from collections import OrderedDict
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Hashable, Iterator, Mapping, MutableMapping
 
+from Bio.SeqRecord import SeqRecord  # type: ignore[reportMissingImports]
 from pandas import DataFrame  # type: ignore[reportMissingImports]
 
+from gbdraw.exceptions import ValidationError
 from gbdraw.features.colors import preprocess_color_tables
 from gbdraw.features.visibility import compile_feature_visibility_rules
 
@@ -21,6 +28,708 @@ class ResolvedFeatureInputs:
     feature_visibility_rules: list[dict[str, Any]]
     specific_color_rules: Mapping[str, Any]
     default_color_map: Mapping[str, str]
+
+
+@dataclass(frozen=True, order=True)
+class PreparedResourceIdentity:
+    """Compact identity for one Worker-owned canonical resource."""
+
+    resource_id: str
+    cache_token: str
+    size: int
+
+
+@dataclass(frozen=True)
+class _PreparedCacheEntry:
+    value: Any
+    resource_identities: frozenset[PreparedResourceIdentity]
+    owner_stamp: Hashable
+    retained_bytes: int
+
+
+@dataclass
+class _PreparedCacheTransaction:
+    cache: "PreparedBiologicalInputCache"
+    resource_paths: Mapping[Path, PreparedResourceIdentity]
+    active_identities: frozenset[PreparedResourceIdentity]
+    diagnostics: MutableMapping[str, Any] | None
+    pending: dict[str, OrderedDict[Hashable, _PreparedCacheEntry]] = field(
+        default_factory=lambda: {
+            "parsed": OrderedDict(),
+            "resolved": OrderedDict(),
+            "interactive": OrderedDict(),
+        }
+    )
+    used: dict[str, set[Hashable]] = field(
+        default_factory=lambda: {
+            "parsed": set(),
+            "resolved": set(),
+            "interactive": set(),
+        }
+    )
+    accessed: dict[str, dict[Hashable, Any]] = field(
+        default_factory=lambda: {
+            "parsed": {},
+            "resolved": {},
+            "interactive": {},
+        }
+    )
+    decoded_resource_values: dict[int, tuple[Any, PreparedResourceIdentity]] = field(
+        default_factory=dict
+    )
+    resolved_record_membership: dict[int, tuple[Hashable, int]] = field(
+        default_factory=dict
+    )
+
+
+_ACTIVE_PREPARED_TRANSACTION: ContextVar[_PreparedCacheTransaction | None] = (
+    ContextVar("gbdraw_active_prepared_transaction", default=None)
+)
+
+_CACHE_METRICS = (
+    "parsedSourceCacheHitCount",
+    "parsedSourceCacheMissCount",
+    "parsedSourceParseCount",
+    "resolvedRecordCacheHitCount",
+    "resolvedRecordCacheMissCount",
+    "resolvedRecordBuildCount",
+    "interactiveContextCacheHitCount",
+    "interactiveContextCacheMissCount",
+    "interactiveContextBuildCount",
+    "interactiveFeatureTraversalCount",
+    "selectorSafetyScopeBuildCount",
+    "preparedInputCacheEvictionCount",
+    "preparedInputCacheRetainedBytes",
+    "preparedInputCacheMutationViolationCount",
+)
+
+_LAYER_METRICS = {
+    "parsed": (
+        "parsedSourceCacheHitCount",
+        "parsedSourceCacheMissCount",
+        "parsedSourceParseCount",
+    ),
+    "resolved": (
+        "resolvedRecordCacheHitCount",
+        "resolvedRecordCacheMissCount",
+        "resolvedRecordBuildCount",
+    ),
+    "interactive": (
+        "interactiveContextCacheHitCount",
+        "interactiveContextCacheMissCount",
+        "interactiveContextBuildCount",
+    ),
+}
+
+
+def _record_metric(
+    transaction: _PreparedCacheTransaction | None,
+    name: str,
+    value: int = 1,
+) -> None:
+    if transaction is None or transaction.diagnostics is None:
+        return
+    metrics = transaction.diagnostics.setdefault("metrics", {})
+    metrics[name] = int(metrics.get(name, 0)) + int(value)
+
+
+def record_prepared_input_metric(name: str, value: int = 1) -> None:
+    """Record a private Web preparation metric when its cache is active."""
+
+    _record_metric(_ACTIVE_PREPARED_TRANSACTION.get(), name, value)
+
+
+def prepared_input_cache_active() -> bool:
+    """Return whether the current call is inside a Worker cache transaction."""
+
+    return _ACTIVE_PREPARED_TRANSACTION.get() is not None
+
+
+def prepared_resource_identity(
+    value: str | Path,
+) -> PreparedResourceIdentity | None:
+    """Resolve an ephemeral staged path to its compact Worker identity."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    if transaction is None:
+        return None
+    try:
+        path = Path(value)
+        candidates = (path.absolute(), path.resolve(strict=True))
+    except (OSError, RuntimeError, ValueError):
+        return None
+    for candidate in candidates:
+        identity = transaction.resource_paths.get(candidate)
+        if identity is not None:
+            return identity
+    return None
+
+
+def register_prepared_resource_value(value: Any, source: str | Path) -> Any:
+    """Associate one decoded value with the resource that supplied it."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    identity = prepared_resource_identity(source)
+    if transaction is not None and identity is not None and value is not None:
+        transaction.decoded_resource_values[id(value)] = (value, identity)
+    return value
+
+
+def prepared_resource_value_identity(value: Any) -> PreparedResourceIdentity | None:
+    """Return the compact resource identity registered for a decoded value."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    if transaction is None or value is None:
+        return None
+    registered = transaction.decoded_resource_values.get(id(value))
+    if registered is None or registered[0] is not value:
+        return None
+    return registered[1]
+
+
+def _shallow_value_stamp(value: Any) -> Hashable:
+    if value is None or isinstance(value, (bool, int, float, str, bytes, Enum)):
+        return value
+    if isinstance(value, Mapping):
+        return (
+            "mapping",
+            id(value),
+            len(value),
+            tuple(
+                sorted(
+                    (
+                        str(key),
+                        (
+                            entry
+                            if entry is None
+                            or isinstance(entry, (bool, int, float, str, bytes, Enum))
+                            else (type(entry).__name__, id(entry), len(entry))
+                            if hasattr(entry, "__len__")
+                            else (type(entry).__name__, id(entry))
+                        ),
+                    )
+                    for key, entry in value.items()
+                )
+            ),
+        )
+    if isinstance(value, (list, tuple)):
+        return (
+            type(value).__name__,
+            id(value),
+            len(value),
+            tuple(
+                entry
+                if entry is None
+                or isinstance(entry, (bool, int, float, str, bytes, Enum))
+                else (type(entry).__name__, id(entry), len(entry))
+                if hasattr(entry, "__len__")
+                else (type(entry).__name__, id(entry))
+                for entry in value
+            ),
+        )
+    return (type(value).__name__, id(value))
+
+
+def _feature_stamp(feature: Any) -> Hashable:
+    location = getattr(feature, "location", None)
+    qualifiers = getattr(feature, "qualifiers", None)
+    return (
+        id(feature),
+        str(getattr(feature, "type", "") or ""),
+        id(location),
+        int(location.start) if location is not None else None,
+        int(location.end) if location is not None else None,
+        getattr(location, "strand", None),
+        _shallow_value_stamp(qualifiers),
+    )
+
+
+def _record_stamp(record: SeqRecord) -> Hashable:
+    features = getattr(record, "features", ())
+    annotations = getattr(record, "annotations", None)
+    return (
+        id(record),
+        str(record.id),
+        str(record.name),
+        id(record.seq),
+        len(record.seq),
+        id(features),
+        len(features),
+        tuple(_feature_stamp(feature) for feature in features),
+        _shallow_value_stamp(annotations),
+    )
+
+
+def _records_from_value(value: Any) -> tuple[SeqRecord, ...] | None:
+    if isinstance(value, tuple) and value and all(
+        isinstance(record, SeqRecord) for record in value
+    ):
+        return value
+    records = getattr(value, "records", None)
+    if isinstance(records, tuple) and records and all(
+        isinstance(record, SeqRecord) for record in records
+    ):
+        return records
+    return None
+
+
+def _owner_stamp(value: Any) -> Hashable:
+    records = _records_from_value(value)
+    if records is not None:
+        provenance = getattr(value, "provenance", None)
+        return (
+            "records",
+            tuple(_record_stamp(record) for record in records),
+            _shallow_value_stamp(provenance),
+        )
+    if all(
+        hasattr(value, field_name)
+        for field_name in (
+            "features",
+            "biological_features",
+            "orthogroups",
+            "annotations",
+            "sequence_sources",
+            "record_keys",
+        )
+    ):
+        return (
+            "interactive-context",
+            tuple(
+                (field_name, _shallow_value_stamp(getattr(value, field_name)))
+                for field_name in (
+                    "features",
+                    "biological_features",
+                    "orthogroups",
+                    "annotations",
+                    "sequence_sources",
+                    "record_keys",
+                    "collinearity_search_scope",
+                )
+            ),
+        )
+    return (type(value).__name__, id(value))
+
+
+def _owner_mutation_detail(before: Hashable, after: Hashable) -> str:
+    if not (
+        isinstance(before, tuple)
+        and isinstance(after, tuple)
+        and before
+        and after
+        and before[0] == after[0] == "records"
+    ):
+        return "owner structure"
+    before_records = before[1]
+    after_records = after[1]
+    if not isinstance(before_records, tuple) or not isinstance(after_records, tuple):
+        return "record collection"
+    if len(before_records) != len(after_records):
+        return "record count"
+    record_fields = (
+        "owner",
+        "id",
+        "name",
+        "sequence owner",
+        "sequence length",
+        "feature-list owner",
+        "feature count",
+        "features",
+        "annotations",
+    )
+    for record_index, (before_record, after_record) in enumerate(
+        zip(before_records, after_records, strict=True)
+    ):
+        if before_record == after_record:
+            continue
+        if not isinstance(before_record, tuple) or not isinstance(after_record, tuple):
+            return f"record {record_index}"
+        for field_index, (before_field, after_field) in enumerate(
+            zip(before_record, after_record, strict=False)
+        ):
+            if before_field != after_field:
+                if (
+                    field_index == 7
+                    and isinstance(before_field, tuple)
+                    and isinstance(after_field, tuple)
+                ):
+                    feature_fields = (
+                        "owner",
+                        "type",
+                        "location owner",
+                        "start",
+                        "end",
+                        "strand",
+                        "qualifiers",
+                    )
+                    for feature_index, (before_feature, after_feature) in enumerate(
+                        zip(before_field, after_field, strict=False)
+                    ):
+                        if before_feature == after_feature:
+                            continue
+                        if isinstance(before_feature, tuple) and isinstance(
+                            after_feature, tuple
+                        ):
+                            for feature_field_index, (
+                                before_feature_field,
+                                after_feature_field,
+                            ) in enumerate(
+                                zip(before_feature, after_feature, strict=False)
+                            ):
+                                if before_feature_field != after_feature_field:
+                                    if (
+                                        feature_field_index == 6
+                                        and isinstance(before_feature_field, tuple)
+                                        and isinstance(after_feature_field, tuple)
+                                        and len(before_feature_field) >= 4
+                                        and len(after_feature_field) >= 4
+                                        and isinstance(before_feature_field[3], tuple)
+                                        and isinstance(after_feature_field[3], tuple)
+                                    ):
+                                        before_qualifiers = dict(before_feature_field[3])
+                                        after_qualifiers = dict(after_feature_field[3])
+                                        changed_keys = sorted(
+                                            key
+                                            for key in (
+                                                set(before_qualifiers)
+                                                | set(after_qualifiers)
+                                            )
+                                            if before_qualifiers.get(key)
+                                            != after_qualifiers.get(key)
+                                        )
+                                        if changed_keys:
+                                            return (
+                                                f"record {record_index} feature "
+                                                f"{feature_index} qualifier owner "
+                                                f"{changed_keys[0]}"
+                                            )
+                                    feature_field = (
+                                        feature_fields[feature_field_index]
+                                        if feature_field_index < len(feature_fields)
+                                        else f"field {feature_field_index}"
+                                    )
+                                    return (
+                                        f"record {record_index} feature "
+                                        f"{feature_index} {feature_field}"
+                                    )
+                        return f"record {record_index} feature {feature_index}"
+                field_name = (
+                    record_fields[field_index]
+                    if field_index < len(record_fields)
+                    else f"field {field_index}"
+                )
+                return f"record {record_index} {field_name}"
+    return "record provenance"
+
+
+def _retained_bytes(value: Any) -> int:
+    records = _records_from_value(value)
+    if records is not None:
+        total = 0
+        for record in records:
+            features = getattr(record, "features", ())
+            total += len(record.seq) + len(features) * 512
+            total += sum(
+                len(getattr(feature, "qualifiers", None) or {}) * 64
+                for feature in features
+            )
+        return total
+    if all(
+        hasattr(value, field_name)
+        for field_name in ("features", "biological_features", "sequence_sources")
+    ):
+        total = 0
+        for field_name in (
+            "features",
+            "biological_features",
+            "orthogroups",
+            "annotations",
+        ):
+            total += len(getattr(value, field_name, ()) or ()) * 512
+        for source in getattr(value, "sequence_sources", ()) or ():
+            if isinstance(source, Mapping):
+                total += len(str(source.get("sequence") or "")) + 256
+        return total
+    return 0
+
+
+class PreparedBiologicalInputCache:
+    """One-project Worker cache for parsed, resolved, and interactive inputs.
+
+    The Pyodide Worker owns one instance. Keys contain resource ID, cache token,
+    byte size, and the semantic fields for the corresponding preparation layer.
+    Values are parsed source records, one resolved record collection, and the
+    interactive contexts used by the current request, including batch items.
+    Publication waits until SVG generation and catalog construction succeed.
+
+    A successful transaction is the one-project bound: it discards entries that
+    the request did not use. A changed semantic key rebuilds its dependent layer;
+    a changed or removed resource identity evicts every entry that refers to it.
+    The retained-byte diagnostic estimates source bytes, sequence lengths,
+    feature counts, qualifier counts, and interactive-context payloads without
+    serializing them. Worker termination releases the cache with the Python
+    runtime.
+    """
+
+    def __init__(self) -> None:
+        self._layers: dict[str, OrderedDict[Hashable, _PreparedCacheEntry]] = {
+            "parsed": OrderedDict(),
+            "resolved": OrderedDict(),
+            "interactive": OrderedDict(),
+        }
+
+    def _evict(
+        self,
+        layer: str,
+        key: Hashable,
+        transaction: _PreparedCacheTransaction,
+    ) -> None:
+        if self._layers[layer].pop(key, None) is not None:
+            _record_metric(transaction, "preparedInputCacheEvictionCount")
+
+    def _synchronize_resources(
+        self,
+        transaction: _PreparedCacheTransaction,
+    ) -> None:
+        for layer, entries in self._layers.items():
+            for key, entry in tuple(entries.items()):
+                if not entry.resource_identities.issubset(
+                    transaction.active_identities
+                ):
+                    self._evict(layer, key, transaction)
+
+    def _set_retained_metric(
+        self,
+        transaction: _PreparedCacheTransaction,
+    ) -> None:
+        retained = sum(
+            entry.retained_bytes
+            for entries in self._layers.values()
+            for entry in entries.values()
+        )
+        if transaction.diagnostics is not None:
+            metrics = transaction.diagnostics.setdefault("metrics", {})
+            metrics["preparedInputCacheRetainedBytes"] = int(retained)
+
+    @contextmanager
+    def transaction(
+        self,
+        *,
+        resource_paths: Mapping[str | Path, PreparedResourceIdentity],
+        diagnostics: MutableMapping[str, Any] | None,
+    ) -> Iterator[None]:
+        """Activate one transactional Web render against the active manifest."""
+
+        if _ACTIVE_PREPARED_TRANSACTION.get() is not None:
+            raise ValidationError("Prepared input cache transactions cannot be nested.")
+        normalized_paths: dict[Path, PreparedResourceIdentity] = {}
+        for raw_path, identity in resource_paths.items():
+            path = Path(raw_path)
+            normalized_paths[path.absolute()] = identity
+            normalized_paths[path.resolve(strict=True)] = identity
+        transaction = _PreparedCacheTransaction(
+            cache=self,
+            resource_paths=normalized_paths,
+            active_identities=frozenset(resource_paths.values()),
+            diagnostics=diagnostics,
+        )
+        if diagnostics is not None:
+            metrics = diagnostics.setdefault("metrics", {})
+            for name in _CACHE_METRICS:
+                metrics.setdefault(name, 0)
+        self._synchronize_resources(transaction)
+        self._set_retained_metric(transaction)
+        token = _ACTIVE_PREPARED_TRANSACTION.set(transaction)
+        try:
+            yield
+            self._commit(transaction)
+        finally:
+            self._set_retained_metric(transaction)
+            _ACTIVE_PREPARED_TRANSACTION.reset(token)
+
+    def _entry(
+        self,
+        layer: str,
+        key: Hashable,
+        transaction: _PreparedCacheTransaction,
+    ) -> _PreparedCacheEntry | None:
+        pending = transaction.pending[layer].get(key)
+        if pending is not None:
+            return pending
+        entry = self._layers[layer].get(key)
+        if entry is None:
+            return None
+        current_stamp = _owner_stamp(entry.value)
+        if current_stamp != entry.owner_stamp:
+            _record_metric(
+                transaction,
+                "preparedInputCacheMutationViolationCount",
+            )
+            self._evict(layer, key, transaction)
+            raise ValidationError(
+                f"Cached {layer} biological input ownership was mutated "
+                f"({_owner_mutation_detail(entry.owner_stamp, current_stamp)})."
+            )
+        self._layers[layer].move_to_end(key)
+        return entry
+
+    def get_or_build(
+        self,
+        layer: str,
+        key: Hashable,
+        resource_identities: frozenset[PreparedResourceIdentity],
+        builder: Callable[[], Any],
+        *,
+        publish: Callable[[Any], bool] | None = None,
+    ) -> Any:
+        transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+        if transaction is None or transaction.cache is not self:
+            return builder()
+        if key in transaction.accessed[layer]:
+            return transaction.accessed[layer][key]
+        hit_metric, miss_metric, build_metric = _LAYER_METRICS[layer]
+        entry = self._entry(layer, key, transaction)
+        if entry is not None:
+            _record_metric(transaction, hit_metric)
+            transaction.used[layer].add(key)
+            transaction.accessed[layer][key] = entry.value
+            return entry.value
+        _record_metric(transaction, miss_metric)
+        _record_metric(transaction, build_metric)
+        value = builder()
+        transaction.accessed[layer][key] = value
+        if publish is not None and not publish(value):
+            return value
+        entry = _PreparedCacheEntry(
+            value=value,
+            resource_identities=resource_identities,
+            owner_stamp=_owner_stamp(value),
+            retained_bytes=(
+                _retained_bytes(value)
+                + sum(identity.size for identity in resource_identities)
+            ),
+        )
+        transaction.pending[layer][key] = entry
+        transaction.used[layer].add(key)
+        return value
+
+    def register_resolved_records(self, key: Hashable, value: Any) -> None:
+        transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+        records = _records_from_value(value)
+        if transaction is None or records is None:
+            return
+        for index, record in enumerate(records):
+            transaction.resolved_record_membership[id(record)] = (key, index)
+
+    def _commit(self, transaction: _PreparedCacheTransaction) -> None:
+        replacements: dict[str, OrderedDict[Hashable, _PreparedCacheEntry]] = {}
+        for layer in self._layers:
+            retained: OrderedDict[Hashable, _PreparedCacheEntry] = OrderedDict()
+            for key in transaction.used[layer]:
+                entry = transaction.pending[layer].get(key) or self._layers[layer].get(
+                    key
+                )
+                if entry is None:
+                    continue
+                current_stamp = _owner_stamp(entry.value)
+                if current_stamp != entry.owner_stamp:
+                    _record_metric(
+                        transaction,
+                        "preparedInputCacheMutationViolationCount",
+                    )
+                    self._evict(layer, key, transaction)
+                    raise ValidationError(
+                        f"Cached {layer} biological input ownership was mutated "
+                        f"({_owner_mutation_detail(entry.owner_stamp, current_stamp)})."
+                    )
+                retained[key] = entry
+            replacements[layer] = retained
+        for layer, replacement in replacements.items():
+            evicted = set(self._layers[layer]) - set(replacement)
+            if evicted:
+                _record_metric(
+                    transaction,
+                    "preparedInputCacheEvictionCount",
+                    len(evicted),
+                )
+            self._layers[layer] = replacement
+        self._set_retained_metric(transaction)
+
+
+def get_or_build_parsed_source(
+    key: Hashable,
+    resource_identities: frozenset[PreparedResourceIdentity],
+    builder: Callable[[], Any],
+    *,
+    publish: Callable[[Any], bool] | None = None,
+) -> Any:
+    """Get or transactionally stage one parsed biological source."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    if transaction is None:
+        return builder()
+    return transaction.cache.get_or_build(
+        "parsed",
+        key,
+        resource_identities,
+        builder,
+        publish=publish,
+    )
+
+
+def get_or_build_resolved_records(
+    key: Hashable,
+    resource_identities: frozenset[PreparedResourceIdentity],
+    builder: Callable[[], Any],
+) -> Any:
+    """Get or transactionally stage one resolved record collection."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    if transaction is None:
+        return builder()
+    value = transaction.cache.get_or_build(
+        "resolved",
+        key,
+        resource_identities,
+        builder,
+    )
+    transaction.cache.register_resolved_records(key, value)
+    return value
+
+
+def get_or_build_interactive_context(
+    key: Hashable,
+    resource_identities: frozenset[PreparedResourceIdentity],
+    builder: Callable[[], Any],
+) -> Any:
+    """Get or transactionally stage one interactive metadata context."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    if transaction is None:
+        return builder()
+    return transaction.cache.get_or_build(
+        "interactive",
+        key,
+        resource_identities,
+        builder,
+    )
+
+
+def prepared_record_membership(
+    records: tuple[SeqRecord, ...],
+) -> tuple[tuple[Hashable, int], ...] | None:
+    """Return cached resolved-record membership without inspecting records."""
+
+    transaction = _ACTIVE_PREPARED_TRANSACTION.get()
+    if transaction is None:
+        return None
+    membership: list[tuple[Hashable, int]] = []
+    for record in records:
+        item = transaction.resolved_record_membership.get(id(record))
+        if item is None:
+            return None
+        membership.append(item)
+    return tuple(membership)
 
 
 def resolve_feature_inputs(

--- a/gbdraw/api/record_planning.py
+++ b/gbdraw/api/record_planning.py
@@ -6,7 +6,7 @@ import copy
 import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Callable, Literal, Sequence
+from typing import Callable, Hashable, Literal, Sequence
 
 import pandas as pd
 from Bio.SeqRecord import SeqRecord  # type: ignore[reportMissingImports]
@@ -33,6 +33,11 @@ from .options import (
     DepthTrackInput,
     LinearDiagramOptions,
     LinearMultiRecordOptions,
+)
+from .prepared import (
+    PreparedResourceIdentity,
+    get_or_build_parsed_source,
+    prepared_resource_identity,
 )
 from .requests import (
     CircularBatchOutputPolicy,
@@ -256,22 +261,71 @@ def _load_source_records(
     genbank_loader: GenBankLoader,
     gff_loader: GffFastaLoader,
 ) -> tuple[SeqRecord, ...]:
+    def load() -> tuple[SeqRecord, ...]:
+        if isinstance(source, GenBankInputSource):
+            records = genbank_loader([str(source.path)])
+        elif isinstance(source, GffFastaInputSource):
+            records = gff_loader(
+                [str(source.gff_path)],
+                [str(source.fasta_path)],
+                selected_features_set=gff_candidate_features,
+                keep_all_features=gff_keep_all_features,
+            )
+        elif isinstance(source, InMemoryRecordSource):
+            records = [source.record]
+        else:  # pragma: no cover - RecordInput validates this union.
+            raise ValidationError("Unsupported record input source.")
+        if not records:
+            raise ValidationError("A record input source resolved to no records.")
+        return tuple(records)
+
+    cache_spec = _prepared_source_cache_spec(
+        source,
+        gff_candidate_features=gff_candidate_features,
+        gff_keep_all_features=gff_keep_all_features,
+    )
+    if cache_spec is None:
+        return load()
+    key, identities = cache_spec
+    return get_or_build_parsed_source(
+        key,
+        identities,
+        load,
+        publish=lambda value: bool(value),
+    )
+
+
+def _prepared_source_cache_spec(
+    source: RecordInputSource,
+    *,
+    gff_candidate_features: Sequence[str] | None,
+    gff_keep_all_features: bool,
+) -> tuple[Hashable, frozenset[PreparedResourceIdentity]] | None:
+    """Build a path-independent parsed-source cache key for a Web resource."""
+
     if isinstance(source, GenBankInputSource):
-        records = genbank_loader([str(source.path)])
-    elif isinstance(source, GffFastaInputSource):
-        records = gff_loader(
-            [str(source.gff_path)],
-            [str(source.fasta_path)],
-            selected_features_set=gff_candidate_features,
-            keep_all_features=gff_keep_all_features,
+        identity = prepared_resource_identity(source.path)
+        if identity is None:
+            return None
+        return ("parsed-source-v1", "genbank", identity), frozenset({identity})
+    if isinstance(source, GffFastaInputSource):
+        gff_identity = prepared_resource_identity(source.gff_path)
+        fasta_identity = prepared_resource_identity(source.fasta_path)
+        if gff_identity is None or fasta_identity is None:
+            return None
+        identities = frozenset({gff_identity, fasta_identity})
+        return (
+            (
+                "parsed-source-v1",
+                "gff-fasta",
+                gff_identity,
+                fasta_identity,
+                tuple(sorted(gff_candidate_features or ())),
+                bool(gff_keep_all_features),
+            ),
+            identities,
         )
-    elif isinstance(source, InMemoryRecordSource):
-        records = [source.record]
-    else:  # pragma: no cover - RecordInput validates this union.
-        raise ValidationError("Unsupported record input source.")
-    if not records:
-        raise ValidationError("A record input source resolved to no records.")
-    return tuple(records)
+    return None
 
 
 def _selector_from_region(region: RegionSpec | None) -> RecordSelector | None:

--- a/gbdraw/api/request_render.py
+++ b/gbdraw/api/request_render.py
@@ -11,7 +11,16 @@ import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
 from time import perf_counter
-from typing import Any, Iterator, Literal, Mapping, MutableMapping, Sequence, TypeAlias
+from typing import (
+    Any,
+    Hashable,
+    Iterator,
+    Literal,
+    Mapping,
+    MutableMapping,
+    Sequence,
+    TypeAlias,
+)
 
 from Bio import SeqIO  # type: ignore[reportMissingImports]
 from Bio.SeqRecord import SeqRecord  # type: ignore[reportMissingImports]
@@ -75,10 +84,24 @@ from .options import (
     LinearDiagramOptions,
     LinearMultiRecordOptions,
 )
-from .prepared import ResolvedFeatureInputs, resolve_feature_inputs
+from .prepared import (
+    PreparedResourceIdentity,
+    ResolvedFeatureInputs,
+    get_or_build_interactive_context,
+    get_or_build_parsed_source,
+    get_or_build_resolved_records,
+    prepared_input_cache_active,
+    prepared_record_membership,
+    prepared_resource_identity,
+    prepared_resource_value_identity,
+    register_prepared_resource_value,
+    resolve_feature_inputs,
+)
 from .record_planning import (
     ResolvedRecordCollection,
     ResolvedRecordProvenance,
+    _load_source_records,
+    _prepared_source_cache_spec,
     resolve_circular_batch_outputs,
     resolve_circular_options,
     resolve_implicit_record_output_prefix,
@@ -172,13 +195,19 @@ def _resolve_request_option_tables(
     if colors is not None:
         color_table = colors.color_table
         if color_table is None and colors.color_table_file is not None:
-            color_table = read_color_table(colors.color_table_file)
+            color_table = register_prepared_resource_value(
+                read_color_table(colors.color_table_file),
+                colors.color_table_file,
+            )
         default_colors = colors.default_colors
         if default_colors is None and colors.default_colors_file is not None:
-            default_colors = load_default_colors(
-                user_defined_default_colors=colors.default_colors_file,
-                palette=colors.default_colors_palette,
-                load_comparison=load_comparison_colors,
+            default_colors = register_prepared_resource_value(
+                load_default_colors(
+                    user_defined_default_colors=colors.default_colors_file,
+                    palette=colors.default_colors_palette,
+                    load_comparison=load_comparison_colors,
+                ),
+                colors.default_colors_file,
             )
         if colors.color_table_file is not None or colors.default_colors_file is not None:
             colors = replace(
@@ -193,8 +222,11 @@ def _resolve_request_option_tables(
     feature_visibility_table = options.feature_visibility_table
     if options.feature_visibility_table_file is not None:
         if feature_visibility_table is None:
-            feature_visibility_table = read_feature_visibility_file(
-                options.feature_visibility_table_file
+            feature_visibility_table = register_prepared_resource_value(
+                read_feature_visibility_file(
+                    options.feature_visibility_table_file
+                ),
+                options.feature_visibility_table_file,
             )
         changed = True
     label_whitelist_table = options.label_whitelist_table
@@ -204,8 +236,9 @@ def _resolve_request_option_tables(
                 "Pass either label_whitelist_table or label_whitelist_file, not both."
             )
         if label_whitelist_table is None:
-            label_whitelist_table = read_filter_list_file(
-                options.label_whitelist_file
+            label_whitelist_table = register_prepared_resource_value(
+                read_filter_list_file(options.label_whitelist_file),
+                options.label_whitelist_file,
             )
         changed = True
     qualifier_priority_table = options.qualifier_priority_table
@@ -216,8 +249,9 @@ def _resolve_request_option_tables(
                 "qualifier_priority_file, not both."
             )
         if qualifier_priority_table is None:
-            qualifier_priority_table = read_qualifier_priority_file(
-                options.qualifier_priority_file
+            qualifier_priority_table = register_prepared_resource_value(
+                read_qualifier_priority_file(options.qualifier_priority_file),
+                options.qualifier_priority_file,
             )
         changed = True
     label_override_table = options.label_override_table
@@ -227,19 +261,23 @@ def _resolve_request_option_tables(
                 "Pass either label_override_table or label_override_file, not both."
             )
         if label_override_table is None:
-            label_override_table = read_label_override_file(
-                options.label_override_file
+            label_override_table = register_prepared_resource_value(
+                read_label_override_file(options.label_override_file),
+                options.label_override_file,
             )
         changed = True
     annotations = options.annotations
     if annotations is not None and annotations.table_file is not None:
-        annotations = AnnotationOptions(
-            sets=tuple(
-                read_annotation_table(
-                    annotations.table_file,
-                    mode=mode,
+        annotations = register_prepared_resource_value(
+            AnnotationOptions(
+                sets=tuple(
+                    read_annotation_table(
+                        annotations.table_file,
+                        mode=mode,
+                    )
                 )
-            )
+            ),
+            annotations.table_file,
         )
         changed = True
     if not changed:
@@ -266,12 +304,58 @@ class _ComparisonSequenceSources:
     paths: tuple[str | None, ...]
     _records: tuple[tuple[SeqRecord, ...], ...] | None = None
 
+    def cache_specs(
+        self,
+    ) -> tuple[
+        tuple[Hashable, frozenset[PreparedResourceIdentity]] | None,
+        ...,
+    ]:
+        specs: list[
+            tuple[Hashable, frozenset[PreparedResourceIdentity]] | None
+        ] = []
+        for path in self.paths:
+            if path is None:
+                specs.append(None)
+                continue
+            identity = prepared_resource_identity(path)
+            specs.append(
+                None
+                if identity is None
+                else (
+                    ("parsed-source-v1", "comparison-fasta", identity),
+                    frozenset({identity}),
+                )
+            )
+        return tuple(specs)
+
     def load(self) -> tuple[tuple[SeqRecord, ...], ...]:
         if self._records is None:
-            self._records = tuple(
-                tuple(SeqIO.parse(path, "fasta")) if path else ()
-                for path in self.paths
-            )
+            loaded: list[tuple[SeqRecord, ...]] = []
+            for path, cache_spec in zip(
+                self.paths,
+                self.cache_specs(),
+                strict=True,
+            ):
+                if not path:
+                    loaded.append(())
+                    continue
+
+                def parse(path: str = path) -> tuple[SeqRecord, ...]:
+                    return tuple(SeqIO.parse(path, "fasta"))
+
+                if cache_spec is None:
+                    loaded.append(parse())
+                    continue
+                key, identities = cache_spec
+                loaded.append(
+                    get_or_build_parsed_source(
+                        key,
+                        identities,
+                        parse,
+                        publish=lambda value: bool(value),
+                    )
+                )
+            self._records = tuple(loaded)
         return self._records
 
 
@@ -900,13 +984,106 @@ def _normalize_request_records(
     request: DiagramRequest,
     inputs: PreparedDiagramInputs,
 ) -> ResolvedRecordCollection:
-    return resolve_record_inputs(
+    def resolve() -> ResolvedRecordCollection:
+        return resolve_record_inputs(
+            request.records,
+            record_options=request.record_options,
+            gff_candidate_features=inputs.gff_candidate_features,
+            gff_keep_all_features=inputs.gff_keep_all_features,
+            genbank_loader=load_gbks,
+            gff_loader=load_gff_fasta,
+        )
+
+    if not prepared_input_cache_active():
+        return resolve()
+    source_specs = tuple(
+        _prepared_source_cache_spec(
+            record_input.source,
+            gff_candidate_features=inputs.gff_candidate_features,
+            gff_keep_all_features=inputs.gff_keep_all_features,
+        )
+        for record_input in request.records
+    )
+    if any(spec is None for spec in source_specs):
+        return resolve()
+    typed_source_specs = tuple(
+        spec for spec in source_specs if spec is not None
+    )
+    seen_source_keys: set[Hashable] = set()
+    for record_input, (source_key, _identities) in zip(
         request.records,
-        record_options=request.record_options,
-        gff_candidate_features=inputs.gff_candidate_features,
-        gff_keep_all_features=inputs.gff_keep_all_features,
-        genbank_loader=load_gbks,
-        gff_loader=load_gff_fasta,
+        typed_source_specs,
+        strict=True,
+    ):
+        if source_key in seen_source_keys:
+            continue
+        seen_source_keys.add(source_key)
+        _load_source_records(
+            record_input.source,
+            gff_candidate_features=inputs.gff_candidate_features,
+            gff_keep_all_features=inputs.gff_keep_all_features,
+            genbank_loader=load_gbks,
+            gff_loader=load_gff_fasta,
+        )
+    resource_identities = frozenset(
+        identity
+        for _key, identities in typed_source_specs
+        for identity in identities
+    )
+    key = (
+        "resolved-records-v1",
+        tuple(source_key for source_key, _identities in typed_source_specs),
+        tuple(_record_input_preparation_key(item) for item in request.records),
+        _record_collection_preparation_key(request.record_options),
+    )
+    return get_or_build_resolved_records(key, resource_identities, resolve)
+
+
+def _selector_preparation_key(value: Any) -> Hashable:
+    if value is None:
+        return None
+    return (value.record_id, value.record_index)
+
+
+def _region_preparation_key(value: Any) -> Hashable:
+    if value is None:
+        return None
+    return (
+        value.record_id,
+        value.record_index,
+        int(value.start),
+        int(value.end),
+        bool(value.reverse_complement),
+    )
+
+
+def _presentation_preparation_key(value: RecordPresentation) -> Hashable:
+    return (
+        value.label,
+        value.subtitle,
+        bool(value.reverse_complement),
+        value.grid_row,
+        value.grid_column,
+    )
+
+
+def _record_input_preparation_key(value: RecordInput) -> Hashable:
+    return (
+        _selector_preparation_key(value.selector),
+        value.cardinality.value,
+        _region_preparation_key(value.region),
+        _presentation_preparation_key(value.presentation),
+        value.record_key,
+    )
+
+
+def _record_collection_preparation_key(
+    value: RecordCollectionOptions,
+) -> Hashable:
+    return (
+        tuple(_region_preparation_key(region) for region in value.regions),
+        tuple(value.labels),
+        tuple(value.subtitles),
     )
 
 
@@ -1773,16 +1950,7 @@ def build_prepared_interactive_context(
     def build() -> InteractiveSvgContext:
         options = prepared.request.options
         inputs = prepared.inputs or _prepare_diagram_inputs(prepared.request)
-        computed_orthogroups = (
-            prepared.linear_metadata.orthogroups
-            if prepared.linear_metadata is not None
-            else None
-        )
-        if computed_orthogroups is None and isinstance(
-            options,
-            LinearDiagramOptions,
-        ):
-            computed_orthogroups = options.orthogroups
+        computed_orthogroups = _prepared_orthogroups(prepared)
         collinearity_search_scope = None
         if (
             isinstance(options, LinearDiagramOptions)
@@ -1810,6 +1978,222 @@ def build_prepared_interactive_context(
     return require_interactive_svg_metadata(build)
 
 
+def _prepared_orthogroups(prepared: PreparedDiagramRequest) -> object | None:
+    computed = (
+        prepared.linear_metadata.orthogroups
+        if prepared.linear_metadata is not None
+        else None
+    )
+    if computed is None and isinstance(prepared.request.options, LinearDiagramOptions):
+        computed = prepared.request.options.orthogroups
+    return computed
+
+
+def _prepared_key_resource_identities(
+    value: object,
+) -> frozenset[PreparedResourceIdentity]:
+    identities: set[PreparedResourceIdentity] = set()
+
+    def collect(item: object) -> None:
+        if isinstance(item, PreparedResourceIdentity):
+            identities.add(item)
+            return
+        if isinstance(item, (tuple, list, frozenset)):
+            for child in item:
+                collect(child)
+
+    collect(value)
+    return frozenset(identities)
+
+
+def _resource_backed_context_key(value: object) -> Hashable | None:
+    if value is None:
+        return ("none",)
+    identity = prepared_resource_value_identity(value)
+    if identity is None:
+        return None
+    return ("resource", identity)
+
+
+def _annotation_style_context_key(value: object | None) -> Hashable:
+    if value is None:
+        return None
+    hatch = getattr(value, "hatch", None)
+    hatch_key = None
+    if hatch is not None:
+        hatch_key = (
+            hatch.angle,
+            hatch.spacing,
+            hatch.color,
+            hatch.width,
+            hatch.cross,
+        )
+    return (
+        value.stroke,
+        value.stroke_width,
+        tuple(value.stroke_dasharray),
+        value.line_cap,
+        value.fill,
+        value.fill_opacity,
+        hatch_key,
+        value.label_color,
+        value.label_font_size,
+        value.label_orientation,
+        value.label_position,
+        value.label_offset,
+    )
+
+
+def _annotation_target_context_key(value: object) -> Hashable:
+    record = getattr(value, "record", None)
+    record_key = _selector_preparation_key(record)
+    if hasattr(value, "start") and hasattr(value, "end"):
+        return (
+            "coordinates",
+            record_key,
+            int(value.start),
+            int(value.end),
+            value.coordinate_space,
+            bool(value.wraps_origin),
+            value.out_of_bounds,
+        )
+    return (
+        "features",
+        record_key,
+        tuple((selector.key, selector.value) for selector in value.selectors),
+        value.envelope,
+        value.circular_path,
+    )
+
+
+def _annotation_context_key(value: AnnotationOptions | None) -> Hashable | None:
+    if value is None:
+        return ("none",)
+    identity = prepared_resource_value_identity(value)
+    if identity is not None:
+        return ("resource", identity)
+    if value.table is not None:
+        table_identity = prepared_resource_value_identity(value.table)
+        return (
+            None
+            if table_identity is None
+            else ("resource-table", table_identity)
+        )
+    if value.table_file is not None:
+        return None
+    return (
+        "inline-annotation-sets-v1",
+        tuple(
+            (
+                annotation_set.id,
+                annotation_set.legend_label,
+                _annotation_style_context_key(annotation_set.default_style),
+                tuple(
+                    (
+                        annotation.id,
+                        _annotation_target_context_key(annotation.target),
+                        annotation.label,
+                        annotation.mark,
+                        annotation.lane,
+                        _annotation_style_context_key(annotation.style),
+                        annotation.legend_label,
+                        tuple(sorted(annotation.metadata.items())),
+                    )
+                    for annotation in annotation_set.annotations
+                ),
+            )
+            for annotation_set in value.sets
+        ),
+    )
+
+
+def _interactive_context_cache_spec(
+    prepared: PreparedDiagramRequest,
+    *,
+    include_feature_catalog: bool,
+) -> tuple[Hashable, frozenset[PreparedResourceIdentity]] | None:
+    records = tuple(prepared.records)
+    membership = prepared_record_membership(records)
+    if membership is None:
+        return None
+    options = prepared.request.options
+    inputs = prepared.inputs
+    if inputs is None:
+        return None
+    visibility_key = _resource_backed_context_key(
+        inputs.features.feature_visibility_table
+    )
+    color_key = _resource_backed_context_key(inputs.features.color_table)
+    annotation_key = _annotation_context_key(options.annotations)
+    if None in {visibility_key, color_key, annotation_key}:
+        return None
+    orthogroups = _prepared_orthogroups(prepared)
+    orthogroup_key = _resource_backed_context_key(orthogroups)
+    derived_keys = tuple(
+        (
+            str(entry.get("kind") or ""),
+            str(entry.get("key") or ""),
+            str(entry.get("mode") or ""),
+        )
+        for entry in prepared.losat_derived_cache_entries
+        if str(entry.get("key") or "")
+    )
+    if orthogroups is not None and orthogroup_key is None:
+        if not derived_keys:
+            return None
+        orthogroup_key = ("derived-artifacts", derived_keys)
+    comparison_keys: list[Hashable] = []
+    if inputs.comparison_sequences is not None:
+        for path, spec in zip(
+            inputs.comparison_sequences.paths,
+            inputs.comparison_sequences.cache_specs(),
+            strict=True,
+        ):
+            if path is None:
+                comparison_keys.append(("none",))
+            elif spec is None:
+                return None
+            else:
+                comparison_keys.append(spec[0])
+    record_keys = tuple(
+        str(
+            (getattr(record, "annotations", {}) or {}).get(
+                "gbdraw_record_key",
+                f"record-{index + 1}",
+            )
+        )
+        for index, record in enumerate(records)
+    )
+    collinearity_scope = None
+    if (
+        isinstance(options, LinearDiagramOptions)
+        and prepared.linear_metadata is not None
+        and prepared.linear_metadata.collinearity_result is not None
+        and prepared.linear_metadata.collinearity_result.orthogroups is not None
+    ):
+        collinearity_scope = str(options.collinearity_search_scope)
+    popup_policy = (
+        str(prepared.request.output.interactive_metadata_policy),
+        bool(include_feature_catalog),
+    )
+    key = (
+        "interactive-context-v1",
+        prepared.mode,
+        membership,
+        tuple(options.selected_features_set or DEFAULT_SELECTED_FEATURES),
+        visibility_key,
+        color_key,
+        annotation_key,
+        orthogroup_key,
+        derived_keys,
+        tuple(comparison_keys),
+        record_keys,
+        collinearity_scope,
+        popup_policy,
+    )
+    return key, _prepared_key_resource_identities(key)
+
+
 def _interactive_context(
     prepared: PreparedDiagramRequest,
     *,
@@ -1823,10 +2207,21 @@ def _interactive_context(
     )
     if not needs_interactive_metadata and not include_feature_catalog:
         return None
-    return build_prepared_interactive_context(
+    cache_spec = _interactive_context_cache_spec(
         prepared,
-        comparison_sequence_records=comparison_sequence_records,
+        include_feature_catalog=include_feature_catalog,
     )
+
+    def build() -> InteractiveSvgContext:
+        return build_prepared_interactive_context(
+            prepared,
+            comparison_sequence_records=comparison_sequence_records,
+        )
+
+    if cache_spec is None:
+        return build()
+    key, identities = cache_spec
+    return get_or_build_interactive_context(key, identities, build)
 
 
 def render_request(

--- a/gbdraw/render/interactive_context.py
+++ b/gbdraw/render/interactive_context.py
@@ -11,6 +11,7 @@ from pandas import DataFrame  # type: ignore[reportMissingImports]
 from gbdraw.features.colors import preprocess_color_tables
 from gbdraw.features.visibility import compile_feature_visibility_rules
 from gbdraw.exceptions import ExportError, ValidationError
+from gbdraw.api.prepared import record_prepared_input_metric
 from gbdraw.render.interactive_svg import InteractiveSvgContext
 from gbdraw.annotations import AnnotationOptions, resolve_annotations
 from gbdraw.web_support.feature_metadata import extract_features_from_records_payload
@@ -82,6 +83,7 @@ def build_interactive_svg_context(
         resolved_color_rules, _ = preprocess_color_tables(color_table, default_colors)
 
     record_list = list(records)
+    record_prepared_input_metric("interactiveFeatureTraversalCount")
     payload = extract_features_from_records_payload(
         record_list,
         selected_features=selected_features_set,
@@ -89,6 +91,7 @@ def build_interactive_svg_context(
         specific_color_rules=resolved_color_rules,
         linear_rendered_feature_ids=linear_rendered_feature_ids,
         include_biological_features=True,
+        include_selector_safety_scope=False,
     )
     features = payload.get("features", [])
     biological_features = payload.get("biological_features", [])

--- a/gbdraw/session_request_codec.py
+++ b/gbdraw/session_request_codec.py
@@ -3400,11 +3400,14 @@ def _resource_ref(
 
 def _read_canonical_table(file_path: Path, *, context: str) -> DataFrame:
     try:
-        return read_csv(file_path, sep="\t")
+        table = read_csv(file_path, sep="\t")
     except Exception as exc:
         raise CanonicalRequestDecodingError(
             f"Could not decode canonical TSV resource for {context}."
         ) from exc
+    from gbdraw.api.prepared import register_prepared_resource_value
+
+    return register_prepared_resource_value(table, file_path)
 
 
 def _typed_json_resource(
@@ -3476,12 +3479,15 @@ def _read_typed_json_resource(
         raise CanonicalRequestDecodingError(
             f"Canonical JSON resource metadata does not match {path}."
         )
-    return _decode_typed_tree(
+    value = _decode_typed_tree(
         payload["value"],
         expected,
         path=f"{path}.value",
         resource_schema=resource_schema,
     )
+    from gbdraw.api.prepared import register_prepared_resource_value
+
+    return register_prepared_resource_value(value, resource_path)
 
 
 def _encode_typed_tree(value: object) -> Any:

--- a/gbdraw/web/CLAUDE.md
+++ b/gbdraw/web/CLAUDE.md
@@ -41,6 +41,13 @@ planning, loading, diagram assembly, and rendering.
 The application has one Pyodide runtime, owned by the lazy diagram Worker.
 Typed helper operations, generation-time feature extraction, and diagram
 rendering share that runtime; Python must not return to the main thread.
+The Worker may retain a bounded cache of parsed biological sources, resolved
+records, and interactive metadata. Key it only by validated resource tokens and
+the semantic fields used to prepare those values. Every Generate still decodes
+and validates the request, builds the drawing, writes the SVG, and builds the
+feature catalog. Publish cache fills only after the full render succeeds, and
+release them with the Worker; never cache drawings, catalogs, SVG, or final
+results.
 
 App-shell readiness means Vue is mounted and required local UI assets and
 palette definitions are available. It is independent of diagram-Worker

--- a/gbdraw/web/js/app/python-helpers.js
+++ b/gbdraw/web/js/app/python-helpers.js
@@ -11,13 +11,18 @@ from gbdraw.web_support.feature_metadata import (
     extract_features_from_genbank_json,
     extract_features_from_gff_fasta_json,
 )
-from gbdraw.web_support.request_render import render_staged_canonical_web_request
+from gbdraw.web_support.request_render import (
+    _render_staged_canonical_web_request_with_prepared_inputs as
+    render_staged_canonical_web_request,
+)
 from gbdraw.session_request_codec import encode_canonical_typed_resource
+from gbdraw.api.prepared import PreparedBiologicalInputCache
 
 _WEB_LOSATP_FILTERED_HIT_CACHE = {}
 _WEB_LOSATP_CONVERTED_PAYLOAD_CACHE = {}
 _WEB_LOSATP_CACHE_ORDER = []
 _WEB_LOSATP_CACHE_LIMIT = 64
+_WEB_PREPARED_INPUT_CACHE = PreparedBiologicalInputCache()
 
 def _web_losatp_cache_by_name(name):
     if name == "filtered":
@@ -80,16 +85,28 @@ def run_canonical_request_wrapper(
     resource_paths_json,
     workspace,
     diagnostics_enabled=False,
+    resource_identities_json=None,
 ):
     try:
         payload = json.loads(str(request_json))
         resource_paths = json.loads(str(resource_paths_json))
+        resource_identities = None
+        if resource_identities_json is not None and type(resource_identities_json).__name__ not in {"JsNull", "JsUndefined"}:
+            identity_text = str(resource_identities_json).strip()
+            if identity_text and identity_text.lower() not in {"null", "undefined", "none"}:
+                resource_identities = json.loads(identity_text)
         diagnostics = {"timingsMs": {}, "metrics": {}} if diagnostics_enabled else None
         result = render_staged_canonical_web_request(
             payload,
             resource_paths=resource_paths,
             workspace=str(workspace),
             _diagnostics=diagnostics,
+            _prepared_input_cache=(
+                _WEB_PREPARED_INPUT_CACHE
+                if resource_identities is not None
+                else None
+            ),
+            _resource_identities=resource_identities,
         )
         if diagnostics is not None:
             for name in (
@@ -107,6 +124,23 @@ def run_canonical_request_wrapper(
                 "geometryMetadata",
             ):
                 diagnostics["timingsMs"].setdefault(name, 0.0)
+            for name in (
+                "parsedSourceCacheHitCount",
+                "parsedSourceCacheMissCount",
+                "parsedSourceParseCount",
+                "resolvedRecordCacheHitCount",
+                "resolvedRecordCacheMissCount",
+                "resolvedRecordBuildCount",
+                "interactiveContextCacheHitCount",
+                "interactiveContextCacheMissCount",
+                "interactiveContextBuildCount",
+                "interactiveFeatureTraversalCount",
+                "selectorSafetyScopeBuildCount",
+                "preparedInputCacheEvictionCount",
+                "preparedInputCacheRetainedBytes",
+                "preparedInputCacheMutationViolationCount",
+            ):
+                diagnostics["metrics"].setdefault(name, 0)
             result["_diagnostics"] = diagnostics
         for item in result.get("results", []):
             content = item.get("content")

--- a/gbdraw/web/js/services/history-snapshot.js
+++ b/gbdraw/web/js/services/history-snapshot.js
@@ -995,7 +995,7 @@ export const createHistorySnapshotService = ({
       ),
       losatCache,
       losatDerivedCache,
-      losatCacheInfo: cloneJsonData(
+      losatCacheInfo: artifactOwnedValue(
         getGeneratedArtifactRef(state.losatCacheInfo, [])
       ) || [],
       collinearGroups: artifactOwnedValue(
@@ -1187,7 +1187,7 @@ export const createHistorySnapshotService = ({
       );
       setGeneratedArtifactRef(
         state.losatCacheInfo,
-        cloneJsonData(handle.losatCacheInfo) || []
+        handle.losatCacheInfo || []
       );
       setGeneratedArtifactRef(state.collinearGroups, handle.collinearGroups || []);
       if (typeof state.matchSequenceRegistry?.resetTrusted === 'function') {

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -11,6 +11,29 @@ const RENDER_RESOURCE_ID_RE = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const RENDER_RESOURCE_TOKEN_RE = /^render-resource-[1-9][0-9]*$/;
 const cachedRenderResources = new Map();
 
+export const buildPreparedResourceIdentityMap = (resourceManifest) => {
+  if (!Array.isArray(resourceManifest)) {
+    throw new TypeError('Prepared resource identities require a resource manifest.');
+  }
+  const identities = {};
+  resourceManifest.forEach((metadata) => {
+    const resourceId = String(metadata?.resourceId || '').trim();
+    const cacheToken = String(metadata?.cacheToken || '');
+    const size = Number(metadata?.size);
+    if (!RENDER_RESOURCE_ID_RE.test(resourceId) || resourceId in identities) {
+      throw new TypeError(`Invalid or duplicate prepared render resource '${resourceId}'.`);
+    }
+    if (!RENDER_RESOURCE_TOKEN_RE.test(cacheToken)) {
+      throw new TypeError(`Invalid cache token for prepared render resource '${resourceId}'.`);
+    }
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new TypeError(`Invalid byte size for prepared render resource '${resourceId}'.`);
+    }
+    identities[resourceId] = { cacheToken, size };
+  });
+  return identities;
+};
+
 const emitTestLifecycle = (enabled, requestId, name, detail = {}) => {
   if (!enabled) return;
   self.postMessage({
@@ -826,8 +849,12 @@ const runGeneration = async ({
     });
     emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-resource-manifest-json-start');
     const resourcePathsJson = JSON.stringify(resourcePaths);
+    const preparedResourceIdentitiesJson = JSON.stringify(
+      buildPreparedResourceIdentityMap(resourceManifest)
+    );
     emitTestLifecycle(testLifecycleEnabled, requestId, 'worker-resource-manifest-json-end', {
-      characters: resourcePathsJson.length
+      characters: resourcePathsJson.length,
+      preparedIdentityCharacters: preparedResourceIdentitiesJson.length
     });
     emitTestLifecycle(
       testLifecycleEnabled,
@@ -840,7 +867,8 @@ const runGeneration = async ({
       requestJson,
       resourcePathsJson,
       workspace,
-      testLifecycleEnabled
+      testLifecycleEnabled,
+      preparedResourceIdentitiesJson
     );
     emitTestLifecycle(testLifecycleEnabled, requestId, 'python-wrapper-end');
     emitTestLifecycle(testLifecycleEnabled, requestId, 'result-object-conversion-start');

--- a/gbdraw/web_support/feature_metadata.py
+++ b/gbdraw/web_support/feature_metadata.py
@@ -324,6 +324,7 @@ def extract_features_from_records_payload(
     specific_color_rules: dict | None = None,
     linear_rendered_feature_ids: bool = False,
     include_biological_features: bool = False,
+    include_selector_safety_scope: bool = True,
 ) -> dict[str, object]:
     """Extract feature metadata from processed records.
 
@@ -339,7 +340,12 @@ def extract_features_from_records_payload(
     features: list[dict[str, object]] = []
     biological_features: list[dict[str, object]] = []
     record_ids: list[str] = []
-    selector_safety_scope = _build_selector_safety_scope(records)
+    selector_safety_scope: list[dict[str, object]] = []
+    if include_selector_safety_scope:
+        from gbdraw.api.prepared import record_prepared_input_metric
+
+        record_prepared_input_metric("selectorSafetyScopeBuildCount")
+        selector_safety_scope = _build_selector_safety_scope(records)
     idx = 0
     biological_idx = 0
     for rec_idx, record in enumerate(records):

--- a/gbdraw/web_support/request_render.py
+++ b/gbdraw/web_support/request_render.py
@@ -15,6 +15,10 @@ from gbdraw.api.request_render import (
     _capture_request_render_diagnostics,
     render_request,
 )
+from gbdraw.api.prepared import (
+    PreparedBiologicalInputCache,
+    PreparedResourceIdentity,
+)
 from gbdraw.exceptions import ValidationError
 from gbdraw.render.formats import SVG_FORMAT, resolve_format_output_path
 from gbdraw.render.track_slot_metadata import (
@@ -30,6 +34,7 @@ from gbdraw.web_support.feature_catalog import (
 
 
 _RESOURCE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
+_RESOURCE_CACHE_TOKEN_RE = re.compile(r"^render-resource-[1-9][0-9]*$")
 _STAGED_WORKSPACE_RE = re.compile(r"^gbdraw-web-render-[1-9][0-9]*$")
 _STAGED_WORKSPACE_MARKER = ".gbdraw-worker-render-workspace"
 
@@ -90,13 +95,53 @@ def render_canonical_web_request(
 ) -> dict[str, Any]:
     """Decode and render one browser request without a CLI translation layer."""
 
-    with _capture_request_render_diagnostics(_diagnostics):
-        return _render_canonical_web_request(
-            payload,
-            resource_paths=resource_paths,
-            output_directory=output_directory,
-            diagnostics=_diagnostics,
+    return _render_canonical_web_request_with_prepared_inputs(
+        payload,
+        resource_paths=resource_paths,
+        output_directory=output_directory,
+        _diagnostics=_diagnostics,
+        _prepared_input_cache=None,
+        _resource_identities=None,
+    )
+
+
+def _render_canonical_web_request_with_prepared_inputs(
+    payload: Mapping[str, Any],
+    *,
+    resource_paths: Mapping[str, str | Path],
+    output_directory: str | Path,
+    _diagnostics: MutableMapping[str, Any] | None,
+    _prepared_input_cache: PreparedBiologicalInputCache | None,
+    _resource_identities: Mapping[str, PreparedResourceIdentity] | None,
+) -> dict[str, Any]:
+    def render() -> dict[str, Any]:
+        with _capture_request_render_diagnostics(_diagnostics):
+            return _render_canonical_web_request(
+                payload,
+                resource_paths=resource_paths,
+                output_directory=output_directory,
+                diagnostics=_diagnostics,
+            )
+
+    if _prepared_input_cache is None:
+        if _resource_identities is not None:
+            raise ValidationError(
+                "Prepared resource identities require a prepared input cache."
+            )
+        return render()
+    if _resource_identities is None:
+        raise ValidationError(
+            "A prepared input cache requires validated resource identities."
         )
+    cache_paths = {
+        resource_paths[resource_id]: identity
+        for resource_id, identity in _resource_identities.items()
+    }
+    with _prepared_input_cache.transaction(
+        resource_paths=cache_paths,
+        diagnostics=_diagnostics,
+    ):
+        return render()
 
 
 def _render_canonical_web_request(
@@ -266,6 +311,25 @@ def render_staged_canonical_web_request(
 ) -> dict[str, Any]:
     """Render a browser request from paths staged by the diagram Worker."""
 
+    return _render_staged_canonical_web_request_with_prepared_inputs(
+        payload,
+        resource_paths=resource_paths,
+        workspace=workspace,
+        _diagnostics=_diagnostics,
+        _prepared_input_cache=None,
+        _resource_identities=None,
+    )
+
+
+def _render_staged_canonical_web_request_with_prepared_inputs(
+    payload: Mapping[str, Any],
+    *,
+    resource_paths: Mapping[str, str | Path],
+    workspace: str | Path,
+    _diagnostics: MutableMapping[str, Any] | None = None,
+    _prepared_input_cache: PreparedBiologicalInputCache | None = None,
+    _resource_identities: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
     if not isinstance(resource_paths, Mapping):
         raise ValidationError("The staged Web render resource map must be an object.")
     workspace_path = Path(workspace)
@@ -310,16 +374,23 @@ def render_staged_canonical_web_request(
                     f"Staged Web render resource {resource_id!r} is outside its workspace."
                 )
             validated_paths[resource_id] = path
+        validated_identities = _validate_prepared_resource_identities(
+            _resource_identities,
+            resource_paths=validated_paths,
+            cache_requested=_prepared_input_cache is not None,
+        )
         if output_directory.exists():
             raise ValidationError("The staged Web render output directory already exists.")
         output_directory.mkdir()
         if output_directory.resolve(strict=True).parent != workspace_identity:
             raise ValidationError("The staged Web render output directory is invalid.")
-        return render_canonical_web_request(
+        return _render_canonical_web_request_with_prepared_inputs(
             payload,
             resource_paths=validated_paths,
             output_directory=output_directory,
             _diagnostics=_diagnostics,
+            _prepared_input_cache=_prepared_input_cache,
+            _resource_identities=validated_identities,
         )
     except BaseException as exc:
         render_error = exc
@@ -341,6 +412,67 @@ def render_staged_canonical_web_request(
                     raise ValidationError(
                         "The temporary staged Web render workspace could not be cleaned up."
                     ) from cleanup_error
+
+
+def _validate_prepared_resource_identities(
+    value: Mapping[str, Mapping[str, Any]] | None,
+    *,
+    resource_paths: Mapping[str, Path],
+    cache_requested: bool,
+) -> dict[str, PreparedResourceIdentity] | None:
+    if value is None:
+        if cache_requested:
+            raise ValidationError(
+                "The staged Web render prepared-resource map is missing."
+            )
+        return None
+    if not cache_requested:
+        raise ValidationError(
+            "Prepared resource identities require a prepared input cache."
+        )
+    if not isinstance(value, Mapping) or set(value) != set(resource_paths):
+        raise ValidationError(
+            "The staged Web render prepared-resource map does not match its manifest."
+        )
+    identities: dict[str, PreparedResourceIdentity] = {}
+    for resource_id, raw_identity in value.items():
+        if (
+            not isinstance(resource_id, str)
+            or not _RESOURCE_ID_RE.fullmatch(resource_id)
+            or not isinstance(raw_identity, Mapping)
+            or set(raw_identity) != {"cacheToken", "size"}
+        ):
+            raise ValidationError(
+                f"Invalid prepared resource identity for {resource_id!r}."
+            )
+        cache_token = raw_identity.get("cacheToken")
+        size = raw_identity.get("size")
+        if (
+            not isinstance(cache_token, str)
+            or not _RESOURCE_CACHE_TOKEN_RE.fullmatch(cache_token)
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+        ):
+            raise ValidationError(
+                f"Invalid prepared resource identity for {resource_id!r}."
+            )
+        try:
+            actual_size = resource_paths[resource_id].resolve(strict=True).stat().st_size
+        except OSError as exc:
+            raise ValidationError(
+                f"Prepared resource {resource_id!r} could not be inspected."
+            ) from exc
+        if actual_size != size:
+            raise ValidationError(
+                f"Prepared resource {resource_id!r} does not match its byte size."
+            )
+        identities[resource_id] = PreparedResourceIdentity(
+            resource_id=resource_id,
+            cache_token=cache_token,
+            size=size,
+        )
+    return identities
 
 
 __all__ = [

--- a/tests/run_losat_cache_browser_acceptance.py
+++ b/tests/run_losat_cache_browser_acceptance.py
@@ -934,25 +934,33 @@ def _cancel_during_render(page: Any) -> dict[str, Any]:
               entries.length === current.size &&
               entries.every(([key, value]) => current.get(key) === value)
             );
+            const authorityDomains = {
+              proteinIdentityManifestSame:
+                state.proteinIdentityManifest.value === before.proteinIdentityManifest,
+              legacyProteinRawCandidatesSame:
+                state.legacyProteinRawCandidates.value ===
+                  before.legacyProteinRawCandidates,
+              legacyProteinDerivedEvidenceSame:
+                state.legacyProteinDerivedEvidence.value ===
+                  before.legacyProteinDerivedEvidence,
+              losatCacheValuesSame:
+                sameMapEntries(before.losatCache, state.losatCache.value),
+              losatDerivedCacheValuesSame:
+                sameMapEntries(
+                  before.losatDerivedCache,
+                  state.losatDerivedCache.value
+                ),
+              losatCacheInfoSame:
+                state.losatCacheInfo.value === before.losatCacheInfo
+            };
             return {
               result,
               sawRendering,
               cancelInvoked,
               errorSummary: String(app.errorLog?.summary || ''),
               executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
-              authorityRestored: (
-                state.proteinIdentityManifest.value === before.proteinIdentityManifest &&
-                state.legacyProteinRawCandidates.value ===
-                  before.legacyProteinRawCandidates &&
-                state.legacyProteinDerivedEvidence.value ===
-                  before.legacyProteinDerivedEvidence &&
-                sameMapEntries(before.losatCache, state.losatCache.value) &&
-                sameMapEntries(
-                  before.losatDerivedCache,
-                  state.losatDerivedCache.value
-                ) &&
-                state.losatCacheInfo.value === before.losatCacheInfo
-              )
+              ...authorityDomains,
+              authorityRestored: Object.values(authorityDomains).every(Boolean)
             };
           } finally {
             clearInterval(cancelPoll);
@@ -1001,24 +1009,32 @@ def _fail_renderer_after_migration(page: Any) -> dict[str, Any]:
               entries.length === current.size &&
               entries.every(([key, value]) => current.get(key) === value)
             );
+            const authorityDomains = {
+              proteinIdentityManifestSame:
+                state.proteinIdentityManifest.value === before.proteinIdentityManifest,
+              legacyProteinRawCandidatesSame:
+                state.legacyProteinRawCandidates.value ===
+                  before.legacyProteinRawCandidates,
+              legacyProteinDerivedEvidenceSame:
+                state.legacyProteinDerivedEvidence.value ===
+                  before.legacyProteinDerivedEvidence,
+              losatCacheValuesSame:
+                sameMapEntries(before.losatCache, state.losatCache.value),
+              losatDerivedCacheValuesSame:
+                sameMapEntries(
+                  before.losatDerivedCache,
+                  state.losatDerivedCache.value
+                ),
+              losatCacheInfoSame:
+                state.losatCacheInfo.value === before.losatCacheInfo
+            };
             return {
               result,
               errorSummary: String(app.errorLog?.summary || ''),
               executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
               rendererFailureInjected,
-              authorityRestored: (
-                state.proteinIdentityManifest.value === before.proteinIdentityManifest &&
-                state.legacyProteinRawCandidates.value ===
-                  before.legacyProteinRawCandidates &&
-                state.legacyProteinDerivedEvidence.value ===
-                  before.legacyProteinDerivedEvidence &&
-                sameMapEntries(before.losatCache, state.losatCache.value) &&
-                sameMapEntries(
-                  before.losatDerivedCache,
-                  state.losatDerivedCache.value
-                ) &&
-                state.losatCacheInfo.value === before.losatCacheInfo
-              )
+              ...authorityDomains,
+              authorityRestored: Object.values(authorityDomains).every(Boolean)
             };
           } finally {
             Worker.prototype.postMessage = originalWorkerPostMessage;
@@ -1043,6 +1059,23 @@ def _assert_telemetry(
         run.get("executorCalls") == expected["workerCalls"],
         "Counting LOSAT executor was called.",
     )
+
+
+def _assert_authority_restored(
+    run: dict[str, Any], label: str, checks: AcceptanceChecks
+) -> None:
+    for field in (
+        "proteinIdentityManifestSame",
+        "legacyProteinRawCandidatesSame",
+        "legacyProteinDerivedEvidenceSame",
+        "losatCacheValuesSame",
+        "losatDerivedCacheValuesSame",
+        "losatCacheInfoSame",
+    ):
+        checks.require(
+            run.get(field) is True,
+            f"{label} did not restore {field}: {run}",
+        )
 
 
 def _inspect_layout(page: Any) -> dict[str, Any]:
@@ -1260,6 +1293,11 @@ def _run_python_adapter() -> int:
                 )
                 legacy_ui_before_cancel = _migration_ui_snapshot(page)
                 canceled_legacy_run = _cancel_during_render(page)
+                _assert_authority_restored(
+                    canceled_legacy_run,
+                    "Legacy render cancellation",
+                    checks,
+                )
                 checks.require(
                     canceled_legacy_run.get("sawRendering")
                     and canceled_legacy_run.get("cancelInvoked")
@@ -1278,6 +1316,11 @@ def _run_python_adapter() -> int:
                 )
                 legacy_ui_before_render_error = _migration_ui_snapshot(page)
                 failed_legacy_run = _fail_renderer_after_migration(page)
+                _assert_authority_restored(
+                    failed_legacy_run,
+                    "Legacy renderer failure",
+                    checks,
+                )
                 checks.require(
                     failed_legacy_run.get("result") == {"status": "error"}
                     and failed_legacy_run.get("authorityRestored")

--- a/tests/test_web_render_preparation_cache.py
+++ b/tests/test_web_render_preparation_cache.py
@@ -1,0 +1,812 @@
+from __future__ import annotations
+
+import base64
+import copy
+import json
+from pathlib import Path
+
+from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqFeature import FeatureLocation, SeqFeature
+from Bio.SeqRecord import SeqRecord
+import pandas as pd
+import pytest
+
+from gbdraw.analysis.protein_colinearity import OrthogroupMember, OrthogroupResult
+from gbdraw.api import (
+    CircularDiagramOptions,
+    CircularDiagramRequest,
+    CircularOutputOptions,
+    GenBankInputSource,
+    GffFastaInputSource,
+    LinearDiagramOptions,
+    LinearDiagramRequest,
+    RecordCardinality,
+    RecordInput,
+    RecordPresentation,
+    RenderOutputRequest,
+)
+from gbdraw.api.prepared import (
+    PreparedBiologicalInputCache,
+    PreparedResourceIdentity,
+    get_or_build_parsed_source,
+)
+from gbdraw.annotations import (
+    AnnotationOptions,
+    AnnotationSet,
+    CoordinateSpan,
+    RegionAnnotation,
+)
+from gbdraw.exceptions import ValidationError
+import gbdraw.api.request_render as request_render_module
+from gbdraw.api.request_render import normalize_request_records
+from gbdraw.io.regions import parse_region_spec
+from gbdraw.io.record_select import parse_record_selector
+from gbdraw.session import build_session_document
+from gbdraw.web_support.request_render import (
+    _render_staged_canonical_web_request_with_prepared_inputs as
+    render_staged_canonical_web_request,
+)
+
+
+def _record(record_id: str, *, product: str = "cache target") -> SeqRecord:
+    record = SeqRecord(
+        Seq("ATG" * 240),
+        id=record_id,
+        name=record_id,
+        description=f"{record_id} preparation cache fixture",
+    )
+    record.annotations["molecule_type"] = "DNA"
+    record.features = [
+        SeqFeature(
+            FeatureLocation(30, 180, strand=1),
+            type="CDS",
+            qualifiers={
+                "locus_tag": [f"{record_id}_0001"],
+                "product": [product],
+                "translation": ["M" * 49],
+            },
+        ),
+        SeqFeature(
+            FeatureLocation(240, 330, strand=-1),
+            type="rRNA",
+            qualifiers={"locus_tag": [f"{record_id}_r01"]},
+        ),
+    ]
+    return record
+
+
+def _write_genbank(path: Path, records: tuple[SeqRecord, ...]) -> None:
+    SeqIO.write(records, path, "genbank")
+
+
+def _document(
+    source: Path,
+    *,
+    title: str | None = None,
+    selected_features: tuple[str, ...] | None = None,
+    region: str | None = None,
+    reverse: bool = False,
+    annotations: AnnotationOptions | None = None,
+    feature_visibility_table: pd.DataFrame | None = None,
+) -> dict[str, object]:
+    request = CircularDiagramRequest(
+        records=(
+            RecordInput(
+                source=GenBankInputSource(source),
+                region=parse_region_spec(region) if region else None,
+                presentation=RecordPresentation(reverse_complement=reverse),
+                record_key="record-1",
+            ),
+        ),
+        options=CircularDiagramOptions(
+            plot_title=title,
+            selected_features_set=selected_features,
+            output=CircularOutputOptions(plot_title_position="top"),
+            annotations=annotations,
+            feature_visibility_table=feature_visibility_table,
+        ),
+        output=RenderOutputRequest(
+            output_prefix="prepared-cache",
+            formats=("svg",),
+        ),
+    )
+    return build_session_document(request).to_dict()
+
+
+def _render(
+    tmp_path: Path,
+    cache: PreparedBiologicalInputCache,
+    document: dict[str, object],
+    *,
+    request_id: int,
+    token_generation: int = 1,
+    token_numbers: dict[str, int] | None = None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    resources = document["resources"]
+    assert isinstance(resources, dict)
+    workspace = tmp_path / f"gbdraw-web-render-{request_id}"
+    resource_directory = workspace / "resources"
+    resource_directory.mkdir(parents=True)
+    (workspace / ".gbdraw-worker-render-workspace").touch()
+    cache_directory = tmp_path / "gbdraw-web-render-resource-cache"
+    cache_directory.mkdir(exist_ok=True)
+    resource_paths: dict[str, Path] = {}
+    identities: dict[str, dict[str, object]] = {}
+    for index, (resource_id, entry) in enumerate(resources.items(), start=1):
+        assert isinstance(entry, dict)
+        content = base64.b64decode(str(entry["data"]), validate=True)
+        token_number = (token_numbers or {}).get(
+            resource_id,
+            token_generation * 100 + index,
+        )
+        cache_token = f"render-resource-{token_number}"
+        cache_path = cache_directory / f"{cache_token}.bin"
+        if cache_path.exists():
+            assert cache_path.read_bytes() == content
+        else:
+            cache_path.write_bytes(content)
+        request_path = resource_directory / f"{index:04d}.bin"
+        request_path.symlink_to(cache_path)
+        resource_paths[resource_id] = request_path
+        identities[resource_id] = {
+            "cacheToken": cache_token,
+            "size": len(content),
+        }
+    diagnostics: dict[str, object] = {"timingsMs": {}, "metrics": {}}
+    result = render_staged_canonical_web_request(
+        document["renderRequest"],
+        resource_paths=resource_paths,
+        workspace=workspace,
+        _diagnostics=diagnostics,
+        _prepared_input_cache=cache,
+        _resource_identities=identities,
+    )
+    return result, diagnostics
+
+
+def _metrics(diagnostics: dict[str, object]) -> dict[str, int]:
+    metrics = diagnostics["metrics"]
+    assert isinstance(metrics, dict)
+    return {str(key): int(value) for key, value in metrics.items()}
+
+
+def test_warm_and_render_only_generates_reuse_biological_preparation(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    cache = PreparedBiologicalInputCache()
+    cold_document = _document(source, title="Cold title")
+
+    cold, cold_diagnostics = _render(
+        tmp_path,
+        cache,
+        cold_document,
+        request_id=1,
+    )
+    warm, warm_diagnostics = _render(
+        tmp_path,
+        cache,
+        cold_document,
+        request_id=2,
+    )
+    render_only, render_only_diagnostics = _render(
+        tmp_path,
+        cache,
+        _document(source, title="Render-only title change"),
+        request_id=3,
+    )
+
+    cold_metrics = _metrics(cold_diagnostics)
+    assert cold_metrics["parsedSourceCacheMissCount"] == 1
+    assert cold_metrics["parsedSourceParseCount"] == 1
+    assert cold_metrics["resolvedRecordCacheMissCount"] == 1
+    assert cold_metrics["resolvedRecordBuildCount"] == 1
+    assert cold_metrics["interactiveContextCacheMissCount"] == 1
+    assert cold_metrics["interactiveContextBuildCount"] == 1
+    assert cold_metrics["interactiveFeatureTraversalCount"] == 1
+    assert cold_metrics["selectorSafetyScopeBuildCount"] == 0
+    assert cold_metrics["preparedInputCacheRetainedBytes"] > 0
+
+    for diagnostics in (warm_diagnostics, render_only_diagnostics):
+        metrics = _metrics(diagnostics)
+        assert metrics["parsedSourceCacheHitCount"] == 1
+        assert metrics["parsedSourceParseCount"] == 0
+        assert metrics["resolvedRecordCacheHitCount"] == 1
+        assert metrics["resolvedRecordBuildCount"] == 0
+        assert metrics["interactiveContextCacheHitCount"] == 1
+        assert metrics["interactiveContextBuildCount"] == 0
+        assert metrics["interactiveFeatureTraversalCount"] == 0
+        assert metrics["selectorSafetyScopeBuildCount"] == 0
+        assert metrics["preparedInputCacheRetainedBytes"] > 0
+        assert metrics["preparedInputCacheMutationViolationCount"] == 0
+
+    assert warm["results"] == cold["results"]
+    assert render_only["results"] != cold["results"]
+    assert _metrics(warm_diagnostics)["featureCatalogSvgParseCount"] == 1
+    assert _metrics(render_only_diagnostics)["featureCatalogSvgParseCount"] == 1
+    assert float(render_only_diagnostics["timingsMs"]["drawing"]) > 0
+    assert float(render_only_diagnostics["timingsMs"]["svgWrite"]) > 0
+
+
+def test_public_render_request_remains_uncached_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("public-record"),))
+    request = CircularDiagramRequest(
+        records=(RecordInput(source=GenBankInputSource(source)),),
+        output=RenderOutputRequest(
+            output_prefix="public-uncached",
+            output_directory=tmp_path,
+            formats=("svg",),
+            overwrite=True,
+        ),
+    )
+    original_loader = request_render_module.load_gbks
+    load_count = 0
+
+    def counting_loader(paths: list[str]) -> list[SeqRecord]:
+        nonlocal load_count
+        load_count += 1
+        return original_loader(paths)
+
+    monkeypatch.setattr(request_render_module, "load_gbks", counting_loader)
+
+    first = request_render_module.render_request(request)
+    second = request_render_module.render_request(request)
+
+    assert load_count == 2
+    assert second is not first
+
+
+def test_gallery_genbank_preparation_owner_remains_read_only(tmp_path: Path) -> None:
+    session_path = (
+        Path(__file__).parents[1]
+        / "gbdraw"
+        / "web"
+        / "gallery"
+        / "sessions"
+        / "HmmtDNA_basic_circular.gbdraw-session.json"
+    )
+    document = json.loads(session_path.read_text(encoding="utf-8"))
+    cache = PreparedBiologicalInputCache()
+
+    first, first_diagnostics = _render(
+        tmp_path,
+        cache,
+        document,
+        request_id=1,
+    )
+    second, second_diagnostics = _render(
+        tmp_path,
+        cache,
+        document,
+        request_id=2,
+    )
+
+    assert second["results"] == first["results"]
+    assert _metrics(first_diagnostics)["preparedInputCacheMutationViolationCount"] == 0
+    assert _metrics(second_diagnostics)["parsedSourceCacheHitCount"] == 1
+
+
+def test_annotation_change_invalidates_interactive_context_only(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    first_annotations = AnnotationOptions(
+        sets=(
+            AnnotationSet(
+                "regions",
+                (
+                    RegionAnnotation(
+                        "focus",
+                        CoordinateSpan(None, 20, 80),
+                        label="First",
+                    ),
+                ),
+            ),
+        )
+    )
+    changed_annotations = AnnotationOptions(
+        sets=(
+            AnnotationSet(
+                "regions",
+                (
+                    RegionAnnotation(
+                        "focus",
+                        CoordinateSpan(None, 40, 100),
+                        label="Changed",
+                    ),
+                ),
+            ),
+        )
+    )
+    cache = PreparedBiologicalInputCache()
+    document = _document(source, annotations=first_annotations)
+    first, _first_diagnostics = _render(tmp_path, cache, document, request_id=1)
+    _warm, warm_diagnostics = _render(
+        tmp_path,
+        cache,
+        document,
+        request_id=2,
+    )
+    changed, changed_diagnostics = _render(
+        tmp_path,
+        cache,
+        _document(source, annotations=changed_annotations),
+        request_id=3,
+    )
+
+    assert _metrics(warm_diagnostics)["interactiveContextCacheHitCount"] == 1
+    changed_metrics = _metrics(changed_diagnostics)
+    assert changed_metrics["parsedSourceCacheHitCount"] == 1
+    assert changed_metrics["resolvedRecordCacheHitCount"] == 1
+    assert changed_metrics["interactiveContextCacheMissCount"] == 1
+    assert changed_metrics["interactiveContextBuildCount"] == 1
+    assert changed["metadata"] != first["metadata"]
+
+
+def test_visibility_resource_invalidates_context_but_not_genbank_records(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    cache = PreparedBiologicalInputCache()
+    first, _first_diagnostics = _render(
+        tmp_path,
+        cache,
+        _document(source),
+        request_id=1,
+    )
+    visibility = pd.DataFrame(
+        [["*", "CDS", "product", ".*", "off"]],
+        columns=["record_id", "feature_type", "qualifier", "value", "action"],
+    )
+
+    result, diagnostics = _render(
+        tmp_path,
+        cache,
+        _document(source, feature_visibility_table=visibility),
+        request_id=2,
+    )
+    metrics = _metrics(diagnostics)
+    assert metrics["parsedSourceCacheHitCount"] == 1
+    assert metrics["resolvedRecordCacheHitCount"] == 1
+    assert metrics["interactiveContextCacheMissCount"] == 1
+    assert metrics["interactiveContextBuildCount"] == 1
+    assert result["results"] != first["results"]
+
+
+def _orthogroup_document(source: Path, group_id: str) -> dict[str, object]:
+    protein_id = "cache-record_0001"
+    member = OrthogroupMember(
+        orthogroup_id=group_id,
+        protein_id=protein_id,
+        record_index=0,
+        feature_index=0,
+        record_id="cache-record",
+        label=group_id,
+        start=30,
+        end=180,
+        strand=1,
+        feature_svg_id=None,
+        source_protein_id=protein_id,
+    )
+    orthogroups = OrthogroupResult(
+        orthogroups={group_id: [member]},
+        member_by_protein_id={protein_id: member},
+    )
+    request = LinearDiagramRequest(
+        records=(
+            RecordInput(
+                source=GenBankInputSource(source),
+                record_key="record-1",
+            ),
+        ),
+        options=LinearDiagramOptions(orthogroups=orthogroups),
+        output=RenderOutputRequest(
+            output_prefix="prepared-orthogroups",
+            formats=("svg",),
+        ),
+    )
+    return build_session_document(request).to_dict()
+
+
+def test_orthogroup_resource_invalidates_interactive_context_only(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    first_document = _orthogroup_document(source, "OG-A")
+    changed_document = _orthogroup_document(source, "OG-B")
+    changed_resources = changed_document["resources"]
+    assert isinstance(changed_resources, dict)
+    orthogroup_resource_id = next(
+        resource_id
+        for resource_id in changed_resources
+        if "orthogroup" in resource_id
+    )
+    cache = PreparedBiologicalInputCache()
+
+    first, _first_diagnostics = _render(
+        tmp_path,
+        cache,
+        first_document,
+        request_id=1,
+    )
+    changed, changed_diagnostics = _render(
+        tmp_path,
+        cache,
+        changed_document,
+        request_id=2,
+        token_numbers={orthogroup_resource_id: 999},
+    )
+
+    metrics = _metrics(changed_diagnostics)
+    assert metrics["parsedSourceCacheHitCount"] == 1
+    assert metrics["parsedSourceParseCount"] == 0
+    assert metrics["resolvedRecordCacheHitCount"] == 1
+    assert metrics["resolvedRecordBuildCount"] == 0
+    assert metrics["interactiveContextCacheMissCount"] == 1
+    assert metrics["interactiveContextBuildCount"] == 1
+    assert changed["metadata"] != first["metadata"]
+    changed_payload = json.dumps(changed, sort_keys=True)
+    assert "OG-B" in changed_payload
+    assert "OG-A" not in changed_payload
+
+
+def test_gff_fasta_policy_is_part_of_the_parsed_source_key(tmp_path: Path) -> None:
+    fixture_root = Path(__file__).parent / "test_inputs"
+    gff_path = fixture_root / "NC_013668.gff3"
+    fasta_path = fixture_root / "NC_013668.fasta"
+    identities = {
+        gff_path: PreparedResourceIdentity(
+            "record-1-gff3",
+            "render-resource-1",
+            gff_path.stat().st_size,
+        ),
+        fasta_path: PreparedResourceIdentity(
+            "record-1-fasta",
+            "render-resource-2",
+            fasta_path.stat().st_size,
+        ),
+    }
+    cache = PreparedBiologicalInputCache()
+
+    def request(selected_features: tuple[str, ...]) -> CircularDiagramRequest:
+        return CircularDiagramRequest(
+            records=(
+                RecordInput(
+                    source=GffFastaInputSource(gff_path, fasta_path),
+                    record_key="record-1",
+                ),
+            ),
+            options=CircularDiagramOptions(
+                selected_features_set=selected_features,
+            ),
+        )
+
+    cold_diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(resource_paths=identities, diagnostics=cold_diagnostics):
+        assert len(normalize_request_records(request(("CDS",)))) == 1
+    warm_diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(resource_paths=identities, diagnostics=warm_diagnostics):
+        assert len(normalize_request_records(request(("CDS",)))) == 1
+    changed_diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(resource_paths=identities, diagnostics=changed_diagnostics):
+        assert len(normalize_request_records(request(("rRNA",)))) == 1
+
+    assert _metrics(cold_diagnostics)["parsedSourceParseCount"] == 1
+    assert _metrics(warm_diagnostics)["parsedSourceCacheHitCount"] == 1
+    assert _metrics(warm_diagnostics)["resolvedRecordCacheHitCount"] == 1
+    assert _metrics(changed_diagnostics)["parsedSourceCacheMissCount"] == 1
+    assert _metrics(changed_diagnostics)["parsedSourceParseCount"] == 1
+    assert _metrics(changed_diagnostics)["resolvedRecordBuildCount"] == 1
+
+
+def test_comparison_fasta_cache_reuses_only_nonempty_sources(tmp_path: Path) -> None:
+    fasta_path = tmp_path / "comparison.fasta"
+    fasta_path.write_text(">comparison\nATGATGATG\n", encoding="utf-8")
+    identity = PreparedResourceIdentity(
+        "comparison-1-fasta",
+        "render-resource-1",
+        fasta_path.stat().st_size,
+    )
+    cache = PreparedBiologicalInputCache()
+    diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(
+        resource_paths={fasta_path: identity},
+        diagnostics=diagnostics,
+    ):
+        assert request_render_module._ComparisonSequenceSources(
+            (str(fasta_path),)
+        ).load()[0][0].id == "comparison"
+    warm_diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(
+        resource_paths={fasta_path: identity},
+        diagnostics=warm_diagnostics,
+    ):
+        assert request_render_module._ComparisonSequenceSources(
+            (str(fasta_path),)
+        ).load()[0][0].id == "comparison"
+    assert _metrics(warm_diagnostics)["parsedSourceCacheHitCount"] == 1
+    assert _metrics(warm_diagnostics)["parsedSourceParseCount"] == 0
+
+    empty_path = tmp_path / "empty.fasta"
+    empty_path.touch()
+    empty_identity = PreparedResourceIdentity(
+        "comparison-1-fasta",
+        "render-resource-2",
+        0,
+    )
+    for _request_index in range(2):
+        empty_diagnostics: dict[str, object] = {"metrics": {}}
+        with cache.transaction(
+            resource_paths={empty_path: empty_identity},
+            diagnostics=empty_diagnostics,
+        ):
+            assert request_render_module._ComparisonSequenceSources(
+                (str(empty_path),)
+            ).load() == ((),)
+        assert _metrics(empty_diagnostics)["parsedSourceCacheMissCount"] == 1
+        assert _metrics(empty_diagnostics)["parsedSourceParseCount"] == 1
+
+
+def test_selector_and_cardinality_changes_rebuild_resolved_records_only(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "multi-record.gbk"
+    _write_genbank(source, (_record("first"), _record("second")))
+    identity = PreparedResourceIdentity(
+        "record-1-genbank",
+        "render-resource-1",
+        source.stat().st_size,
+    )
+    cache = PreparedBiologicalInputCache()
+
+    def request(
+        cardinality: RecordCardinality,
+        selector: str | None = None,
+    ) -> CircularDiagramRequest:
+        return CircularDiagramRequest(
+            records=(
+                RecordInput(
+                    source=GenBankInputSource(source),
+                    cardinality=cardinality,
+                    selector=parse_record_selector(selector),
+                    record_key="record-1",
+                ),
+            ),
+        )
+
+    with cache.transaction(resource_paths={source: identity}, diagnostics=None):
+        assert len(normalize_request_records(request(RecordCardinality.FIRST))) == 1
+    all_diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(
+        resource_paths={source: identity},
+        diagnostics=all_diagnostics,
+    ):
+        assert len(normalize_request_records(request(RecordCardinality.ALL))) == 2
+    selected_diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(
+        resource_paths={source: identity},
+        diagnostics=selected_diagnostics,
+    ):
+        records = normalize_request_records(
+            request(RecordCardinality.EXACTLY_ONE, "#2")
+        )
+        assert [record.id for record in records] == ["second"]
+
+    for diagnostics in (all_diagnostics, selected_diagnostics):
+        metrics = _metrics(diagnostics)
+        assert metrics["parsedSourceCacheHitCount"] == 1
+        assert metrics["parsedSourceParseCount"] == 0
+        assert metrics["resolvedRecordCacheMissCount"] == 1
+        assert metrics["resolvedRecordBuildCount"] == 1
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_parse_hits"),
+    [
+        ({"region": "20-400"}, 1),
+        ({"reverse": True}, 1),
+        ({"selected_features": ("rRNA",)}, 1),
+    ],
+)
+def test_semantic_changes_invalidate_only_the_dependent_layers(
+    tmp_path: Path,
+    kwargs: dict[str, object],
+    expected_parse_hits: int,
+) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    cache = PreparedBiologicalInputCache()
+    document = _document(source)
+    _render(tmp_path, cache, document, request_id=1)
+    changed_document = copy.deepcopy(document)
+    render_request = changed_document["renderRequest"]
+    assert isinstance(render_request, dict)
+    records = render_request["records"]
+    assert isinstance(records, list)
+    record = records[0]
+    assert isinstance(record, dict)
+    if "region" in kwargs:
+        record["region"] = {
+            "selector": None,
+            "start": 20,
+            "end": 400,
+            "reverseComplement": False,
+        }
+    if "reverse" in kwargs:
+        presentation = record["presentation"]
+        assert isinstance(presentation, dict)
+        presentation["reverseComplement"] = True
+    if "selected_features" in kwargs:
+        options = render_request["diagramOptions"]
+        assert isinstance(options, dict)
+        options["selectedFeaturesSet"] = ["rRNA"]
+
+    result, diagnostics = _render(
+        tmp_path,
+        cache,
+        changed_document,
+        request_id=2,
+    )
+    metrics = _metrics(diagnostics)
+    assert metrics["parsedSourceCacheHitCount"] == expected_parse_hits
+    assert metrics["parsedSourceParseCount"] == 0
+    if "selected_features" in kwargs:
+        assert metrics["resolvedRecordCacheHitCount"] == 1
+        assert metrics["resolvedRecordBuildCount"] == 0
+    else:
+        assert metrics["resolvedRecordCacheMissCount"] == 1
+        assert metrics["resolvedRecordBuildCount"] == 1
+    assert metrics["interactiveContextCacheMissCount"] == 1
+    assert metrics["interactiveContextBuildCount"] == 1
+    assert metrics["interactiveFeatureTraversalCount"] == 1
+
+
+def test_source_token_replacement_invalidates_every_layer(tmp_path: Path) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    cache = PreparedBiologicalInputCache()
+    original, _original_diagnostics = _render(
+        tmp_path,
+        cache,
+        _document(source),
+        request_id=1,
+    )
+    _write_genbank(source, (_record("cache-record", product="replacement"),))
+
+    result, diagnostics = _render(
+        tmp_path,
+        cache,
+        _document(source),
+        request_id=2,
+        token_generation=2,
+    )
+    metrics = _metrics(diagnostics)
+    assert metrics["parsedSourceCacheMissCount"] == 1
+    assert metrics["parsedSourceParseCount"] == 1
+    assert metrics["resolvedRecordCacheMissCount"] == 1
+    assert metrics["resolvedRecordBuildCount"] == 1
+    assert metrics["interactiveContextCacheMissCount"] == 1
+    assert metrics["interactiveContextBuildCount"] == 1
+    assert metrics["preparedInputCacheEvictionCount"] >= 3
+    assert result != original
+    replacement_payload = json.dumps(result, sort_keys=True)
+    assert "replacement" in replacement_payload
+    assert "cache target" not in replacement_payload
+
+
+def test_identity_validation_rejects_paths_and_size_mismatches(tmp_path: Path) -> None:
+    source = tmp_path / "records.gbk"
+    _write_genbank(source, (_record("cache-record"),))
+    document = _document(source)
+    resources = document["resources"]
+    assert isinstance(resources, dict)
+    workspace = tmp_path / "gbdraw-web-render-1"
+    resource_directory = workspace / "resources"
+    resource_directory.mkdir(parents=True)
+    (workspace / ".gbdraw-worker-render-workspace").touch()
+    resource_paths: dict[str, Path] = {}
+    identities: dict[str, dict[str, object]] = {}
+    for index, (resource_id, entry) in enumerate(resources.items(), start=1):
+        assert isinstance(entry, dict)
+        content = base64.b64decode(str(entry["data"]), validate=True)
+        path = resource_directory / f"{index:04d}.bin"
+        path.write_bytes(content)
+        resource_paths[resource_id] = path
+        identities[resource_id] = {
+            "cacheToken": f"render-resource-{index}",
+            "size": len(content) + 1,
+            "path": str(path),
+        }
+
+    with pytest.raises(ValidationError, match="Invalid prepared resource identity"):
+        render_staged_canonical_web_request(
+            document["renderRequest"],
+            resource_paths=resource_paths,
+            workspace=workspace,
+            _prepared_input_cache=PreparedBiologicalInputCache(),
+            _resource_identities=identities,
+        )
+    assert not workspace.exists()
+
+
+def test_failed_fill_is_not_published_and_prior_entry_survives(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "resource.bin"
+    path.write_bytes(b"resource")
+    identity = PreparedResourceIdentity(
+        resource_id="record-1",
+        cache_token="render-resource-1",
+        size=8,
+    )
+    identities = frozenset({identity})
+    cache = PreparedBiologicalInputCache()
+    original = (_record("original"),)
+    with cache.transaction(resource_paths={path: identity}, diagnostics=None):
+        assert get_or_build_parsed_source(
+            ("source", identity),
+            identities,
+            lambda: original,
+        ) is original
+
+    with pytest.raises(RuntimeError, match="fill failed"):
+        with cache.transaction(resource_paths={path: identity}, diagnostics=None):
+            assert get_or_build_parsed_source(
+                ("source", identity),
+                identities,
+                lambda: pytest.fail("the committed source should be reused"),
+            ) is original
+            get_or_build_parsed_source(
+                ("replacement", identity),
+                identities,
+                lambda: (_ for _ in ()).throw(RuntimeError("fill failed")),
+            )
+
+    diagnostics: dict[str, object] = {"metrics": {}}
+    with cache.transaction(resource_paths={path: identity}, diagnostics=diagnostics):
+        assert get_or_build_parsed_source(
+            ("source", identity),
+            identities,
+            lambda: pytest.fail("the prior committed source was poisoned"),
+        ) is original
+    assert _metrics(diagnostics)["parsedSourceCacheHitCount"] == 1
+
+
+def test_mutation_guard_rejects_changed_cached_owners(tmp_path: Path) -> None:
+    path = tmp_path / "resource.bin"
+    path.write_bytes(b"resource")
+    identity = PreparedResourceIdentity(
+        resource_id="record-1",
+        cache_token="render-resource-1",
+        size=8,
+    )
+    identities = frozenset({identity})
+    cache = PreparedBiologicalInputCache()
+    records = (_record("mutable"),)
+    with cache.transaction(resource_paths={path: identity}, diagnostics=None):
+        get_or_build_parsed_source(("source", identity), identities, lambda: records)
+    records[0].features.append(
+        SeqFeature(FeatureLocation(400, 450), type="misc_feature")
+    )
+
+    diagnostics: dict[str, object] = {"metrics": {}}
+    with pytest.raises(ValidationError, match="ownership was mutated"):
+        with cache.transaction(
+            resource_paths={path: identity},
+            diagnostics=diagnostics,
+        ):
+            get_or_build_parsed_source(
+                ("source", identity),
+                identities,
+                lambda: pytest.fail("a mutated owner must not be reused"),
+            )
+    assert _metrics(diagnostics)["preparedInputCacheMutationViolationCount"] == 1

--- a/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
+++ b/tests/web/contracts/current-session-lazy-materialization.playwright.spec.js
@@ -659,6 +659,138 @@ test('Generate materializes only required resources and reuses one Worker', asyn
   expect(worker.instances[0].terminated).toBe(false);
 });
 
+test('render-only Generate reuses preparation and remains undoable', async ({ page }) => {
+  test.setTimeout(300_000);
+  await openInstrumentedApp(page);
+  await armHistoryCompletion(page);
+  expect(await loadSyntheticSession(page)).toMatchObject({
+    status: 'ok',
+    degradedRecovery: false
+  });
+
+  const first = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    window.__GBDRAW_LAZY_SESSION_PROBE__.reset();
+    const before = history.getDiagnostics();
+    const result = await app.runAnalysis();
+    const content = String(app.results?.[app.selectedResultIndex]?.content || '');
+    const after = history.getDiagnostics();
+    window.__GBDRAW_PREPARED_CACHE_A__ = content;
+    window.__GBDRAW_PREPARED_CACHE_SCALE_A__ = Boolean(app.form.show_scale);
+    return {
+      result,
+      contentLength: content.length,
+      showScale: Boolean(app.form.show_scale),
+      undoCount: history.getUndoCount(),
+      historyEntries: Number(after.artifactReplacementHistoryEntryCount || 0)
+        - Number(before.artifactReplacementHistoryEntryCount || 0),
+      errorSummary: String(app.errorLog?.summary || '')
+    };
+  });
+  const firstProbe = await probeSnapshot(page);
+  expect(first).toMatchObject({
+    result: { status: 'ok' },
+    undoCount: 1,
+    historyEntries: 1,
+    errorSummary: ''
+  });
+  expect(first.contentLength).toBeGreaterThan(0);
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    app.form.show_scale = !Boolean(app.form.show_scale);
+    window.__GBDRAW_LAZY_SESSION_PROBE__.reset();
+  });
+  const second = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    const before = history.getDiagnostics();
+    const result = await app.runAnalysis();
+    const content = String(app.results?.[app.selectedResultIndex]?.content || '');
+    const after = history.getDiagnostics();
+    const undoOk = await history.undo();
+    const afterUndo = String(app.results?.[app.selectedResultIndex]?.content || '');
+    const redoOk = await history.redo();
+    const afterRedo = String(app.results?.[app.selectedResultIndex]?.content || '');
+    return {
+      result,
+      outputChanged: content !== window.__GBDRAW_PREPARED_CACHE_A__,
+      renderOnlyValueChanged:
+        Boolean(app.form.show_scale) !== window.__GBDRAW_PREPARED_CACHE_SCALE_A__,
+      historyEntries: Number(after.artifactReplacementHistoryEntryCount || 0)
+        - Number(before.artifactReplacementHistoryEntryCount || 0),
+      undoOk,
+      undoRestoredA: afterUndo === window.__GBDRAW_PREPARED_CACHE_A__,
+      redoOk,
+      redoRestoredB: afterRedo === content,
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount(),
+      errorSummary: String(app.errorLog?.summary || '')
+    };
+  });
+  const secondProbe = await probeSnapshot(page);
+  expect(second).toEqual({
+    result: { status: 'ok' },
+    outputChanged: true,
+    renderOnlyValueChanged: true,
+    historyEntries: 1,
+    undoOk: true,
+    undoRestoredA: true,
+    redoOk: true,
+    redoRestoredB: true,
+    undoCount: 2,
+    redoCount: 0,
+    errorSummary: ''
+  });
+
+  const firstPython = firstProbe.lifecycle.find(
+    ({ name }) => name === 'python-diagnostics'
+  );
+  const secondPython = secondProbe.lifecycle.find(
+    ({ name }) => name === 'python-diagnostics'
+  );
+  expect(firstPython?.metrics).toMatchObject({
+    parsedSourceCacheMissCount: 1,
+    parsedSourceParseCount: 1,
+    resolvedRecordCacheMissCount: 1,
+    resolvedRecordBuildCount: 1,
+    interactiveContextCacheMissCount: 1,
+    interactiveContextBuildCount: 1,
+    interactiveFeatureTraversalCount: 1,
+    selectorSafetyScopeBuildCount: 0,
+    preparedInputCacheMutationViolationCount: 0
+  });
+  expect(secondPython?.metrics).toMatchObject({
+    parsedSourceCacheHitCount: 1,
+    parsedSourceParseCount: 0,
+    resolvedRecordCacheHitCount: 1,
+    resolvedRecordBuildCount: 0,
+    interactiveContextCacheHitCount: 1,
+    interactiveContextBuildCount: 0,
+    interactiveFeatureTraversalCount: 0,
+    selectorSafetyScopeBuildCount: 0,
+    preparedInputCacheMutationViolationCount: 0,
+    featureCatalogSvgParseCount: 1,
+    featureCatalogFullDomTraversalCount: 1
+  });
+  expect(Number(secondPython?.metrics?.preparedInputCacheRetainedBytes || 0))
+    .toBeGreaterThan(0);
+  expect(Number(secondPython?.timingsMs?.drawing || 0)).toBeGreaterThan(0);
+  expect(Number(secondPython?.timingsMs?.svgWrite || 0)).toBeGreaterThan(0);
+  expect(Number(secondProbe.hookMetrics.resourceMaterializationCount || 0)).toBe(0);
+  expect(secondProbe.lifecycle.find(
+    ({ name }) => name === 'worker-resource-linking-end'
+  )).toMatchObject({ newlyStagedResourceBytes: 0 });
+
+  const worker = await getDiagramWorkerActivity(page);
+  expect(worker.constructions).toBe(1);
+  expect(worker.initializations).toBe(1);
+  expect(worker.runs).toBe(2);
+  expect(worker.instances).toHaveLength(1);
+  expect(worker.instances[0].terminated).toBe(false);
+});
+
 test('the real Cancel control restores the committed artifact and leaves no History entry', async ({
   page
 }) => {
@@ -785,6 +917,7 @@ test('the real Cancel control restores the committed artifact and leaves no Hist
   expect(canceledWorker.runs).toBe(1);
   expect(canceledWorker.instances[0].terminated).toBe(true);
 
+  await page.evaluate(() => window.__GBDRAW_LAZY_SESSION_PROBE__.reset());
   const retry = await page.evaluate(async () => ({
     result: await window.__GBDRAW_APP__.runAnalysis(),
     undoCount: window.__GBDRAW_HISTORY__.getUndoCount(),
@@ -798,6 +931,21 @@ test('the real Cancel control restores the committed artifact and leaves no Hist
     redoCount: 0,
     previewVisible: true,
     errorSummary: ''
+  });
+  const retryProbe = await probeSnapshot(page);
+  const retryPython = retryProbe.lifecycle.find(
+    ({ name }) => name === 'python-diagnostics'
+  );
+  expect(retryPython?.metrics).toMatchObject({
+    parsedSourceCacheHitCount: 0,
+    parsedSourceCacheMissCount: 1,
+    parsedSourceParseCount: 1,
+    resolvedRecordCacheHitCount: 0,
+    resolvedRecordCacheMissCount: 1,
+    resolvedRecordBuildCount: 1,
+    interactiveContextCacheHitCount: 0,
+    interactiveContextCacheMissCount: 1,
+    interactiveContextBuildCount: 1
   });
   const afterRetryWorker = await getDiagramWorkerActivity(page);
   expect(afterRetryWorker.constructions).toBe(2);

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -226,6 +226,48 @@ const generationPhaseAttribution = (outcome, probe) => {
     pythonFeatureCatalogMs: Number(pythonTimings.featureCatalog || 0),
     pythonGeometryMetadataMs: Number(pythonTimings.geometryMetadata || 0),
     pythonArtifactMetrics: { ...pythonMetrics },
+    preparedInputCacheStructural: {
+      parsedSourceCacheHitCount: Number(
+        pythonMetrics.parsedSourceCacheHitCount || 0
+      ),
+      parsedSourceCacheMissCount: Number(
+        pythonMetrics.parsedSourceCacheMissCount || 0
+      ),
+      parsedSourceParseCount: Number(pythonMetrics.parsedSourceParseCount || 0),
+      resolvedRecordCacheHitCount: Number(
+        pythonMetrics.resolvedRecordCacheHitCount || 0
+      ),
+      resolvedRecordCacheMissCount: Number(
+        pythonMetrics.resolvedRecordCacheMissCount || 0
+      ),
+      resolvedRecordBuildCount: Number(
+        pythonMetrics.resolvedRecordBuildCount || 0
+      ),
+      interactiveContextCacheHitCount: Number(
+        pythonMetrics.interactiveContextCacheHitCount || 0
+      ),
+      interactiveContextCacheMissCount: Number(
+        pythonMetrics.interactiveContextCacheMissCount || 0
+      ),
+      interactiveContextBuildCount: Number(
+        pythonMetrics.interactiveContextBuildCount || 0
+      ),
+      interactiveFeatureTraversalCount: Number(
+        pythonMetrics.interactiveFeatureTraversalCount || 0
+      ),
+      selectorSafetyScopeBuildCount: Number(
+        pythonMetrics.selectorSafetyScopeBuildCount || 0
+      ),
+      preparedInputCacheEvictionCount: Number(
+        pythonMetrics.preparedInputCacheEvictionCount || 0
+      ),
+      preparedInputCacheRetainedBytes: Number(
+        pythonMetrics.preparedInputCacheRetainedBytes || 0
+      ),
+      preparedInputCacheMutationViolationCount: Number(
+        pythonMetrics.preparedInputCacheMutationViolationCount || 0
+      )
+    },
     featureCatalogStructural: {
       featureCatalogSvgParseCount: Number(
         pythonMetrics.featureCatalogSvgParseCount || 0
@@ -789,6 +831,43 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     legacyFeatureOverrideScanSkipCount: 2
   });
   expect(secondPhaseAttribution.pythonInvocationMs).toBeGreaterThan(0);
+  expect(firstPhaseAttribution.preparedInputCacheStructural).toMatchObject({
+    parsedSourceCacheHitCount: 0,
+    resolvedRecordCacheHitCount: 0,
+    resolvedRecordCacheMissCount: 1,
+    resolvedRecordBuildCount: 1,
+    interactiveContextCacheHitCount: 0,
+    interactiveContextCacheMissCount: 1,
+    interactiveContextBuildCount: 1,
+    interactiveFeatureTraversalCount: 1,
+    selectorSafetyScopeBuildCount: 0,
+    preparedInputCacheMutationViolationCount: 0
+  });
+  expect(firstPhaseAttribution.preparedInputCacheStructural
+    .parsedSourceCacheMissCount).toBeGreaterThan(0);
+  expect(firstPhaseAttribution.preparedInputCacheStructural
+    .parsedSourceParseCount).toBe(
+      firstPhaseAttribution.preparedInputCacheStructural.parsedSourceCacheMissCount
+    );
+  expect(firstPhaseAttribution.preparedInputCacheStructural
+    .preparedInputCacheRetainedBytes).toBeGreaterThan(0);
+  expect(secondPhaseAttribution.preparedInputCacheStructural).toMatchObject({
+    parsedSourceCacheMissCount: 0,
+    parsedSourceParseCount: 0,
+    resolvedRecordCacheHitCount: 1,
+    resolvedRecordCacheMissCount: 0,
+    resolvedRecordBuildCount: 0,
+    interactiveContextCacheHitCount: 1,
+    interactiveContextCacheMissCount: 0,
+    interactiveContextBuildCount: 0,
+    interactiveFeatureTraversalCount: 0,
+    selectorSafetyScopeBuildCount: 0,
+    preparedInputCacheMutationViolationCount: 0
+  });
+  expect(secondPhaseAttribution.preparedInputCacheStructural
+    .parsedSourceCacheHitCount).toBeGreaterThan(0);
+  expect(secondPhaseAttribution.preparedInputCacheStructural
+    .preparedInputCacheRetainedBytes).toBeGreaterThan(0);
   expect(firstPhaseAttribution.featureCatalogStructural).toMatchObject({
     featureCatalogSvgParseCount: 1,
     featureCatalogFullDomTraversalCount: 1,

--- a/tests/web/diagram-generation-worker.test.mjs
+++ b/tests/web/diagram-generation-worker.test.mjs
@@ -5,11 +5,41 @@ globalThis.self = {};
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 
 const {
+  buildPreparedResourceIdentityMap,
   buildGeneratedArtifactTransportIdentity,
   collectGenerationResultTransferList,
   resolveGenerationCleanupOutcome,
   serializeError
 } = await import('../../gbdraw/web/js/workers/diagram-generation-worker.js');
+
+const preparedIdentities = buildPreparedResourceIdentityMap([
+  {
+    resourceId: 'record-1-genbank',
+    cacheToken: 'render-resource-7',
+    size: 1234,
+    name: 'secret-name.gbk',
+    path: '/temporary/workspace/0001.bin',
+    kind: 'genbank'
+  }
+]);
+assert.deepEqual(preparedIdentities, {
+  'record-1-genbank': { cacheToken: 'render-resource-7', size: 1234 }
+});
+assert.equal(JSON.stringify(preparedIdentities).includes('secret-name.gbk'), false);
+assert.equal(JSON.stringify(preparedIdentities).includes('/temporary/workspace'), false);
+assert.throws(
+  () => buildPreparedResourceIdentityMap([
+    { resourceId: 'record-1-genbank', cacheToken: 'bad-token', size: 1 }
+  ]),
+  /Invalid cache token/
+);
+assert.throws(
+  () => buildPreparedResourceIdentityMap([
+    { resourceId: 'record-1-genbank', cacheToken: 'render-resource-1', size: 1 },
+    { resourceId: 'record-1-genbank', cacheToken: 'render-resource-2', size: 1 }
+  ]),
+  /duplicate/
+);
 
 const svgBytes = new TextEncoder().encode('<svg />');
 const metadataBytes = new TextEncoder().encode('{"featureCatalog":{}}');

--- a/tests/web/history.test.mjs
+++ b/tests/web/history.test.mjs
@@ -1630,6 +1630,15 @@ const createLayoutPreferences = () => ({
   const biologicalA = [{ biological_feature_id: 'bio-a', payload: 'y'.repeat(100_000) }];
   const catalogA = { schema: 3, items: [{ payload: 'z'.repeat(100_000) }] };
   const groupsA = [{ id: 'group-a', members: ['feature-a'] }];
+  const proteinIdentityManifestA = { schema: 2, records: [{ id: 'manifest-a' }] };
+  const legacyProteinRawCandidatesA = { schema: 1, entries: [{ id: 'raw-a' }] };
+  const legacyProteinDerivedEvidenceA = {
+    schema: 1,
+    entries: [{ id: 'derived-evidence-a' }]
+  };
+  const rawCacheValueA = { text: 'raw-a\n' };
+  const derivedCacheValueA = { payload: { id: 'derived-a' } };
+  const losatCacheInfoA = [{ key: 'raw-a' }];
   const state = {
     files: {},
     linearSeqs: [],
@@ -1685,12 +1694,12 @@ const createLayoutPreferences = () => ({
     featureExtractionPending: ref(false),
     featureExtractionError: ref(null),
     labelOverrideBuildWarning: ref(''),
-    proteinIdentityManifest: ref({ schema: 1, records: [] }),
-    legacyProteinRawCandidates: ref({ schema: 1, entries: [] }),
-    legacyProteinDerivedEvidence: ref({ schema: 1, entries: [] }),
-    losatCache: ref(new Map([['raw-a', { text: 'row\n' }]])),
-    losatDerivedCache: ref(new Map()),
-    losatCacheInfo: ref([{ key: 'raw-a' }]),
+    proteinIdentityManifest: ref(proteinIdentityManifestA),
+    legacyProteinRawCandidates: ref(legacyProteinRawCandidatesA),
+    legacyProteinDerivedEvidence: ref(legacyProteinDerivedEvidenceA),
+    losatCache: ref(new Map([['raw-a', rawCacheValueA]])),
+    losatDerivedCache: ref(new Map([['derived-a', derivedCacheValueA]])),
+    losatCacheInfo: ref(losatCacheInfoA),
     matchSequenceRegistry: {
       current: [{ key: 'record-a', recordId: 'record-a', aliases: [], sequence: 'ACGT' }],
       values() { return this.current; },
@@ -1703,6 +1712,32 @@ const createLayoutPreferences = () => ({
     trustedArtifactRestoreInProgress: ref(false),
     semanticFileWatchersSuppressed: ref(false)
   };
+  const captureAuthorityOwners = () => ({
+    proteinIdentityManifest: state.proteinIdentityManifest.value,
+    legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
+    legacyProteinDerivedEvidence: state.legacyProteinDerivedEvidence.value,
+    losatCache: Array.from(state.losatCache.value.entries()),
+    losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
+    losatCacheInfo: state.losatCacheInfo.value
+  });
+  const assertAuthorityOwners = (expected) => {
+    assert.equal(state.proteinIdentityManifest.value, expected.proteinIdentityManifest);
+    assert.equal(state.legacyProteinRawCandidates.value, expected.legacyProteinRawCandidates);
+    assert.equal(
+      state.legacyProteinDerivedEvidence.value,
+      expected.legacyProteinDerivedEvidence
+    );
+    assert.equal(state.losatCache.value.size, expected.losatCache.length);
+    expected.losatCache.forEach(([key, value]) => {
+      assert.equal(state.losatCache.value.get(key), value);
+    });
+    assert.equal(state.losatDerivedCache.value.size, expected.losatDerivedCache.length);
+    expected.losatDerivedCache.forEach(([key, value]) => {
+      assert.equal(state.losatDerivedCache.value.get(key), value);
+    });
+    assert.equal(state.losatCacheInfo.value, expected.losatCacheInfo);
+  };
+  const authorityOwnersA = captureAuthorityOwners();
   let resultAdmissionCalls = 0;
   const snapshots = createHistorySnapshotService({
     state,
@@ -1766,6 +1801,12 @@ const createLayoutPreferences = () => ({
   assert.equal(handleA.features.biologicalFeatures, biologicalA);
   assert.equal(handleA.editorState.featureCatalog, catalogA);
   assert.equal(handleA.orthogroupState.groups, groupsA);
+  assert.equal(handleA.proteinIdentityManifest, proteinIdentityManifestA);
+  assert.equal(handleA.legacyProteinRawCandidates, legacyProteinRawCandidatesA);
+  assert.equal(handleA.legacyProteinDerivedEvidence, legacyProteinDerivedEvidenceA);
+  assert.equal(handleA.losatCache[0][1], rawCacheValueA);
+  assert.equal(handleA.losatDerivedCache[0][1], derivedCacheValueA);
+  assert.equal(handleA.losatCacheInfo, losatCacheInfoA);
   assert.equal(
     Object.fromEntries(handleA.features.featureVisibilitySelectorCache)['feature-a'].value,
     'feature-a'
@@ -1790,6 +1831,22 @@ const createLayoutPreferences = () => ({
   state.biologicalFeatures.value = [{ biological_feature_id: 'bio-b' }];
   state.featureCatalog.value = { schema: 3, items: [] };
   state.orthogroups.value = [{ id: 'group-b' }];
+  const proteinIdentityManifestB = { schema: 2, records: [{ id: 'manifest-b' }] };
+  const legacyProteinRawCandidatesB = { schema: 1, entries: [{ id: 'raw-b' }] };
+  const legacyProteinDerivedEvidenceB = {
+    schema: 1,
+    entries: [{ id: 'derived-evidence-b' }]
+  };
+  const rawCacheValueB = { text: 'raw-b\n' };
+  const derivedCacheValueB = { payload: { id: 'derived-b' } };
+  const losatCacheInfoB = [{ key: 'raw-b' }];
+  state.proteinIdentityManifest.value = proteinIdentityManifestB;
+  state.legacyProteinRawCandidates.value = legacyProteinRawCandidatesB;
+  state.legacyProteinDerivedEvidence.value = legacyProteinDerivedEvidenceB;
+  state.losatCache.value = new Map([['raw-b', rawCacheValueB]]);
+  state.losatDerivedCache.value = new Map([['derived-b', derivedCacheValueB]]);
+  state.losatCacheInfo.value = losatCacheInfoB;
+  const authorityOwnersB = captureAuthorityOwners();
   snapshots.setGeneratedArtifactIdentity({
     schema: 1,
     algorithm: 'SHA-256',
@@ -1806,7 +1863,19 @@ const createLayoutPreferences = () => ({
     'feature-a'
   );
   assert.equal(handleB.results[0].name, 'edited.svg');
+  assert.equal(handleB.proteinIdentityManifest, proteinIdentityManifestB);
+  assert.equal(handleB.legacyProteinRawCandidates, legacyProteinRawCandidatesB);
+  assert.equal(handleB.legacyProteinDerivedEvidence, legacyProteinDerivedEvidenceB);
+  assert.equal(handleB.losatCache[0][1], rawCacheValueB);
+  assert.equal(handleB.losatDerivedCache[0][1], derivedCacheValueB);
+  assert.equal(handleB.losatCacheInfo, losatCacheInfoB);
 
+  state.proteinIdentityManifest.value = { schema: 2, records: [{ id: 'replacement' }] };
+  state.legacyProteinRawCandidates.value = { schema: 1, entries: [] };
+  state.legacyProteinDerivedEvidence.value = { schema: 1, entries: [] };
+  state.losatCache.value = new Map([['replacement', { text: 'replacement\n' }]]);
+  state.losatDerivedCache.value = new Map([['replacement', { payload: {} }]]);
+  state.losatCacheInfo.value = [{ key: 'replacement' }];
   await snapshots.restoreGeneratedArtifactHandle(handleA);
   assert.equal(resultAdmissionCalls, 0);
   assert.equal(state.results.value[0], resultA);
@@ -1817,6 +1886,7 @@ const createLayoutPreferences = () => ({
   assert.equal(state.featureColorOverrides['feature-a'], '#112233');
   assert.equal(state.legendEntries.value[0].caption, 'A');
   assert.equal(state.featureVisibilitySelectorCache['feature-a'].value, 'feature-a');
+  assertAuthorityOwners(authorityOwnersA);
   const recapturedA = snapshots.captureGeneratedArtifactHandle();
   assert.equal(recapturedA.identity.fingerprint, 'a'.repeat(64));
   assert.equal(recapturedA.retainedBytes, handleA.retainedBytes);
@@ -1831,6 +1901,7 @@ const createLayoutPreferences = () => ({
   await snapshots.restoreGeneratedArtifactHandle(handleB);
   assert.equal(state.results.value[0].name, 'edited.svg');
   assert.equal(state.extractedFeatures.value[0].svg_id, 'feature-b');
+  assertAuthorityOwners(authorityOwnersB);
 
   await Promise.all([
     snapshots.restoreGeneratedArtifactHandle(handleA),
@@ -1838,6 +1909,86 @@ const createLayoutPreferences = () => ({
   ]);
   assert.equal(state.trustedArtifactRestoreInProgress.value, false);
   assert.equal(state.semanticFileWatchersSuppressed.value, false);
+
+  await snapshots.restoreGeneratedArtifactHandle(handleA);
+  const installAuthorityOwnersB = () => {
+    state.results.value = [...handleB.results];
+    state.proteinIdentityManifest.value = authorityOwnersB.proteinIdentityManifest;
+    state.legacyProteinRawCandidates.value = authorityOwnersB.legacyProteinRawCandidates;
+    state.legacyProteinDerivedEvidence.value =
+      authorityOwnersB.legacyProteinDerivedEvidence;
+    state.losatCache.value = new Map(authorityOwnersB.losatCache);
+    state.losatDerivedCache.value = new Map(authorityOwnersB.losatDerivedCache);
+    state.losatCacheInfo.value = authorityOwnersB.losatCacheInfo;
+    snapshots.setGeneratedArtifactIdentity({
+      schema: 1,
+      algorithm: 'SHA-256',
+      fingerprint: 'b'.repeat(64),
+      retainedBytes: 1024
+    }, { results: state.results.value });
+  };
+  const ownerHistory = createHistoryManager({
+    fileStore,
+    buildIntent: async () => ({}),
+    applyIntent: async () => {},
+    buildCheckpoint: () => {
+      throw new Error('LOSAT authority History must not build a full checkpoint.');
+    },
+    applyCheckpoint: async () => {
+      throw new Error('LOSAT authority History must not apply a full checkpoint.');
+    },
+    captureGeneratedArtifactHandle: snapshots.captureGeneratedArtifactHandle,
+    restoreGeneratedArtifactHandle: snapshots.restoreGeneratedArtifactHandle,
+    compareGeneratedArtifactHandles: snapshots.compareGeneratedArtifactHandles
+  });
+  await ownerHistory.initializeIntentBaseline('LOSAT authority baseline');
+  let successfulGenerateCalls = 0;
+  await ownerHistory.runUndoableArtifactReplacement('Generate LOSAT owners B', async () => {
+    successfulGenerateCalls += 1;
+    installAuthorityOwnersB();
+    return { status: 'ok' };
+  }, { shouldCommit: (result) => result.status === 'ok' });
+  assertAuthorityOwners(authorityOwnersB);
+  assert.equal(ownerHistory.getUndoCount(), 1);
+
+  await ownerHistory.undo();
+  assertAuthorityOwners(authorityOwnersA);
+  await ownerHistory.redo();
+  assertAuthorityOwners(authorityOwnersB);
+  assert.equal(successfulGenerateCalls, 1, 'Undo/Redo must not rerun Generate.');
+
+  const installDiscardedAuthorityOwners = (status) => {
+    state.proteinIdentityManifest.value = { schema: 2, records: [{ id: status }] };
+    state.legacyProteinRawCandidates.value = { schema: 1, entries: [{ id: status }] };
+    state.legacyProteinDerivedEvidence.value = { schema: 1, entries: [{ id: status }] };
+    state.losatCache.value = new Map([[status, { text: `${status}\n` }]]);
+    state.losatDerivedCache.value = new Map([[status, { payload: { id: status } }]]);
+    state.losatCacheInfo.value = [{ key: status }];
+  };
+  const undoCountBeforeDiscardedRuns = ownerHistory.getUndoCount();
+  await assert.rejects(
+    ownerHistory.runUndoableArtifactReplacement('Failed LOSAT Generate', async () => {
+      installDiscardedAuthorityOwners('failed');
+      throw new Error('injected LOSAT generation failure');
+    }),
+    /injected LOSAT generation failure/
+  );
+  assertAuthorityOwners(authorityOwnersB);
+
+  for (const status of ['error', 'canceled', 'stale']) {
+    const result = await ownerHistory.runUndoableArtifactReplacement(
+      `${status} LOSAT Generate`,
+      async (before) => {
+        installDiscardedAuthorityOwners(status);
+        await snapshots.restoreGeneratedArtifactHandle(before);
+        return { status };
+      },
+      { shouldCommit: (outcome) => outcome.status === 'ok' }
+    );
+    assert.deepEqual(result, { status });
+    assertAuthorityOwners(authorityOwnersB);
+  }
+  assert.equal(ownerHistory.getUndoCount(), undoCountBeforeDiscardedRuns);
 }
 
 console.log('history tests passed');

--- a/tests/web/losat-cache-migration.playwright.spec.js
+++ b/tests/web/losat-cache-migration.playwright.spec.js
@@ -399,21 +399,26 @@ const cancelDuringRender = async (page) => page.evaluate(async () => {
       entries.length === current.size &&
       entries.every(([key, value]) => current.get(key) === value)
     );
+    const authorityDomains = {
+      proteinIdentityManifestSame:
+        state.proteinIdentityManifest.value === before.proteinIdentityManifest,
+      legacyProteinRawCandidatesSame:
+        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates,
+      legacyProteinDerivedEvidenceSame:
+        state.legacyProteinDerivedEvidence.value === before.legacyProteinDerivedEvidence,
+      losatCacheValuesSame: sameMapEntries(before.losatCache, state.losatCache.value),
+      losatDerivedCacheValuesSame:
+        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value),
+      losatCacheInfoSame: state.losatCacheInfo.value === before.losatCacheInfo
+    };
     return {
       result,
       runRequestIssued: Boolean(heldCanonicalRun),
       cancelInvoked,
       errorSummary: String(app.errorLog?.summary || ''),
       executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
-      authorityRestored: (
-        state.proteinIdentityManifest.value === before.proteinIdentityManifest &&
-        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates &&
-        state.legacyProteinDerivedEvidence.value ===
-          before.legacyProteinDerivedEvidence &&
-        sameMapEntries(before.losatCache, state.losatCache.value) &&
-        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value) &&
-        state.losatCacheInfo.value === before.losatCacheInfo
-      )
+      ...authorityDomains,
+      authorityRestored: Object.values(authorityDomains).every(Boolean)
     };
   } finally {
     Worker.prototype.postMessage = originalWorkerPostMessage;
@@ -457,20 +462,25 @@ const failRendererAfterMigration = async (page) => page.evaluate(async () => {
       entries.length === current.size &&
       entries.every(([key, value]) => current.get(key) === value)
     );
+    const authorityDomains = {
+      proteinIdentityManifestSame:
+        state.proteinIdentityManifest.value === before.proteinIdentityManifest,
+      legacyProteinRawCandidatesSame:
+        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates,
+      legacyProteinDerivedEvidenceSame:
+        state.legacyProteinDerivedEvidence.value === before.legacyProteinDerivedEvidence,
+      losatCacheValuesSame: sameMapEntries(before.losatCache, state.losatCache.value),
+      losatDerivedCacheValuesSame:
+        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value),
+      losatCacheInfoSame: state.losatCacheInfo.value === before.losatCacheInfo
+    };
     return {
       result,
       errorSummary: String(app.errorLog?.summary || ''),
       executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
       rendererFailureInjected,
-      authorityRestored: (
-        state.proteinIdentityManifest.value === before.proteinIdentityManifest &&
-        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates &&
-        state.legacyProteinDerivedEvidence.value ===
-          before.legacyProteinDerivedEvidence &&
-        sameMapEntries(before.losatCache, state.losatCache.value) &&
-        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value) &&
-        state.losatCacheInfo.value === before.losatCacheInfo
-      )
+      ...authorityDomains,
+      authorityRestored: Object.values(authorityDomains).every(Boolean)
     };
   } finally {
     Worker.prototype.postMessage = originalWorkerPostMessage;
@@ -834,6 +844,12 @@ test('legacy protein caches migrate, export readable TSV, and preserve uploads',
     cancelInvoked: true,
     errorSummary: '',
     executorCalls: 0,
+    proteinIdentityManifestSame: true,
+    legacyProteinRawCandidatesSame: true,
+    legacyProteinDerivedEvidenceSame: true,
+    losatCacheValuesSame: true,
+    losatDerivedCacheValuesSame: true,
+    losatCacheInfoSame: true,
     authorityRestored: true
   });
   expect(await migrationUiSnapshot(page)).toEqual(legacyUiBeforeCancel);
@@ -842,6 +858,12 @@ test('legacy protein caches migrate, export readable TSV, and preserve uploads',
   await settleAppRender(page);
   expect(failedLegacyRun).toMatchObject({
     result: { status: 'error' },
+    proteinIdentityManifestSame: true,
+    legacyProteinRawCandidatesSame: true,
+    legacyProteinDerivedEvidenceSame: true,
+    losatCacheValuesSame: true,
+    losatDerivedCacheValuesSame: true,
+    losatCacheInfoSame: true,
     authorityRestored: true,
     executorCalls: 0,
     rendererFailureInjected: true


### PR DESCRIPTION
Add transactionally published Worker-lifetime caches for parsed sources, resolved records, and interactive metadata using compact staged-resource identities. Preserve per-Generate validation, drawing, SVG, catalog, Result, and History behavior while adding mutation, eviction, and retained-memory diagnostics. Cover warm reuse, render-only changes, semantic invalidation, failure rollback, Worker disposal, and real Vibrio output parity.