### PR TITLE
Contract Feature visibility Result ownership

### DIFF
--- a/gbdraw/web/js/app/feature-editor/visibility-actions.js
+++ b/gbdraw/web/js/app/feature-editor/visibility-actions.js
@@ -37,7 +37,7 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
     svgContainer
   } = state;
 
-  const { applyVisibilityPreviewBySvgId, applyVisibilityPreviewChanges } = featureSvgActions;
+  const { applyVisibilityPreviewChanges } = featureSvgActions;
   const ruleFields = new Set(['recordId', 'featureType', 'qualifier', 'value', 'action']);
 
   const normalizeText = (value) => String(value ?? '').trim();
@@ -209,8 +209,7 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
   };
 
   const applyVisibilityPreviewForScope = (scope, feat, mode) => {
-    let changed = false;
-    collectAffectedFeatureIds(scope, feat).forEach((svgId) => {
+    const changes = collectAffectedFeatureIds(scope, feat).map((svgId) => {
       const specificHashMode = (scope?.id === 'product' || scope?.id === 'protein_id')
         ? featureVisibilityOverrides[svgId]
         : '';
@@ -218,10 +217,9 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
         (mode === 'default'
           ? resolveEffectiveFeatureVisibility(svgId, featureVisibilityOverrides, null, featureVisibilityManualRules)
           : mode);
-      changed = applyVisibilityPreviewBySvgId(svgId, effectiveMode) || changed;
+      return { featureId: svgId, mode: effectiveMode };
     });
-    if (changed) previewRuntime?.flushActiveResult?.();
-    return changed;
+    return applyVisibilityPreviewChanges(changes);
   };
 
   const updateClickedFeatureVisibilityFromRules = (featureIds) => {
@@ -304,9 +302,6 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
         { reason }
       );
       if (!updated && !overrideChanged) return false;
-      if (updated && previewRuntime?.flushActiveResult) {
-        previewRuntime.flushActiveResult({ force: true });
-      }
       updateClickedFeatureVisibilityFromRules(affectedFeatureIds);
       markFeatureVisibilityLabelLayoutDirty(reason);
       return true;
@@ -488,7 +483,6 @@ export const createFeatureVisibilityActions = ({ state, featureSvgActions, previ
           mode: getFeatureVisibility(feature)
         }))
     );
-    if (changed) previewRuntime?.flushActiveResult?.();
     return changed;
   };
 

--- a/gbdraw/web/js/app/preview-runtime.js
+++ b/gbdraw/web/js/app/preview-runtime.js
@@ -210,8 +210,10 @@ export const createPreviewRuntime = ({ state, serializeSvg }) => {
       });
     });
 
