### PR TITLE
refactor: centralize Web architecture detectors

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -21,6 +21,13 @@ import {
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
+  detectPrivilegedWebCapabilities,
+  detectReportOnlySourceFacts,
+  WEB_ARCHITECTURE_DETECTORS,
+  WEB_PRIVILEGED_CAPABILITY_KEYS,
+  WEB_PRIVILEGED_IMPORT_TARGETS
+} from '../../tools/web-architecture-detectors.mjs';
+import {
   literalImportSpecifiers,
   maskJavaScript
 } from '../../tools/web-change-source.mjs';
@@ -120,12 +127,6 @@ const reachableModules = (entryPath, importGraph = directImports) => {
 const occurrenceOwners = (pattern) => new Map(
   [...productionSources]
     .map(([owner, source]) => [owner, [...source.matchAll(pattern)].length])
-    .filter(([, count]) => count > 0)
-);
-
-const executableOccurrenceOwners = (pattern) => new Map(
-  [...productionSources]
-    .map(([owner, source]) => [owner, [...maskJavaScript(source).matchAll(pattern)].length])
     .filter(([, count]) => count > 0)
 );
 
@@ -357,50 +358,257 @@ test('right drawer availability and transitions have one production owner', () =
 });
 
 test('privileged capability owners and importers stay within their allowlists', () => {
-  const ownerPatterns = new Map([
-    ['Render request', /\bbuildCanonicalRenderRequest\s*\(/g],
-    ['Diagram Worker', /\b(?:new\s+Worker|runDiagramGeneration|loadPyodide)\s*\(/g],
-    ['Python helper', /\b(?:runPythonAsync|runPython|PYTHON_HELPERS|globals\.get)\b/g],
-    [
-      'Resource staging',
-      /\b(?:createDiagramResourceTransport|stageRenderResources|setResourcePayloadOwner)\b/g
-    ],
-    [
-      'SVG/Result admission',
-      /\b(?:sanitizeSvgContent|ingestSvgResult|markCommitted)\b/g
-    ],
-    [
-      'Mounted SVG/Result replacement',
-      /\b(?:serializeCleanSvg|flushActiveResult)\s*\(|\b(?:results|state\.results)\.value(?:\[[^\]]+\])?\s*=(?!=)/g
-    ],
-    [
-      'History',
-      /\b(?:createHistoryManager|beginCheckpoint|commitCheckpoint|buildArtifactCheckpoint)\b/g
-    ],
-    [
-      'Session',
-      /\b(?:exportSession|compressSessionData|migrateSessionDataToCurrent|migratePersistedGalleryConfig)\b/g
-    ],
-    [
-      'Canonical editor state',
-      /\b(?:createFeatureEditor|createLegendManager|createRightDrawerController|createPreviewRuntime)\b/g
-    ]
-  ]);
+  const detected = detectPrivilegedWebCapabilities(productionSources);
   const assertSubset = (actual, allowed, label) => {
     const allowedSet = new Set(allowed);
     assert.deepEqual(actual.filter((path) => !allowedSet.has(path)), [], label);
   };
 
   Object.entries(WEB_CHANGE_POLICY.allowedPrivilegedImporters).forEach(([target, allowed]) => {
-    assertSubset(importersOf(target), allowed, `${target} importers`);
+    assertSubset(detected.importersByTarget[target], allowed, `${target} importers`);
   });
   assert.deepEqual(
     Object.keys(WEB_CHANGE_POLICY.allowedPrivilegedOwners).sort(),
-    [...ownerPatterns.keys()].sort()
+    WEB_PRIVILEGED_CAPABILITY_KEYS
   );
-  ownerPatterns.forEach((pattern, capability) => {
-    const actual = [...executableOccurrenceOwners(pattern).keys()].sort();
+  assert.deepEqual(
+    Object.keys(WEB_CHANGE_POLICY.allowedPrivilegedImporters).sort(),
+    WEB_PRIVILEGED_IMPORT_TARGETS
+  );
+  Object.entries(detected.operatorMatchesByCapability).forEach(([capability, matches_]) => {
+    const actual = matches_.map(({ path }) => path);
     assertSubset(actual, WEB_CHANGE_POLICY.allowedPrivilegedOwners[capability], capability);
+  });
+});
+
+test('shared privileged detectors preserve the characterized current-source facts', () => {
+  assert.deepEqual(WEB_PRIVILEGED_CAPABILITY_KEYS, [
+    'Canonical editor state',
+    'Diagram Worker',
+    'History',
+    'Mounted SVG/Result replacement',
+    'Python helper',
+    'Render request',
+    'Resource staging',
+    'SVG/Result admission',
+    'Session'
+  ]);
+  assert.deepEqual(WEB_PRIVILEGED_IMPORT_TARGETS, [
+    'app/feature-editor.js',
+    'app/legend.js',
+    'app/preview-runtime.js',
+    'app/python-helpers.js',
+    'app/right-drawer.js',
+    'services/config.js',
+    'services/diagram-generation.js',
+    'services/diagram-resource-staging.js',
+    'services/diagram-worker-protocol.js',
+    'services/gallery-session-migration.js',
+    'services/history-snapshot.js',
+    'services/history.js',
+    'services/resource-payload-owner.js',
+    'services/session-authority.js',
+    'services/session-file.js',
+    'services/session-request.js',
+    'services/svg-result-ingestion.js',
+    'services/svg-sanitization.js',
+    'services/svg-serialization.js',
+    'workers/diagram-generation-worker.js'
+  ]);
+
+  const detected = detectPrivilegedWebCapabilities(productionSources);
+  assert.deepEqual(
+    detected.importersByTarget,
+    Object.fromEntries(
+      WEB_PRIVILEGED_IMPORT_TARGETS.map((target) => [target, importersOf(target)])
+    )
+  );
+  assert.deepEqual(detected.operatorMatchesByCapability, {
+    'Canonical editor state': [
+      { path: 'app/app-setup.js', count: 8 },
+      { path: 'app/feature-editor.js', count: 1 },
+      { path: 'app/legend.js', count: 1 },
+      { path: 'app/preview-runtime.js', count: 1 },
+      { path: 'app/right-drawer.js', count: 1 }
+    ],
+    'Diagram Worker': [
+      { path: 'app/run-analysis.js', count: 1 },
+      { path: 'services/diagram-generation.js', count: 1 },
+      { path: 'services/losat.js', count: 2 },
+      { path: 'workers/diagram-generation-worker.js', count: 1 },
+      { path: 'workers/losat-threaded-worker.js', count: 2 }
+    ],
+    History: [
+      { path: 'app/app-setup.js', count: 3 },
+      { path: 'services/history-snapshot.js', count: 2 },
+      { path: 'services/history.js', count: 7 }
+    ],
+    'Mounted SVG/Result replacement': [
+      { path: 'app/app-setup.js', count: 1 },
+      { path: 'app/feature-editor/color-actions.js', count: 1 },
+      { path: 'app/feature-editor/label-actions.js', count: 2 },
+      { path: 'app/feature-editor/svg-actions.js', count: 4 },
+      { path: 'app/legend-layout/canvas-actions.js', count: 2 },
+      { path: 'app/legend-layout/diagram-drag.js', count: 2 },
+      { path: 'app/legend-layout/reposition-actions.js', count: 2 },
+      { path: 'app/legend/drag-actions.js', count: 4 },
+      { path: 'app/legend/entry-actions.js', count: 5 },
+      { path: 'app/legend/sort-actions.js', count: 2 },
+      { path: 'app/legend/stroke-actions.js', count: 2 },
+      { path: 'app/preview-runtime.js', count: 4 },
+      { path: 'app/results.js', count: 4 },
+      { path: 'app/run-analysis.js', count: 2 },
+      { path: 'app/svg-styles.js', count: 2 },
+      { path: 'services/config.js', count: 5 },
+      { path: 'services/history-snapshot.js', count: 1 },
+      { path: 'services/svg-result-ingestion.js', count: 1 }
+    ],
+    'Python helper': [
+      { path: 'app/python-helpers.js', count: 1 },
+      { path: 'workers/diagram-generation-worker.js', count: 6 }
+    ],
+    'Render request': [
+      { path: 'app/run-analysis.js', count: 1 },
+      { path: 'services/config.js', count: 1 },
+      { path: 'services/gallery-session-migration.js', count: 1 }
+    ],
+    'Resource staging': [
+      { path: 'services/config.js', count: 3 },
+      { path: 'services/diagram-generation.js', count: 2 },
+      { path: 'services/diagram-resource-staging.js', count: 1 },
+      { path: 'services/resource-payload-owner.js', count: 1 },
+      { path: 'services/session-request.js', count: 2 },
+      { path: 'workers/diagram-generation-worker.js', count: 2 }
+    ],
+    'SVG/Result admission': [
+      { path: 'services/svg-result-ingestion.js', count: 7 },
+      { path: 'services/svg-sanitization.js', count: 1 }
+    ],
+    Session: [
+      { path: 'app/app-setup.js', count: 2 },
+      { path: 'services/config.js', count: 5 },
+      { path: 'services/gallery-session-migration.js', count: 3 },
+      { path: 'services/session-file.js', count: 1 }
+    ]
+  });
+});
+
+test('versioned architecture detectors expose stable normalized subjects', () => {
+  const fixture = new Map([
+    [
+      'services/session-request.js',
+      'export const buildCanonicalRenderRequest = () => ({});\n'
+        + '// export const buildCanonicalRenderRequest = () => fake();\n'
+    ],
+    [
+      'app/run-analysis.js',
+      "import { buildCanonicalRenderRequest } from '../services/session-request.js';\n"
+        + 'const note = "buildCanonicalRenderRequest(); runDiagramGeneration();";\n'
+        + 'export const generate = () => {\n'
+        + '  const canonical = buildCanonicalRenderRequest();\n'
+        + '  return runDiagramGeneration(canonical);\n'
+        + '};\n'
+    ],
+    [
+      'services/config.js',
+      "import { buildCanonicalRenderRequest } from './session-request.js';\n"
+        + 'export const save = () => buildCanonicalRenderRequest();\n'
+    ],
+    [
+      'app/ignored.js',
+      '// buildCanonicalRenderRequest(); runDiagramGeneration();\n'
+        + 'export const note = "buildCanonicalRenderRequest";\n'
+    ]
+  ]);
+  const semantic = WEB_ARCHITECTURE_DETECTORS['semantic-owner.render-request.v1'];
+  const canonical = WEB_ARCHITECTURE_DETECTORS['canonical-path.render-request.v1'];
+
+  assert.deepEqual(Object.keys(WEB_ARCHITECTURE_DETECTORS).sort(), [
+    'canonical-path.render-request.v1',
+    'semantic-owner.render-request.v1'
+  ]);
+  assert.equal(semantic.subjectCategory, 'definition-path');
+  assert.deepEqual(semantic.detect(fixture), {
+    definitionCount: 1,
+    observedDefinitions: [{
+      path: 'services/session-request.js',
+      count: 1,
+      subject: 'services/session-request.js'
+    }],
+    subjects: ['services/session-request.js']
+  });
+  assert.equal(
+    semantic.encodeSubject({ path: 'gbdraw/web/js/services/session-request.js' }),
+    'services/session-request.js'
+  );
+
+  assert.equal(canonical.subjectCategory, 'canonical-entry-edge');
+  assert.deepEqual(canonical.detect(fixture), {
+    observedEdges: [{
+      from: 'app/run-analysis.js',
+      to: 'services/session-request.js',
+      subject: 'app/run-analysis.js -> services/session-request.js'
+    }],
+    subjects: ['app/run-analysis.js -> services/session-request.js']
+  });
+  assert.equal(
+    canonical.encodeSubject({
+      from: 'gbdraw/web/js/app/run-analysis.js',
+      to: 'gbdraw/web/js/services/session-request.js'
+    }),
+    'app/run-analysis.js -> services/session-request.js'
+  );
+});
+
+test('versioned architecture detectors characterize the untouched source tree', () => {
+  assert.deepEqual(
+    WEB_ARCHITECTURE_DETECTORS['semantic-owner.render-request.v1']
+      .detect(productionSources),
+    {
+      definitionCount: 1,
+      observedDefinitions: [{
+        path: 'services/session-request.js',
+        count: 1,
+        subject: 'services/session-request.js'
+      }],
+      subjects: ['services/session-request.js']
+    }
+  );
+  assert.deepEqual(
+    WEB_ARCHITECTURE_DETECTORS['canonical-path.render-request.v1']
+      .detect(productionSources),
+    {
+      observedEdges: [{
+        from: 'app/run-analysis.js',
+        to: 'services/session-request.js',
+        subject: 'app/run-analysis.js -> services/session-request.js'
+      }],
+      subjects: ['app/run-analysis.js -> services/session-request.js']
+    }
+  );
+});
+
+test('report-only source facts preserve the characterized masking behavior', () => {
+  const facts = detectReportOnlySourceFacts(
+    "import helper from './helper.js';\n"
+      + '// export const createCommentManager = () => watch(commentCache);\n'
+      + 'const note = "migrateLegacyString watch(stringCache)";\n'
+      + 'export const createFixtureManager = () => {\n'
+      + '  const activeCache = ref(0);\n'
+      + '  watch(activeCache, () => migrateLegacyFixture());\n'
+      + '  return { activeCache: activeCache };\n'
+      + '};\n'
+  );
+
+  assert.deepEqual(facts, {
+    exportedNames: ['createFixtureManager'],
+    declaredNames: ['note', 'createFixtureManager', 'activeCache'],
+    reactiveDeclarations: ['activeCache (ref)'],
+    watcherCount: 1,
+    objectKeys: ['activeCache'],
+    compatibilityNames: ['migrateLegacyFixture'],
+    namedResourceNames: ['createFixtureManager', 'activeCache'],
+    importSpecifiers: ['./helper.js']
   });
 });
 
@@ -515,6 +723,10 @@ test('supported-version and slow matrices cover dev staging runs', () => {
 });
 
 const CHANGE_BUDGET_CHECKER = join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs');
+const WEB_ARCHITECTURE_DETECTOR_MODULE = join(
+  REPOSITORY_ROOT,
+  'tools/web-architecture-detectors.mjs'
+);
 const BUDGET_POLICY = Object.freeze({
   allowedPrivilegedImporters: {
     'services/diagram-generation.js': ['app/editor.js'],
@@ -562,6 +774,10 @@ const BUDGET_FIXTURE = Object.freeze({
   'package.json': '{"private":true}\n',
   'tests/web/architecture-contracts.test.mjs': '// baseline contract\n',
   'tools/check-web-change-budget.mjs': readFileSync(CHANGE_BUDGET_CHECKER, 'utf8'),
+  'tools/web-architecture-detectors.mjs': readFileSync(
+    WEB_ARCHITECTURE_DETECTOR_MODULE,
+    'utf8'
+  ),
   'tools/web-change-source.mjs': readFileSync(
     join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
     'utf8'
@@ -586,14 +802,12 @@ const BUDGET_FIXTURE = Object.freeze({
 const FUTURE_GUARD_PATHS = Object.freeze([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   '.github/pull_request_template.md',
-  'tools/web-architecture-detectors.mjs',
   'tools/web-architecture-evaluation.mjs',
   'tools/web-architecture-rules.json',
   'tools/web-architecture-violations.json',
   'tests/web/architecture-ratchet-fixtures.test.mjs'
 ]);
 const FUTURE_CHECKER_IMPLEMENTATION_PATHS = Object.freeze([
-  'tools/web-architecture-detectors.mjs',
   'tools/web-architecture-evaluation.mjs'
 ]);
 const FUTURE_AUTHORITY_PATHS = Object.freeze([
@@ -892,6 +1106,17 @@ test('dependency, vendor, binary, and runtime/guard rules are non-waivable', () 
         write('.github/workflows/test.yml', 'name: changed guard\n');
       },
       expected: /production runtime files and Web guard\/CI files changed together/
+    },
+    {
+      name: 'production and detector co-change',
+      mutate: (write) => {
+        write('gbdraw/web/js/app/editor.js', 'export const editExistingOwner = () => 2;\n');
+        write(
+          'tools/web-architecture-detectors.mjs',
+          `${BUDGET_FIXTURE['tools/web-architecture-detectors.mjs']}\n// changed\n`
+        );
+      },
+      expected: /production runtime files and Web guard\/CI files changed together/
     }
   ];
 
@@ -925,7 +1150,8 @@ test('runtime cannot co-change with any reserved future guard path', () => {
 test('checker implementation and authority files cannot change together', () => {
   const implementationPaths = [
     'tools/check-web-change-budget.mjs',
-    'tools/web-change-source.mjs'
+    'tools/web-change-source.mjs',
+    'tools/web-architecture-detectors.mjs'
   ];
   const authorityPaths = [
     'tools/web-change-policy.json',
@@ -952,6 +1178,7 @@ test('all checker implementations are separated from reserved future authority',
   const implementationPaths = [
     'tools/check-web-change-budget.mjs',
     'tools/web-change-source.mjs',
+    'tools/web-architecture-detectors.mjs',
     ...FUTURE_CHECKER_IMPLEMENTATION_PATHS
   ];
 
@@ -1280,6 +1507,7 @@ test('runtime plus a semantically unchanged policy remains separated', () => {
 test('runtime plus policy contraction rejects every additional guard change', () => {
   const guardCases = [
     ['checker', 'tools/check-web-change-budget.mjs'],
+    ['architecture detectors', 'tools/web-architecture-detectors.mjs'],
     ['source parser', 'tools/web-change-source.mjs'],
     ['architecture contracts', 'tests/web/architecture-contracts.test.mjs'],
     ['normal workflow', '.github/workflows/test.yml'],

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
 
 import { appendFileSync, existsSync, readFileSync } from 'node:fs';
-import { join, posix, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { execFileSync } from 'node:child_process';
-import { literalImportSpecifiers, maskJavaScript } from './web-change-source.mjs';
+import {
+  detectPrivilegedWebCapabilities,
+  detectReportOnlySourceFacts,
+  isWebSessionSourcePath,
+  WEB_PRIVILEGED_CAPABILITY_KEYS,
+  WEB_PRIVILEGED_IMPORT_TARGETS
+} from './web-architecture-detectors.mjs';
 
 const runGit = (root, args, options = {}) => execFileSync(
   'git',
@@ -150,130 +156,6 @@ const changedCheckerImplementations = [...changed.keys()]
   .filter((path) => checkerImplementationPaths.has(path));
 const changedAuthorities = [...changed.keys()].filter((path) => authorityPaths.has(path));
 
-const exportedNames = (source = '') => {
-  const code = maskJavaScript(source);
-  const names = new Set();
-  const declaration = /^\s*export\s+(?:async\s+)?(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/gm;
-  for (const match of code.matchAll(declaration)) names.add(match[1]);
-  for (const match of code.matchAll(/^\s*export\s*\{([\s\S]*?)\}/gm)) {
-    match[1].split(',').forEach((entry) => {
-      const cleaned = entry.replace(/\/\*[\s\S]*?\*\//g, '').trim();
-      if (!cleaned) return;
-      const parts = cleaned.split(/\s+as\s+/);
-      names.add((parts[1] || parts[0]).trim());
-    });
-  }
-  if (/^\s*export\s+default\b/m.test(code)) names.add('default');
-  for (const match of code.matchAll(/^\s*export\s+\*\s+as\s+([A-Za-z_$][\w$]*)/gm)) {
-    names.add(match[1]);
-  }
-  return names;
-};
-
-const declaredNames = (source = '') => new Set(
-  [...maskJavaScript(source).matchAll(/\b(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g)]
-    .map((match) => match[1])
-);
-
-const reactiveDeclarations = (source = '') => new Set(
-  [...maskJavaScript(source).matchAll(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:[A-Za-z_$][\w$]*\.)?(ref|shallowRef|reactive|computed)\s*\(/g)]
-    .map((match) => `${match[1]} (${match[2]})`)
-);
-
-const countWatchers = (source = '') => [
-  ...maskJavaScript(source).matchAll(/\bwatch(?:Effect)?\s*\(/g)
-].length;
-const importSpecifiers = literalImportSpecifiers;
-
-const resolvedProductionImport = (owner, specifier) => {
-  if (!specifier.startsWith('.')) return null;
-  const relativeOwner = owner.slice('gbdraw/web/js/'.length);
-  return posix.normalize(posix.join(posix.dirname(relativeOwner), specifier));
-};
-
-const capabilitySpecs = [
-  {
-    name: 'Render request',
-    imports: ['services/session-request.js'],
-    owner: /\bbuildCanonicalRenderRequest\s*\(/
-  },
-  {
-    name: 'Diagram Worker',
-    imports: [
-      'services/diagram-generation.js',
-      'services/diagram-worker-protocol.js',
-      'workers/diagram-generation-worker.js'
-    ],
-    owner: /\b(?:new\s+Worker|runDiagramGeneration|loadPyodide)\s*\(/
-  },
-  {
-    name: 'Python helper',
-    imports: ['app/python-helpers.js'],
-    owner: /\b(?:runPythonAsync|runPython|PYTHON_HELPERS|globals\.get)\b/
-  },
-  {
-    name: 'Resource staging',
-    imports: ['services/diagram-resource-staging.js', 'services/resource-payload-owner.js'],
-    owner: /\b(?:createDiagramResourceTransport|stageRenderResources|setResourcePayloadOwner)\b/
-  },
-  {
-    name: 'SVG/Result admission',
-    imports: ['services/svg-sanitization.js', 'services/svg-result-ingestion.js'],
-    owner: /\b(?:sanitizeSvgContent|ingestSvgResult|markCommitted)\b/
-  },
-  {
-    name: 'Mounted SVG/Result replacement',
-    imports: ['services/svg-serialization.js', 'app/preview-runtime.js'],
-    owner: /\b(?:serializeCleanSvg|flushActiveResult)\s*\(|\b(?:results|state\.results)\.value(?:\[[^\]]+\])?\s*=(?!=)/
-  },
-  {
-    name: 'History',
-    imports: ['services/history.js', 'services/history-snapshot.js'],
-    owner: /\b(?:createHistoryManager|beginCheckpoint|commitCheckpoint|buildArtifactCheckpoint)\b/
-  },
-  {
-    name: 'Session',
-    imports: [
-      'services/config.js',
-      'services/gallery-session-migration.js',
-      'services/session-authority.js',
-      'services/session-file.js'
-    ],
-    owner: /\b(?:exportSession|compressSessionData|migrateSessionDataToCurrent|migratePersistedGalleryConfig)\b/
-  },
-  {
-    name: 'Canonical editor state',
-    imports: [
-      'app/feature-editor.js',
-      'app/legend.js',
-      'app/right-drawer.js',
-      'app/preview-runtime.js'
-    ],
-    owner: /\b(?:createFeatureEditor|createLegendManager|createRightDrawerController|createPreviewRuntime)\b/
-  }
-];
-
-const sessionOwnerPaths = new Set([
-  'gbdraw/web/js/services/config.js',
-  'gbdraw/web/js/services/gallery-session-migration.js',
-  'gbdraw/web/js/services/session-authority.js',
-  'gbdraw/web/js/services/session-file.js',
-  'gbdraw/web/js/services/session-request.js'
-]);
-const objectKeys = (source = '') => new Set(
-  [...maskJavaScript(source).matchAll(/(?:^|[,{]\s*)([A-Za-z_$][\w$]*)\s*:/gm)]
-    .map((match) => match[1])
-);
-const compatibilityNames = (source = '') => new Set(
-  [...maskJavaScript(source).matchAll(/\b(?:[A-Za-z_$][\w$]*(?:Migration|Migrator|Legacy|Fallback)[\w$]*|(?:migrate|promoteLegacy|normalizeLegacy|readLegacy)[A-Za-z0-9_$]*)\b/g)]
-    .map((match) => match[0])
-);
-const namedResourceNames = (source = '') => new Set(
-  [...maskJavaScript(source).matchAll(/\b[A-Za-z_$][\w$]*\b/g)]
-    .map((match) => match[0])
-    .filter((name) => /(?:cache|token|handle|journal|protocol|manager)/i.test(name))
-);
-
 const addedEntries = (before, after, prefix = '') => [...after]
   .filter((entry) => !before.has(entry))
   .map((entry) => `${prefix}${entry}`);
@@ -290,30 +172,44 @@ const newBareImports = [];
 productionJavaScriptPaths.forEach((path) => {
   const before = readRevisionFile(base, path) || '';
   const after = readHeadFile(path) || '';
-  newExports.push(...addedEntries(exportedNames(before), exportedNames(after), `${path}: `));
+  const beforeFacts = detectReportOnlySourceFacts(before);
+  const afterFacts = detectReportOnlySourceFacts(after);
+  newExports.push(...addedEntries(
+    new Set(beforeFacts.exportedNames), new Set(afterFacts.exportedNames), `${path}: `
+  ));
   newCreateOwners.push(...addedEntries(
-    new Set([...declaredNames(before)].filter((name) => /^create[A-Z]/.test(name))),
-    new Set([...declaredNames(after)].filter((name) => /^create[A-Z]/.test(name))),
+    new Set(beforeFacts.declaredNames.filter((name) => /^create[A-Z]/.test(name))),
+    new Set(afterFacts.declaredNames.filter((name) => /^create[A-Z]/.test(name))),
     `${path}: `
   ));
   newReactiveState.push(...addedEntries(
-    reactiveDeclarations(before), reactiveDeclarations(after), `${path}: `
+    new Set(beforeFacts.reactiveDeclarations),
+    new Set(afterFacts.reactiveDeclarations),
+    `${path}: `
   ));
-  const watcherIncrease = countWatchers(after) - countWatchers(before);
+  const watcherIncrease = afterFacts.watcherCount - beforeFacts.watcherCount;
   if (watcherIncrease > 0) newWatchers.push(`${path}: +${watcherIncrease} watcher call(s)`);
   newNamedResources.push(...addedEntries(
-    namedResourceNames(before),
-    namedResourceNames(after),
+    new Set(beforeFacts.namedResourceNames),
+    new Set(afterFacts.namedResourceNames),
     `${path}: `
   ));
   newCompatibilityPaths.push(...addedEntries(
-    compatibilityNames(before), compatibilityNames(after), `${path}: `
+    new Set(beforeFacts.compatibilityNames),
+    new Set(afterFacts.compatibilityNames),
+    `${path}: `
   ));
-  if (sessionOwnerPaths.has(path)) {
-    newSessionFields.push(...addedEntries(objectKeys(before), objectKeys(after), `${path}: `));
+  if (isWebSessionSourcePath(path)) {
+    newSessionFields.push(...addedEntries(
+      new Set(beforeFacts.objectKeys), new Set(afterFacts.objectKeys), `${path}: `
+    ));
   }
-  const bareBefore = new Set(importSpecifiers(before).filter((specifier) => !specifier.startsWith('.')));
-  const bareAfter = new Set(importSpecifiers(after).filter((specifier) => !specifier.startsWith('.')));
+  const bareBefore = new Set(
+    beforeFacts.importSpecifiers.filter((specifier) => !specifier.startsWith('.'))
+  );
+  const bareAfter = new Set(
+    afterFacts.importSpecifiers.filter((specifier) => !specifier.startsWith('.'))
+  );
   newBareImports.push(...addedEntries(bareBefore, bareAfter, `${path}: `));
 });
 
@@ -388,34 +284,27 @@ if (basePolicySource !== null && changed.has(policyPath)) {
 }
 const allProductionJavaScriptPaths = listProductionJavaScriptPaths();
 const allProductionSources = new Map(allProductionJavaScriptPaths.map((path) => [
-  path,
+  path.slice('gbdraw/web/js/'.length),
   readHeadFile(path) || ''
 ]));
 
-const importerTargets = new Set(capabilitySpecs.flatMap((capability) => capability.imports));
+const detectedCapabilities = detectPrivilegedWebCapabilities(allProductionSources);
 const capabilityCoverageViolations = (candidatePolicy) => {
   const violations = [];
-  importerTargets.forEach((target) => {
+  WEB_PRIVILEGED_IMPORT_TARGETS.forEach((target) => {
     const allowed = new Set(candidatePolicy.allowedPrivilegedImporters[target] || []);
-    allProductionSources.forEach((source, path) => {
-      const imports = importSpecifiers(source)
-        .map((specifier) => resolvedProductionImport(path, specifier));
-      if (imports.includes(target)) {
-        const relativePath = path.slice('gbdraw/web/js/'.length);
-        if (!allowed.has(relativePath)) {
-          violations.push(`${target}: importer ${relativePath}`);
-        }
+    detectedCapabilities.importersByTarget[target].forEach((path) => {
+      if (!allowed.has(path)) {
+        violations.push(`${target}: importer ${path}`);
       }
     });
   });
 
-  capabilitySpecs.forEach((capability) => {
-    const allowed = new Set(candidatePolicy.allowedPrivilegedOwners[capability.name] || []);
-    allProductionSources.forEach((source, path) => {
-      if (!capability.owner.test(maskJavaScript(source))) return;
-      const relativePath = path.slice('gbdraw/web/js/'.length);
-      if (!allowed.has(relativePath)) {
-        violations.push(`${capability.name}: owner ${relativePath}`);
+  WEB_PRIVILEGED_CAPABILITY_KEYS.forEach((capability) => {
+    const allowed = new Set(candidatePolicy.allowedPrivilegedOwners[capability] || []);
+    detectedCapabilities.operatorMatchesByCapability[capability].forEach(({ path }) => {
+      if (!allowed.has(path)) {
+        violations.push(`${capability}: owner ${path}`);
       }
     });
   });

--- a/tools/web-architecture-detectors.mjs
+++ b/tools/web-architecture-detectors.mjs
@@ -1,0 +1,253 @@
+import { posix } from 'node:path';
+
+import { literalImportSpecifiers, maskJavaScript } from './web-change-source.mjs';
+
+const WEB_SOURCE_PREFIX = 'gbdraw/web/js/';
+const normalizeModulePath = (path) => String(path || '')
+  .replaceAll('\\', '/')
+  .replace(new RegExp(`^${WEB_SOURCE_PREFIX}`), '');
+const sourceEntries = (sources) => (
+  sources instanceof Map ? [...sources] : Object.entries(sources || {})
+).map(([path, source]) => [normalizeModulePath(path), String(source || '')])
+  .sort(([left], [right]) => left.localeCompare(right));
+const unique = (values) => [...new Set(values)];
+const matches = (source, pattern) => [...source.matchAll(pattern)];
+
+const resolvedProductionImport = (owner, specifier) => {
+  if (!specifier.startsWith('.')) return null;
+  return posix.normalize(posix.join(posix.dirname(owner), specifier));
+};
+
+const PRIVILEGED_CAPABILITY_SPECS = Object.freeze([
+  Object.freeze({
+    name: 'Render request',
+    importTargets: Object.freeze(['services/session-request.js']),
+    operatorPattern: /\bbuildCanonicalRenderRequest\s*\(/g
+  }),
+  Object.freeze({
+    name: 'Diagram Worker',
+    importTargets: Object.freeze([
+      'services/diagram-generation.js',
+      'services/diagram-worker-protocol.js',
+      'workers/diagram-generation-worker.js'
+    ]),
+    operatorPattern: /\b(?:new\s+Worker|runDiagramGeneration|loadPyodide)\s*\(/g
+  }),
+  Object.freeze({
+    name: 'Python helper',
+    importTargets: Object.freeze(['app/python-helpers.js']),
+    operatorPattern: /\b(?:runPythonAsync|runPython|PYTHON_HELPERS|globals\.get)\b/g
+  }),
+  Object.freeze({
+    name: 'Resource staging',
+    importTargets: Object.freeze([
+      'services/diagram-resource-staging.js',
+      'services/resource-payload-owner.js'
+    ]),
+    operatorPattern: /\b(?:createDiagramResourceTransport|stageRenderResources|setResourcePayloadOwner)\b/g
+  }),
+  Object.freeze({
+    name: 'SVG/Result admission',
+    importTargets: Object.freeze([
+      'services/svg-sanitization.js',
+      'services/svg-result-ingestion.js'
+    ]),
+    operatorPattern: /\b(?:sanitizeSvgContent|ingestSvgResult|markCommitted)\b/g
+  }),
+  Object.freeze({
+    name: 'Mounted SVG/Result replacement',
+    importTargets: Object.freeze([
+      'services/svg-serialization.js',
+      'app/preview-runtime.js'
+    ]),
+    operatorPattern: /\b(?:serializeCleanSvg|flushActiveResult)\s*\(|\b(?:results|state\.results)\.value(?:\[[^\]]+\])?\s*=(?!=)/g
+  }),
+  Object.freeze({
+    name: 'History',
+    importTargets: Object.freeze([
+      'services/history.js',
+      'services/history-snapshot.js'
+    ]),
+    operatorPattern: /\b(?:createHistoryManager|beginCheckpoint|commitCheckpoint|buildArtifactCheckpoint)\b/g
+  }),
+  Object.freeze({
+    name: 'Session',
+    importTargets: Object.freeze([
+      'services/config.js',
+      'services/gallery-session-migration.js',
+      'services/session-authority.js',
+      'services/session-file.js'
+    ]),
+    operatorPattern: /\b(?:exportSession|compressSessionData|migrateSessionDataToCurrent|migratePersistedGalleryConfig)\b/g
+  }),
+  Object.freeze({
+    name: 'Canonical editor state',
+    importTargets: Object.freeze([
+      'app/feature-editor.js',
+      'app/legend.js',
+      'app/right-drawer.js',
+      'app/preview-runtime.js'
+    ]),
+    operatorPattern: /\b(?:createFeatureEditor|createLegendManager|createRightDrawerController|createPreviewRuntime)\b/g
+  })
+]);
+
+export const WEB_PRIVILEGED_CAPABILITY_KEYS = Object.freeze(
+  PRIVILEGED_CAPABILITY_SPECS.map(({ name }) => name).sort()
+);
+export const WEB_PRIVILEGED_IMPORT_TARGETS = Object.freeze(
+  unique(PRIVILEGED_CAPABILITY_SPECS.flatMap(({ importTargets }) => importTargets)).sort()
+);
+
+export const detectPrivilegedWebCapabilities = (sources) => {
+  const entries = sourceEntries(sources);
+  const importerTargets = new Set(WEB_PRIVILEGED_IMPORT_TARGETS);
+  const importersByTarget = Object.fromEntries(
+    WEB_PRIVILEGED_IMPORT_TARGETS.map((target) => [target, []])
+  );
+  const operatorMatchesByCapability = Object.fromEntries(
+    WEB_PRIVILEGED_CAPABILITY_KEYS.map((capability) => [capability, []])
+  );
+
+  entries.forEach(([path, source]) => {
+    unique(literalImportSpecifiers(source)
+      .map((specifier) => resolvedProductionImport(path, specifier))
+      .filter((target) => importerTargets.has(target)))
+      .forEach((target) => importersByTarget[target].push(path));
+
+    const code = maskJavaScript(source);
+    PRIVILEGED_CAPABILITY_SPECS.forEach(({ name, operatorPattern }) => {
+      const count = matches(code, operatorPattern).length;
+      if (count) operatorMatchesByCapability[name].push(Object.freeze({ path, count }));
+    });
+  });
+
+  Object.values(importersByTarget).forEach(Object.freeze);
+  Object.values(operatorMatchesByCapability).forEach(Object.freeze);
+  return Object.freeze({
+    importersByTarget: Object.freeze(importersByTarget),
+    operatorMatchesByCapability: Object.freeze(operatorMatchesByCapability)
+  });
+};
+
+const SESSION_SOURCE_PATHS = new Set([
+  'services/config.js',
+  'services/gallery-session-migration.js',
+  'services/session-authority.js',
+  'services/session-file.js',
+  'services/session-request.js'
+]);
+
+export const isWebSessionSourcePath = (path) => SESSION_SOURCE_PATHS.has(
+  normalizeModulePath(path)
+);
+
+export const detectReportOnlySourceFacts = (source = '') => {
+  const code = maskJavaScript(source);
+  const exportedNames = new Set();
+  for (const match of code.matchAll(
+    /^\s*export\s+(?:async\s+)?(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/gm
+  )) exportedNames.add(match[1]);
+  for (const match of code.matchAll(/^\s*export\s*\{([\s\S]*?)\}/gm)) {
+    match[1].split(',').forEach((entry) => {
+      const cleaned = entry.replace(/\/\*[\s\S]*?\*\//g, '').trim();
+      if (!cleaned) return;
+      const parts = cleaned.split(/\s+as\s+/);
+      exportedNames.add((parts[1] || parts[0]).trim());
+    });
+  }
+  if (/^\s*export\s+default\b/m.test(code)) exportedNames.add('default');
+  for (const match of code.matchAll(
+    /^\s*export\s+\*\s+as\s+([A-Za-z_$][\w$]*)/gm
+  )) exportedNames.add(match[1]);
+
+  return Object.freeze({
+    exportedNames: Object.freeze([...exportedNames]),
+    declaredNames: Object.freeze(unique(
+      [...code.matchAll(/\b(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g)]
+        .map((match) => match[1])
+    )),
+    reactiveDeclarations: Object.freeze(unique(
+      [...code.matchAll(/\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:[A-Za-z_$][\w$]*\.)?(ref|shallowRef|reactive|computed)\s*\(/g)]
+        .map((match) => `${match[1]} (${match[2]})`)
+    )),
+    watcherCount: matches(code, /\bwatch(?:Effect)?\s*\(/g).length,
+    objectKeys: Object.freeze(unique(
+      [...code.matchAll(/(?:^|[,{]\s*)([A-Za-z_$][\w$]*)\s*:/gm)]
+        .map((match) => match[1])
+    )),
+    compatibilityNames: Object.freeze(unique(
+      [...code.matchAll(/\b(?:[A-Za-z_$][\w$]*(?:Migration|Migrator|Legacy|Fallback)[\w$]*|(?:migrate|promoteLegacy|normalizeLegacy|readLegacy)[A-Za-z0-9_$]*)\b/g)]
+        .map((match) => match[0])
+    )),
+    namedResourceNames: Object.freeze(unique(
+      [...code.matchAll(/\b[A-Za-z_$][\w$]*\b/g)]
+        .map((match) => match[0])
+        .filter((name) => /(?:cache|token|handle|journal|protocol|manager)/i.test(name))
+    )),
+    importSpecifiers: Object.freeze(literalImportSpecifiers(source))
+  });
+};
+
+const RENDER_REQUEST_DEFINITION_PATTERN = /\b(?:(?:export\s+)?(?:async\s+)?function\s+buildCanonicalRenderRequest\b|(?:export\s+)?(?:const|let|var)\s+buildCanonicalRenderRequest\s*=)/g;
+const RENDER_REQUEST_CALL_PATTERN = /\bbuildCanonicalRenderRequest\s*\(/g;
+const RENDER_CALL_PATTERN = /\brunDiagramGeneration\s*\(/g;
+const encodeDefinitionPathSubject = ({ path }) => normalizeModulePath(path);
+const encodeCanonicalEntryEdgeSubject = ({ from, to }) => (
+  `${normalizeModulePath(from)} -> ${normalizeModulePath(to)}`
+);
+
+const detectRenderRequestAuthority = (sources) => {
+  const observedDefinitions = sourceEntries(sources).flatMap(([path, source]) => {
+    const count = matches(maskJavaScript(source), RENDER_REQUEST_DEFINITION_PATTERN).length;
+    return count ? [Object.freeze({ path, count, subject: encodeDefinitionPathSubject({ path }) })] : [];
+  });
+  return Object.freeze({
+    definitionCount: observedDefinitions.reduce((total, { count }) => total + count, 0),
+    observedDefinitions: Object.freeze(observedDefinitions),
+    subjects: Object.freeze(observedDefinitions.map(({ subject }) => subject))
+  });
+};
+
+const detectCanonicalRenderRequestPath = (sources) => {
+  const entries = sourceEntries(sources);
+  const definitionPaths = new Set(
+    detectRenderRequestAuthority(sources).observedDefinitions.map(({ path }) => path)
+  );
+  const edgesBySubject = new Map();
+  entries.forEach(([from, source]) => {
+    const code = maskJavaScript(source);
+    if (!matches(code, RENDER_REQUEST_CALL_PATTERN).length
+        || !matches(code, RENDER_CALL_PATTERN).length) return;
+    unique(literalImportSpecifiers(source)
+      .map((specifier) => resolvedProductionImport(from, specifier))
+      .filter((to) => definitionPaths.has(to)))
+      .forEach((to) => {
+        const edge = Object.freeze({ from, to });
+        edgesBySubject.set(encodeCanonicalEntryEdgeSubject(edge), edge);
+      });
+  });
+  const subjects = [...edgesBySubject.keys()].sort();
+  return Object.freeze({
+    observedEdges: Object.freeze(subjects.map((subject) => Object.freeze({
+      ...edgesBySubject.get(subject),
+      subject
+    }))),
+    subjects: Object.freeze(subjects)
+  });
+};
+
+// Keep each detector ID and its transitive helpers executable-identical while referenced.
+// Add a versioned detector beside it, then migrate authority in a separate pull request.
+export const WEB_ARCHITECTURE_DETECTORS = Object.freeze({
+  'semantic-owner.render-request.v1': Object.freeze({
+    subjectCategory: 'definition-path',
+    encodeSubject: encodeDefinitionPathSubject,
+    detect: detectRenderRequestAuthority
+  }),
+  'canonical-path.render-request.v1': Object.freeze({
+    subjectCategory: 'canonical-entry-edge',
+    encodeSubject: encodeCanonicalEntryEdgeSubject,
+    detect: detectCanonicalRenderRequestPath
+  })
+});


### PR DESCRIPTION
## Purpose

Centralize executable Web architecture source detectors so the checker and architecture contract tests consume one implementation.

This is PR B from revision 7 of the architecture fitness-function ratchet plan.

- Base: `dev` at `3e1d1a09944fd2e9087cc14efd9be22a342880b0`
- Head: `ee3bae4492517dd158234dbe28905bf5be6f5cff`
- Production runtime changes: none
- Policy, workflow, dependency, and compatibility changes: none

## Verification

- `node --check tools/web-architecture-detectors.mjs`: PASS
- `node --check tools/check-web-change-budget.mjs`: PASS
- `node --check tests/web/architecture-contracts.test.mjs`: PASS
- `node --test tests/web/architecture-contracts.test.mjs`: PASS, 59/59
- `node --test tests/web/*.test.mjs`: PASS, 258/258
- `node tools/check-web-change-budget.mjs --base 3e1d1a09944fd2e9087cc14efd9be22a342880b0 --head ee3bae4492517dd158234dbe28905bf5be6f5cff`: PASS
- `git diff --check 3e1d1a09944fd2e9087cc14efd9be22a342880b0...ee3bae4492517dd158234dbe28905bf5be6f5cff`: PASS
- GitHub `Tests` run [32154201384](https://github.com/satoshikawato/gbdraw/actions/runs/32154201384): SUCCESS for exact head `ee3bae4492517dd158234dbe28905bf5be6f5cff`; all 11 executed jobs passed and 2 matrix jobs were conditionally skipped.
- [`Web change budget`](https://github.com/satoshikawato/gbdraw/actions/runs/32154201384/job/95767506218): PASS under the `architecture-change` profile.
- [`Web base policy (trusted base)`](https://github.com/satoshikawato/gbdraw/actions/runs/32154201699/job/95767493518): PASS for base `3e1d1a09944fd2e9087cc14efd9be22a342880b0` and head `ee3bae4492517dd158234dbe28905bf5be6f5cff`.
- External `Workers Builds: gbdraw`: PASS.
- Initial runs [32154159421](https://github.com/satoshikawato/gbdraw/actions/runs/32154159421) and [32154159361](https://github.com/satoshikawato/gbdraw/actions/runs/32154159361) were canceled by the workflow concurrency group when `architecture-change` was added. The replacement runs above completed successfully; PR merge state is `CLEAN`.

## Architecture impact

Select exactly one:

- [ ] This is not architecture-bearing. Rationale:
- [x] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior: Executable Web source-evidence detection for report-only inventories, privileged capability owner/importer facts, and the initial render-request semantic-owner and canonical-path facts.
- Why this changed-capability scope is complete: The change is limited to the two files that previously implemented or duplicated these scans, their shared source parser, and the new detector module. Tests enumerate every current privileged capability key, import target, operator path/count tuple, detector ID, subject category, and current-source result. Runtime modules and intended-constraint authority are unchanged.
- Semantic owners before: `tools/check-web-change-budget.mjs` owned report-only and privileged scanning; `tests/web/architecture-contracts.test.mjs` duplicated privileged patterns and import detection. No versioned render-request detector catalog existed.
- Semantic owners after: `tools/web-architecture-detectors.mjs` is the sole owner of shared executable source-fact detection and the two versioned render-request detectors. The checker owns I/O, policy evaluation, and reporting. The test owns independent expectations.
- Canonical production paths before: Guard evidence followed checker-local scans through `tools/web-change-source.mjs`; architecture tests used a separate pattern table and import graph. No Web runtime production path changes.
- Canonical production paths after: Both consumers call `tools/web-architecture-detectors.mjs`, which uses `tools/web-change-source.mjs` for masking and literal import extraction. Checker policy evaluation and independent test assertions remain separate consumers. No Web runtime production path changes.
- Compatibility paths before, with stable IDs: none.
- Compatibility paths after, with stable IDs: none.
- Superseded owner/path removed: Yes. Checker-local scanner definitions and the test-local privileged pattern table were removed.
- New module classification: Sole semantic owner for executable Web architecture source-fact detection. It contains detection scope and normalized facts, not intended definition paths, allowed edges, counts, modes, baseline eligibility, accepted violations, compatibility authorization, or privileged permission arrays.
- Persisted-compatibility evidence and removal condition: Not applicable; no compatibility path or persisted format changed.
- Performance/scientific-output evidence, when material: Not applicable; no runtime or scientific output changed.
- Deterministic checker evidence: The final-head checker command above passed with zero production churn, no policy/dependency changes, three guard files, and no violations. The focused and full Web suites passed on the same content. GitHub `Tests` run 32154201384 and trusted-base run 32154201699 passed for the exact base/head pair.
- Maintainer architecture decision comment permalink, required before merge: [APPROVED for exact head `ee3bae4492517dd158234dbe28905bf5be6f5cff`](https://github.com/satoshikawato/gbdraw/pull/354#issuecomment-5331223139).

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.

## Maintainer review packet

### Changed files

- Guard/checker: `tools/web-architecture-detectors.mjs`, `tools/check-web-change-budget.mjs`
- Tests: `tests/web/architecture-contracts.test.mjs`
- Production, docs, policy authority, workflow, dependency, and generated files: none

### Detector characterization

- Versioned IDs: `semantic-owner.render-request.v1` with subject category `definition-path`; `canonical-path.render-request.v1` with subject category `canonical-entry-edge`.
- Current privileged inventory: 9 exact capability keys, 20 exact import targets, and 48 exact operator path/count tuples. All are literal assertions in `shared privileged detectors preserve the characterized current-source facts`; importer results are compared with the test's independent import graph.
- Fixed corpus: comments and string literals are masked; definition paths and canonical entry edges are normalized; subject encoders accept repository-prefixed paths and emit canonical subjects.
- Untouched current-source results: one definition, `services/session-request.js`; one edge, `app/run-analysis.js -> services/session-request.js`.
- Report-only facts: a fixed corpus locks export, declaration, reactive declaration, watcher, object-key, compatibility-name, resource-name, and literal-import masking behavior.
- Authority separation: tests reject detector/runtime co-change and forbidden authority fields in the detector module.
- The fixed corpus and untouched-source comparison are characterization evidence, not proof of equivalence for arbitrary future JavaScript.

### Ratchet decision inputs

- Owner excess: duplicated executable detector ownership converges on one module; `delta(OE) <= 0`.
- Path excess: duplicated detector implementation paths converge on the shared detector path; `delta(PE) <= 0`.
- Compatibility burden: none before or after; `delta(CB) = 0`.
- Superseded executable detector implementations are removed in this change.
- No deterministic violation is accepted.

### CI evidence

- Head SHA: `ee3bae4492517dd158234dbe28905bf5be6f5cff`
- Base SHA: `3e1d1a09944fd2e9087cc14efd9be22a342880b0`
- `Tests` run 32154201384: SUCCESS. Web budget/contracts, Browser, Core 3.10/3.11/3.12, Gallery, LOSAT, Lint, Playwright functional/performance, and Recipes passed. Acceptance and Slow matrix jobs were conditionally skipped.
- `Web base policy` run 32154201699: SUCCESS.
- External Workers build: PASS.
- The label event canceled the initial in-progress runs through the configured concurrency groups. Those canceled jobs did not report test failures and were replaced by the successful runs above.

### Known limitations

- Regex and masked-source tests do not prove semantic equivalence for arbitrary JavaScript syntax.
- Detector code is trusted checker code. A future executable change to an active detector ID requires a new versioned ID and staged authority migration.
- Intended constraints remain inline until the planned PR E. This PR adds source evidence only and grants no authority.
- Any later head change invalidates the recorded decision and requires a new maintainer comment.

### Maintainer decision

- Decision: `APPROVED`
- Reviewed head: `ee3bae4492517dd158234dbe28905bf5be6f5cff`
- Permalink: https://github.com/satoshikawato/gbdraw/pull/354#issuecomment-5331223139
- Posted by the maintainer; automation did not post or edit the decision comment.
