### PR TITLE
ci: reserve architecture ratchet guard paths

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -564,6 +564,27 @@ const BUDGET_FIXTURE = Object.freeze({
   ),
   'gbdraw/web/vendor/library.js': 'globalThis.vendorLibrary = true;\n'
 });
+const FUTURE_GUARD_PATHS = Object.freeze([
+  'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+  '.github/pull_request_template.md',
+  'tools/web-architecture-detectors.mjs',
+  'tools/web-architecture-evaluation.mjs',
+  'tools/web-architecture-rules.json',
+  'tools/web-architecture-violations.json',
+  'tests/web/architecture-ratchet-fixtures.test.mjs'
+]);
+const FUTURE_CHECKER_IMPLEMENTATION_PATHS = Object.freeze([
+  'tools/web-architecture-detectors.mjs',
+  'tools/web-architecture-evaluation.mjs'
+]);
+const FUTURE_AUTHORITY_PATHS = Object.freeze([
+  'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+  'tools/web-architecture-rules.json',
+  'tools/web-architecture-violations.json'
+]);
+const reservedPathContent = (path) => path.endsWith('.json')
+  ? '{}\n'
+  : `// reserved fixture for ${path}\n`;
 
 const writeFixtureFile = (root, path, content) => {
   const target = join(root, path);
@@ -860,6 +881,28 @@ test('dependency, vendor, binary, and runtime/guard rules are non-waivable', () 
   });
 });
 
+test('reserved future guard paths need not exist before their rollout', () => {
+  assert.deepEqual(
+    FUTURE_GUARD_PATHS.filter((path) => Object.hasOwn(BUDGET_FIXTURE, path)),
+    []
+  );
+  const result = runChangeBudgetCase(() => {});
+  assert.equal(result.status, 0, result.output);
+  assert.match(result.output, /Result: \*\*PASS\*\*/);
+});
+
+test('runtime cannot co-change with any reserved future guard path', () => {
+  FUTURE_GUARD_PATHS.forEach((guardPath) => {
+    assertNonWaivableWorkingTreeFailure((write) => {
+      write(
+        'gbdraw/web/js/services/session-file.js',
+        'export const readSession = () => ({ version: 2 });\n'
+      );
+      write(guardPath, reservedPathContent(guardPath));
+    }, [/production runtime files and Web guard\/CI files changed together/], guardPath);
+  });
+});
+
 test('checker implementation and authority files cannot change together', () => {
   const implementationPaths = [
     'tools/check-web-change-budget.mjs',
@@ -884,6 +927,101 @@ test('checker implementation and authority files cannot change together', () => 
       }, [/Web checker\/source parser and authority policy\/workflow files changed together/]);
     });
   });
