### PR TITLE
ci: activate dev test events on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["main", "refactoring", "dev"]
   pull_request:
-    branches: ["main"]
+    branches: ["dev", "main"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 


### PR DESCRIPTION
## What changed

Run the Tests workflow for pull requests targeting either `dev` or `main`.

## Why

PR #347 promotes checker and workflow changes that were merged into `dev` separately. Its cumulative `main`-to-`dev` range makes the Web guard treat them as one self-authorizing change. Landing this workflow trigger on `main` first removes the workflow authority change from the range used by the guard.

After this PR merges, reopening #347 will run both Web guards against the new `main` base.

## Validation

- `node tools/check-web-change-budget.mjs --base origin/main --head HEAD` (pass)
- `node --test tests/web/architecture-contracts.test.mjs` (48 tests passed)
