### PR TITLE
Preserve loaded session intent on regeneration

### DIFF
--- a/gbdraw/web/js/app/candidate-render.js
+++ b/gbdraw/web/js/app/candidate-render.js
@@ -20,7 +20,10 @@ import {
 } from '../services/runtime-test-hooks.js';
 import { ingestSvgResults } from '../services/svg-result-ingestion.js';
 import { PAIRWISE_LEGEND_SELECTOR } from './legend/utils.js';
-import { applyStrokeOverridesToSvg } from './legend/stroke-actions.js';
+import {
+  applyLegendColorOverridesToSvg,
+  applyStrokeOverridesToSvg
+} from './legend/stroke-actions.js';
 
 const text = (value) => String(value ?? '').trim();
 const hasOwn = (object, key) => Object.prototype.hasOwnProperty.call(object || {}, key);
@@ -155,6 +158,7 @@ export const prepareReflowResultCommit = ({
   suppressPairwiseIdentityLegend = false,
   features = [],
   featureStrokeOverrides = {},
+  legendColorOverrides = {},
   legendStrokeOverrides = {},
   sanitizer = globalThis.DOMPurify || globalThis.window?.DOMPurify
 }) => ({
@@ -170,7 +174,11 @@ export const prepareReflowResultCommit = ({
         featureStrokeOverrides,
         legendStrokeOverrides
       }) > 0;
-      return legendChanged || strokeChanged;
+      const legendFillChanged = applyLegendColorOverridesToSvg({
+        svg,
+        legendColorOverrides
+      }) > 0;
+      return legendChanged || strokeChanged || legendFillChanged;
     }
   })
 });