+});
+
+test('all checker implementations are separated from reserved future authority', () => {
+  const implementationPaths = [
+    'tools/check-web-change-budget.mjs',
+    'tools/web-change-source.mjs',
+    ...FUTURE_CHECKER_IMPLEMENTATION_PATHS
+  ];
+
+  implementationPaths.forEach((implementationPath) => {
+    FUTURE_AUTHORITY_PATHS.forEach((authorityPath) => {
+      assertNonWaivableWorkingTreeFailure((write) => {
+        write(
+          implementationPath,
+          BUDGET_FIXTURE[implementationPath]
+            ? `${BUDGET_FIXTURE[implementationPath]}\n// changed\n`
+            : reservedPathContent(implementationPath)
+        );
+        write(authorityPath, reservedPathContent(authorityPath));
+      }, [/Web checker\/source parser and authority policy\/workflow files changed together/]);
+    });
+  });
+});
+
+test('the evaluator implementation and ratchet fixture classifications stay disjoint', () => {
+  const evaluatorAndFixture = runChangeBudgetCase((write) => {
+    write(
+      'tools/web-architecture-evaluation.mjs',
+      reservedPathContent('tools/web-architecture-evaluation.mjs')
+    );
+    write(
+      'tests/web/architecture-ratchet-fixtures.test.mjs',
+      reservedPathContent('tests/web/architecture-ratchet-fixtures.test.mjs')
+    );
+  });
+  assert.equal(evaluatorAndFixture.status, 0, evaluatorAndFixture.output);
+
+  const fixtureAndAuthority = runChangeBudgetCase((write) => {
+    write(
+      'tests/web/architecture-ratchet-fixtures.test.mjs',
+      reservedPathContent('tests/web/architecture-ratchet-fixtures.test.mjs')
+    );
+    write(
+      'tools/web-architecture-rules.json',
+      reservedPathContent('tools/web-architecture-rules.json')
+    );
+  });
+  assert.equal(fixtureAndAuthority.status, 0, fixtureAndAuthority.output);
+});
+
+test('the reserved PR template is guard-only', () => {
+  const templateAndChecker = runChangeBudgetCase((write) => {
+    write(
+      '.github/pull_request_template.md',
+      reservedPathContent('.github/pull_request_template.md')
+    );
+    write(
+      'tools/web-architecture-evaluation.mjs',
+      reservedPathContent('tools/web-architecture-evaluation.mjs')
+    );
+  });
+  assert.equal(templateAndChecker.status, 0, templateAndChecker.output);
+
+  const templateAndAuthority = runChangeBudgetCase((write) => {
+    write(
+      '.github/pull_request_template.md',
+      reservedPathContent('.github/pull_request_template.md')
+    );
+    write(
+      'tools/web-architecture-rules.json',
+      reservedPathContent('tools/web-architecture-rules.json')
+    );
+  });
+  assert.equal(templateAndAuthority.status, 0, templateAndAuthority.output);
+});
+
+test('an unregistered path acquires no guard or authority classification', () => {
+  const unregisteredPath = 'docs/internal/UNREGISTERED_ARCHITECTURE_NOTE.md';
+  const runtimeChange = runChangeBudgetCase((write) => {
+    write(
+      'gbdraw/web/js/services/session-file.js',
+      'export const readSession = () => ({ version: 2 });\n'
+    );
+    write(unregisteredPath, '# Unregistered fixture\n');
+  });
+  assert.equal(runtimeChange.status, 0, runtimeChange.output);
+
+  const checkerChange = runChangeBudgetCase((write) => {
+    write(
+      'tools/web-architecture-evaluation.mjs',
+      reservedPathContent('tools/web-architecture-evaluation.mjs')
+    );
+    write(unregisteredPath, '# Unregistered fixture\n');
+  });
+  assert.equal(checkerChange.status, 0, checkerChange.output);
 });
 
 test('the Web change-budget checker allows an owner-internal edit', () => {

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -116,20 +116,32 @@ const addedBinaryRuntimePaths = productionPaths.filter((path) => {
 const changedVendorPaths = productionPaths.filter((path) => path.startsWith('gbdraw/web/vendor/'));
 const policyPath = 'tools/web-change-policy.json';
 const guardPaths = new Set([
+  'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+  '.github/pull_request_template.md',
   'tools/check-web-change-budget.mjs',
+  'tools/web-architecture-detectors.mjs',
+  'tools/web-architecture-evaluation.mjs',
+  'tools/web-architecture-rules.json',
+  'tools/web-architecture-violations.json',
   'tools/web-change-source.mjs',
   policyPath,
   'docs/internal/WEB_CHANGE_POLICY.md',
   'tests/web/architecture-contracts.test.mjs',
+  'tests/web/architecture-ratchet-fixtures.test.mjs',
   '.github/workflows/test.yml',
   '.github/workflows/web-base-policy.yml'
 ]);
 const changedGuards = [...changed.keys()].filter((path) => guardPaths.has(path)).sort();
 const checkerImplementationPaths = new Set([
   'tools/check-web-change-budget.mjs',
+  'tools/web-architecture-detectors.mjs',
+  'tools/web-architecture-evaluation.mjs',
   'tools/web-change-source.mjs'
 ]);
 const authorityPaths = new Set([
+  'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+  'tools/web-architecture-rules.json',
+  'tools/web-architecture-violations.json',
   policyPath,
   '.github/workflows/test.yml',
   '.github/workflows/web-base-policy.yml'


### PR DESCRIPTION
## What changed

- Reserve all seven future architecture-ratchet paths as Web guard files.
- Classify the detector and evaluator modules as checker implementation.
- Classify the normative document, rules registry, and accepted-violation store as authority.
- Add fixture coverage for every separation rule, absent future files, and unrelated unregistered paths.

## Why

Later ratchet PRs will create these files. Registering them first lets the trusted base checker reject runtime self-authorization and checker/authority co-changes from the first commit that introduces each path.

## Impact

This PR changes only the Web checker and its architecture contract test. It adds no future ratchet file and changes no Web runtime, workflow, privileged allowlist, dependency, or generated artifact.

## Verification

- `node tools/check-web-change-budget.mjs`
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD`
- `node --test tests/web/architecture-contracts.test.mjs` (54 passed)
- `node --test tests/web/*.test.mjs` (253 passed)
- `git diff --check origin/dev...HEAD`

Explicit ref check: base `0ab874f3`, head `a0026bce`, PASS.

## CI observation

- The initial `opened` and `labeled` events started the normal `Tests` workflow but not `Web base policy`. The default-branch copy of the trusted workflow still limited `pull_request_target` to `main`.
- Bootstrap PR #346 copied the one-line 0A trigger change to the default branch. This 0B PR kept its required no-workflow-change scope.
- An `unlabeled` event after that merge created both runs at 2026-08-18 00:57:57 UTC for head `a0026bceea68a96e5caa9202880a9e7b1c50a5a9`.
- Normal run `32086481964`: `Web change budget` and `Check Web architecture contracts` passed. Earlier full normal run `32085210883` passed for the same head.
- Trusted-base run `32086482146`: `Web base policy (trusted base)` passed, including trusted-base checkout, PR-head Git fetch, and base-checker evaluation.