-    if (updated > 0) markActiveResultDirty(reason);
-    return updated > 0;
+    if (updated === 0) return false;
+    markActiveResultDirty(reason);
+    flushActiveResult();
+    return true;
   };
 
   const applyFeatureStrokeChanges = (changes, { reason = 'feature-stroke' } = {}) => {

--- a/tests/web/feature-visibility-actions.test.mjs
+++ b/tests/web/feature-visibility-actions.test.mjs
@@ -44,7 +44,6 @@ const featureVisibilityScopeDialog = {};
 const selectedResultIndex = ref(0);
 const resultGenerationKey = ref('generation-1');
 const appliedPreviewChanges = [];
-const flushes = [];
 
 const actions = createFeatureVisibilityActions({
   state: {
@@ -65,7 +64,6 @@ const actions = createFeatureVisibilityActions({
     })
   },
   featureSvgActions: {
-    applyVisibilityPreviewBySvgId: () => true,
     applyVisibilityPreviewChanges: (changes, options = {}) => {
       appliedPreviewChanges.push({ changes, reason: options.reason });
       return true;
@@ -76,10 +74,7 @@ const actions = createFeatureVisibilityActions({
       selectedResultIndex.value = index;
       return true;
     },
-    flushActiveResult: (options = {}) => {
-      flushes.push(options);
-      return true;
-    }
+    flushActiveResult: () => assert.fail('visibility actions must not flush Results directly')
   }
 });
 
@@ -95,7 +90,6 @@ assert.deepEqual(
   appliedPreviewChanges[0].changes.map((change) => [change.featureId, change.mode]),
   [['feature-a', 'off'], ['feature-b', 'off']]
 );
-assert.deepEqual(flushes, [{ force: true }]);
 
 assert.equal(await command.revert(), true);
 assert.deepEqual(featureVisibilityOverrides, {});
@@ -104,14 +98,17 @@ assert.deepEqual(
   appliedPreviewChanges[1].changes.map((change) => [change.featureId, change.mode]),
   [['feature-a', 'on'], ['feature-b', 'on']]
 );
-assert.deepEqual(flushes, [{ force: true }, { force: true }]);
 
 assert.equal(actions.setFeatureVisibility(featureA, 'off', {
   triggerReflow: false,
   scope: { id: 'feature' }
 }), true);
 assert.equal(featureVisibilityOverrides['feature-a'], 'off');
-assert.deepEqual(flushes, [{ force: true }, { force: true }, {}]);
+assert.equal(appliedPreviewChanges.length, 3);
+assert.deepEqual(
+  appliedPreviewChanges[2].changes.map((change) => [change.featureId, change.mode]),
+  [['feature-a', 'off']]
+);
 delete featureVisibilityOverrides['feature-a'];
 
 const sourceIdFeature = {
@@ -266,11 +263,10 @@ actions.updateClickedFeatureVisibility('off');
 assert.equal(featureVisibilityScopeDialog.show, false);
 delete featureVisibilityOverrides[strictTrigger.svg_id];
 
-flushes.length = 0;
+const previewChangeCountBeforeStaleApply = appliedPreviewChanges.length;
 resultGenerationKey.value = 'generation-2';
 assert.equal(await command.apply(), false);
 assert.deepEqual(featureVisibilityOverrides, {});
-assert.equal(appliedPreviewChanges.length, 2);
-assert.deepEqual(flushes, []);
+assert.equal(appliedPreviewChanges.length, previewChangeCountBeforeStaleApply);
 
 console.log('feature visibility action tests passed');

--- a/tests/web/preview-runtime.test.mjs
+++ b/tests/web/preview-runtime.test.mjs
@@ -70,11 +70,18 @@ const featureBConnector = new FakeFeatureElement('feature-b__line1', {
   fill: 'none'
 });
 const svg = makeSvg([featureA, featureBConnector, featureBBlock]);
+let resultReplacementCount = 0;
+const trackedResults = new Proxy([
+  { name: 'one.svg', content: '<svg id="old-one"></svg>' },
+  { name: 'two.svg', content: '<svg id="old-two"></svg>' }
+], {
+  set(target, property, value) {
+    if (/^\d+$/.test(String(property))) resultReplacementCount += 1;
+    return Reflect.set(target, property, value);
+  }
+});
 const state = {
-  results: ref([
-    { name: 'one.svg', content: '<svg id="old-one"></svg>' },
-    { name: 'two.svg', content: '<svg id="old-two"></svg>' }
-  ]),
+  results: ref(trackedResults),
   selectedResultIndex: ref(0),
   skipCaptureBaseConfig: ref(false),
   svgContainer: ref({
@@ -93,17 +100,40 @@ const runtime = createPreviewRuntime({
 runtime.mountResultSvg(0, svg);
 assert.equal(runtime.applyFeatureVisibilityChanges([{ featureId: 'feature-a', mode: 'off' }]), true);
 assert.equal(featureA.getAttribute('display'), 'none');
-assert.equal(state.results.value[0].content, '<svg id="old-one"></svg>');
-assert.equal(serializeCount, 0);
-assert.equal(state.skipCaptureBaseConfig.value, false);
-
-assert.equal(runtime.flushActiveResult(), true);
 assert.equal(serializeCount, 1);
+assert.equal(resultReplacementCount, 1);
 assert.equal(state.results.value[0].content, '<svg data-count="1" data-elements="3"></svg>');
 assert.equal(state.skipCaptureBaseConfig.value, true);
 
 state.skipCaptureBaseConfig.value = false;
+const resultAfterSingleEdit = state.results.value[0];
 assert.equal(runtime.applyFeatureVisibilityChanges([{ featureId: 'feature-a', mode: 'off' }]), false);
+assert.equal(serializeCount, 1);
+assert.equal(resultReplacementCount, 1);
+assert.equal(state.results.value[0], resultAfterSingleEdit);
+assert.equal(state.skipCaptureBaseConfig.value, false);
+
+assert.equal(runtime.applyFeatureVisibilityChanges([
+  { featureId: 'feature-a', mode: 'on' },
+  { featureId: 'feature-b', mode: 'off' }
+]), true);
+assert.equal(featureA.getAttribute('display'), null);
+assert.equal(featureBBlock.getAttribute('display'), 'none');
+assert.equal(featureBConnector.getAttribute('display'), 'none');
+assert.equal(serializeCount, 2);
+assert.equal(resultReplacementCount, 2);
+
+state.skipCaptureBaseConfig.value = false;
+const resultAfterBulkEdit = state.results.value[0];
+assert.equal(runtime.applyFeatureVisibilityChanges([
+  { featureId: 'feature-a', mode: 'on' },
+  { featureId: 'feature-b', mode: 'off' }
+]), false);
+assert.equal(serializeCount, 2);
+assert.equal(resultReplacementCount, 2);
+assert.equal(state.results.value[0], resultAfterBulkEdit);
+assert.equal(state.skipCaptureBaseConfig.value, false);
+
 assert.equal(runtime.applyFeatureFillChanges([{ featureId: 'feature-b', color: '#111111' }]), false);
 featureBBlock.setAttribute('stroke', '#222222');
 featureBBlock.setAttribute('stroke-width', '3');
@@ -116,23 +146,21 @@ assert.equal(runtime.applyFeatureStrokeChanges([{
 }]), false);
 assert.equal(runtime.getActiveRuntime().dirty, false);
 assert.equal(runtime.flushActiveResult(), false);
-assert.equal(serializeCount, 1);
+assert.equal(serializeCount, 2);
 assert.equal(state.skipCaptureBaseConfig.value, false);
 state.skipCaptureBaseConfig.value = false;
 assert.equal(runtime.flushActiveResult(), false);
-assert.equal(serializeCount, 1);
+assert.equal(serializeCount, 2);
 
 runtime.applyFeatureFillChanges([{ featureId: 'feature-b', color: '#abcdef' }]);
 assert.equal(featureBBlock.getAttribute('fill'), '#abcdef');
 assert.equal(featureBConnector.getAttribute('fill'), 'none');
-runtime.applyFeatureVisibilityChanges([{ featureId: 'feature-b', mode: 'off' }]);
-assert.equal(featureBBlock.getAttribute('display'), 'none');
-assert.equal(featureBConnector.getAttribute('display'), 'none');
 runtime.selectResult(1);
-assert.equal(serializeCount, 2);
+assert.equal(serializeCount, 3);
+assert.equal(resultReplacementCount, 3);
 assert.equal(state.skipCaptureBaseConfig.value, false);
 assert.equal(state.selectedResultIndex.value, 1);
-assert.equal(state.results.value[0].content, '<svg data-count="2" data-elements="3"></svg>');
+assert.equal(state.results.value[0].content, '<svg data-count="3" data-elements="3"></svg>');
 
 const legacyConnector = new FakeFeatureElement('feature-c__line1', {
   featureId: '',

--- a/tools/web-change-policy.json
+++ b/tools/web-change-policy.json
@@ -119,7 +119,6 @@
       "app/feature-editor/color-actions.js",
       "app/feature-editor/label-actions.js",
       "app/feature-editor/svg-actions.js",
-      "app/feature-editor/visibility-actions.js",
       "app/legend-layout/canvas-actions.js",
       "app/legend-layout/diagram-drag.js",
       "app/legend-layout/reposition-actions.js",


### PR DESCRIPTION
Move Feature visibility serialization and Result replacement into the preview runtime, batch bulk visibility DOM updates, and prove exact flush counts.