### PR TITLE
Codex/architecture ratchet 0a

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["main", "refactoring", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["dev", "main"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 

--- a/.github/workflows/web-base-policy.yml
+++ b/.github/workflows/web-base-policy.yml
@@ -2,7 +2,7 @@ name: Web base policy
 
 on:
   pull_request_target:
-    branches: ["main"]
+    branches: ["dev", "main"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,16 +133,33 @@ not alongside user-facing pages.
 - Don't add speculative options, fallbacks, or abstractions for
   hypothetical future use; keep changes scoped to the problem at hand.
 
+## Branch roles
+
+- Work-branch base: the latest merged `origin/dev`.
+- Pull-request target: `dev`.
+- Integration branch: `dev`.
+- Release branch: `main`.
+
+Agent-authored work branches must start from `origin/dev` without tracking
+`dev` or `main`. Maintainers promote `dev` to `main` through a pull request
+after the integration checks pass. Feature work must not target `main`
+directly.
+
 ## Submitting a pull request
 
-1. Create a branch from `main`.
+1. Fetch `origin` and create a non-tracking work branch from `origin/dev`:
+
+   ```bash
+   git fetch origin
+   git switch --no-track -c <branch-name> origin/dev
+   ```
+
 2. Make your change with tests that cover it (a bug fix without a
    regression test is unlikely to be merged).
 3. Run `ruff check gbdraw/` and `pytest tests/ -v -m "not slow"` locally.
-4. Open a pull request against `main` describing what changed and why.
+4. Open a pull request against `dev` describing what changed and why.
    Link the issue it resolves, if any.
-5. CI runs the fast test suite on Python 3.10–3.12, a CairoSVG-specific job,
-   and a lint job; all three must pass before merge.
+5. Wait for all required CI checks to pass before merge.
 
 By contributing, you agree that your contribution is licensed under the
 project's [MIT License](./LICENSE.txt).

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -402,11 +402,24 @@ test('privileged capability owners and importers stay within their allowlists', 
 
 test('PR workflows separate normal tests from trusted base-policy execution', () => {
   const activityTypes = /types: \[opened, synchronize, reopened, labeled, unlabeled\]/;
+  const triggerBranches = (workflow, trigger) => {
+    const match = workflow.match(new RegExp(
+      `\\n  ${trigger}:\\n    branches: (\\[[^\\n]+\\])`
+    ));
+    assert.ok(match, `${trigger} branch filter must exist`);
+    return JSON.parse(match[1]);
+  };
+
   assert.match(TEST_WORKFLOW, /\n  pull_request:\n/);
+  assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'pull_request'), ['dev', 'main']);
   assert.match(TEST_WORKFLOW, activityTypes);
   assert.match(TEST_WORKFLOW, /name: Run core tests/);
 
   assert.match(BASE_POLICY_WORKFLOW, /\n  pull_request_target:\n/);
+  assert.deepEqual(
+    triggerBranches(BASE_POLICY_WORKFLOW, 'pull_request_target'),
+    ['dev', 'main']
+  );
   assert.match(BASE_POLICY_WORKFLOW, activityTypes);
   assert.match(BASE_POLICY_WORKFLOW, /permissions:\n  contents: read/);
   assert.match(BASE_POLICY_WORKFLOW, /name: Web base policy \(trusted base\)/);


### PR DESCRIPTION
## Purpose

Run normal and trusted-base pull-request checks for both `dev` and `main`,
and document the repository branch roles.

## Verification

- `node --test tests/web/architecture-contracts.test.mjs` — 48 passed
- `node --test tests/web/*.test.mjs` — 247 passed
- `node tools/check-web-change-budget.mjs` — PASS
- `git diff --check` — PASS

## Bootstrap limitation

This PR introduces the `dev` pull-request triggers, so those triggers cannot
protect this PR itself. After merge, the next guard-only PR targeting `dev`
must receive both `Web change budget` and
`Web base policy (trusted base)` checks.

No Web runtime, privileged allowlist, dependency, or generated artifact changed.