@@ -181,6 +189,7 @@ export const prepareCandidateRenderCommit = ({
   mode = '',
   featureColorOverrides,
   featureStrokeOverrides,
+  legendColorOverrides = {},
   legendStrokeOverrides = {},
   manualSpecificRules = [],
   legacyFeatures = [],
@@ -194,6 +203,11 @@ export const prepareCandidateRenderCommit = ({
   recordSessionLifecycleEvent('feature-catalog-adoption-end');
   const fillOverrides = cloneJsonValue(featureColorOverrides, {});
   const strokeOverrides = cloneJsonValue(featureStrokeOverrides, {});
+  const legendFillOverrides = Object.fromEntries(
+    Object.entries(cloneJsonValue(legendColorOverrides, {}))
+      .map(([caption, color]) => [caption, normalizePaint(color, 'legend color')])
+      .filter(([, color]) => Boolean(color))
+  );
   const migrationOptions = (overrideKind) => ({
     legacyFeatures,
     onDiagnostic: (diagnostic) => {
@@ -283,10 +297,15 @@ export const prepareCandidateRenderCommit = ({
         legendStrokeOverrides,
         featureStrokeOverrides: {}
       }) > 0;
+      const legendFillChanged = applyLegendColorOverridesToSvg({
+        svg,
+        legendColorOverrides: legendFillOverrides
+      }) > 0;
       const callerChanged = typeof transformSvg === 'function'
         ? Boolean(transformSvg(svg, { resultIndex }))
         : false;
-      return legendChanged || overridesChanged || legendStrokeChanged || callerChanged;
+      return legendChanged || overridesChanged || legendStrokeChanged ||
+        legendFillChanged || callerChanged;
     }
   });
   recordSessionLifecycleEvent('svg-admission-end');

--- a/gbdraw/web/js/app/feature-editor/label-actions.js
+++ b/gbdraw/web/js/app/feature-editor/label-actions.js
@@ -339,6 +339,19 @@ const buildContextKey = (svg, mode) => {
   return `${mode}:${ids.join(',')}`;
 };
 
+const hasFeatureScopedOverrideInSvg = (svg, ...overrideMaps) => {
+  const renderedFeatureIds = new Set(
+    Array.from(svg.querySelectorAll(FEATURE_SELECTOR))
+      .map((element) => normalizeKeyToken(getFeatureIdentity(element)))
+      .filter(Boolean)
+  );
+  return overrideMaps.some((overrides) => (
+    Object.keys(overrides || {}).some(
+      (featureId) => renderedFeatureIds.has(normalizeKeyToken(featureId))
+    )
+  ));
+};
+
 export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
   const {
     mode,
@@ -630,7 +643,15 @@ export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
     if (!svg) return;
 
     const contextKey = buildContextKey(svg, mode.value);
-    if (labelOverrideContextKey.value && labelOverrideContextKey.value !== contextKey) {
+    if (
+      labelOverrideContextKey.value &&
+      labelOverrideContextKey.value !== contextKey &&
+      !hasFeatureScopedOverrideInSvg(
+        svg,
+        labelTextFeatureOverrides,
+        labelVisibilityOverrides
+      )
+    ) {
       clearOverrides();
       labelTextScopeDialog.show = false;
       closeGlobalLabelModeDialog();
@@ -807,9 +828,9 @@ export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
     if (clickedFeature.value.hasEditableLabel) {
       applyDirectTextToCurrentSvg(featureId, nextText);
     }
-    if (visibilityChanged) {
-      applyDirectVisibilityToCurrentSvg(featureId, clickedFeature.value.labelVisibility);
-    }
+    const visibilityAppliedDirectly = visibilityChanged
+      ? applyDirectVisibilityToCurrentSvg(featureId, clickedFeature.value.labelVisibility)
+      : false;
 
     const requiresGlobalSelection = isGlobalLabelsOff() && (visibilityChanged || textChanged);
     if (requiresGlobalSelection) {
@@ -820,7 +841,7 @@ export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
     }
 
     if (visibilityChanged || (!clickedFeature.value.hasEditableLabel && textChanged)) {
-      queueLabelReflow('label-visibility-apply', true);
+      queueLabelReflow('label-visibility-apply', !visibilityAppliedDirectly);
       return;
     }
 

--- a/gbdraw/web/js/app/feature-editor/visibility-actions.js
+++ b/gbdraw/web/js/app/feature-editor/visibility-actions.js
@@ -209,6 +209,7 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
   };
 
   const applyVisibilityPreviewForScope = (scope, feat, mode) => {
+    let changed = false;
     collectAffectedFeatureIds(scope, feat).forEach((svgId) => {
       const specificHashMode = (scope?.id === 'product' || scope?.id === 'protein_id')
         ? featureVisibilityOverrides[svgId]
@@ -217,8 +218,10 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
         (mode === 'default'
           ? resolveEffectiveFeatureVisibility(svgId, featureVisibilityOverrides, null, featureVisibilityManualRules)
           : mode);
-      applyVisibilityPreviewBySvgId(svgId, effectiveMode);
+      changed = applyVisibilityPreviewBySvgId(svgId, effectiveMode) || changed;
     });
+    if (changed) previewRuntime?.flushActiveResult?.();
+    return changed;
   };
 
   const updateClickedFeatureVisibilityFromRules = (featureIds) => {
@@ -477,13 +480,17 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
     return '';
   };
 
-  const reconcileFeatureVisibility = () => applyVisibilityPreviewChanges(
-    uniqueFeaturesBySvgId(Array.isArray(extractedFeatures.value) ? extractedFeatures.value : [])
-      .map((feature) => ({
-        featureId: normalizeText(feature?.svg_id ?? feature?.svgId ?? feature?.id),
-        mode: getFeatureVisibility(feature)
-      }))
-  );
+  const reconcileFeatureVisibility = () => {
+    const changed = applyVisibilityPreviewChanges(
+      uniqueFeaturesBySvgId(Array.isArray(extractedFeatures.value) ? extractedFeatures.value : [])
+        .map((feature) => ({
+          featureId: normalizeText(feature?.svg_id ?? feature?.svgId ?? feature?.id),
+          mode: getFeatureVisibility(feature)
+        }))
+    );
+    if (changed) previewRuntime?.flushActiveResult?.();
+    return changed;
+  };
 
   return {
     addFeatureVisibilityRule,

--- a/gbdraw/web/js/app/legend/stroke-actions.js
+++ b/gbdraw/web/js/app/legend/stroke-actions.js
@@ -71,6 +71,24 @@ const getLegendSwatches = (svg, caption) => {
   return swatches;
 };
 
+export const applyLegendColorOverridesToSvg = ({
+  svg,
+  legendColorOverrides = {}
+} = {}) => {
+  if (!svg) return 0;
+  let changedCount = 0;
+  Object.entries(legendColorOverrides || {}).forEach(([caption, color]) => {
+    const normalized = String(color || '').trim();
+    if (!normalized) return;
+    getLegendSwatches(svg, caption).forEach((swatch) => {
+      if (swatch.getAttribute('fill') === normalized) return;
+      swatch.setAttribute('fill', normalized);
+      changedCount += 1;
+    });
+  });
+  return changedCount;
+};
+
 export const applyStrokeOverridesToSvg = ({
   svg,
   features = [],

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -834,6 +834,7 @@ export const createRunAnalysis = ({
     featureColorOverrides,
     featureVisibilityRules,
     featureStrokeOverrides,
+    legendColorOverrides,
     legendStrokeOverrides,
     selectedPalette,
     currentColors,
@@ -4021,6 +4022,7 @@ export const createRunAnalysis = ({
               suppressPairwiseIdentityLegend,
               features: extractedFeatures.value,
               featureStrokeOverrides,
+              legendColorOverrides,
               legendStrokeOverrides
             })
           )
@@ -4033,6 +4035,7 @@ export const createRunAnalysis = ({
               mode: mode.value,
               featureColorOverrides,
               featureStrokeOverrides,
+              legendColorOverrides,
               legendStrokeOverrides,
               manualSpecificRules,
               legacyFeatures: committedArtifactHandle?.features?.extractedFeatures || [],

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -10,9 +10,7 @@ import { serializeCleanSvg } from './svg-serialization.js';
 import { cloneJsonData, cloneJsonValue } from './json-clone.js';
 import {
   applyCircularTrackOrderPlacements,
-  buildCircularTrackSlotPayload,
   CIRCULAR_TRACK_RENDERERS,
-  circularTrackAxisIndexForEnabledSlots,
   clampCircularTrackAxisIndex,
   inferLegacyAxisIndexFromFeature,
   migrateLegacyCircularTrackSlot,
@@ -22,14 +20,12 @@ import {
 } from '../app/circular-track-slots.js';
 import {
   applyLinearTrackOrderPlacements,
-  buildLinearTrackSlotPayload,
   clampLinearTrackAxisIndex,
   LEGACY_LINEAR_TRACK_SLOT_SCHEMA_VERSION,
   LINEAR_TRACK_RENDERERS,
   LINEAR_TRACK_SLOT_SCHEMA_VERSION,
   migrateLinearTrackSlotsToCurrentSchema,
   normalizeLinearTrackSlots,
-  linearTrackAxisIndexForEnabledSlots,
   resolveLinearTrackAxisIndex
 } from '../app/linear-track-slots.js';
 import {
@@ -197,8 +193,8 @@ const CURRENT_ARTIFACT_SESSION_MIN_VERSION = 39;
 const LOSAT_DERIVED_CACHE_LIMIT = 16;
 const SESSION_FEATURE_CATALOG_SAVE_ERROR =
   'Generate again before using Save Session. The current results are missing compatible feature metadata.';
-const SESSION_ACTIVE_DRAFT_SAVE_ERROR =
-  'Generate again before using Save Session. The active Custom Track draft has changed since the committed render.';
+const SESSION_ACTIVE_CONFIG_SAVE_ERROR =
+  'Save Session could not validate the active configuration.';
 const CIRCULAR_TRACK_SLOT_SCHEMA_VERSION = 4;
 const LEGACY_CIRCULAR_TRACK_SLOT_SCHEMA_VERSION = 3;
 const OBSOLETE_CIRCULAR_TRACK_SLOT_KEYS = [
@@ -1435,113 +1431,284 @@ const restoreStoredNonCanonicalConfig = (
   return restored;
 };
 
-const CURRENT_WRITER_DRAFT_ADV_FIELDS = Object.freeze([
-  'circular_track_slots_enabled',
-  'circular_track_slots',
-  'circular_track_slots_axis_index',
-  'circular_track_slots_schema_version',
-  'linear_track_slots_enabled',
-  'linear_track_slots',
-  'linear_track_slots_axis_index',
-  'linear_track_slots_schema_version',
-  'feature_width_circular',
-  'depth_width_circular',
-  'gc_content_width_circular',
-  'gc_content_radius_circular',
-  'gc_skew_width_circular',
-  'gc_skew_radius_circular',
-  'comparison_height',
-  'pairwise_match_style',
-  'min_bitscore',
-  'evalue',
-  'identity',
-  'alignment_length'
+export const CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS = Object.freeze([
+  'form',
+  'adv',
+  'losat',
+  'cliOptions',
+  'colors',
+  'palette',
+  'paletteInstantPreviewEnabled',
+  'rules',
+  'qualifierPriorityRules',
+  'filterMode',
+  'whitelist',
+  'blacklistText',
+  'losatProgram',
+  'circularConservation',
+  'annotationSets',
+  'modeProfiles',
+  'linearRecordLayout',
+  'linearComparisonPlan',
+  'webEdits'
 ]);
 
-export const overlayCurrentWriterDraftConfig = (projectedConfig, storedConfig) => {
-  const restored = cloneJsonData(projectedConfig);
-  if (!isPlainObject(storedConfig)) return restored;
-  if (isPlainObject(storedConfig.adv)) {
-    if (!isPlainObject(restored.adv)) restored.adv = {};
-    CURRENT_WRITER_DRAFT_ADV_FIELDS.forEach((field) => {
-      if (Object.prototype.hasOwnProperty.call(storedConfig.adv, field)) {
-        restored.adv[field] = cloneJsonData(storedConfig.adv[field]);
+const CURRENT_WRITER_ACTIVE_CONFIG_DOMAIN_SET = new Set(
+  CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS
+);
+const CURRENT_WRITER_COMPAT_CONFIG_FIELDS = new Set(['colorsAreOverrides']);
+const CURRENT_WRITER_ADV_COMPAT_FIELDS = new Set(['losatProgram']);
+const CURRENT_WRITER_OBJECT_CONFIG_DOMAINS = new Set([
+  'form',
+  'adv',
+  'losat',
+  'cliOptions',
+  'colors',
+  'circularConservation',
+  'modeProfiles',
+  'linearRecordLayout',
+  'linearComparisonPlan',
+  'webEdits'
+]);
+const CURRENT_WRITER_ARRAY_CONFIG_DOMAINS = new Set([
+  'rules',
+  'qualifierPriorityRules',
+  'whitelist',
+  'annotationSets'
+]);
+const CURRENT_WRITER_STRING_CONFIG_DOMAINS = new Set([
+  'palette',
+  'filterMode',
+  'blacklistText',
+  'losatProgram'
+]);
+const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+const assertNoPrototypeConfigKeys = (value, path = 'config') => {
+  if (!value || typeof value !== 'object') return;
+  Object.keys(value).forEach((key) => {
+    if (PROTOTYPE_KEYS.has(key)) {
+      throw new Error(`Current session active configuration contains unsafe key ${path}.${key}.`);
+    }
+    assertNoPrototypeConfigKeys(value[key], `${path}.${key}`);
+  });
+};
+
+const assertKnownObjectFields = (value, allowedFields, path) => {
+  const unknown = Object.keys(value).filter((field) => !allowedFields.has(field));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Current session active configuration contains unknown ${path} field(s): ${unknown.join(', ')}.`
+    );
+  }
+};
+
+const assertPlainArrayEntries = (entries, allowedFields, path) => {
+  entries.forEach((entry, index) => {
+    if (!isPlainObject(entry)) {
+      throw new Error(`Current session active configuration ${path}[${index}] must be an object.`);
+    }
+    assertKnownObjectFields(entry, allowedFields, `${path}[${index}]`);
+  });
+};
+
+const validateCurrentWriterDomainShapes = (storedConfig) => {
+  for (const domain of CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS) {
+    if (!Object.prototype.hasOwnProperty.call(storedConfig, domain)) continue;
+    const value = storedConfig[domain];
+    if (value === undefined && ['cliOptions', 'modeProfiles'].includes(domain)) continue;
+    if (CURRENT_WRITER_OBJECT_CONFIG_DOMAINS.has(domain) && !isPlainObject(value)) {
+      throw new Error(`Current session active configuration config.${domain} must be an object.`);
+    }
+    if (CURRENT_WRITER_ARRAY_CONFIG_DOMAINS.has(domain) && !Array.isArray(value)) {
+      throw new Error(`Current session active configuration config.${domain} must be an array.`);
+    }
+    if (CURRENT_WRITER_STRING_CONFIG_DOMAINS.has(domain) && typeof value !== 'string') {
+      throw new Error(`Current session active configuration config.${domain} must be a string.`);
+    }
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(storedConfig, 'paletteInstantPreviewEnabled') &&
+    typeof storedConfig.paletteInstantPreviewEnabled !== 'boolean'
+  ) {
+    throw new Error(
+      'Current session active configuration config.paletteInstantPreviewEnabled must be a boolean.'
+    );
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(storedConfig, 'colorsAreOverrides') &&
+    typeof storedConfig.colorsAreOverrides !== 'boolean'
+  ) {
+    throw new Error(
+      'Current session compatibility field config.colorsAreOverrides must be a boolean.'
+    );
+  }
+};
+
+const validateCurrentWriterCollectionShapes = (storedConfig) => {
+  if (Array.isArray(storedConfig.rules)) {
+    assertPlainArrayEntries(
+      storedConfig.rules,
+      new Set(['feat', 'qual', 'val', 'color', 'cap', 'fromFile']),
+      'config.rules'
+    );
+  }
+  if (Array.isArray(storedConfig.qualifierPriorityRules)) {
+    assertPlainArrayEntries(
+      storedConfig.qualifierPriorityRules,
+      new Set(['feat', 'order']),
+      'config.qualifierPriorityRules'
+    );
+  }
+  if (Array.isArray(storedConfig.whitelist)) {
+    assertPlainArrayEntries(
+      storedConfig.whitelist,
+      new Set(['feat', 'qual', 'key']),
+      'config.whitelist'
+    );
+  }
+  if (Array.isArray(storedConfig.annotationSets)) {
+    assertPlainArrayEntries(
+      storedConfig.annotationSets,
+      new Set(['id', 'annotations', 'defaultStyle', 'legendLabel']),
+      'config.annotationSets'
+    );
+    storedConfig.annotationSets.forEach((set, setIndex) => {
+      if (!Array.isArray(set.annotations)) {
+        throw new Error(
+          `Current session active configuration config.annotationSets[${setIndex}].annotations must be an array.`
+        );
       }
+      assertPlainArrayEntries(
+        set.annotations,
+        new Set(['id', 'target', 'label', 'mark', 'lane', 'style', 'legendLabel', 'metadata']),
+        `config.annotationSets[${setIndex}].annotations`
+      );
     });
   }
-  if (isPlainObject(storedConfig.linearComparisonPlan)) {
-    if (isPlainObject(storedConfig.losat)) {
-      restored.losat = cloneJsonData(storedConfig.losat);
-    }
-    if (Object.prototype.hasOwnProperty.call(storedConfig, 'losatProgram')) {
-      restored.losatProgram = cloneJsonData(storedConfig.losatProgram);
-    }
+};
+
+export const validateCurrentWriterActiveConfig = ({ mode, storedConfig }) => {
+  if (!['circular', 'linear'].includes(mode)) {
+    throw new Error(`Current session active configuration has unsupported mode: ${String(mode)}.`);
   }
-  return restored;
-};
-
-const stableJsonValue = (value) => {
-  if (Array.isArray(value)) return value.map((item) => stableJsonValue(item));
-  if (!isPlainObject(value)) return value;
-  return Object.fromEntries(
-    Object.keys(value).sort().map((key) => [key, stableJsonValue(value[key])])
+  if (!isPlainObject(storedConfig)) {
+    throw new Error('Current session is missing its active Web configuration.');
+  }
+  assertNoPrototypeConfigKeys(storedConfig);
+  const unknownDomains = Object.keys(storedConfig).filter(
+    (domain) => (
+      !CURRENT_WRITER_ACTIVE_CONFIG_DOMAIN_SET.has(domain) &&
+      !CURRENT_WRITER_COMPAT_CONFIG_FIELDS.has(domain)
+    )
   );
+  if (unknownDomains.length > 0) {
+    throw new Error(
+      `Current session active configuration contains unknown domain(s): ${unknownDomains.join(', ')}.`
+    );
+  }
+  if (!isPlainObject(storedConfig.form) || !isPlainObject(storedConfig.adv)) {
+    throw new Error('Current session is missing its active form or advanced settings.');
+  }
+  validateCurrentWriterDomainShapes(storedConfig);
+  validateCurrentWriterCollectionShapes(storedConfig);
+  requireCurrentWebStateFieldNames(storedConfig);
+  assertKnownObjectFields(
+    storedConfig.form,
+    new Set(Object.getOwnPropertyNames(state.form)),
+    'config.form'
+  );
+  assertKnownObjectFields(
+    storedConfig.adv,
+    new Set([
+      ...Object.getOwnPropertyNames(state.adv),
+      ...CURRENT_WRITER_ADV_COMPAT_FIELDS
+    ]),
+    'config.adv'
+  );
+  if (
+    Object.prototype.hasOwnProperty.call(storedConfig.adv, 'losatProgram') &&
+    !['blastn', 'tblastx', 'blastp'].includes(storedConfig.adv.losatProgram)
+  ) {
+    throw new Error(
+      'Current session compatibility field config.adv.losatProgram is invalid.'
+    );
+  }
+  if (Object.prototype.hasOwnProperty.call(storedConfig.form, 'linear_track_layout')) {
+    requireCurrentLinearTrackLayout(storedConfig.form.linear_track_layout);
+  }
+  if (Object.prototype.hasOwnProperty.call(storedConfig.adv, 'label_placement')) {
+    requireCurrentLinearLabelPlacement(storedConfig.adv.label_placement);
+  }
+  if (Object.prototype.hasOwnProperty.call(storedConfig.adv, 'multi_record_size_mode')) {
+    requireCurrentCircularMultiRecordSizeMode(storedConfig.adv.multi_record_size_mode);
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(storedConfig, 'filterMode') &&
+    !['None', 'Whitelist', 'Blacklist'].includes(storedConfig.filterMode)
+  ) {
+    throw new Error('Current session active configuration config.filterMode is invalid.');
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(storedConfig, 'losatProgram') &&
+    !['blastn', 'tblastx', 'blastp'].includes(storedConfig.losatProgram)
+  ) {
+    throw new Error('Current session active configuration config.losatProgram is invalid.');
+  }
+  if (
+    Object.prototype.hasOwnProperty.call(storedConfig, 'palette') &&
+    !storedConfig.palette.trim()
+  ) {
+    throw new Error('Current session active configuration config.palette cannot be empty.');
+  }
+  validateImportedCircularTrackSlots(storedConfig);
+  validateImportedLinearTrackSlots(storedConfig);
 };
 
-const trackPayloadSignature = (payload) => JSON.stringify(stableJsonValue(payload));
-
-export const validateCurrentWriterActiveDraft = ({
+// Version-40 config owns the active controls and the next Generate. The
+// canonical projection owns the committed artifact and only fills fields the
+// current writer deliberately omitted.
+export const restoreCurrentWriterActiveConfig = ({
   mode,
   projectedConfig,
   storedConfig
 }) => {
-  const storedAdv = storedConfig?.adv;
-  const projectedAdv = projectedConfig?.adv;
-  if (!isPlainObject(storedAdv) || !isPlainObject(projectedAdv)) {
-    throw new Error('Current session is missing its Web track draft state.');
+  if (!isPlainObject(projectedConfig)) {
+    throw new Error('Current session is missing its canonical configuration projection.');
   }
+  validateCurrentWriterActiveConfig({ mode, storedConfig });
+  const restored = cloneJsonData(projectedConfig);
+  const restoredDomains = [];
+  CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS.forEach((domain) => {
+    if (!Object.prototype.hasOwnProperty.call(storedConfig, domain)) return;
+    restored[domain] = cloneJsonData(storedConfig[domain]);
+    restoredDomains.push(domain);
+  });
+  if (Object.prototype.hasOwnProperty.call(storedConfig, 'colors')) {
+    delete restored.colorsAreOverrides;
+  }
+  if (isPlainObject(restored.adv)) delete restored.adv.losatProgram;
 
-  const circular = mode === 'circular';
-  const enabledField = circular
-    ? 'circular_track_slots_enabled'
-    : 'linear_track_slots_enabled';
-  if (!Boolean(storedAdv[enabledField])) return;
-
-  const slotsField = circular ? 'circular_track_slots' : 'linear_track_slots';
-  const axisField = circular
-    ? 'circular_track_slots_axis_index'
-    : 'linear_track_slots_axis_index';
-  const storedDraft = Array.isArray(storedAdv[slotsField]) ? storedAdv[slotsField] : [];
-  const storedEnabled = storedDraft.filter((slot) => slot?.enabled !== false);
-  const projectedEnabled = Array.isArray(projectedAdv[slotsField])
-    ? projectedAdv[slotsField]
-    : [];
-  const storedPayloads = circular
-    ? storedEnabled.map((slot) => buildCircularTrackSlotPayload(
-        slot,
-        storedAdv.nt || 'GC',
-        storedConfig?.form?.track_type || 'tuckin'
-      ))
-    : storedEnabled.map((slot) => buildLinearTrackSlotPayload(slot));
-  const projectedPayloads = circular
-    ? projectedEnabled.map((slot) => buildCircularTrackSlotPayload(
-        slot,
-        projectedAdv.nt || 'GC',
-        projectedConfig?.form?.track_type || 'tuckin'
-      ))
-    : projectedEnabled.map((slot) => buildLinearTrackSlotPayload(slot));
-  const storedAxis = circular
-    ? circularTrackAxisIndexForEnabledSlots(storedDraft, storedAdv[axisField])
-    : linearTrackAxisIndexForEnabledSlots(storedDraft, storedAdv[axisField]);
-  const projectedAxis = projectedAdv[axisField];
+  // The current writer deliberately omits this generated-pipeline authority
+  // from config.losat. Preserve the committed projection only when the active
+  // config has no value of its own.
+  const projectedAnchorMode = projectedConfig?.losat?.blastp?.collinearAnchorMode;
   if (
-    trackPayloadSignature(storedPayloads) !== trackPayloadSignature(projectedPayloads)
-    || Number(storedAxis) !== Number(projectedAxis)
+    projectedAnchorMode !== undefined &&
+    isPlainObject(restored.losat) &&
+    isPlainObject(restored.losat.blastp) &&
+    !Object.prototype.hasOwnProperty.call(restored.losat.blastp, 'collinearAnchorMode')
   ) {
-    throw new Error(
-      `Current ${mode} Web track draft does not match the committed render request.`
-    );
+    restored.losat.blastp.collinearAnchorMode = cloneJsonData(projectedAnchorMode);
   }
+
+  recordStructuralMetric('currentWriterActiveConfigRestoreCount', 1, {
+    domains: restoredDomains
+  });
+  recordStructuralMetric('activeConfigCanonicalOverwriteCount', 0, {
+    domains: restoredDomains
+  });
+  return restored;
 };
 
 const validateCurrentWriterFeatureCatalog = (data, { adopt = false } = {}) => {
@@ -1630,17 +1797,19 @@ const preflightSessionImport = (rawData) => {
     : null;
   if (currentSession) recordSessionLifecycleEvent('canonical-request-projection-end');
   let restoredConfig = canonicalProjection
-    ? {
-        ...restoreStoredNonCanonicalConfig(
-          canonicalProjection.config,
-          runtimeStoredConfig,
-          { hasCanonicalProteinPipeline: Boolean(canonicalProjection.pipelineState) }
-        ),
-        rules: applySpecificRuleProvenance(
-          canonicalProjection.config.rules,
-          runtimeStoredConfig?.rules
-        )
-      }
+    ? sourceSessionVersion === SESSION_VERSION
+      ? cloneJsonData(canonicalProjection.config)
+      : {
+          ...restoreStoredNonCanonicalConfig(
+            canonicalProjection.config,
+            runtimeStoredConfig,
+            { hasCanonicalProteinPipeline: Boolean(canonicalProjection.pipelineState) }
+          ),
+          rules: applySpecificRuleProvenance(
+            canonicalProjection.config.rules,
+            runtimeStoredConfig?.rules
+          )
+        }
     : data.config;
   if (sourceSessionVersion < SESSION_VERSION && restoredConfig) {
     const sourceStoredConfig = isPlainObject(normalizedData.config)
@@ -1669,34 +1838,30 @@ const preflightSessionImport = (rawData) => {
   }
   if (canonicalProjection && sourceSessionVersion === SESSION_VERSION) {
     recordSessionLifecycleEvent('current-draft-validation-start');
-    validateCurrentWriterActiveDraft({
+    restoredConfig = restoreCurrentWriterActiveConfig({
       mode: canonicalProjection.mode,
       projectedConfig: canonicalProjection.config,
       storedConfig: runtimeStoredConfig
     });
     recordSessionLifecycleEvent('current-draft-validation-end');
-    restoredConfig = overlayCurrentWriterDraftConfig(
-      restoredConfig,
-      runtimeStoredConfig
-    );
   }
   if (!canonicalProjection && restoredConfig) {
     hydrateMissingMultiRecordPositionsFromCliInvocation(restoredConfig, data.cliInvocation);
   }
   if (restoredConfig) {
-    const projectedDepthTrackCount = Array.isArray(canonicalProjection?.config?.adv?.depth_tracks)
-      ? canonicalProjection.config.adv.depth_tracks.length
+    const activeDepthTrackCount = Array.isArray(restoredConfig?.adv?.depth_tracks)
+      ? restoredConfig.adv.depth_tracks.length
       : null;
     validateImportedCircularTrackSlots(restoredConfig, {
       depthTrackCount: canonicalProjection?.mode === 'circular' &&
         restoredConfig.adv?.circular_track_slots_enabled
-        ? projectedDepthTrackCount
+        ? activeDepthTrackCount
         : null
     });
     validateImportedLinearTrackSlots(restoredConfig, {
       depthTrackCount: canonicalProjection?.mode === 'linear' &&
         restoredConfig.adv?.linear_track_slots_enabled
-        ? projectedDepthTrackCount
+        ? activeDepthTrackCount
         : null
     });
   }
@@ -3783,14 +3948,13 @@ export const exportSession = async (
         deferResourceContent: adoptedCommitted,
         adoptCanonicalPayloads: adoptedCommitted
       });
-      validateCurrentWriterActiveDraft({
+      validateCurrentWriterActiveConfig({
         mode: projected.mode,
-        projectedConfig: projected.config,
         storedConfig
       });
     } catch (error) {
-      console.warn('Session active draft validation failed.', error);
-      throw new Error(SESSION_ACTIVE_DRAFT_SAVE_ERROR);
+      console.warn('Session active configuration validation failed.', error);
+      throw new Error(SESSION_ACTIVE_CONFIG_SAVE_ERROR);
     }
   }
   if (!committed) {

--- a/tests/web/contracts/session-regenerate-intent.playwright.spec.js
+++ b/tests/web/contracts/session-regenerate-intent.playwright.spec.js
@@ -1,0 +1,971 @@
+const { test, expect } = require('@playwright/test');
+const { createHash } = require('node:crypto');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { gunzipSync } = require('node:zlib');
+const {
+  getDiagramWorkerActivity,
+  openApp
+} = require('../helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const sourceSessionPath = join(
+  repoRoot,
+  'gbdraw',
+  'web',
+  'gallery',
+  'sessions',
+  'HmmtDNA_basic_circular.gbdraw-session.json'
+);
+const sourceSession = JSON.parse(readFileSync(sourceSessionPath, 'utf8'));
+const sessionInputSelector =
+  'input[type="file"][accept*="application/json"][accept*="application/gzip"]';
+
+const ACTIVE_CONFIG_DOMAINS = Object.freeze([
+  'form',
+  'adv',
+  'losat',
+  'cliOptions',
+  'colors',
+  'palette',
+  'paletteInstantPreviewEnabled',
+  'rules',
+  'qualifierPriorityRules',
+  'filterMode',
+  'whitelist',
+  'blacklistText',
+  'losatProgram',
+  'circularConservation',
+  'annotationSets',
+  'modeProfiles',
+  'linearRecordLayout',
+  'linearComparisonPlan',
+  'webEdits'
+]);
+
+const stableValue = (value) => {
+  if (Array.isArray(value)) return value.map((item) => stableValue(item));
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.keys(value).sort().map((key) => [key, stableValue(value[key])])
+  );
+};
+
+const jsonDigest = (value) => createHash('sha256')
+  .update(JSON.stringify(stableValue(value)))
+  .digest('hex');
+
+const sessionCanonicalEvidence = (session) => {
+  const active = {
+    palette: session.config?.palette,
+    colors: session.config?.colors,
+    rules: (session.config?.rules || []).map((rule) => ({
+      ...rule,
+      fromFile: Boolean(rule.fromFile)
+    })),
+    qualifierPriorityRules: session.config?.qualifierPriorityRules,
+    filterMode: session.config?.filterMode,
+    whitelist: session.config?.whitelist,
+    blacklistText: session.config?.blacklistText,
+    form: {
+      plot_title: session.config?.form?.plot_title,
+      labels_mode: session.config?.form?.labels_mode,
+      show_scale: session.config?.form?.show_scale
+    },
+    adv: {
+      axis_stroke_width: session.config?.adv?.axis_stroke_width,
+      label_font_size: session.config?.adv?.label_font_size,
+      feature_width_circular: session.config?.adv?.feature_width_circular
+    },
+    annotationSetIds: (session.config?.annotationSets || []).map(({ id }) => id)
+  };
+  return {
+    renderRequestSha256: jsonDigest(session.renderRequest),
+    activeConfigSha256: jsonDigest(active),
+    resourcePayloadsSha256: jsonDigest(Object.fromEntries(
+      Object.entries(session.resources || {}).map(([resourceId, resource]) => [
+        resourceId,
+        {
+          kind: resource.kind,
+          encoding: resource.encoding,
+          payloadSha256: createHash('sha256')
+            .update(Buffer.from(String(resource.data || ''), 'base64'))
+            .digest('hex')
+        }
+      ])
+    )),
+    featureCatalogSha256: jsonDigest(session.editorState?.featureCatalog || null),
+    mode: session.renderRequest?.mode,
+    requestSchema: session.renderRequest?.schema,
+    recordCount: session.renderRequest?.records?.length || 0,
+    comparisonCount: session.renderRequest?.comparisons?.length || 0,
+    active
+  };
+};
+
+const installIntentProbe = (page) => page.addInitScript(() => {
+  const metrics = {};
+  const details = [];
+  const lifecycle = [];
+  window.__GBDRAW_SESSION_INTENT_PROBE__ = {
+    metrics,
+    details,
+    lifecycle,
+    reset() {
+      Object.keys(metrics).forEach((name) => delete metrics[name]);
+      details.length = 0;
+      lifecycle.length = 0;
+    },
+    snapshot() {
+      return {
+        metrics: { ...metrics },
+        details: details.map((entry) => ({ ...entry })),
+        lifecycle: lifecycle.map((entry) => ({ ...entry }))
+      };
+    }
+  };
+  window.__GBDRAW_TEST_HOOKS__ = {
+    onStructuralMetric(metric) {
+      const name = String(metric?.name || '');
+      metrics[name] = Number(metrics[name] || 0) + Number(metric?.value || 0);
+      details.push({ ...metric });
+    },
+    onSessionLifecycleEvent(event) {
+      lifecycle.push({ ...event });
+    }
+  };
+});
+
+const openIntentApp = async (page) => {
+  page.on('dialog', (dialog) => dialog.accept());
+  await installIntentProbe(page);
+  await openApp(page);
+};
+
+const loadCurrentSession = async (page, filePath, session) => {
+  await page.evaluate(() => window.__GBDRAW_SESSION_INTENT_PROBE__.reset());
+  await page.locator(sessionInputSelector).setInputFiles(filePath);
+  await page.waitForFunction(() => (
+    window.__GBDRAW_SESSION_INTENT_PROBE__?.lifecycle?.some(
+      (event) => event.name === 'interactiveReady'
+    )
+  ), null, { timeout: 180_000 });
+  await page.evaluate(() => new Promise((resolveFrame) => (
+    requestAnimationFrame(() => requestAnimationFrame(resolveFrame))
+  )));
+
+  const probe = await page.evaluate(() => (
+    window.__GBDRAW_SESSION_INTENT_PROBE__.snapshot()
+  ));
+  const ready = probe.lifecycle.find((event) => event.name === 'interactiveReady');
+  expect(ready).toMatchObject({ status: 'success', degradedRecovery: false });
+  expect(probe.metrics.currentWriterActiveConfigRestoreCount).toBe(1);
+  expect(probe.metrics.activeConfigCanonicalOverwriteCount || 0).toBe(0);
+
+  const suppliedDomains = ACTIVE_CONFIG_DOMAINS.filter((domain) => (
+    Object.prototype.hasOwnProperty.call(session.config, domain)
+  ));
+  const restored = probe.details.find(
+    (entry) => entry.name === 'currentWriterActiveConfigRestoreCount'
+  );
+  const noCanonicalOverwrite = probe.details.find(
+    (entry) => entry.name === 'activeConfigCanonicalOverwriteCount'
+  );
+  expect(restored?.domains).toEqual(suppliedDomains);
+  expect(noCanonicalOverwrite).toMatchObject({ value: 0, domains: suppliedDomains });
+  return probe;
+};
+
+const saveCurrentSession = async (page, title) => {
+  await page.evaluate((nextTitle) => {
+    window.__GBDRAW_APP__.sessionTitle = nextTitle;
+  }, title);
+  const downloadPromise = page.waitForEvent('download', { timeout: 180_000 });
+  const result = await page.evaluate(() => (
+    window.__GBDRAW_APP__.saveSessionWithTitle()
+  ));
+  expect(result).toMatchObject({ status: 'saved' });
+  const download = await downloadPromise;
+  const path = await download.path();
+  expect(path).toBeTruthy();
+  const session = JSON.parse(gunzipSync(readFileSync(path)).toString('utf8'));
+  expect(session).toMatchObject({
+    format: 'gbdraw-session',
+    version: 40,
+    renderRequest: { schema: 5 }
+  });
+  return { path, session };
+};
+
+const capturePageEvidence = (page) => page.evaluate(async () => {
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const { resolveColorToHex } = await import('/gbdraw/web/js/app/color-utils.js');
+  const { serializeCleanSvg } = await import('/gbdraw/web/js/services/svg-serialization.js');
+  const app = window.__GBDRAW_APP__;
+  const history = window.__GBDRAW_HISTORY__;
+  const plain = (value) => JSON.parse(JSON.stringify(value ?? null));
+  const sortedObject = (value) => Object.fromEntries(
+    Object.entries(plain(value) || {}).sort(([left], [right]) => left.localeCompare(right))
+  );
+  const hashText = (text) => {
+    let hash = 2166136261;
+    for (let index = 0; index < text.length; index += 1) {
+      hash ^= text.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+    return { length: text.length, hash: hash >>> 0 };
+  };
+  const mountedSvg = state.svgContainer.value?.querySelector?.('svg');
+  const svgContent = mountedSvg
+    ? serializeCleanSvg(mountedSvg)
+    : String(app.results?.[app.selectedResultIndex]?.content || '');
+  const svgDocument = new DOMParser().parseFromString(svgContent, 'image/svg+xml');
+  const root = svgDocument.documentElement;
+  if (!root || root.localName === 'parsererror') {
+    throw new Error('The committed preview is not valid SVG.');
+  }
+  const canonicalSvg = new XMLSerializer().serializeToString(root);
+  const semanticAttributes = [
+    'id',
+    'viewBox',
+    'd',
+    'points',
+    'x',
+    'y',
+    'x1',
+    'y1',
+    'x2',
+    'y2',
+    'cx',
+    'cy',
+    'r',
+    'rx',
+    'ry',
+    'transform',
+    'fill',
+    'fill-opacity',
+    'stroke',
+    'stroke-width',
+    'stroke-dasharray',
+    'display',
+    'visibility',
+    'font-size'
+  ];
+  const semanticRows = [...root.querySelectorAll('*')].map((element) => ({
+    tag: element.localName,
+    attributes: Object.fromEntries(semanticAttributes
+      .filter((name) => element.hasAttribute(name))
+      .map((name) => {
+        const raw = String(element.getAttribute(name) || '');
+        if (['fill', 'stroke'].includes(name) && !/^(none|url\(|currentcolor)/i.test(raw)) {
+          return [name, String(resolveColorToHex(raw) || raw).toLowerCase()];
+        }
+        if (['stroke-width', 'fill-opacity', 'font-size'].includes(name)) {
+          const numeric = Number(raw);
+          if (Number.isFinite(numeric)) return [name, String(numeric)];
+        }
+        return [name, raw];
+      })),
+    text: element.children.length === 0 ? String(element.textContent || '') : ''
+  }));
+  const svgBlobUrl = URL.createObjectURL(new Blob([svgContent], { type: 'image/svg+xml' }));
+  const svgImage = new Image();
+  svgImage.src = svgBlobUrl;
+  await new Promise((resolveImage, rejectImage) => {
+    svgImage.onload = resolveImage;
+    svgImage.onerror = () => rejectImage(new Error('Could not rasterize the committed SVG.'));
+  });
+  const rasterWidth = 600;
+  const rasterHeight = Math.max(
+    1,
+    Math.round(rasterWidth * Number(svgImage.naturalHeight || 1) / Number(svgImage.naturalWidth || 1))
+  );
+  const rasterCanvas = document.createElement('canvas');
+  rasterCanvas.width = rasterWidth;
+  rasterCanvas.height = rasterHeight;
+  const rasterContext = rasterCanvas.getContext('2d', { willReadFrequently: true });
+  rasterContext.drawImage(svgImage, 0, 0, rasterWidth, rasterHeight);
+  const rasterPixels = rasterContext.getImageData(0, 0, rasterWidth, rasterHeight).data;
+  const rasterDigest = new Uint8Array(await crypto.subtle.digest('SHA-256', rasterPixels));
+  URL.revokeObjectURL(svgBlobUrl);
+  const catalogJson = JSON.stringify(state.featureCatalog.value || null);
+  const catalogBytes = new TextEncoder().encode(catalogJson);
+  const catalogDigest = new Uint8Array(await crypto.subtle.digest('SHA-256', catalogBytes));
+  const historyDiagnostics = history.getDiagnostics();
+  const normalizeStrokeOverrides = (value) => Object.fromEntries(
+    Object.entries(plain(value) || {})
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, override]) => [key, {
+        ...override,
+        ...(override?.strokeColor == null
+          ? {}
+          : { strokeColor: resolveColorToHex(String(override.strokeColor)) }),
+        ...(override?.originalStrokeColor == null
+          ? {}
+          : { originalStrokeColor: resolveColorToHex(String(override.originalStrokeColor)) })
+      }])
+  );
+
+  return {
+    active: {
+      modeAndInput: {
+        mode: state.mode.value,
+        inputType: state.mode.value === 'circular'
+          ? state.cInputType.value
+          : state.lInputType.value
+      },
+      palette: {
+        selected: state.selectedPalette.value,
+        currentColors: sortedObject(state.currentColors.value),
+        selectedDefaults: sortedObject(
+          state.paletteDefinitions.value?.[state.selectedPalette.value] || {}
+        ),
+        instantPreview: state.paletteInstantPreviewEnabled.value,
+        appliedName: state.appliedPaletteName.value,
+        appliedColors: sortedObject(state.appliedPaletteColors.value),
+        pendingName: state.pendingPaletteName.value,
+        pendingColors: sortedObject(state.pendingPaletteColors.value)
+      },
+      specificRules: state.manualSpecificRules.map((rule) => ({
+        ...plain(rule),
+        fromFile: Boolean(rule.fromFile)
+      })),
+      qualifierPriorityRules: plain(state.manualPriorityRules),
+      filters: {
+        mode: state.filterMode.value,
+        whitelist: plain(state.manualWhitelist),
+        blacklistText: state.manualBlacklist.value
+      },
+      form: {
+        plot_title: state.form.plot_title,
+        labels_mode: state.form.labels_mode,
+        show_scale: state.form.show_scale,
+        legend: state.form.legend,
+        track_type: state.form.track_type
+      },
+      adv: {
+        axis_stroke_width: state.adv.axis_stroke_width,
+        label_font_size: state.adv.label_font_size,
+        feature_width_circular: state.adv.feature_width_circular,
+        plot_title_position: state.adv.plot_title_position
+      },
+      annotations: state.annotationSets.map((set) => ({
+        id: set.id,
+        annotations: set.annotations.map((annotation) => ({
+          id: annotation.id,
+          mark: annotation.mark,
+          target: {
+            kind: annotation.target?.kind,
+            record: annotation.target?.record ?? null,
+            start: annotation.target?.start,
+            end: annotation.target?.end
+          }
+        }))
+      })),
+      tracks: {
+        enabled: state.adv.circular_track_slots_enabled,
+        axisIndex: state.adv.circular_track_slots_axis_index,
+        slots: state.adv.circular_track_slots.map((slot) => ({
+          id: slot.id,
+          renderer: slot.renderer,
+          enabled: slot.enabled,
+          side: slot.side,
+          width: slot.width,
+          radius: slot.radius
+        }))
+      },
+      layout: {
+        preferences: plain(state.layoutPreferences),
+        linearRecordLayout: {
+          enabled: state.linearRecordLayoutEnabled.value,
+          recordGap: state.linearRecordGap.value,
+          rows: plain(state.linearRecordRows)
+        }
+      },
+      editorOverrides: {
+        fills: sortedObject(state.featureColorOverrides),
+        strokes: normalizeStrokeOverrides(state.featureStrokeOverrides),
+        visibility: sortedObject(state.featureVisibilityOverrides),
+        labelText: sortedObject(state.labelTextFeatureOverrides),
+        labelVisibility: sortedObject(state.labelVisibilityOverrides),
+        legendColors: sortedObject(state.legendColorOverrides),
+        legendStrokes: normalizeStrokeOverrides(state.legendStrokeOverrides),
+        orthogroupNames: sortedObject(state.orthogroupNameOverrides),
+        orthogroupDescriptions: sortedObject(state.orthogroupDescriptionOverrides)
+      }
+    },
+    svg: {
+      source: hashText(svgContent),
+      canonical: hashText(canonicalSvg),
+      semantic: hashText(JSON.stringify(semanticRows)),
+      visual: {
+        width: rasterWidth,
+        height: rasterHeight,
+        sha256: [...rasterDigest]
+          .map((value) => value.toString(16).padStart(2, '0'))
+          .join('')
+      },
+      name: String(app.results?.[app.selectedResultIndex]?.name || '')
+    },
+    featureCatalog: {
+      sha256: [...catalogDigest]
+        .map((value) => value.toString(16).padStart(2, '0'))
+        .join(''),
+      jsonBytes: catalogBytes.byteLength,
+      schema: Number(state.featureCatalog.value?.schema || 0),
+      itemCount: state.featureCatalog.value?.items?.length || 0
+    },
+    history: {
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount(),
+      currentCheckpointAbsent: history.getCurrentCheckpoint() === null,
+      artifactCheckpointBuilds: Number(historyDiagnostics.artifactCheckpointBuilds || 0),
+      artifactCheckpointSignatureComputations: Number(
+        historyDiagnostics.artifactCheckpointSignatureComputations || 0
+      ),
+      generatedArtifactFullCloneCount: Number(
+        historyDiagnostics.generatedArtifactFullCloneCount || 0
+      ),
+      generatedArtifactFullSerializationCount: Number(
+        historyDiagnostics.generatedArtifactFullSerializationCount || 0
+      )
+    }
+  };
+});
+
+const runGenerate = async (page) => {
+  const result = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const outcome = await app.runAnalysis();
+    return {
+      outcome,
+      errorSummary: String(app.errorLog?.summary || ''),
+      resultCount: app.results?.length || 0
+    };
+  });
+  expect(result).toMatchObject({
+    outcome: { status: 'ok' },
+    errorSummary: ''
+  });
+  expect(result.resultCount).toBeGreaterThan(0);
+  return capturePageEvidence(page);
+};
+
+const svgEquivalence = (left, right) => ({
+  exact: left.source.length === right.source.length && left.source.hash === right.source.hash,
+  canonical:
+    left.canonical.length === right.canonical.length &&
+    left.canonical.hash === right.canonical.hash,
+  semantic:
+    left.semantic.length === right.semantic.length &&
+    left.semantic.hash === right.semantic.hash,
+  visual:
+    left.visual.width === right.visual.width &&
+    left.visual.height === right.visual.height &&
+    left.visual.sha256 === right.visual.sha256
+});
+
+const expectSvgEquivalent = (left, right, label) => {
+  const comparison = svgEquivalence(left, right);
+  expect(
+    comparison.exact || comparison.canonical || comparison.semantic || comparison.visual,
+    `${label}: ${JSON.stringify({ left, right, comparison }, null, 2)}`
+  ).toBe(true);
+  return comparison;
+};
+
+const applyDivergentDraft = async (page) => page.evaluate(async () => {
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const { createAnnotationSet } = await import('/gbdraw/web/js/app/annotations/state.js');
+  const app = window.__GBDRAW_APP__;
+  const history = window.__GBDRAW_HISTORY__;
+  state.autoLabelReflowEnabled.value = false;
+
+  const orange = state.paletteDefinitions.value.orange || state.currentColors.value;
+  const draftColors = state.normalizePaletteColors({
+    ...orange,
+    CDS: '#0b4f6c',
+    tRNA: '#f59e0b'
+  });
+  state.selectedPalette.value = 'orange';
+  state.currentColors.value = draftColors;
+  state.paletteInstantPreviewEnabled.value = false;
+  state.pendingPaletteName.value = 'orange';
+  state.pendingPaletteColors.value = { ...draftColors };
+
+  state.manualSpecificRules.splice(0, state.manualSpecificRules.length, {
+    feat: 'CDS',
+    qual: 'gene',
+    val: '^ND2$',
+    color: '#dc2626',
+    cap: 'Saved ND2 rule',
+    fromFile: false
+  });
+  state.manualPriorityRules.splice(0, state.manualPriorityRules.length, {
+    feat: 'CDS',
+    order: 'product,gene'
+  });
+  state.filterMode.value = 'Whitelist';
+  state.manualWhitelist.splice(0, state.manualWhitelist.length, {
+    feat: 'CDS',
+    qual: 'gene',
+    key: 'ND1'
+  });
+  state.manualBlacklist.value = 'hypothetical, draft-only';
+  Object.assign(state.form, {
+    plot_title: 'Saved active draft',
+    labels_mode: 'both',
+    show_scale: false
+  });
+  Object.assign(state.adv, {
+    axis_stroke_width: 6,
+    label_font_size: 27,
+    feature_width_circular: 18
+  });
+  state.annotationSets.splice(0, state.annotationSets.length, createAnnotationSet({
+    id: 'saved-regenerate-annotations',
+    legendLabel: 'Saved annotation',
+    annotations: [{
+      id: 'saved-window',
+      target: {
+        kind: 'coordinateSpan',
+        record: null,
+        start: 100,
+        end: 300,
+        coordinateSpace: 'source'
+      },
+      label: 'Saved window',
+      mark: 'band'
+    }]
+  }));
+
+  const feature = app.extractedFeatures.find((candidate) => (
+    candidate.type === 'CDS' && app.canEditFeatureColor(candidate)
+  )) || app.extractedFeatures.find((candidate) => app.canEditFeatureColor(candidate));
+  if (!feature) throw new Error('No editable Feature is available for the round-trip contract.');
+  const featureId = String(feature.svg_id || feature.id || '');
+  const fillApplied = await app.setFeatureColorValue(
+    feature,
+    '#7c3aed',
+    'Saved direct fill'
+  );
+  app.openFeatureEditorFromList(feature, { clientX: 200, clientY: 200 });
+  const strokeApplied = await app.updateClickedFeatureStroke('#111827', 4);
+
+  const labelFeature = app.extractedFeatures.find((candidate) => (
+    app.getEditableLabelByFeatureId(String(candidate.svg_id || candidate.id || ''))
+  ));
+  if (!labelFeature) throw new Error('No editable Feature label is available for the contract.');
+  const labelFeatureId = String(labelFeature.svg_id || labelFeature.id || '');
+  const labelRequested = await app.requestLabelTextChangeByFeatureId(
+    labelFeatureId,
+    'Saved direct label'
+  );
+  await app.handleLabelTextScopeChoice('single');
+  app.openFeatureEditorFromList(labelFeature, { clientX: 220, clientY: 220 });
+  if (!app.clickedFeature?.hasEditableLabel) {
+    throw new Error('The selected Feature label could not be opened for direct editing.');
+  }
+  app.clickedFeature.labelText = 'Saved direct label';
+  app.clickedFeature.labelVisibility = 'off';
+  await app.updateClickedFeatureLabelText();
+  const labelVisibilityApplied = state.labelVisibilityOverrides[labelFeatureId] === 'off';
+  const visibilityApplied = await app.setFeatureVisibility(
+    feature,
+    'off',
+    { triggerReflow: false, scope: { id: 'feature' } }
+  );
+  state.legendColorOverrides['Saved direct fill'] = '#7c3aed';
+  state.legendStrokeOverrides['Saved direct fill'] = {
+    strokeColor: '#111827',
+    strokeWidth: 4
+  };
+  state.clickedFeature.value = null;
+
+  await new Promise((resolveFrame) => (
+    requestAnimationFrame(() => requestAnimationFrame(resolveFrame))
+  ));
+  const fillOverrideKey = Object.keys(state.featureColorOverrides).find((key) => (
+    state.featureColorOverrides[key]?.color === '#7c3aed'
+  ));
+  const strokeOverrideKey = Object.keys(state.featureStrokeOverrides).find((key) => (
+    state.featureStrokeOverrides[key]?.strokeColor === '#111827'
+  ));
+  return {
+    featureId,
+    labelFeatureId,
+    fillOverrideKey,
+    strokeOverrideKey,
+    fillApplied,
+    strokeApplied,
+    labelRequested,
+    labelVisibilityApplied,
+    visibilityApplied,
+    undoCount: history.getUndoCount()
+  };
+});
+
+test.describe.configure({ mode: 'serial' });
+
+test('no-draft session preserves preview, active config, canonical request, and catalog', async ({
+  page,
+  context
+}, testInfo) => {
+  test.setTimeout(420_000);
+  await openIntentApp(page);
+  await loadCurrentSession(page, sourceSessionPath, sourceSession);
+  const initiallyLoaded = await capturePageEvidence(page);
+
+  const generatedA = await runGenerate(page);
+  const sourceFixtureToSeed = svgEquivalence(initiallyLoaded.svg, generatedA.svg);
+  const firstSave = await saveCurrentSession(page, 'intent-no-draft-first');
+  const firstCanonical = sessionCanonicalEvidence(firstSave.session);
+
+  const freshPage = await context.newPage();
+  await openIntentApp(freshPage);
+  await loadCurrentSession(freshPage, firstSave.path, firstSave.session);
+  const reloadedA = await capturePageEvidence(freshPage);
+  expect(reloadedA.active).toEqual(generatedA.active);
+  expect(reloadedA.featureCatalog).toEqual(generatedA.featureCatalog);
+  const savedToLoaded = expectSvgEquivalent(
+    generatedA.svg,
+    reloadedA.svg,
+    'saved generated preview versus fresh load'
+  );
+
+  const generatedAPrime = await runGenerate(freshPage);
+  const firstToRegenerated = expectSvgEquivalent(
+    generatedA.svg,
+    generatedAPrime.svg,
+    'no-draft Generate A versus A prime'
+  );
+  const secondSave = await saveCurrentSession(freshPage, 'intent-no-draft-second');
+  const secondCanonical = sessionCanonicalEvidence(secondSave.session);
+  expect(secondCanonical).toEqual(firstCanonical);
+  expect(generatedAPrime.featureCatalog).toEqual(generatedA.featureCatalog);
+
+  await testInfo.attach('session-regenerate-no-draft.json', {
+    body: Buffer.from(JSON.stringify({
+      sourceFixtureToSeed,
+      savedToLoaded,
+      firstToRegenerated,
+      firstCanonical,
+      secondCanonical,
+      activeIntentSha256: jsonDigest(generatedA.active),
+      featureCatalog: generatedA.featureCatalog
+    }, null, 2)),
+    contentType: 'application/json'
+  });
+  await freshPage.close();
+});
+
+test('divergent draft and direct editor overrides survive repeated Save, Load, and Generate', async ({
+  page,
+  context
+}, testInfo) => {
+  test.setTimeout(600_000);
+  await openIntentApp(page);
+  await loadCurrentSession(page, sourceSessionPath, sourceSession);
+  const generatedA = await runGenerate(page);
+  const actions = await applyDivergentDraft(page);
+  expect(actions).toMatchObject({
+    fillApplied: true,
+    strokeApplied: true,
+    labelRequested: true,
+    labelVisibilityApplied: true,
+    visibilityApplied: true
+  });
+  expect(actions.undoCount).toBeGreaterThan(0);
+
+  const savedDraftIntent = await capturePageEvidence(page);
+  expect(savedDraftIntent.active.palette).toMatchObject({
+    selected: 'orange',
+    instantPreview: false,
+    pendingName: 'orange'
+  });
+  expect(savedDraftIntent.active.palette.currentColors).toMatchObject({
+    CDS: '#0b4f6c',
+    tRNA: '#f59e0b'
+  });
+  expect(savedDraftIntent.active.specificRules).toEqual(expect.arrayContaining([
+    expect.objectContaining({ val: '^ND2$', color: '#dc2626' })
+  ]));
+  expect(savedDraftIntent.active.annotations.map(({ id }) => id)).toContain(
+    'saved-regenerate-annotations'
+  );
+  expect(savedDraftIntent.active.editorOverrides).toMatchObject({
+    fills: { [actions.fillOverrideKey]: expect.objectContaining({ color: '#7c3aed' }) },
+    strokes: {
+      [actions.strokeOverrideKey]: expect.objectContaining({ strokeColor: '#111827' })
+    },
+    visibility: { [actions.featureId]: 'off' },
+    labelText: { [actions.labelFeatureId]: 'Saved direct label' },
+    labelVisibility: { [actions.labelFeatureId]: 'off' }
+  });
+
+  const divergentSave = await saveCurrentSession(page, 'intent-divergent-draft');
+  expect(divergentSave.session.config.palette).toBe('orange');
+  expect(divergentSave.session.config.colors).toMatchObject({
+    CDS: '#0b4f6c',
+    tRNA: '#f59e0b'
+  });
+  expect(divergentSave.session.renderRequest.diagramOptions.colors.defaultColorsPalette).toBe(
+    sourceSession.renderRequest.diagramOptions.colors.defaultColorsPalette
+  );
+
+  const expectedB = await runGenerate(page);
+  expect(svgEquivalence(expectedB.svg, generatedA.svg).semantic).toBe(false);
+  const expectedBSave = await saveCurrentSession(page, 'intent-expected-b');
+  const expectedBCanonical = sessionCanonicalEvidence(expectedBSave.session);
+
+  const freshPage = await context.newPage();
+  await openIntentApp(freshPage);
+  await loadCurrentSession(freshPage, divergentSave.path, divergentSave.session);
+  const loadedDraft = await capturePageEvidence(freshPage);
+  expect(loadedDraft.active).toEqual(savedDraftIntent.active);
+  expectSvgEquivalent(
+    loadedDraft.svg,
+    savedDraftIntent.svg,
+    'divergent session must retain the saved committed preview'
+  );
+  expect(svgEquivalence(loadedDraft.svg, expectedB.svg).visual).toBe(false);
+  expect(loadedDraft.history).toMatchObject({
+    undoCount: 0,
+    redoCount: 0,
+    currentCheckpointAbsent: true,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0
+  });
+  await freshPage.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    window.__GBDRAW_LOADED_DRAFT_CONTENT__ = String(
+      app.results?.[app.selectedResultIndex]?.content || ''
+    );
+  });
+
+  const beforeGenerateHistory = await freshPage.evaluate(() => (
+    window.__GBDRAW_HISTORY__.getDiagnostics()
+  ));
+  const actualBPrime = await runGenerate(freshPage);
+  const expectedToActual = expectSvgEquivalent(
+    expectedB.svg,
+    actualBPrime.svg,
+    'expected B versus actual B prime after loading the divergent draft'
+  );
+  expect(actualBPrime.active.editorOverrides).toEqual(
+    expectedB.active.editorOverrides
+  );
+  const actualBSave = await saveCurrentSession(freshPage, 'intent-actual-b');
+  const actualBCanonical = sessionCanonicalEvidence(actualBSave.session);
+  expect(actualBCanonical).toEqual(expectedBCanonical);
+  const afterGenerateHistory = await freshPage.evaluate(() => ({
+    diagnostics: window.__GBDRAW_HISTORY__.getDiagnostics(),
+    undoCount: window.__GBDRAW_HISTORY__.getUndoCount(),
+    redoCount: window.__GBDRAW_HISTORY__.getRedoCount()
+  }));
+  expect(afterGenerateHistory.undoCount).toBe(1);
+  expect(afterGenerateHistory.redoCount).toBe(0);
+  expect(
+    Number(afterGenerateHistory.diagnostics.artifactCheckpointBuilds || 0) -
+      Number(beforeGenerateHistory.artifactCheckpointBuilds || 0)
+  ).toBe(0);
+  expect(
+    Number(afterGenerateHistory.diagnostics.generatedArtifactFullCloneCount || 0) -
+      Number(beforeGenerateHistory.generatedArtifactFullCloneCount || 0)
+  ).toBe(0);
+
+  const undoRedo = await freshPage.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const history = window.__GBDRAW_HISTORY__;
+    const content = () => String(app.results?.[app.selectedResultIndex]?.content || '');
+    const generated = content();
+    const undo = await history.undo();
+    const loaded = content();
+    const redo = await history.redo();
+    return {
+      undo,
+      redo,
+      loadedRestored: loaded === window.__GBDRAW_LOADED_DRAFT_CONTENT__,
+      generatedRestored: content() === generated,
+      undoCount: history.getUndoCount(),
+      redoCount: history.getRedoCount()
+    };
+  });
+  expect(undoRedo).toMatchObject({
+    undo: true,
+    redo: true,
+    loadedRestored: true,
+    generatedRestored: true,
+    undoCount: 1,
+    redoCount: 0
+  });
+
+  const undoCountBeforeWarmGenerate = await freshPage.evaluate(() => (
+    window.__GBDRAW_HISTORY__.getUndoCount()
+  ));
+  const warmBPrime = await runGenerate(freshPage);
+  expectSvgEquivalent(actualBPrime.svg, warmBPrime.svg, 'unchanged warm Generate');
+  expect(await freshPage.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(
+    undoCountBeforeWarmGenerate
+  );
+  const worker = await getDiagramWorkerActivity(freshPage);
+  expect(worker.constructions).toBe(1);
+  expect(worker.initializations).toBe(1);
+  expect(worker.runs).toBe(2);
+  expect(worker.instances[0].runs).toHaveLength(2);
+  expect(worker.instances[0].runs[1].stagedResourceBytes).toBeLessThan(1_024);
+  expect(worker.instances[0].runs[1].stagedResourceBytes).toBeLessThan(
+    worker.instances[0].runs[1].referencedDeclaredBytes
+  );
+  expect(worker.instances[0].runs[1].transferredBytes).toBe(
+    worker.instances[0].runs[1].stagedResourceBytes
+  );
+
+  const repeatedSave = await saveCurrentSession(freshPage, 'intent-repeated-b');
+  const activeBeforeRepeatedLoad = await capturePageEvidence(freshPage);
+
+  const repeatedPage = await context.newPage();
+  await openIntentApp(repeatedPage);
+  await loadCurrentSession(repeatedPage, repeatedSave.path, repeatedSave.session);
+  const repeatedLoad = await capturePageEvidence(repeatedPage);
+  expect(repeatedLoad.active).toEqual(activeBeforeRepeatedLoad.active);
+  expect(repeatedLoad.featureCatalog).toEqual(activeBeforeRepeatedLoad.featureCatalog);
+  expectSvgEquivalent(
+    repeatedLoad.svg,
+    activeBeforeRepeatedLoad.svg,
+    'second saved preview versus second load'
+  );
+  const repeatedGenerate = await runGenerate(repeatedPage);
+  const repeatedComparison = expectSvgEquivalent(
+    actualBPrime.svg,
+    repeatedGenerate.svg,
+    'repeated Save, Load, and Generate'
+  );
+  expect(repeatedGenerate.active.editorOverrides).toEqual(
+    activeBeforeRepeatedLoad.active.editorOverrides
+  );
+
+  await testInfo.attach('session-regenerate-divergent.json', {
+    body: Buffer.from(JSON.stringify({
+      actions,
+      expectedToActual,
+      repeatedComparison,
+      savedDraftIntentSha256: jsonDigest(savedDraftIntent.active),
+      loadedDraftIntentSha256: jsonDigest(loadedDraft.active),
+      expectedBCanonical,
+      actualBCanonical,
+      worker: {
+        constructions: worker.constructions,
+        initializations: worker.initializations,
+        runs: worker.instances[0].runs
+      }
+    }, null, 2)),
+    contentType: 'application/json'
+  });
+  await freshPage.close();
+  await repeatedPage.close();
+});
+
+test('bare legacy configuration drives the next canonical request and SVG', async ({ page }) => {
+  test.setTimeout(300_000);
+  await openIntentApp(page);
+  await loadCurrentSession(page, sourceSessionPath, sourceSession);
+  const baseline = await capturePageEvidence(page);
+  const legacyImport = await page.evaluate(async () => {
+    const legacyConfig = {
+      form: {
+        plot_title: 'Legacy JSON Generate',
+        labels_mode: 'both',
+        show_scale: false
+      },
+      adv: {
+        axis_stroke_width: 8,
+        label_font_size: 25,
+        feature_width_circular: 22
+      },
+      colors: { CDS: '#0b4f6c', tRNA: '#f59e0b' },
+      palette: 'orange',
+      paletteInstantPreviewEnabled: true,
+      rules: [{
+        feat: 'CDS',
+        qual: 'gene',
+        val: '^ND3$',
+        color: '#be123c',
+        cap: 'Legacy ND3',
+        fromFile: false
+      }],
+      qualifierPriorityRules: [{ feat: 'CDS', order: 'product,gene' }],
+      filterMode: 'Blacklist',
+      whitelist: [{ feat: 'CDS', qual: 'gene', key: 'ND3' }],
+      blacklistText: 'legacy-hidden'
+    };
+    const result = await window.__GBDRAW_APP__.importSession({
+      target: {
+        files: [new File(
+          [JSON.stringify(legacyConfig)],
+          'legacy-regenerate-config.json',
+          { type: 'application/json' }
+        )],
+        value: 'selected'
+      }
+    });
+    return { status: result?.status };
+  });
+  expect(legacyImport).toEqual({ status: 'legacy' });
+  const loadedLegacyIntent = await capturePageEvidence(page);
+  expect(loadedLegacyIntent.active).toMatchObject({
+    palette: {
+      selected: 'orange',
+      currentColors: { CDS: '#0b4f6c', tRNA: '#f59e0b' },
+      appliedName: 'orange',
+      pendingName: ''
+    },
+    filters: {
+      mode: 'Blacklist',
+      blacklistText: 'legacy-hidden'
+    },
+    form: {
+      plot_title: 'Legacy JSON Generate',
+      labels_mode: 'both',
+      show_scale: false
+    },
+    adv: {
+      axis_stroke_width: 8,
+      label_font_size: 25,
+      feature_width_circular: 22
+    }
+  });
+
+  const generated = await runGenerate(page);
+  expect(svgEquivalence(generated.svg, baseline.svg).visual).toBe(false);
+  const saved = await saveCurrentSession(page, 'legacy-config-generated');
+  expect(saved.session.config).toMatchObject({
+    palette: 'orange',
+    colors: { CDS: '#0b4f6c', tRNA: '#f59e0b' },
+    filterMode: 'Blacklist',
+    blacklistText: 'legacy-hidden',
+    form: {
+      plot_title: 'Legacy JSON Generate',
+      labels_mode: 'both',
+      show_scale: false
+    },
+    adv: {
+      axis_stroke_width: 8,
+      label_font_size: 25,
+      feature_width_circular: 22
+    }
+  });
+  expect(saved.session.config.rules).toEqual([
+    expect.objectContaining({ val: '^ND3$', color: '#be123c' })
+  ]);
+  expect(saved.session.config.qualifierPriorityRules).toEqual([
+    { feat: 'CDS', order: 'product,gene' }
+  ]);
+  const colors = saved.session.renderRequest.diagramOptions.colors;
+  const defaultColorRef = colors.defaultColorsFile || colors.defaultColors;
+  expect(defaultColorRef?.resourceId).toBeTruthy();
+  const defaultColorResource = saved.session.resources[defaultColorRef.resourceId];
+  const defaultColorText = Buffer.from(defaultColorResource.data, 'base64').toString('utf8');
+  expect(defaultColorText).toContain('CDS\t#0b4f6c');
+  expect(defaultColorText).toContain('tRNA\t#f59e0b');
+});

--- a/tests/web/contracts/session-regenerate-intent.playwright.spec.js
+++ b/tests/web/contracts/session-regenerate-intent.playwright.spec.js
@@ -20,6 +20,14 @@ const sourceSessionPath = join(
 const sourceSession = JSON.parse(readFileSync(sourceSessionPath, 'utf8'));
 const sessionInputSelector =
   'input[type="file"][accept*="application/json"][accept*="application/gzip"]';
+const DIRECT_FILL = '#c026d3';
+const DIRECT_STROKE = '#059669';
+const DIRECT_STROKE_WIDTH = 5;
+const DIRECT_LABEL_TEXT = 'Loaded preview direct label';
+const DIRECT_LEGEND_COLOR = '#f43f5e';
+const DIRECT_LEGEND_STROKE = '#1d4ed8';
+const DIRECT_LEGEND_STROKE_WIDTH = 3;
+const DIRECT_REGENERATED_TITLE = 'Loaded preview direct edit regeneration';
 
 const ACTIVE_CONFIG_DOMAINS = Object.freeze([
   'form',
@@ -195,6 +203,567 @@ const saveCurrentSession = async (page, title) => {
     renderRequest: { schema: 5 }
   });
   return { path, session };
+};
+
+const settleMountedDom = (page) => page.evaluate(() => new Promise((resolveFrame) => (
+  requestAnimationFrame(() => requestAnimationFrame(resolveFrame))
+)));
+
+const diagramWorkerResourceBytes = (activity) => (
+  (activity.instances || []).reduce((total, instance) => (
+    total
+    + (instance.helpers || []).reduce(
+      (helperTotal, helper) => helperTotal + Number(helper.transferredBytes || 0),
+      0
+    )
+    + (instance.runs || []).reduce(
+      (runTotal, run) => runTotal + Number(run.transferredBytes || 0),
+      0
+    )
+  ), 0)
+);
+
+const captureIdleWorkerStage = async (page, label, evidence) => {
+  const activity = await getDiagramWorkerActivity(page);
+  const stage = {
+    label,
+    constructions: activity.constructions,
+    initializations: activity.initializations,
+    helpers: activity.helpers,
+    runs: activity.runs,
+    transferredResourceBytes: diagramWorkerResourceBytes(activity)
+  };
+  expect(stage, `${label}: diagram Worker must remain idle`).toEqual({
+    label,
+    constructions: 0,
+    initializations: 0,
+    helpers: 0,
+    runs: 0,
+    transferredResourceBytes: 0
+  });
+  evidence.push(stage);
+  return activity;
+};
+
+const prepareLoadedPreviewDirectEditTarget = (page, expected = null) => page.evaluate(
+  async (expectedTarget) => {
+    const { state } = await import('/gbdraw/web/js/state.js');
+    const { featureOverrideKey } = await import(
+      '/gbdraw/web/js/services/feature-override-identity.js'
+    );
+    const { serializeCleanSvg } = await import(
+      '/gbdraw/web/js/services/svg-serialization.js'
+    );
+    const app = window.__GBDRAW_APP__;
+    const svg = state.svgContainer.value?.querySelector?.('svg');
+    if (!svg) throw new Error('The loaded session did not mount its committed SVG preview.');
+
+    const featureId = (feature) => String(
+      feature?.rendered_svg_id
+      || feature?.renderedSvgId
+      || feature?.rendered_feature_svg_id
+      || feature?.renderedFeatureSvgId
+      || feature?.svg_id
+      || feature?.id
+      || ''
+    ).trim();
+    const hasFeatureElement = (id) => Boolean(
+      svg.querySelector(`[data-gbdraw-feature-id="${CSS.escape(id)}"]`)
+      || svg.querySelector(`[data-gbdraw-rendered-feature-id="${CSS.escape(id)}"]`)
+      || svg.querySelector(`#${CSS.escape(id)}`)
+      || svg.querySelector(`[id^="${CSS.escape(id)}__"]`)
+    );
+    const hasLegendEntry = (caption) => Boolean(
+      svg.querySelector(`g[data-legend-key="${CSS.escape(caption)}"]`)
+    );
+
+    let feature = null;
+    let fillLegendEntry = null;
+    if (expectedTarget) {
+      feature = app.extractedFeatures.find(
+        (candidate) => featureId(candidate) === expectedTarget.featureId
+      );
+      fillLegendEntry = app.legendEntries.find(
+        (entry) => entry.caption === expectedTarget.fillLegendCaption
+      );
+    } else {
+      const groupedEntries = app.legendEntries.filter((entry) => (
+        Array.isArray(entry?.featureIds)
+        && entry.featureIds.length > 1
+        && hasLegendEntry(String(entry.caption || ''))
+      ));
+      for (const entry of groupedEntries) {
+        feature = app.extractedFeatures.find((candidate) => (
+          entry.featureIds.includes(featureId(candidate))
+          && app.canEditFeatureColor(candidate)
+          && hasFeatureElement(featureId(candidate))
+        ));
+        if (feature) {
+          fillLegendEntry = entry;
+          break;
+        }
+      }
+      if (!feature) {
+        fillLegendEntry = app.legendEntries.find(
+          (entry) => hasLegendEntry(String(entry?.caption || ''))
+        ) || null;
+        feature = app.extractedFeatures.find((candidate) => (
+          app.canEditFeatureColor(candidate) && hasFeatureElement(featureId(candidate))
+        ));
+      }
+    }
+    if (!feature || !fillLegendEntry) {
+      throw new Error('No loaded Feature with a supported legend entry is editable.');
+    }
+
+    const labelFeature = expectedTarget
+      ? app.extractedFeatures.find(
+          (candidate) => featureId(candidate) === expectedTarget.labelFeatureId
+        ) || null
+      : [...app.extractedFeatures].reverse().find((candidate) => (
+          hasFeatureElement(featureId(candidate))
+          && app.getEditableLabelByFeatureId(featureId(candidate))
+        )) || null;
+    const labelEntry = labelFeature
+      ? app.getEditableLabelByFeatureId(featureId(labelFeature))
+      : null;
+    const labelVisibilityFeature = expectedTarget
+      ? app.extractedFeatures.find(
+          (candidate) => featureId(candidate) === expectedTarget.labelVisibilityFeatureId
+        ) || null
+      : null;
+    const labelVisibilityEntry = labelVisibilityFeature
+      ? app.getEditableLabelByFeatureId(featureId(labelVisibilityFeature))
+      : null;
+
+    const visibilityFeature = expectedTarget
+      ? app.extractedFeatures.find(
+          (candidate) => featureId(candidate) === expectedTarget.visibilityFeatureId
+        ) || null
+      : app.extractedFeatures.find((candidate) => (
+          featureId(candidate) !== featureId(feature)
+          && hasFeatureElement(featureId(candidate))
+        )) || null;
+    if (!visibilityFeature) {
+      throw new Error('No second loaded Feature is available for visibility editing.');
+    }
+
+    const legendEntry = expectedTarget
+      ? app.legendEntries.find((entry) => entry.caption === expectedTarget.legendCaption)
+      : app.legendEntries.find((entry) => (
+          entry.caption !== fillLegendEntry.caption
+          && hasLegendEntry(String(entry?.caption || ''))
+        )) || fillLegendEntry;
+    if (!legendEntry) throw new Error('No editable loaded legend entry is available.');
+
+    const target = {
+      feature,
+      featureId: featureId(feature),
+      featureOverrideKey: featureOverrideKey(feature),
+      featureRecordKey: String(feature.record_key || feature.recordKey || ''),
+      biologicalFeatureId: String(
+        feature.biological_feature_id || feature.biologicalFeatureId || ''
+      ),
+      visibilityFeature,
+      visibilityFeatureId: featureId(visibilityFeature),
+      visibilityFeatureOverrideKey: featureOverrideKey(visibilityFeature),
+      fillLegendCaption: String(fillLegendEntry.caption || ''),
+      labelFeature,
+      labelFeatureId: labelFeature ? featureId(labelFeature) : String(
+        expectedTarget?.labelFeatureId || ''
+      ),
+      labelKey: String(labelEntry?.key || expectedTarget?.labelKey || ''),
+      labelVisibilityFeature,
+      labelVisibilityFeatureId: labelVisibilityFeature
+        ? featureId(labelVisibilityFeature)
+        : String(expectedTarget?.labelVisibilityFeatureId || ''),
+      labelVisibilityKey: String(
+        labelVisibilityEntry?.key || expectedTarget?.labelVisibilityKey || ''
+      ),
+      legendCaption: String(legendEntry.caption || ''),
+      baselineMountedContent: serializeCleanSvg(svg),
+      loadedResultContent: String(
+        state.results.value[state.selectedResultIndex.value]?.content || ''
+      )
+    };
+    if (!target.featureOverrideKey) {
+      throw new Error('The loaded Feature has no stable compound override identity.');
+    }
+    window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__ = target;
+    return {
+      featureId: target.featureId,
+      featureOverrideKey: target.featureOverrideKey,
+      featureRecordKey: target.featureRecordKey,
+      biologicalFeatureId: target.biologicalFeatureId,
+      visibilityFeatureId: target.visibilityFeatureId,
+      visibilityFeatureOverrideKey: target.visibilityFeatureOverrideKey,
+      fillLegendCaption: target.fillLegendCaption,
+      labelFeatureId: target.labelFeatureId,
+      labelKey: target.labelKey,
+      labelVisibilityFeatureId: target.labelVisibilityFeatureId,
+      labelVisibilityKey: target.labelVisibilityKey,
+      legendCaption: target.legendCaption
+    };
+  },
+  expected
+);
+
+const bindLoadedPreviewDirectEditLabel = (page, expected = null) => page.evaluate(
+  async (expectedTarget) => {
+    const { state } = await import('/gbdraw/web/js/state.js');
+    const { serializeCleanSvg } = await import(
+      '/gbdraw/web/js/services/svg-serialization.js'
+    );
+    const app = window.__GBDRAW_APP__;
+    const target = window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__;
+    const svg = state.svgContainer.value?.querySelector?.('svg');
+    if (!target || !svg) throw new Error('The loaded direct-edit preview is unavailable.');
+    const featureId = (feature) => String(feature?.svg_id || feature?.id || '').trim();
+    const resolveTargets = () => {
+      const candidates = app.extractedFeatures.filter((candidate) => (
+        featureId(candidate) !== target.visibilityFeatureId
+        && app.getEditableLabelByFeatureId(featureId(candidate))
+      ));
+      const labelFeature = expectedTarget?.labelFeatureId
+        ? candidates.find(
+            (candidate) => featureId(candidate) === expectedTarget.labelFeatureId
+          )
+        : candidates[0];
+      const labelVisibilityFeature = expectedTarget?.labelVisibilityFeatureId
+        ? candidates.find(
+            (candidate) => featureId(candidate) === expectedTarget.labelVisibilityFeatureId
+          )
+        : [...candidates].reverse().find(
+            (candidate) => featureId(candidate) !== featureId(labelFeature)
+          );
+      return {
+        labelFeature,
+        labelEntry: labelFeature
+          ? app.getEditableLabelByFeatureId(featureId(labelFeature))
+          : null,
+        labelVisibilityFeature,
+        labelVisibilityEntry: labelVisibilityFeature
+          ? app.getEditableLabelByFeatureId(featureId(labelVisibilityFeature))
+          : null
+      };
+    };
+    let resolved = resolveTargets();
+    if (!resolved.labelEntry || !resolved.labelVisibilityEntry) {
+      app.openFeatureEditorFromList(target.feature, { clientX: 200, clientY: 200 });
+      resolved = resolveTargets();
+    }
+    if (
+      !resolved.labelFeature || !resolved.labelEntry?.key ||
+      !resolved.labelVisibilityFeature || !resolved.labelVisibilityEntry?.key
+    ) {
+      throw new Error('Opening the loaded Feature did not initialize two editable label bindings.');
+    }
+    target.labelFeature = resolved.labelFeature;
+    target.labelFeatureId = featureId(resolved.labelFeature);
+    target.labelKey = String(resolved.labelEntry.key || '');
+    target.labelVisibilityFeature = resolved.labelVisibilityFeature;
+    target.labelVisibilityFeatureId = featureId(resolved.labelVisibilityFeature);
+    target.labelVisibilityKey = String(resolved.labelVisibilityEntry.key || '');
+    target.baselineMountedContent = serializeCleanSvg(svg);
+    target.loadedResultContent = String(
+      state.results.value[state.selectedResultIndex.value]?.content || ''
+    );
+    return {
+      labelFeatureId: target.labelFeatureId,
+      labelKey: target.labelKey,
+      labelVisibilityFeatureId: target.labelVisibilityFeatureId,
+      labelVisibilityKey: target.labelVisibilityKey
+    };
+  },
+  expected
+);
+
+const startLoadedPreviewDirectEditProbe = (page) => page.evaluate(async () => {
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const owned = (value) => (
+    typeof window.Vue.toRaw === 'function' ? window.Vue.toRaw(value) : value
+  );
+  const counters = {
+    directEditResultFlushCount: 0,
+    directEditSvgSerializationCount: 0,
+    directEditFeatureCatalogReplacementCount: 0,
+    directEditExtractedFeatureReplacementCount: 0,
+    directEditBiologicalFeatureReplacementCount: 0,
+    directEditOrthogroupReplacementCount: 0
+  };
+  const ownerCounters = {
+    featureCatalog: 'directEditFeatureCatalogReplacementCount',
+    extractedFeatures: 'directEditExtractedFeatureReplacementCount',
+    biologicalFeatures: 'directEditBiologicalFeatureReplacementCount',
+    orthogroups: 'directEditOrthogroupReplacementCount'
+  };
+  const ownerRefs = {
+    featureCatalog: state.featureCatalog,
+    extractedFeatures: state.extractedFeatures,
+    biologicalFeatures: state.biologicalFeatures,
+    orthogroups: state.orthogroups
+  };
+  let active = true;
+  const stopOwnerWatches = Object.entries(ownerCounters).map(([owner, counter]) => (
+    window.Vue.watch(
+      () => ownerRefs[owner].value,
+      (value, previousValue) => {
+        if (active && owned(value) !== owned(previousValue)) counters[counter] += 1;
+      },
+      { flush: 'sync' }
+    )
+  ));
+
+  const nativeSerializeToString = XMLSerializer.prototype.serializeToString;
+  const trackedSerializeToString = function trackedSerializeToString(...args) {
+    if (active && String(args[0]?.localName || '').toLowerCase() === 'svg') {
+      counters.directEditSvgSerializationCount += 1;
+    }
+    return nativeSerializeToString.apply(this, args);
+  };
+  XMLSerializer.prototype.serializeToString = trackedSerializeToString;
+
+  const stopResultWatch = window.Vue.watch(
+    () => state.results.value[state.selectedResultIndex.value]?.content,
+    (content, previousContent) => {
+      if (active && content !== previousContent) counters.directEditResultFlushCount += 1;
+    },
+    { flush: 'sync' }
+  );
+  window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_PROBE__ = {
+    snapshot() {
+      return { ...counters };
+    },
+    stop() {
+      active = false;
+      stopResultWatch();
+      stopOwnerWatches.forEach((stopWatch) => stopWatch());
+      if (XMLSerializer.prototype.serializeToString === trackedSerializeToString) {
+        XMLSerializer.prototype.serializeToString = nativeSerializeToString;
+      }
+      return { ...counters };
+    }
+  };
+  return window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_PROBE__.snapshot();
+});
+
+const captureLoadedPreviewDirectEditState = (page) => page.evaluate(async () => {
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const { featureOverrideKey } = await import(
+    '/gbdraw/web/js/services/feature-override-identity.js'
+  );
+  const target = window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__;
+  if (!target) throw new Error('The loaded-preview direct-edit target is not configured.');
+  const svg = state.svgContainer.value?.querySelector?.('svg');
+  if (!svg) throw new Error('The loaded SVG preview is no longer mounted.');
+  const resultContent = String(
+    state.results.value[state.selectedResultIndex.value]?.content || ''
+  );
+  const resultDocument = new DOMParser().parseFromString(resultContent, 'image/svg+xml');
+  const resultSvg = resultDocument.documentElement;
+  if (!resultSvg || resultSvg.localName === 'parsererror') {
+    throw new Error('The selected Result no longer contains valid SVG.');
+  }
+  const digest = async (value) => {
+    const bytes = new TextEncoder().encode(String(value || ''));
+    const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+    return [...hash].map((entry) => entry.toString(16).padStart(2, '0')).join('');
+  };
+  const renderedFeatureId = (feature) => String(
+    feature?.rendered_svg_id
+    || feature?.renderedSvgId
+    || feature?.rendered_feature_svg_id
+    || feature?.renderedFeatureSvgId
+    || feature?.svg_id
+    || feature?.id
+    || ''
+  ).trim();
+  const currentFeature = state.extractedFeatures.value.find(
+    (feature) => featureOverrideKey(feature) === target.featureOverrideKey
+  );
+  const currentVisibilityFeature = state.extractedFeatures.value.find(
+    (feature) => featureOverrideKey(feature) === target.visibilityFeatureOverrideKey
+  );
+  const featureIds = Array.from(new Set([
+    target.featureId,
+    renderedFeatureId(currentFeature)
+  ].filter(Boolean)));
+  const visibilityFeatureIds = Array.from(new Set([
+    target.visibilityFeatureId,
+    renderedFeatureId(currentVisibilityFeature)
+  ].filter(Boolean)));
+  const collectFeatureElements = (root, ids) => {
+    const elements = ids.flatMap((featureId) => {
+      const escaped = CSS.escape(featureId);
+      return [
+        ...root.querySelectorAll(`[data-gbdraw-feature-id="${escaped}"]`),
+        ...root.querySelectorAll(`[data-gbdraw-rendered-feature-id="${escaped}"]`),
+        ...root.querySelectorAll(`#${escaped}`),
+        ...root.querySelectorAll(`[id^="${escaped}__"]`)
+      ];
+    });
+    return Array.from(new Set(elements));
+  };
+  const featureAttributes = (root, ids) => collectFeatureElements(root, ids).map(
+    (element) => ({
+      id: String(element.id || ''),
+      part: String(element.getAttribute('data-gbdraw-feature-part') || ''),
+      fill: element.getAttribute('fill'),
+      stroke: element.getAttribute('stroke'),
+      strokeWidth: element.getAttribute('stroke-width'),
+      display: element.getAttribute('display')
+    })
+  );
+  const labelAttributes = (root, featureId, expectedText = '') => {
+    const element = root.querySelector(
+      `text[data-label-feature-id="${CSS.escape(featureId)}"]`
+    ) || (expectedText
+      ? Array.from(root.querySelectorAll('text')).find(
+          (candidate) => String(candidate.textContent || '') === expectedText
+        )
+      : null);
+    return element
+      ? { text: String(element.textContent || ''), display: element.getAttribute('display') }
+      : null;
+  };
+  const legendAttributes = (root) => {
+    const group = root.querySelector(
+      `g[data-legend-key="${CSS.escape(target.legendCaption)}"]`
+    );
+    const swatch = Array.from(group?.querySelectorAll?.('path') || []).find((path) => {
+      const fill = path.getAttribute('fill');
+      return fill && fill !== 'none' && !fill.startsWith('url(');
+    });
+    return swatch
+      ? {
+          fill: swatch.getAttribute('fill'),
+          stroke: swatch.getAttribute('stroke'),
+          strokeWidth: swatch.getAttribute('stroke-width')
+        }
+      : null;
+  };
+  const plain = (value) => JSON.parse(JSON.stringify(value ?? null));
+  const historyDiagnostics = window.__GBDRAW_HISTORY__.getDiagnostics();
+  const baselineDifferenceIndex = (() => {
+    const baseline = String(target.baselineMountedContent || '');
+    const length = Math.min(baseline.length, resultContent.length);
+    for (let index = 0; index < length; index += 1) {
+      if (baseline[index] !== resultContent[index]) return index;
+    }
+    return baseline.length === resultContent.length ? -1 : length;
+  })();
+  return {
+    identity: {
+      featureOverrideKey: target.featureOverrideKey,
+      originalFeatureId: target.featureId,
+      currentFeatureId: renderedFeatureId(currentFeature),
+      featureIds,
+      visibilityFeatureOverrideKey: target.visibilityFeatureOverrideKey,
+      originalVisibilityFeatureId: target.visibilityFeatureId,
+      currentVisibilityFeatureId: renderedFeatureId(currentVisibilityFeature),
+      visibilityFeatureIds
+    },
+    result: {
+      characters: resultContent.length,
+      sha256: await digest(resultContent),
+      baselineCharacters: String(target.baselineMountedContent || '').length,
+      baselineSha256: await digest(target.baselineMountedContent),
+      baselineDifferenceIndex,
+      baselineDifferenceContext: baselineDifferenceIndex < 0
+        ? ''
+        : {
+            baseline: String(target.baselineMountedContent || '').slice(
+              Math.max(0, baselineDifferenceIndex - 80),
+              baselineDifferenceIndex + 160
+            ),
+            result: resultContent.slice(
+              Math.max(0, baselineDifferenceIndex - 80),
+              baselineDifferenceIndex + 160
+            )
+          },
+      equalsBaselineMounted: resultContent === target.baselineMountedContent,
+      equalsLoadedResult: resultContent === target.loadedResultContent
+    },
+    dom: {
+      feature: featureAttributes(svg, featureIds),
+      visibilityFeature: featureAttributes(svg, visibilityFeatureIds),
+      label: labelAttributes(
+        svg,
+        target.labelFeatureId,
+        String(state.labelTextFeatureOverrides[target.labelFeatureId] || '')
+      ),
+      labelVisibility: labelAttributes(svg, target.labelVisibilityFeatureId),
+      legend: legendAttributes(svg)
+    },
+    resultDom: {
+      feature: featureAttributes(resultSvg, featureIds),
+      visibilityFeature: featureAttributes(resultSvg, visibilityFeatureIds),
+      label: labelAttributes(
+        resultSvg,
+        target.labelFeatureId,
+        String(state.labelTextFeatureOverrides[target.labelFeatureId] || '')
+      ),
+      labelVisibility: labelAttributes(resultSvg, target.labelVisibilityFeatureId),
+      legend: legendAttributes(resultSvg)
+    },
+    overrides: {
+      fill: plain(state.featureColorOverrides[target.featureOverrideKey]),
+      stroke: plain(state.featureStrokeOverrides[target.featureOverrideKey]),
+      visibility: state.featureVisibilityOverrides[target.visibilityFeatureId] ?? null,
+      labelText: state.labelTextFeatureOverrides[target.labelFeatureId] ?? null,
+      labelVisibility:
+        state.labelVisibilityOverrides[target.labelVisibilityFeatureId] ?? null,
+      legendColor: state.legendColorOverrides[target.legendCaption] ?? null,
+      legendStroke: plain(state.legendStrokeOverrides[target.legendCaption])
+    },
+    history: {
+      undoCount: window.__GBDRAW_HISTORY__.getUndoCount(),
+      redoCount: window.__GBDRAW_HISTORY__.getRedoCount(),
+      currentCheckpointAbsent: window.__GBDRAW_HISTORY__.getCurrentCheckpoint() === null,
+      artifactReplacementHistoryEntryCount: Number(
+        historyDiagnostics.artifactReplacementHistoryEntryCount || 0
+      ),
+      artifactCheckpointBuilds: Number(historyDiagnostics.artifactCheckpointBuilds || 0),
+      generatedArtifactFullCloneCount: Number(
+        historyDiagnostics.generatedArtifactFullCloneCount || 0
+      ),
+      generatedArtifactFullSerializationCount: Number(
+        historyDiagnostics.generatedArtifactFullSerializationCount || 0
+      )
+    },
+    autoLabelReflowEnabled: state.autoLabelReflowEnabled.value,
+    structural: window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_PROBE__?.snapshot?.() || null
+  };
+});
+
+const expectBiologicalOwnersUnchanged = (snapshot) => {
+  expect(snapshot.structural).toMatchObject({
+    directEditFeatureCatalogReplacementCount: 0,
+    directEditExtractedFeatureReplacementCount: 0,
+    directEditBiologicalFeatureReplacementCount: 0,
+    directEditOrthogroupReplacementCount: 0
+  });
+};
+
+const expectDirectEditFlushed = (before, after) => {
+  expect(after.result.sha256).not.toBe(before.result.sha256);
+  expect(after.structural.directEditResultFlushCount).toBeGreaterThan(
+    before.structural.directEditResultFlushCount
+  );
+  expect(after.structural.directEditSvgSerializationCount).toBeGreaterThan(
+    before.structural.directEditSvgSerializationCount
+  );
+  expect(after.history.artifactReplacementHistoryEntryCount).toBe(
+    before.history.artifactReplacementHistoryEntryCount
+  );
+  expect(after.history.artifactCheckpointBuilds).toBe(before.history.artifactCheckpointBuilds);
+  expect(after.history.generatedArtifactFullCloneCount).toBe(
+    before.history.generatedArtifactFullCloneCount
+  );
+  expect(after.history.generatedArtifactFullSerializationCount).toBe(
+    before.history.generatedArtifactFullSerializationCount
+  );
+  expectBiologicalOwnersUnchanged(after);
 };
 
 const capturePageEvidence = (page) => page.evaluate(async () => {
@@ -653,6 +1222,586 @@ test('no-draft session preserves preview, active config, canonical request, and 
       secondCanonical,
       activeIntentSha256: jsonDigest(generatedA.active),
       featureCatalog: generatedA.featureCatalog
+    }, null, 2)),
+    contentType: 'application/json'
+  });
+  await freshPage.close();
+});
+
+test('loaded current preview supports direct edits before the first Generate', async ({
+  page,
+  context
+}, testInfo) => {
+  test.setTimeout(600_000);
+  const idleWorkerStages = [];
+  const featureBlocks = (snapshot, owner = 'dom') => snapshot[owner].feature.filter(
+    (element) => element.part !== 'connector' && !element.id.includes('__line')
+  );
+  const expectFeatureFill = (snapshot, color) => {
+    const domBlocks = featureBlocks(snapshot);
+    const resultBlocks = featureBlocks(snapshot, 'resultDom');
+    expect(domBlocks.length, JSON.stringify(snapshot.identity)).toBeGreaterThan(0);
+    expect(resultBlocks.length).toBeGreaterThan(0);
+    expect(domBlocks.every((element) => element.fill === color)).toBe(true);
+    expect(resultBlocks.every((element) => element.fill === color)).toBe(true);
+  };
+  const expectFeatureStroke = (snapshot) => {
+    expect(snapshot.dom.feature.length).toBeGreaterThan(0);
+    expect(snapshot.resultDom.feature.length).toBeGreaterThan(0);
+    expect(snapshot.dom.feature.every((element) => (
+      element.stroke === DIRECT_STROKE
+      && Number(element.strokeWidth) === DIRECT_STROKE_WIDTH
+    ))).toBe(true);
+    expect(snapshot.resultDom.feature.every((element) => (
+      element.stroke === DIRECT_STROKE
+      && Number(element.strokeWidth) === DIRECT_STROKE_WIDTH
+    ))).toBe(true);
+  };
+  const expectFeatureHidden = (snapshot, { generated = false } = {}) => {
+    const domFeatures = snapshot.dom.visibilityFeature;
+    const resultFeatures = snapshot.resultDom.visibilityFeature;
+    if (!generated) {
+      expect(domFeatures.length).toBeGreaterThan(0);
+      expect(resultFeatures.length).toBeGreaterThan(0);
+    }
+    expect(domFeatures.every((element) => element.display === 'none')).toBe(true);
+    expect(resultFeatures.every((element) => element.display === 'none')).toBe(true);
+  };
+  const expectLabelEdited = (snapshot, { generated = false } = {}) => {
+    expect(
+      snapshot.dom.label,
+      JSON.stringify({ identity: snapshot.identity, overrides: snapshot.overrides })
+    ).toEqual({ text: DIRECT_LABEL_TEXT, display: null });
+    expect(snapshot.resultDom.label).toEqual({ text: DIRECT_LABEL_TEXT, display: null });
+    if (!generated) {
+      expect(snapshot.dom.labelVisibility?.display).toBe('none');
+      expect(snapshot.resultDom.labelVisibility?.display).toBe('none');
+    } else {
+      expect(
+        snapshot.dom.labelVisibility === null ||
+          snapshot.dom.labelVisibility.display === 'none'
+      ).toBe(true);
+      expect(
+        snapshot.resultDom.labelVisibility === null ||
+          snapshot.resultDom.labelVisibility.display === 'none'
+      ).toBe(true);
+    }
+  };
+  const expectLegendEdited = (snapshot) => {
+    expect(snapshot.dom.legend?.fill).toBe(DIRECT_LEGEND_COLOR);
+    expect(snapshot.resultDom.legend?.fill).toBe(DIRECT_LEGEND_COLOR);
+    expect(snapshot.dom.legend).toMatchObject({
+      stroke: DIRECT_LEGEND_STROKE,
+      strokeWidth: String(DIRECT_LEGEND_STROKE_WIDTH)
+    });
+    expect(snapshot.resultDom.legend).toMatchObject({
+      stroke: DIRECT_LEGEND_STROKE,
+      strokeWidth: String(DIRECT_LEGEND_STROKE_WIDTH)
+    });
+  };
+  const expectAllDirectEdits = (snapshot, options = {}) => {
+    expectFeatureFill(snapshot, DIRECT_FILL);
+    expectFeatureStroke(snapshot);
+    expectFeatureHidden(snapshot, options);
+    expectLabelEdited(snapshot, options);
+    expectLegendEdited(snapshot);
+    expect(snapshot.overrides).toMatchObject({
+      fill: { color: DIRECT_FILL },
+      stroke: {
+        strokeColor: DIRECT_STROKE,
+        strokeWidth: DIRECT_STROKE_WIDTH
+      },
+      visibility: 'off',
+      labelText: DIRECT_LABEL_TEXT,
+      labelVisibility: 'off',
+      legendColor: DIRECT_LEGEND_COLOR,
+      legendStroke: {
+        strokeColor: DIRECT_LEGEND_STROKE,
+        strokeWidth: DIRECT_LEGEND_STROKE_WIDTH
+      }
+    });
+  };
+
+  await openIntentApp(page);
+  await loadCurrentSession(page, sourceSessionPath, sourceSession);
+  await captureIdleWorkerStage(page, 'after Load', idleWorkerStages);
+  const target = await prepareLoadedPreviewDirectEditTarget(page);
+  expect(target.featureRecordKey).toBeTruthy();
+  expect(target.biologicalFeatureId).toBeTruthy();
+  expect(target.featureOverrideKey).toBe(
+    `${target.featureRecordKey}\u0000${target.biologicalFeatureId}`
+  );
+  expect(target.visibilityFeatureOverrideKey).toBeTruthy();
+  expect(target.visibilityFeatureId).not.toBe(target.featureId);
+  await captureIdleWorkerStage(page, 'before direct edits', idleWorkerStages);
+
+  const featureSelector = [
+    `[data-gbdraw-feature-id="${target.featureId}"]`,
+    `[data-gbdraw-rendered-feature-id="${target.featureId}"]`,
+    `#${target.featureId}`,
+    `[id^="${target.featureId}__"]`
+  ].join(', ');
+  const featureLocator = page.locator(featureSelector).first();
+  await featureLocator.scrollIntoViewIfNeeded();
+  const featureClickPoint = await featureLocator.evaluate((element, featureId) => {
+    const svg = element.closest('svg');
+    const featureSelector = [
+      'path[data-gbdraw-feature-id]',
+      'polygon[data-gbdraw-feature-id]',
+      'rect[data-gbdraw-feature-id]',
+      'path[id^="f"]',
+      'polygon[id^="f"]',
+      'rect[id^="f"]'
+    ].join(', ');
+    const identity = (candidate) => String(
+      candidate?.getAttribute?.('data-gbdraw-rendered-feature-id')
+      || candidate?.getAttribute?.('data-gbdraw-feature-id')
+      || candidate?.id
+      || ''
+    ).replace(/__(?:part|line)\d+$/, '');
+    const pointIsTarget = (x, y) => {
+      if (x < 0 || y < 0 || x > innerWidth || y > innerHeight) return false;
+      const topFeature = document.elementsFromPoint(x, y)
+        .map((candidate) => (
+          candidate.matches?.(featureSelector)
+            ? candidate
+            : candidate.closest?.(featureSelector)
+        ))
+        .find((candidate) => candidate && svg.contains(candidate));
+      return identity(topFeature) === featureId;
+    };
+    const screenPoint = (point) => {
+      const matrix = element.getScreenCTM();
+      if (!matrix) return null;
+      const transformed = new DOMPoint(point.x, point.y).matrixTransform(matrix);
+      return { x: transformed.x, y: transformed.y };
+    };
+    const candidates = [];
+    if (typeof element.getTotalLength === 'function') {
+      const length = element.getTotalLength();
+      for (let index = 1; index < 40; index += 1) {
+        candidates.push(screenPoint(element.getPointAtLength(length * index / 40)));
+      }
+    }
+    const bounds = element.getBBox?.();
+    if (bounds) {
+      for (const xFactor of [0.25, 0.5, 0.75]) {
+        for (const yFactor of [0.25, 0.5, 0.75]) {
+          candidates.push(screenPoint({
+            x: bounds.x + bounds.width * xFactor,
+            y: bounds.y + bounds.height * yFactor
+          }));
+        }
+      }
+    }
+    for (const candidate of candidates.filter(Boolean)) {
+      for (const dx of [0, -1, 1]) {
+        for (const dy of [0, -1, 1]) {
+          const x = candidate.x + dx;
+          const y = candidate.y + dy;
+          if (pointIsTarget(x, y)) return { x, y };
+        }
+      }
+    }
+    throw new Error(`No painted point is available for loaded Feature ${featureId}.`);
+  }, target.featureId);
+  await page.mouse.click(featureClickPoint.x, featureClickPoint.y);
+  const featureClickDiagnostics = await page.evaluate((featureId) => {
+    const svg = window.__GBDRAW_APP__.svgContainer?.querySelector?.('svg');
+    const escaped = CSS.escape(featureId);
+    const elements = svg
+      ? Array.from(svg.querySelectorAll([
+          `[data-gbdraw-feature-id="${escaped}"]`,
+          `[data-gbdraw-rendered-feature-id="${escaped}"]`,
+          `#${escaped}`,
+          `[id^="${escaped}__"]`
+        ].join(', ')))
+      : [];
+    return {
+      clickedFeatureId: String(window.__GBDRAW_APP__.clickedFeature?.svg_id || ''),
+      elements: elements.map((element) => ({
+        id: String(element.id || ''),
+        cursor: String(element.style?.cursor || ''),
+        display: element.getAttribute('display'),
+        pointerEvents: getComputedStyle(element).pointerEvents
+      }))
+    };
+  }, target.featureId);
+  const featureDialog = page.getByRole('dialog', { name: /Feature details:/ });
+  await expect(featureDialog, JSON.stringify(featureClickDiagnostics, null, 2)).toBeVisible();
+  Object.assign(target, await bindLoadedPreviewDirectEditLabel(page));
+  await page.evaluate(() => window.__GBDRAW_SESSION_INTENT_PROBE__.reset());
+  await startLoadedPreviewDirectEditProbe(page);
+  const initiallyLoaded = await captureLoadedPreviewDirectEditState(page);
+  expect(initiallyLoaded.autoLabelReflowEnabled).toBe(false);
+  expect(initiallyLoaded.structural).toMatchObject({
+    directEditResultFlushCount: 0,
+    directEditSvgSerializationCount: 0
+  });
+  expect(initiallyLoaded.history).toMatchObject({
+    artifactReplacementHistoryEntryCount: 0,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0
+  });
+  expectBiologicalOwnersUnchanged(initiallyLoaded);
+  await featureDialog.getByLabel('Feature fill color').first().fill(DIRECT_FILL);
+  const colorScopeHeading = page.getByRole('heading', { name: 'Color Change Scope' });
+  await expect(colorScopeHeading).toBeVisible();
+  const colorScopeDialog = colorScopeHeading.locator('..');
+  const captionScopeButton = colorScopeDialog.getByRole('button').filter({
+    hasText: `Apply to all "${target.fillLegendCaption}"`
+  }).last();
+  await expect(captionScopeButton).toBeVisible();
+  await captionScopeButton.click();
+  await page.waitForFunction(({ overrideKey, color }) => {
+    const app = window.__GBDRAW_APP__;
+    return app.featureColorOverrides?.[overrideKey]?.color === color
+      && String(app.results?.[app.selectedResultIndex]?.content || '').includes(color);
+  }, { overrideKey: target.featureOverrideKey, color: DIRECT_FILL });
+  await settleMountedDom(page);
+  const afterFill = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(initiallyLoaded, afterFill);
+  expectFeatureFill(afterFill, DIRECT_FILL);
+  expect(afterFill.overrides.fill).toMatchObject({ color: DIRECT_FILL });
+  expect(afterFill.history.undoCount).toBeGreaterThan(initiallyLoaded.history.undoCount);
+  await captureIdleWorkerStage(page, 'after feature fill', idleWorkerStages);
+
+  expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.undo())).toBe(true);
+  await settleMountedDom(page);
+  const afterFillUndo = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(afterFill, afterFillUndo);
+  expectFeatureFill(afterFillUndo, featureBlocks(initiallyLoaded)[0].fill);
+  expect(afterFillUndo.overrides.fill).toBeNull();
+  await captureIdleWorkerStage(page, 'after direct-edit Undo', idleWorkerStages);
+
+  expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.redo())).toBe(true);
+  await settleMountedDom(page);
+  const afterFillRedo = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(afterFillUndo, afterFillRedo);
+  expectFeatureFill(afterFillRedo, DIRECT_FILL);
+  expect(afterFillRedo.overrides.fill).toMatchObject({ color: DIRECT_FILL });
+  await captureIdleWorkerStage(page, 'after direct-edit Redo', idleWorkerStages);
+
+  const strokeApplied = await page.evaluate(async ({ color, width }) => {
+    const app = window.__GBDRAW_APP__;
+    const targetState = window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__;
+    app.openFeatureEditorFromList(targetState.feature, { clientX: 220, clientY: 220 });
+    return app.updateClickedFeatureStroke(color, width);
+  }, { color: DIRECT_STROKE, width: DIRECT_STROKE_WIDTH });
+  expect(strokeApplied).toBe(true);
+  await settleMountedDom(page);
+  const afterStroke = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(afterFillRedo, afterStroke);
+  expectFeatureStroke(afterStroke);
+  expect(afterStroke.overrides.stroke).toMatchObject({
+    strokeColor: DIRECT_STROKE,
+    strokeWidth: DIRECT_STROKE_WIDTH
+  });
+  await captureIdleWorkerStage(page, 'after feature stroke', idleWorkerStages);
+
+  const visibilityApplied = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const targetState = window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__;
+    return app.setFeatureVisibility(targetState.visibilityFeature, 'off', {
+      triggerReflow: false,
+      scope: { id: 'feature' }
+    });
+  });
+  expect(visibilityApplied).toBe(true);
+  await settleMountedDom(page);
+  const afterVisibility = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(afterStroke, afterVisibility);
+  expectFeatureHidden(afterVisibility);
+  expect(afterVisibility.overrides.visibility).toBe('off');
+  await captureIdleWorkerStage(page, 'after feature visibility', idleWorkerStages);
+
+  const labelApplied = await page.evaluate(async ({ text }) => {
+    const app = window.__GBDRAW_APP__;
+    const targetState = window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__;
+    const requested = await app.requestLabelTextChangeByFeatureId(
+      targetState.labelFeatureId,
+      text
+    );
+    await app.handleLabelTextScopeChoice('single');
+    app.openFeatureEditorFromList(targetState.labelFeature, { clientX: 240, clientY: 240 });
+    if (!app.clickedFeature?.hasEditableLabel) {
+      throw new Error('The loaded Feature label could not be reopened for direct editing.');
+    }
+    app.clickedFeature.labelText = text;
+    await app.updateClickedFeatureLabelText();
+    app.openFeatureEditorFromList(
+      targetState.labelVisibilityFeature,
+      { clientX: 260, clientY: 260 }
+    );
+    if (!app.clickedFeature?.hasEditableLabel) {
+      throw new Error('The second loaded Feature label could not be opened.');
+    }
+    app.clickedFeature.labelVisibility = 'off';
+    await app.updateClickedFeatureLabelText();
+    return {
+      requested,
+      textOverride: app.labelTextFeatureOverrides[targetState.labelFeatureId],
+      visibilityOverride:
+        app.labelVisibilityOverrides[targetState.labelVisibilityFeatureId]
+    };
+  }, { text: DIRECT_LABEL_TEXT });
+  expect(labelApplied).toEqual({
+    requested: true,
+    textOverride: DIRECT_LABEL_TEXT,
+    visibilityOverride: 'off'
+  });
+  await settleMountedDom(page);
+  const afterLabel = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(afterVisibility, afterLabel);
+  expectLabelEdited(afterLabel);
+  expect(afterLabel.overrides).toMatchObject({
+    labelText: DIRECT_LABEL_TEXT,
+    labelVisibility: 'off'
+  });
+  await captureIdleWorkerStage(page, 'after label text and visibility', idleWorkerStages);
+
+  const legendApplied = await page.evaluate(async ({ color, stroke, strokeWidth }) => {
+    const app = window.__GBDRAW_APP__;
+    const targetState = window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_TARGET__;
+    const index = app.legendEntries.findIndex(
+      (entry) => entry.caption === targetState.legendCaption
+    );
+    if (index < 0) throw new Error('The loaded legend entry is no longer available.');
+    return {
+      color: app.updateLegendEntryColor(index, color),
+      stroke: await app.setLegendEntryStrokeColorValue(index, stroke),
+      strokeWidth: app.updateLegendEntryStrokeWidth(index, strokeWidth)
+    };
+  }, {
+    color: DIRECT_LEGEND_COLOR,
+    stroke: DIRECT_LEGEND_STROKE,
+    strokeWidth: DIRECT_LEGEND_STROKE_WIDTH
+  });
+  expect(legendApplied).toEqual({ color: true, stroke: true, strokeWidth: true });
+  await settleMountedDom(page);
+  const afterLegend = await captureLoadedPreviewDirectEditState(page);
+  expectDirectEditFlushed(afterLabel, afterLegend);
+  expectLegendEdited(afterLegend);
+  expect(afterLegend.overrides.legendColor).toBe(DIRECT_LEGEND_COLOR);
+  expect(afterLegend.overrides.legendStroke).toMatchObject({
+    strokeColor: DIRECT_LEGEND_STROKE,
+    strokeWidth: DIRECT_LEGEND_STROKE_WIDTH
+  });
+  await captureIdleWorkerStage(page, 'after legend color', idleWorkerStages);
+
+  const titleSummary = page.locator('summary[aria-label="Title & Legend"]');
+  const titleDetails = titleSummary.locator('..');
+  if ((await titleDetails.getAttribute('open')) === null) await titleSummary.click();
+  await page.getByLabel('Plot Title', { exact: true }).fill(DIRECT_REGENERATED_TITLE);
+  await page.getByLabel('Plot Title Position').selectOption('top');
+  await settleMountedDom(page);
+  const afterDraftConfig = await captureLoadedPreviewDirectEditState(page);
+  expect(afterDraftConfig.result.sha256).toBe(afterLegend.result.sha256);
+  expectBiologicalOwnersUnchanged(afterDraftConfig);
+  await captureIdleWorkerStage(page, 'after divergent active config', idleWorkerStages);
+
+  const saved = await saveCurrentSession(page, 'loaded-preview-direct-edit');
+  const afterSave = await captureLoadedPreviewDirectEditState(page);
+  expect(afterSave.result.sha256).toBe(afterLegend.result.sha256);
+  expectAllDirectEdits(afterSave);
+  expectBiologicalOwnersUnchanged(afterSave);
+  await captureIdleWorkerStage(page, 'after Save without Generate', idleWorkerStages);
+  expect(
+    saved.session.results[saved.session.ui.selectedResultIndex].content
+  ).toBe(await page.evaluate(() => (
+    window.__GBDRAW_APP__.results[window.__GBDRAW_APP__.selectedResultIndex].content
+  )));
+  expect(saved.session.config).toMatchObject({
+    form: { plot_title: DIRECT_REGENERATED_TITLE }
+  });
+  expect(saved.session.ui).toMatchObject({
+    layoutPreferences: {
+      circular: { single: { plotTitlePosition: 'top' } }
+    }
+  });
+  expect(saved.session.features).toMatchObject({
+    featureColorOverrides: {
+      [target.featureOverrideKey]: { color: DIRECT_FILL }
+    },
+    featureVisibilityOverrides: { [target.visibilityFeatureId]: 'off' },
+    labelTextFeatureOverrides: { [target.labelFeatureId]: DIRECT_LABEL_TEXT },
+    labelVisibilityOverrides: { [target.labelVisibilityFeatureId]: 'off' }
+  });
+  expect(saved.session.editorState).toMatchObject({
+    legend: {
+      colorOverrides: { [target.legendCaption]: DIRECT_LEGEND_COLOR },
+      strokeOverrides: {
+        [target.legendCaption]: {
+          strokeColor: DIRECT_LEGEND_STROKE,
+          strokeWidth: DIRECT_LEGEND_STROKE_WIDTH
+        }
+      }
+    },
+    featureStrokes: {
+      overrides: {
+        [target.featureOverrideKey]: {
+          strokeColor: DIRECT_STROKE,
+          strokeWidth: DIRECT_STROKE_WIDTH
+        }
+      }
+    }
+  });
+  const directMetrics = await page.evaluate(() => (
+    window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_PROBE__.stop()
+  ));
+  expect(directMetrics.directEditResultFlushCount).toBeGreaterThanOrEqual(7);
+  expect(directMetrics.directEditSvgSerializationCount).toBeGreaterThanOrEqual(
+    directMetrics.directEditResultFlushCount
+  );
+  expect(directMetrics).toMatchObject({
+    directEditFeatureCatalogReplacementCount: 0,
+    directEditExtractedFeatureReplacementCount: 0,
+    directEditBiologicalFeatureReplacementCount: 0,
+    directEditOrthogroupReplacementCount: 0
+  });
+
+  const freshPage = await context.newPage();
+  await openIntentApp(freshPage);
+  await loadCurrentSession(freshPage, saved.path, saved.session);
+  await captureIdleWorkerStage(freshPage, 'after fresh Load', idleWorkerStages);
+  const freshTarget = await prepareLoadedPreviewDirectEditTarget(freshPage, target);
+  Object.assign(
+    freshTarget,
+    await bindLoadedPreviewDirectEditLabel(freshPage, target)
+  );
+  expect(freshTarget).toEqual(target);
+  await startLoadedPreviewDirectEditProbe(freshPage);
+  const freshlyLoaded = await captureLoadedPreviewDirectEditState(freshPage);
+  expectAllDirectEdits(freshlyLoaded);
+  expect(freshlyLoaded.result.equalsLoadedResult).toBe(true);
+  expect(freshlyLoaded.history).toMatchObject({
+    undoCount: 0,
+    redoCount: 0,
+    currentCheckpointAbsent: true,
+    artifactReplacementHistoryEntryCount: 0,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0
+  });
+  expect(freshlyLoaded.autoLabelReflowEnabled).toBe(false);
+  expectBiologicalOwnersUnchanged(freshlyLoaded);
+  await captureIdleWorkerStage(
+    freshPage,
+    'before first Generate on fresh Load',
+    idleWorkerStages
+  );
+  const freshLoadMetrics = await freshPage.evaluate(() => (
+    window.__GBDRAW_LOADED_PREVIEW_DIRECT_EDIT_PROBE__.stop()
+  ));
+  expect(freshLoadMetrics).toMatchObject({
+    directEditResultFlushCount: 0,
+    directEditSvgSerializationCount: 0,
+    directEditFeatureCatalogReplacementCount: 0,
+    directEditExtractedFeatureReplacementCount: 0,
+    directEditBiologicalFeatureReplacementCount: 0,
+    directEditOrthogroupReplacementCount: 0
+  });
+
+  await runGenerate(freshPage);
+  await settleMountedDom(freshPage);
+  const regenerated = await captureLoadedPreviewDirectEditState(freshPage);
+  expect(regenerated.result.sha256).not.toBe(freshlyLoaded.result.sha256);
+  expectAllDirectEdits(regenerated, { generated: true });
+  expect(regenerated.history).toMatchObject({
+    undoCount: 1,
+    redoCount: 0,
+    currentCheckpointAbsent: true,
+    artifactReplacementHistoryEntryCount: 1,
+    generatedArtifactFullCloneCount: 0,
+    generatedArtifactFullSerializationCount: 0
+  });
+  expect(regenerated.history.artifactCheckpointBuilds).toBe(
+    freshlyLoaded.history.artifactCheckpointBuilds
+  );
+  const generatedWorker = await getDiagramWorkerActivity(freshPage);
+  expect({
+    constructions: generatedWorker.constructions,
+    initializations: generatedWorker.initializations,
+    helpers: generatedWorker.helpers,
+    runs: generatedWorker.runs
+  }).toEqual({ constructions: 1, initializations: 1, helpers: 0, runs: 1 });
+
+  expect(await freshPage.evaluate(() => window.__GBDRAW_HISTORY__.undo())).toBe(true);
+  await settleMountedDom(freshPage);
+  const generatedUndo = await captureLoadedPreviewDirectEditState(freshPage);
+  expect(generatedUndo.result.equalsLoadedResult).toBe(true);
+  expectAllDirectEdits(generatedUndo);
+  expect(generatedUndo.history).toMatchObject({
+    undoCount: 0,
+    redoCount: 1,
+    artifactReplacementHistoryEntryCount: 1
+  });
+  const workerAfterGenerateUndo = await getDiagramWorkerActivity(freshPage);
+  expect({
+    constructions: workerAfterGenerateUndo.constructions,
+    initializations: workerAfterGenerateUndo.initializations,
+    helpers: workerAfterGenerateUndo.helpers,
+    runs: workerAfterGenerateUndo.runs
+  }).toEqual({ constructions: 1, initializations: 1, helpers: 0, runs: 1 });
+
+  expect(await freshPage.evaluate(() => window.__GBDRAW_HISTORY__.redo())).toBe(true);
+  await settleMountedDom(freshPage);
+  const generatedRedo = await captureLoadedPreviewDirectEditState(freshPage);
+  expect(generatedRedo.result.sha256).toBe(regenerated.result.sha256);
+  expectAllDirectEdits(generatedRedo, { generated: true });
+  expect(generatedRedo.history).toMatchObject({
+    undoCount: 1,
+    redoCount: 0,
+    artifactReplacementHistoryEntryCount: 1
+  });
+  const workerAfterGenerateRedo = await getDiagramWorkerActivity(freshPage);
+  expect({
+    constructions: workerAfterGenerateRedo.constructions,
+    initializations: workerAfterGenerateRedo.initializations,
+    helpers: workerAfterGenerateRedo.helpers,
+    runs: workerAfterGenerateRedo.runs
+  }).toEqual({ constructions: 1, initializations: 1, helpers: 0, runs: 1 });
+
+  await testInfo.attach('loaded-preview-direct-edit.json', {
+    body: Buffer.from(JSON.stringify({
+      target,
+      actualUiOperation: 'SVG Feature click -> Feature details -> Feature fill color',
+      idleWorkerStages,
+      directMetrics: {
+        ...directMetrics,
+        directEditWorkerConstructionDelta: 0,
+        directEditWorkerInitializationDelta: 0,
+        directEditWorkerRunDelta: 0,
+        directEditResourceTransferBytes: 0
+      },
+      domEvidence: {
+        before: initiallyLoaded.dom,
+        afterFill: afterFill.dom,
+        afterStroke: afterStroke.dom,
+        afterVisibility: afterVisibility.dom,
+        afterLabel: afterLabel.dom,
+        afterLegend: afterLegend.dom,
+        freshLoad: freshlyLoaded.dom,
+        regenerated: regenerated.dom
+      },
+      resultEvidence: {
+        before: initiallyLoaded.result,
+        afterFill: afterFill.result,
+        afterStroke: afterStroke.result,
+        afterVisibility: afterVisibility.result,
+        afterLabel: afterLabel.result,
+        afterLegend: afterLegend.result,
+        freshLoad: freshlyLoaded.result,
+        regenerated: regenerated.result,
+        generatedUndo: generatedUndo.result,
+        generatedRedo: generatedRedo.result
+      },
+      workerAfterGenerate: {
+        constructions: generatedWorker.constructions,
+        initializations: generatedWorker.initializations,
+        helpers: generatedWorker.helpers,
+        runs: generatedWorker.runs,
+        transferredResourceBytes: diagramWorkerResourceBytes(generatedWorker)
+      }
     }, null, 2)),
     contentType: 'application/json'
   });

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -1,5 +1,6 @@
 const { test, expect } = require('@playwright/test');
 const { spawnSync } = require('node:child_process');
+const { createHash } = require('node:crypto');
 const { writeFileSync } = require('node:fs');
 const { join, resolve } = require('node:path');
 const {
@@ -90,6 +91,141 @@ const featureCatalogSummary = (page) => page.evaluate(async () => {
     schema: Number(catalog?.schema || 0),
     itemCount: Array.isArray(catalog?.items) ? catalog.items.length : 0
   };
+});
+
+const svgSourceIdentity = (content) => ({
+  characters: String(content || '').length,
+  sha256: createHash('sha256').update(String(content || '')).digest('hex')
+});
+
+const svgComparisonSummary = (content) => {
+  const source = String(content || '');
+  return {
+    comparisonGroups: (source.match(/<g[^>]*\bid="comparison\d+"/g) || []).length,
+    pairwiseMatches: (source.match(/data-gbdraw-pairwise-match-id=/g) || []).length,
+    comparisonLegends: (source.match(/data-gbdraw-role="comparison-legend"/g) || []).length
+  };
+};
+
+const installCanonicalRequestCapture = (page) => page.evaluate(() => {
+  const previousPostMessage = Worker.prototype.postMessage;
+  window.__GBDRAW_VIBRIO_CANONICAL_REQUESTS__ = [];
+  Worker.prototype.postMessage = function captureCanonicalRequest(message, transfer) {
+    if (message?.type === 'run' && message.payload?.request) {
+      window.__GBDRAW_VIBRIO_CANONICAL_REQUESTS__.push(
+        JSON.stringify(message.payload.request)
+      );
+    }
+    if (transfer === undefined) return previousPostMessage.call(this, message);
+    return previousPostMessage.call(this, message, transfer);
+  };
+});
+
+const canonicalRequestEvidence = async (page) => {
+  const serializedRequests = await page.evaluate(() => (
+    [...(window.__GBDRAW_VIBRIO_CANONICAL_REQUESTS__ || [])]
+  ));
+  return serializedRequests.map((serialized) => {
+    const request = JSON.parse(serialized);
+    return {
+      sha256: createHash('sha256').update(serialized).digest('hex'),
+      schema: Number(request.schema || 0),
+      mode: String(request.mode || ''),
+      recordCount: Array.isArray(request.records) ? request.records.length : 0,
+      comparisonCount: Array.isArray(request.comparisons) ? request.comparisons.length : 0,
+      comparisonKinds: Array.isArray(request.comparisons)
+        ? request.comparisons.map(({ kind }) => String(kind || ''))
+        : [],
+      layout: request.layout || null,
+      colors: request.diagramOptions?.colors || null
+    };
+  });
+};
+
+const activeIntentSummary = (page) => page.evaluate(async () => {
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const stable = (value) => {
+    if (Array.isArray(value)) return value.map((item) => stable(item));
+    if (!value || typeof value !== 'object') return value;
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, stable(value[key])])
+    );
+  };
+  const plain = (value) => JSON.parse(JSON.stringify(value ?? null));
+  const overrides = {
+    fills: plain(state.featureColorOverrides),
+    strokes: plain(state.featureStrokeOverrides),
+    visibility: plain(state.featureVisibilityOverrides),
+    labelText: plain(state.labelTextFeatureOverrides),
+    labelVisibility: plain(state.labelVisibilityOverrides),
+    legendColors: plain(state.legendColorOverrides),
+    legendStrokes: plain(state.legendStrokeOverrides)
+  };
+  const digest = async (value) => {
+    const bytes = new TextEncoder().encode(JSON.stringify(stable(value)));
+    const hash = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+    return [...hash].map((item) => item.toString(16).padStart(2, '0')).join('');
+  };
+  const summary = {
+    mode: state.mode.value,
+    inputType: state.mode.value === 'circular'
+      ? state.cInputType.value
+      : state.lInputType.value,
+    palette: {
+      selected: state.selectedPalette.value,
+      currentColorsSha256: await digest(state.currentColors.value),
+      currentColorCount: Object.keys(state.currentColors.value || {}).length,
+      instantPreview: state.paletteInstantPreviewEnabled.value,
+      applied: state.appliedPaletteName.value,
+      pending: state.pendingPaletteName.value
+    },
+    rules: {
+      specificCount: state.manualSpecificRules.length,
+      specificSha256: await digest(state.manualSpecificRules),
+      priorityCount: state.manualPriorityRules.length,
+      prioritySha256: await digest(state.manualPriorityRules)
+    },
+    filters: {
+      mode: state.filterMode.value,
+      whitelistCount: state.manualWhitelist.length,
+      blacklistText: state.manualBlacklist.value
+    },
+    form: {
+      plotTitle: state.form.plot_title,
+      labelsMode: state.form.labels_mode,
+      showScale: state.form.show_scale,
+      legend: state.form.legend
+    },
+    adv: {
+      axisStrokeWidth: state.adv.axis_stroke_width,
+      labelFontSize: state.adv.label_font_size,
+      featureWidthCircular: state.adv.feature_width_circular,
+      plotTitlePosition: state.adv.plot_title_position
+    },
+    annotationSetIds: state.annotationSets.map(({ id }) => id),
+    circularTracks: {
+      enabled: state.adv.circular_track_slots_enabled,
+      slots: state.adv.circular_track_slots.map(({ id, renderer, enabled }) => ({
+        id,
+        renderer,
+        enabled
+      }))
+    },
+    linearComparisonPlan: plain(state.linearComparisonPlan),
+    linearRecordLayout: {
+      enabled: state.linearRecordLayoutEnabled.value,
+      recordGap: state.linearRecordGap.value,
+      rows: plain(state.linearRecordRows)
+    },
+    layoutPreferences: plain(state.layoutPreferences),
+    editorOverrides: {
+      counts: Object.fromEntries(
+        Object.entries(overrides).map(([name, values]) => [name, Object.keys(values || {}).length])
+      ),
+      sha256: await digest(overrides)
+    }
+  };
+  return { ...summary, sha256: await digest(summary) };
 });
 
 const phaseDuration = (events, startName, endName) => {
@@ -610,6 +746,8 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
       resultCount: Array.isArray(app.results) ? app.results.length : 0
     };
   });
+  const loadedPreviewIdentity = svgSourceIdentity(loaded.originalPreview);
+  const preFirstGenerateActiveIntent = await activeIntentSummary(page);
   const loadProbe = await probeSnapshot(page);
   const ready = loadProbe.lifecycle.find(({ name }) => name === 'interactiveReady');
   const previewMetrics = Object.fromEntries(
@@ -631,7 +769,20 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   ));
   expect(preflightStructural.proteinManifestFullValidationCount).toBe(1);
   expect(preflightStructural.proteinRawTextValidationCount).toBeGreaterThan(0);
+  expect(loadProbe.metrics.currentWriterActiveConfigRestoreCount).toBe(1);
+  expect(loadProbe.metrics.activeConfigCanonicalOverwriteCount || 0).toBe(0);
   expect(await featureCatalogSummary(page)).toEqual({ schema: 3, itemCount: 1 });
+  expect(preFirstGenerateActiveIntent.linearComparisonPlan).toEqual({
+    mode: 'none',
+    defaultSource: 'losat',
+    edges: []
+  });
+  expect(preFirstGenerateActiveIntent.linearRecordLayout).toMatchObject({
+    enabled: true,
+    recordGap: 48
+  });
+  expect(preFirstGenerateActiveIntent.linearRecordLayout.rows).toHaveLength(11);
+  await installCanonicalRequestCapture(page);
 
   await page.evaluate(() => window.__GBDRAW_VIBRIO_GENERATE_PROBE__.reset());
   const first = await invokeGeneration(page, terminal, runnerEvidence, terminalSignal);
@@ -649,6 +800,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     const app = window.__GBDRAW_APP__;
     return String(app.results?.[app.selectedResultIndex]?.content || '');
   });
+  const firstGeneratedIdentity = svgSourceIdentity(firstGeneratedSvg);
 
   await page.evaluate(() => window.__GBDRAW_VIBRIO_GENERATE_PROBE__.reset());
   const second = await invokeGeneration(page, terminal, runnerEvidence, terminalSignal);
@@ -666,6 +818,36 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     const app = window.__GBDRAW_APP__;
     return String(app.results?.[app.selectedResultIndex]?.content || '');
   });
+  const capturedCanonicalRequests = await canonicalRequestEvidence(page);
+  expect(capturedCanonicalRequests).toHaveLength(2);
+  expect(capturedCanonicalRequests[0]).toMatchObject({
+    schema: 5,
+    mode: 'linear',
+    recordCount: 11,
+    comparisonCount: 0,
+    comparisonKinds: [],
+    layout: {
+      recordGapPx: 48,
+      multiRecordPositions: [
+        '#1@1', '#2@1', '#3@1', '#4@2', '#5@2', '#6@3',
+        '#7@3', '#8@4', '#9@4', '#10@5', '#11@5'
+      ]
+    }
+  });
+  expect(capturedCanonicalRequests[1]).toEqual(capturedCanonicalRequests[0]);
+  const loadedComparisonSummary = svgComparisonSummary(loaded.originalPreview);
+  const firstComparisonSummary = svgComparisonSummary(firstGeneratedSvg);
+  const secondComparisonSummary = svgComparisonSummary(secondGeneratedSvg);
+  expect(loadedComparisonSummary.comparisonGroups).toBeGreaterThan(0);
+  expect(loadedComparisonSummary.pairwiseMatches).toBeGreaterThan(0);
+  expect(loadedComparisonSummary.comparisonLegends).toBeGreaterThan(0);
+  expect(firstComparisonSummary).toEqual({
+    comparisonGroups: 0,
+    pairwiseMatches: 0,
+    comparisonLegends: 0
+  });
+  expect(secondComparisonSummary).toEqual(firstComparisonSummary);
+  expect(loaded.originalPreview).not.toBe(firstGeneratedSvg);
   const generatedFeatureCatalogDigest = await featureCatalogDigest(page);
 
   const activity = second.worker;
@@ -937,25 +1119,23 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   expect(afterPing.initializations).toBe(1);
   expect(afterPing.instances[0].terminated).toBe(false);
 
+  const loadedSvgPath = testInfo.outputPath('vibrio-loaded-preview.svg');
   const firstSvgPath = testInfo.outputPath('vibrio-generate-1.svg');
   const secondSvgPath = testInfo.outputPath('vibrio-generate-2.svg');
+  writeFileSync(loadedSvgPath, loaded.originalPreview, 'utf8');
   writeFileSync(firstSvgPath, firstGeneratedSvg, 'utf8');
   writeFileSync(secondSvgPath, secondGeneratedSvg, 'utf8');
+  const svgComparisonCommand = [
+    'import sys',
+    'from tests.utils.svg_compare import compare_svgs',
+    'result = compare_svgs(sys.argv[1], sys.argv[2])',
+    'print(result.message)',
+    'print("\\n".join(result.differences))',
+    'raise SystemExit(0 if result.equal else 1)'
+  ].join(';');
   const semanticComparison = spawnSync(
     process.env.GBDRAW_PYTHON || 'python',
-    [
-      '-c',
-      [
-        'import sys',
-        'from tests.utils.svg_compare import compare_svgs',
-        'result = compare_svgs(sys.argv[1], sys.argv[2])',
-        'print(result.message)',
-        'print("\\n".join(result.differences))',
-        'raise SystemExit(0 if result.equal else 1)'
-      ].join(';'),
-      firstSvgPath,
-      secondSvgPath
-    ],
+    ['-c', svgComparisonCommand, firstSvgPath, secondSvgPath],
     { cwd: repoRoot, encoding: 'utf8' }
   );
   expect(
@@ -1026,6 +1206,8 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     load: {
       previewMetrics,
       preflightStructural,
+      loadedPreviewIdentity,
+      preFirstGenerateActiveIntent,
       timings: loadTimings(loadProbe.lifecycle)
     },
     generations: {
@@ -1051,6 +1233,14 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     },
     deterministicOutput: {
       comparison: 'tests.utils.svg_compare.compare_svgs',
+      loadedToFirstRelationship: 'divergent-active-draft',
+      loadedToFirstExactBytesEqual: loaded.originalPreview === firstGeneratedSvg,
+      loadedPreviewIdentity,
+      firstGeneratedIdentity,
+      loadedComparisonSummary,
+      firstComparisonSummary,
+      secondComparisonSummary,
+      capturedCanonicalRequests,
       semanticallyEquivalent: semanticComparison.status === 0,
       exactBytesEqual: firstGeneratedSvg === secondGeneratedSvg,
       firstCharacters: firstGeneratedSvg.length,
@@ -1070,6 +1260,8 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   });
   console.log(`Vibrio full-generation evidence: ${JSON.stringify({
     loadTimings: report.load.timings,
+    loadedPreviewIdentity: report.load.loadedPreviewIdentity,
+    preFirstGenerateActiveIntent: report.load.preFirstGenerateActiveIntent,
     firstGenerateMs: report.generations.firstElapsedMs,
     secondGenerateMs: report.generations.secondElapsedMs,
     referencedResourceCount: report.generations.referencedResourceCount,

--- a/tests/web/feature-visibility-actions.test.mjs
+++ b/tests/web/feature-visibility-actions.test.mjs
@@ -106,6 +106,14 @@ assert.deepEqual(
 );
 assert.deepEqual(flushes, [{ force: true }, { force: true }]);
 
+assert.equal(actions.setFeatureVisibility(featureA, 'off', {
+  triggerReflow: false,
+  scope: { id: 'feature' }
+}), true);
+assert.equal(featureVisibilityOverrides['feature-a'], 'off');
+assert.deepEqual(flushes, [{ force: true }, { force: true }, {}]);
+delete featureVisibilityOverrides['feature-a'];
+
 const sourceIdFeature = {
   svg_id: 'feature-source-id',
   type: 'CDS',
@@ -258,10 +266,11 @@ actions.updateClickedFeatureVisibility('off');
 assert.equal(featureVisibilityScopeDialog.show, false);
 delete featureVisibilityOverrides[strictTrigger.svg_id];
 
+flushes.length = 0;
 resultGenerationKey.value = 'generation-2';
 assert.equal(await command.apply(), false);
 assert.deepEqual(featureVisibilityOverrides, {});
 assert.equal(appliedPreviewChanges.length, 2);
-assert.deepEqual(flushes, [{ force: true }, { force: true }]);
+assert.deepEqual(flushes, []);
 
 console.log('feature visibility action tests passed');

--- a/tests/web/session-draft-authority.test.mjs
+++ b/tests/web/session-draft-authority.test.mjs
@@ -24,6 +24,7 @@ const alerts = [];
 globalThis.alert = (message) => alerts.push(String(message));
 
 const {
+  CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS,
   buildConfigData,
   buildEditorStateData,
   buildFeatureStateData,
@@ -31,10 +32,15 @@ const {
   buildRunStateData,
   buildUiStateData,
   importSession,
-  overlayCurrentWriterDraftConfig,
-  validateCurrentWriterActiveDraft
+  restoreCurrentWriterActiveConfig,
+  serializeActiveRenderFiles,
+  validateCurrentWriterActiveConfig
 } = await import('../../gbdraw/web/js/services/config.js');
 const { state } = await import('../../gbdraw/web/js/state.js');
+const {
+  buildCanonicalRenderRequest,
+  projectCanonicalSessionRequest
+} = await import('../../gbdraw/web/js/services/session-request.js');
 const {
   COMPOSITION_METADATA_ATTRIBUTE,
   COMPOSITION_SCHEMA_ATTRIBUTE
@@ -49,6 +55,110 @@ const { runRecordDiscoveryWatcher } = await import(
   '../../gbdraw/web/js/app/watchers.js'
 );
 
+const compactActiveIntentSnapshot = () => ({
+  modeAndInput: {
+    mode: state.mode.value,
+    inputType: state.mode.value === 'circular'
+      ? state.cInputType.value
+      : state.lInputType.value
+  },
+  palette: {
+    selected: state.selectedPalette.value,
+    currentColors: {
+      CDS: state.currentColors.value.CDS,
+      tRNA: state.currentColors.value.tRNA
+    },
+    appliedName: state.appliedPaletteName.value,
+    appliedColors: {
+      CDS: state.appliedPaletteColors.value.CDS,
+      tRNA: state.appliedPaletteColors.value.tRNA
+    },
+    pendingName: state.pendingPaletteName.value,
+    pendingColors: {
+      CDS: state.pendingPaletteColors.value.CDS,
+      tRNA: state.pendingPaletteColors.value.tRNA
+    },
+    instantPreview: state.paletteInstantPreviewEnabled.value
+  },
+  specificRules: structuredClone(state.manualSpecificRules),
+  qualifierPriorityRules: structuredClone(state.manualPriorityRules),
+  filters: {
+    mode: state.filterMode.value,
+    whitelist: structuredClone(state.manualWhitelist),
+    blacklistText: state.manualBlacklist.value
+  },
+  form: {
+    plot_title: state.form.plot_title,
+    labels_mode: state.form.labels_mode,
+    show_scale: state.form.show_scale,
+    legend: state.form.legend
+  },
+  adv: {
+    axis_stroke_width: state.adv.axis_stroke_width,
+    label_font_size: state.adv.label_font_size,
+    feature_width_circular: state.adv.feature_width_circular
+  },
+  annotationSets: state.annotationSets.map((set) => ({
+    id: set.id,
+    annotations: set.annotations.map((annotation) => ({
+      id: annotation.id,
+      mark: annotation.mark
+    }))
+  })),
+  trackSlots: {
+    enabled: state.adv.circular_track_slots_enabled,
+    axisIndex: state.adv.circular_track_slots_axis_index,
+    slots: state.adv.circular_track_slots.map((slot) => ({
+      id: slot.id,
+      renderer: slot.renderer,
+      enabled: slot.enabled
+    }))
+  },
+  layout: {
+    preferences: structuredClone(state.layoutPreferences),
+    linearRecordLayout: {
+      enabled: state.linearRecordLayoutEnabled.value,
+      recordGap: state.linearRecordGap.value,
+      rows: state.linearRecordLayoutEnabled.value
+        ? structuredClone(state.linearRecordRows)
+        : []
+    }
+  },
+  editorOverrides: {
+    fills: structuredClone(state.featureColorOverrides),
+    strokes: structuredClone(state.featureStrokeOverrides),
+    visibility: structuredClone(state.featureVisibilityOverrides),
+    labelText: structuredClone(state.labelTextFeatureOverrides),
+    labelVisibility: structuredClone(state.labelVisibilityOverrides),
+    legendColors: structuredClone(state.legendColorOverrides),
+    legendStrokes: structuredClone(state.legendStrokeOverrides)
+  }
+});
+
+const activeIntentDomainMismatches = (expected, actual) => {
+  const mismatches = [];
+  const visit = (expectedValue, actualValue, path, depth) => {
+    if (
+      depth < 2 &&
+      expectedValue &&
+      typeof expectedValue === 'object' &&
+      !Array.isArray(expectedValue)
+    ) {
+      Object.entries(expectedValue).forEach(([key, value]) => {
+        visit(value, actualValue?.[key], [...path, key], depth + 1);
+      });
+      return;
+    }
+    try {
+      assert.deepEqual(actualValue, expectedValue);
+    } catch {
+      mismatches.push(path.join('.'));
+    }
+  };
+  visit(expected, actual, [], 0);
+  return mismatches;
+};
+
 const canonicalFeature = {
   id: 'features',
   renderer: 'features',
@@ -59,17 +169,17 @@ const canonicalFeature = {
   inner_gap_px: null,
   outer_gap_px: null,
   z: 0,
-  params: { lane_direction: 'split' }
+  params: { lane_direction: 'inside' }
 };
 const disabledDraft = {
   id: 'disabled-draft',
   renderer: 'depth',
   enabled: false,
   side: 'outside',
-  width: '27px',
-  radius: '1.2',
-  inner_gap_px: '4px',
-  outer_gap_px: '5px',
+  width: 27,
+  radius: 1.2,
+  inner_gap_px: 4,
+  outer_gap_px: 5,
   z: 3,
   params: { track_index: 99, nested: { keep: true } }
 };
@@ -78,9 +188,11 @@ const projectedConfig = {
   adv: {
     nt: 'GC',
     circular_track_slots_enabled: true,
+    circular_track_slots_schema_version: 4,
     circular_track_slots: [canonicalFeature],
     circular_track_slots_axis_index: 1,
     linear_track_slots_enabled: false,
+    linear_track_slots_schema_version: 2,
     linear_track_slots: [],
     linear_track_slots_axis_index: null
   }
@@ -108,36 +220,95 @@ const storedConfig = {
   }
 };
 
-assert.doesNotThrow(() => validateCurrentWriterActiveDraft({
+assert.deepEqual(CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS, [
+  'form',
+  'adv',
+  'losat',
+  'cliOptions',
+  'colors',
+  'palette',
+  'paletteInstantPreviewEnabled',
+  'rules',
+  'qualifierPriorityRules',
+  'filterMode',
+  'whitelist',
+  'blacklistText',
+  'losatProgram',
+  'circularConservation',
+  'annotationSets',
+  'modeProfiles',
+  'linearRecordLayout',
+  'linearComparisonPlan',
+  'webEdits'
+]);
+assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
+  mode: 'circular',
+  storedConfig
+}));
+const restored = restoreCurrentWriterActiveConfig({
   mode: 'circular',
   projectedConfig,
   storedConfig
-}));
-const restored = overlayCurrentWriterDraftConfig(projectedConfig, storedConfig);
+});
 assert.deepEqual(restored.adv.circular_track_slots, storedConfig.adv.circular_track_slots);
 assert.deepEqual(restored.adv.linear_track_slots, storedConfig.adv.linear_track_slots);
 assert.equal(restored.adv.circular_track_slots_axis_index, 2);
 assert.equal(restored.adv.feature_width_circular, 19);
 assert.equal(restored.adv.depth_width_circular, 23);
 
+const galleryCompatibilityConfig = structuredClone(storedConfig);
+galleryCompatibilityConfig.colors = { CDS: '#123456' };
+galleryCompatibilityConfig.colorsAreOverrides = true;
+galleryCompatibilityConfig.adv.losatProgram = 'blastp';
+assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
+  mode: 'circular',
+  storedConfig: galleryCompatibilityConfig
+}));
+const restoredGalleryCompatibilityConfig = restoreCurrentWriterActiveConfig({
+  mode: 'circular',
+  projectedConfig,
+  storedConfig: galleryCompatibilityConfig
+});
+assert.equal(
+  Object.prototype.hasOwnProperty.call(restoredGalleryCompatibilityConfig, 'colorsAreOverrides'),
+  false
+);
+assert.equal(
+  Object.prototype.hasOwnProperty.call(restoredGalleryCompatibilityConfig.adv, 'losatProgram'),
+  false
+);
+
 const mismatched = structuredClone(storedConfig);
-mismatched.adv.circular_track_slots[1].width = '12px';
-assert.throws(
-  () => validateCurrentWriterActiveDraft({
+mismatched.adv.circular_track_slots[1].width = 12;
+assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
+  mode: 'circular',
+  storedConfig: mismatched
+}));
+assert.equal(
+  restoreCurrentWriterActiveConfig({
     mode: 'circular',
     projectedConfig,
     storedConfig: mismatched
-  }),
-  /does not match the committed render request/
+  }).adv.circular_track_slots[1].width,
+  12
 );
 
 const inactive = structuredClone(mismatched);
 inactive.adv.circular_track_slots_enabled = false;
-assert.doesNotThrow(() => validateCurrentWriterActiveDraft({
+assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
   mode: 'circular',
-  projectedConfig,
   storedConfig: inactive
 }));
+
+const structurallyInvalid = structuredClone(storedConfig);
+structurallyInvalid.adv.circular_track_slots[1].side = 'left';
+assert.throws(
+  () => validateCurrentWriterActiveConfig({
+    mode: 'circular',
+    storedConfig: structurallyInvalid
+  }),
+  /unsupported side/
+);
 
 const divergentSession = JSON.parse(await readFile(
   'gbdraw/web/gallery/sessions/BGC0000708-BGC0000713.gbdraw-session.json',
@@ -214,7 +385,7 @@ const importEvent = {
 
 const imported = await importSession(importEvent);
 
-assert.equal(imported.status, 'ok');
+assert.equal(imported.status, 'ok', imported.error?.message);
 assert.equal(state.linearComparisonPlan.mode, 'none');
 assert.deepEqual(state.linearComparisonPlan.edges, []);
 assert.deepEqual({
@@ -357,6 +528,346 @@ const groupFreeDrawerImport = await importPayload(partialLayoutSession);
 assert.equal(groupFreeDrawerImport.status, 'ok');
 assert.equal(state.showRightDrawer.value, false);
 assert.equal(state.rightDrawerTab.value, 'features');
+
+const activeIntentSession = JSON.parse(await readFile(
+  'gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json',
+  'utf8'
+));
+const activeFeatureId = activeIntentSession.editorState.featureCatalog.items[0].features[0].svgId;
+Object.assign(activeIntentSession.config.form, {
+  plot_title: 'Saved active draft',
+  labels_mode: 'both',
+  show_scale: false,
+  legend: 'left'
+});
+Object.assign(activeIntentSession.config.adv, {
+  plot_title_position: 'top',
+  axis_stroke_width: 7,
+  label_font_size: 31,
+  feature_width_circular: 19,
+  circular_track_slots_enabled: false,
+  circular_track_slots_schema_version: 4,
+  circular_track_slots_axis_index: 0,
+  circular_track_slots: [{
+    ...disabledDraft,
+    width: 27,
+    radius: 1.2,
+    inner_gap_px: 4,
+    outer_gap_px: 5
+  }]
+});
+Object.assign(activeIntentSession.config, {
+  colors: { CDS: '#123456', tRNA: '#abcdef' },
+  palette: 'orange',
+  paletteInstantPreviewEnabled: false,
+  rules: [{
+    feat: 'CDS',
+    qual: 'gene',
+    val: '^ND1$',
+    color: '#f97316',
+    cap: 'Saved rule',
+    fromFile: false
+  }],
+  qualifierPriorityRules: [{ feat: 'CDS', order: 'gene,product' }],
+  filterMode: 'Whitelist',
+  whitelist: [{ feat: 'CDS', qual: 'gene', key: 'ND1' }],
+  blacklistText: 'hypothetical, draft-only',
+  annotationSets: [{
+    id: 'saved-annotations',
+    annotations: [{
+      id: 'saved-window',
+      target: { kind: 'coordinateSpan', start: 10, end: 30 },
+      label: 'Saved window',
+      mark: 'band'
+    }]
+  }],
+  linearRecordLayout: {
+    enabled: false,
+    recordGap: 41,
+    rows: []
+  },
+  linearComparisonPlan: { mode: 'none', defaultSource: 'losat', edges: [] }
+});
+activeIntentSession.ui.paletteInstantPreviewEnabled = false;
+activeIntentSession.ui.appliedPaletteName = 'default';
+activeIntentSession.ui.appliedPaletteColors = { CDS: '#e8b441', tRNA: '#71ee7d' };
+activeIntentSession.ui.pendingPaletteName = 'orange';
+activeIntentSession.ui.pendingPaletteColors = { CDS: '#123456', tRNA: '#abcdef' };
+activeIntentSession.ui.layoutPreferences = {
+  circular: {
+    single: { legend: 'left', plotTitlePosition: 'top' },
+    multi: { legend: 'right', plotTitlePosition: 'bottom' }
+  },
+  linear: { legend: 'bottom', plotTitlePosition: 'bottom' }
+};
+activeIntentSession.features = {
+  selectedFeatureRecordIdx: 0,
+  featureColorOverrides: {
+    [activeFeatureId]: { color: '#334455', caption: 'Saved feature fill' }
+  },
+  featureVisibilityManualRules: [],
+  featureVisibilityOverrides: { [activeFeatureId]: 'off' },
+  labelTextFeatureOverrides: { [activeFeatureId]: 'Saved feature label' },
+  labelOverrideRows: [],
+  labelTextBulkOverrides: {},
+  labelTextFeatureOverrideSources: { [activeFeatureId]: 'Original label' },
+  labelVisibilityOverrides: { [activeFeatureId]: 'off' },
+  labelOverrideContextKey: 'saved-active-context'
+};
+activeIntentSession.editorState = {
+  ...activeIntentSession.editorState,
+  legend: {
+    entries: [],
+    deletedEntries: [],
+    originalOrder: [],
+    originalColors: {},
+    colorOverrides: { 'Saved feature fill': '#334455' },
+    strokeOverrides: {
+      'Saved feature fill': { strokeColor: '#112233', strokeWidth: 2 }
+    },
+    addedCaptions: []
+  },
+  featureStrokes: {
+    overrides: {
+      [activeFeatureId]: { strokeColor: '#654321', strokeWidth: 3 }
+    }
+  },
+  originalSvgStroke: { color: '#000000', width: 1 }
+};
+
+const expectedActiveIntent = {
+  modeAndInput: { mode: 'circular', inputType: 'gb' },
+  palette: {
+    selected: 'orange',
+    currentColors: { CDS: '#123456', tRNA: '#abcdef' },
+    appliedName: 'default',
+    appliedColors: { CDS: '#e8b441', tRNA: '#71ee7d' },
+    pendingName: 'orange',
+    pendingColors: { CDS: '#123456', tRNA: '#abcdef' },
+    instantPreview: false
+  },
+  specificRules: structuredClone(activeIntentSession.config.rules),
+  qualifierPriorityRules: structuredClone(activeIntentSession.config.qualifierPriorityRules),
+  filters: {
+    mode: 'Whitelist',
+    whitelist: structuredClone(activeIntentSession.config.whitelist),
+    blacklistText: 'hypothetical, draft-only'
+  },
+  form: {
+    plot_title: 'Saved active draft',
+    labels_mode: 'both',
+    show_scale: false,
+    legend: 'left'
+  },
+  adv: {
+    axis_stroke_width: 7,
+    label_font_size: 31,
+    feature_width_circular: 19
+  },
+  annotationSets: [{
+    id: 'saved-annotations',
+    annotations: [{ id: 'saved-window', mark: 'band' }]
+  }],
+  trackSlots: {
+    enabled: false,
+    axisIndex: 0,
+    slots: [{ id: 'disabled-draft', renderer: 'depth', enabled: false }]
+  },
+  layout: {
+    preferences: structuredClone(activeIntentSession.ui.layoutPreferences),
+    linearRecordLayout: structuredClone(activeIntentSession.config.linearRecordLayout)
+  },
+  editorOverrides: {
+    fills: structuredClone(activeIntentSession.features.featureColorOverrides),
+    strokes: structuredClone(activeIntentSession.editorState.featureStrokes.overrides),
+    visibility: structuredClone(activeIntentSession.features.featureVisibilityOverrides),
+    labelText: structuredClone(activeIntentSession.features.labelTextFeatureOverrides),
+    labelVisibility: structuredClone(activeIntentSession.features.labelVisibilityOverrides),
+    legendColors: structuredClone(activeIntentSession.editorState.legend.colorOverrides),
+    legendStrokes: structuredClone(activeIntentSession.editorState.legend.strokeOverrides)
+  }
+};
+
+const activeIntentImport = await importPayload(activeIntentSession);
+assert.equal(
+  activeIntentImport.status,
+  'ok',
+  activeIntentImport.error?.message || 'active-intent session import failed'
+);
+const afterSessionLoadIntent = compactActiveIntentSnapshot();
+const immediatelyBeforeGenerateIntent = compactActiveIntentSnapshot();
+const activeFiles = await serializeActiveRenderFiles(state.mode.value, state);
+const firstGeneratedCanonical = buildCanonicalRenderRequest({ state, filesData: activeFiles });
+const firstGeneratedProjection = projectCanonicalSessionRequest(firstGeneratedCanonical);
+
+const afterLoadMismatches = activeIntentDomainMismatches(
+  expectedActiveIntent,
+  afterSessionLoadIntent
+);
+const beforeGenerateMismatches = activeIntentDomainMismatches(
+  expectedActiveIntent,
+  immediatelyBeforeGenerateIntent
+);
+assert.deepEqual(
+  afterLoadMismatches,
+  [],
+  `active-intent domains lost after session load: ${afterLoadMismatches.join(', ')}; ` +
+    `expected=${JSON.stringify(expectedActiveIntent.layout)} ` +
+    `actual=${JSON.stringify(afterSessionLoadIntent.layout)}`
+);
+assert.deepEqual(
+  beforeGenerateMismatches,
+  [],
+  `active-intent domains lost before first Generate: ${beforeGenerateMismatches.join(', ')}`
+);
+assert.equal(firstGeneratedProjection.mode, 'circular');
+assert.equal(firstGeneratedProjection.inputType, 'gb');
+assert.equal(firstGeneratedProjection.config.palette, 'orange');
+assert.equal(firstGeneratedProjection.config.colors.CDS, '#123456');
+assert.equal(firstGeneratedProjection.config.colors.tRNA, '#abcdef');
+assert.deepEqual(
+  firstGeneratedProjection.config.rules,
+  activeIntentSession.config.rules.map(({ fromFile: _fromFile, ...rule }) => rule)
+);
+assert.deepEqual(
+  firstGeneratedProjection.config.qualifierPriorityRules,
+  activeIntentSession.config.qualifierPriorityRules
+);
+assert.equal(firstGeneratedProjection.config.filterMode, 'Whitelist');
+assert.deepEqual(firstGeneratedProjection.config.whitelist, activeIntentSession.config.whitelist);
+assert.equal(firstGeneratedProjection.config.form.plot_title, 'Saved active draft');
+assert.equal(firstGeneratedProjection.config.form.labels_mode, 'both');
+assert.equal(firstGeneratedProjection.config.form.show_scale, false);
+assert.equal(firstGeneratedProjection.config.adv.axis_stroke_width, 7);
+assert.equal(firstGeneratedProjection.config.adv.label_font_size, 31);
+assert.deepEqual(
+  firstGeneratedCanonical.renderRequest.diagramOptions.tracks.circularTrackSlots.find(
+    (slot) => slot.renderer === 'features'
+  )?.width,
+  { value: 19, unit: 'px' }
+);
+assert.deepEqual(
+  firstGeneratedProjection.config.annotationSets.map((set) => set.id),
+  ['saved-annotations']
+);
+
+const stateBeforeInvalidActiveConfig = {
+  activeIntent: compactActiveIntentSnapshot(),
+  results: state.results.value,
+  featureCatalog: state.featureCatalog.value,
+  primaryFile: state.files.c_gb,
+  svgContainer: state.svgContainer.value,
+  sessionTitle: state.sessionTitle.value
+};
+const invalidActiveConfigSession = structuredClone(activeIntentSession);
+invalidActiveConfigSession.config.form.linear_track_layout = 'spreadout';
+const invalidActiveConfigEvent = {
+  target: {
+    files: [new Blob([JSON.stringify(invalidActiveConfigSession)], { type: 'application/json' })],
+    value: 'selected'
+  }
+};
+alerts.length = 0;
+const consoleErrorBeforeInvalidActiveConfig = console.error;
+console.error = () => {};
+let invalidActiveConfigImport;
+try {
+  invalidActiveConfigImport = await importSession(invalidActiveConfigEvent);
+} finally {
+  console.error = consoleErrorBeforeInvalidActiveConfig;
+}
+assert.equal(invalidActiveConfigImport.status, 'error');
+assert.match(
+  invalidActiveConfigImport.error?.message || '',
+  /Linear track layout must be one of: above, middle, below/
+);
+assert.deepEqual(compactActiveIntentSnapshot(), stateBeforeInvalidActiveConfig.activeIntent);
+assert.strictEqual(state.results.value, stateBeforeInvalidActiveConfig.results);
+assert.strictEqual(state.featureCatalog.value, stateBeforeInvalidActiveConfig.featureCatalog);
+assert.strictEqual(state.files.c_gb, stateBeforeInvalidActiveConfig.primaryFile);
+assert.strictEqual(state.svgContainer.value, stateBeforeInvalidActiveConfig.svgContainer);
+assert.equal(state.sessionTitle.value, stateBeforeInvalidActiveConfig.sessionTitle);
+assert.equal(invalidActiveConfigEvent.target.value, '');
+assert.equal(alerts.length, 1);
+assert.match(alerts[0], /^Failed to load session: Linear track layout must be one of/);
+
+const legacyActiveIntent = {
+  form: {
+    plot_title: 'Legacy JSON next Generate',
+    labels_mode: 'both',
+    show_scale: false
+  },
+  adv: {
+    axis_stroke_width: 9,
+    label_font_size: 29,
+    feature_width_circular: 23
+  },
+  colors: { CDS: '#0b4f6c', tRNA: '#f59e0b' },
+  palette: 'orange',
+  paletteInstantPreviewEnabled: true,
+  rules: [{
+    feat: 'CDS',
+    qual: 'gene',
+    val: '^ND2$',
+    color: '#dc2626',
+    cap: 'Legacy ND2',
+    fromFile: false
+  }],
+  qualifierPriorityRules: [{ feat: 'CDS', order: 'product,gene' }],
+  filterMode: 'Blacklist',
+  whitelist: [{ feat: 'CDS', qual: 'gene', key: 'ND2' }],
+  blacklistText: 'legacy-hidden'
+};
+alerts.length = 0;
+const legacyActiveIntentImport = await importPayload(legacyActiveIntent);
+assert.equal(legacyActiveIntentImport.status, 'legacy');
+assert.equal(state.selectedPalette.value, 'orange');
+assert.equal(state.currentColors.value.CDS, '#0b4f6c');
+assert.equal(state.currentColors.value.tRNA, '#f59e0b');
+assert.equal(state.appliedPaletteName.value, 'orange');
+assert.equal(state.appliedPaletteColors.value.CDS, '#0b4f6c');
+assert.equal(state.pendingPaletteName.value, '');
+assert.deepEqual(state.manualSpecificRules, legacyActiveIntent.rules);
+assert.deepEqual(state.manualPriorityRules, legacyActiveIntent.qualifierPriorityRules);
+assert.equal(state.filterMode.value, 'Blacklist');
+assert.deepEqual(state.manualWhitelist, legacyActiveIntent.whitelist);
+assert.equal(state.manualBlacklist.value, 'legacy-hidden');
+assert.equal(state.form.plot_title, 'Legacy JSON next Generate');
+assert.equal(state.form.show_scale, false);
+assert.equal(state.adv.axis_stroke_width, 9);
+assert.equal(state.adv.label_font_size, 29);
+assert.equal(state.adv.feature_width_circular, 23);
+const legacyActiveFiles = await serializeActiveRenderFiles(state.mode.value, state);
+const legacyGeneratedCanonical = buildCanonicalRenderRequest({
+  state,
+  filesData: legacyActiveFiles
+});
+const legacyGeneratedProjection = projectCanonicalSessionRequest(legacyGeneratedCanonical);
+assert.equal(legacyGeneratedProjection.config.palette, 'orange');
+assert.equal(legacyGeneratedProjection.config.colors.CDS, '#0b4f6c');
+assert.equal(legacyGeneratedProjection.config.colors.tRNA, '#f59e0b');
+assert.deepEqual(legacyGeneratedProjection.config.rules, legacyActiveIntent.rules.map(
+  ({ fromFile: _fromFile, ...rule }) => rule
+));
+assert.deepEqual(
+  legacyGeneratedProjection.config.qualifierPriorityRules,
+  legacyActiveIntent.qualifierPriorityRules
+);
+assert.equal(legacyGeneratedProjection.config.filterMode, 'Blacklist');
+assert.equal(legacyGeneratedProjection.config.blacklistText, 'legacy-hidden');
+assert.equal(legacyGeneratedProjection.config.form.plot_title, 'Legacy JSON next Generate');
+assert.equal(legacyGeneratedProjection.config.form.show_scale, false);
+assert.equal(legacyGeneratedProjection.config.adv.axis_stroke_width, 9);
+assert.equal(legacyGeneratedProjection.config.adv.label_font_size, 29);
+assert.deepEqual(
+  legacyGeneratedCanonical.renderRequest.diagramOptions.tracks.circularTrackSlots.find(
+    (slot) => slot.renderer === 'features'
+  )?.width,
+  { value: 23, unit: 'px' }
+);
+assert.deepEqual(alerts, [
+  'Legacy configuration loaded. Save as a session to use the current format.'
+]);
 
 const modeBeforeRollbackSetup = state.mode.value;
 state.mode.value = 'circular';

--- a/tests/web/session-export-validation.test.mjs
+++ b/tests/web/session-export-validation.test.mjs
@@ -1,4 +1,8 @@
 import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
+
+globalThis.crypto = webcrypto;
 
 globalThis.window = {
   Vue: {
@@ -9,7 +13,14 @@ globalThis.window = {
   },
   DOMPurify: { sanitize: (value) => value }
 };
-globalThis.document = {};
+globalThis.document = {
+  body: { appendChild: () => {} },
+  createElement: () => ({
+    addEventListener: () => {},
+    click: () => {},
+    parentNode: null
+  })
+};
 
 const {
   adoptCanonicalRenderArtifacts,
@@ -142,28 +153,41 @@ assert.deepEqual(state.circularConservation.series, [{
   label: 'Retained',
   sourceIndex: 0
 }]);
+state.files.c_conservation_blasts = [];
+state.files.c_conservation_fastas = [];
+state.files.c_conservation_sequence_sources = [];
+state.files.c_conservation_blasts_source = null;
 
 let downloadedBlobs = 0;
+let downloadedBlob = null;
 let compressionAttempts = 0;
 const originalCreateObjectUrl = URL.createObjectURL;
 const OriginalCompressionStream = globalThis.CompressionStream;
-URL.createObjectURL = () => {
+URL.createObjectURL = (blob) => {
   downloadedBlobs += 1;
-  return 'blob:unexpected-session';
+  downloadedBlob = blob;
+  return 'blob:active-draft-session';
 };
 globalThis.CompressionStream = function CountingCompressionStream(...args) {
   compressionAttempts += 1;
   return new OriginalCompressionStream(...args);
 };
 try {
-  await assert.rejects(
-    exportSession('stale-active-draft'),
-    /Generate again before using Save Session\. The active Custom Track draft has changed/
+  const saved = await exportSession('divergent-active-draft');
+  assert.equal(saved.status, 'saved');
+  const session = JSON.parse(gunzipSync(
+    Buffer.from(await saved.blob.arrayBuffer())
+  ).toString('utf8'));
+  assert.equal(session.config.adv.circular_track_slots[0].width, '16px');
+  assert.equal(
+    session.renderRequest.diagramOptions.tracks.circularTrackSlots[0].width,
+    null
   );
 } finally {
   URL.createObjectURL = originalCreateObjectUrl;
   globalThis.CompressionStream = OriginalCompressionStream;
 }
-assert.equal(inputReads, 0, 'active-draft rejection must happen before resource reads');
-assert.equal(compressionAttempts, 0, 'active-draft rejection must happen before gzip Blob creation');
-assert.equal(downloadedBlobs, 0, 'active-draft rejection must not create a download Blob URL');
+assert.ok(inputReads > 0, 'saving must bind the active input file');
+assert.equal(compressionAttempts, 1);
+assert.equal(downloadedBlobs, 1);
+assert.ok(downloadedBlob instanceof Blob);

--- a/tests/web/session-export-validation.test.mjs
+++ b/tests/web/session-export-validation.test.mjs
@@ -2,7 +2,14 @@ import assert from 'node:assert/strict';
 import { webcrypto } from 'node:crypto';
 import { gunzipSync } from 'node:zlib';
 
-globalThis.crypto = webcrypto;
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', {
+    configurable: true,
+    enumerable: true,
+    value: webcrypto,
+    writable: true
+  });
+}
 
 globalThis.window = {
   Vue: {


### PR DESCRIPTION
`config` now remains authoritative for the active version-40 draft during session import, while `renderRequest`, Results, and the feature catalog retain ownership of the committed preview. Current-session validation checks structure instead of equality with the last render, so valid unsent edits survive Save, Load, and Generate. Node and Playwright contracts cover no-draft, divergent-draft, direct-editor, invalid, legacy, repeated, and real Vibrio paths.