### PR TITLE
ci: validate inert Web architecture rules

### DIFF
--- a/docs/internal/WEB_CHANGE_POLICY.md
+++ b/docs/internal/WEB_CHANGE_POLICY.md
@@ -24,11 +24,18 @@ Except for the pure policy contraction described below, Web runtime files cannot
 change in the same pull request as these guard files:
 
 ```text
+docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md
+.github/pull_request_template.md
 tools/check-web-change-budget.mjs
+tools/web-architecture-detectors.mjs
+tools/web-architecture-evaluation.mjs
+tools/web-architecture-rules.json
+tools/web-architecture-violations.json
 tools/web-change-source.mjs
 tools/web-change-policy.json
 docs/internal/WEB_CHANGE_POLICY.md
 tests/web/architecture-contracts.test.mjs
+tests/web/architecture-ratchet-fixtures.test.mjs
 .github/workflows/test.yml
 .github/workflows/web-base-policy.yml
 ```
@@ -88,6 +95,32 @@ The ordinary or architecture production budget and the dependency, vendor,
 binary, and other integrity checks still apply in full. Any other runtime/guard
 combination remains prohibited.
 
+## Architecture evidence and authority
+
+The architecture guard separates source detection, pure evaluation, and intended
+authority:
+
+| Concern | Owner |
+| --- | --- |
+| Versioned executable source-fact detection | `tools/web-architecture-detectors.mjs` |
+| I/O-free schema, observation, and authority-delta mechanics | `tools/web-architecture-evaluation.mjs` |
+| Intended semantic-owner and canonical-path rules | `tools/web-architecture-rules.json` |
+| Permitted privileged operator and importer paths | `tools/web-change-policy.json` |
+| Git and file I/O, trusted-base orchestration, reporting, and the CLI entry point | `tools/check-web-change-budget.mjs` |
+
+Detectors emit normalized facts and stable subjects. They do not contain allowed
+paths, counts, enforcement modes, baseline eligibility, or exceptions. The
+evaluator receives already-loaded plain data and normalized facts. It does not
+read files, run Git, inspect the environment, emit reports, detect source facts,
+or define intended paths and thresholds.
+
+The optional rule registry is inert authority data. Its absence is valid during
+the staged rollout. A proposed registry is parsed strictly and checked with the
+detectors already present on the trusted base. Candidate rules are compared with
+untouched base source before admission and cannot authorize the same head runtime.
+Until rule activation in a later phase, the checker's existing inline constraints
+remain the only active runtime authority.
+
 ## Trusted base check
 
 The pull request workflow runs the normal tests from the pull request checkout.
@@ -96,7 +129,8 @@ The separate `pull_request_target` workflow provides the required
 pull request head only as Git data, and runs the checker from the base checkout.
 It does not check out or execute pull request code. A proposed head policy is read
 only as inert JSON data; neither a head policy nor a head checker can authorize
-itself.
+itself. Proposed head detector code is never imported or executed by this
+workflow.
 
 The checker reports uncertain naming signals without failing the check. These
 signals include cache, token, handle, journal, protocol, manager, compatibility,

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -55,6 +55,14 @@ const PULL_REQUEST_TEMPLATE = readFileSync(
   join(REPOSITORY_ROOT, '.github/pull_request_template.md'),
   'utf8'
 );
+const WEB_ARCHITECTURE_EVALUATION_SOURCE = readFileSync(
+  join(REPOSITORY_ROOT, 'tools/web-architecture-evaluation.mjs'),
+  'utf8'
+);
+const WEB_CHANGE_BUDGET_SOURCE = readFileSync(
+  join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs'),
+  'utf8'
+);
 
 const normalizePath = (path) => path.split(sep).join('/');
 const relativeModulePath = (path) => normalizePath(relative(JAVASCRIPT_ROOT, path));
@@ -588,6 +596,36 @@ test('versioned architecture detectors characterize the untouched source tree', 
   );
 });
 
+test('pure architecture evaluation owns no I/O, source detection, or authority data', () => {
+  assert.doesNotMatch(WEB_ARCHITECTURE_EVALUATION_SOURCE, /^\s*import\s/m);
+  assert.doesNotMatch(
+    WEB_ARCHITECTURE_EVALUATION_SOURCE,
+    /node:(?:fs|path|child_process|process)|process\.|console\.|(?:read|write|append)File|execFile|spawn/
+  );
+  assert.doesNotMatch(
+    WEB_ARCHITECTURE_EVALUATION_SOURCE,
+    /web-architecture-(?:detectors|rules|violations)|web-change-policy/
+  );
+  assert.doesNotMatch(WEB_ARCHITECTURE_EVALUATION_SOURCE, /^#!|process\.argv/);
+});
+
+test('the Web checker remains the sole evaluator orchestrator and CLI entry point', () => {
+  assert.match(
+    WEB_CHANGE_BUDGET_SOURCE,
+    /from '\.\/web-architecture-evaluation\.mjs'/
+  );
+  [
+    'validateArchitectureRuleRegistry',
+    'classifyArchitectureAuthorityDelta',
+    'classifyArchitectureRuleObservation'
+  ].forEach((name) => {
+    assert.match(WEB_CHANGE_BUDGET_SOURCE, new RegExp(`\\b${name}\\s*\\(`));
+  });
+  assert.match(WEB_CHANGE_BUDGET_SOURCE, /^#!\/usr\/bin\/env node/);
+  assert.match(WEB_CHANGE_BUDGET_SOURCE, /WEB_ARCHITECTURE_DETECTORS\[rule\.detector\]/);
+  assert.doesNotMatch(WEB_CHANGE_BUDGET_SOURCE, /import\s*\(.*web-architecture-detectors/);
+});
+
 test('report-only source facts preserve the characterized masking behavior', () => {
   const facts = detectReportOnlySourceFacts(
     "import helper from './helper.js';\n"
@@ -727,6 +765,14 @@ const WEB_ARCHITECTURE_DETECTOR_MODULE = join(
   REPOSITORY_ROOT,
   'tools/web-architecture-detectors.mjs'
 );
+const WEB_ARCHITECTURE_EVALUATION_MODULE = join(
+  REPOSITORY_ROOT,
+  'tools/web-architecture-evaluation.mjs'
+);
+const WEB_ARCHITECTURE_RATCHET_FIXTURES = join(
+  REPOSITORY_ROOT,
+  'tests/web/architecture-ratchet-fixtures.test.mjs'
+);
 const BUDGET_POLICY = Object.freeze({
   allowedPrivilegedImporters: {
     'services/diagram-generation.js': ['app/editor.js'],
@@ -778,11 +824,19 @@ const BUDGET_FIXTURE = Object.freeze({
     WEB_ARCHITECTURE_DETECTOR_MODULE,
     'utf8'
   ),
+  'tools/web-architecture-evaluation.mjs': readFileSync(
+    WEB_ARCHITECTURE_EVALUATION_MODULE,
+    'utf8'
+  ),
   'tools/web-change-source.mjs': readFileSync(
     join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
     'utf8'
   ),
   'tools/web-change-policy.json': `${JSON.stringify(BUDGET_POLICY, null, 2)}\n`,
+  'tests/web/architecture-ratchet-fixtures.test.mjs': readFileSync(
+    WEB_ARCHITECTURE_RATCHET_FIXTURES,
+    'utf8'
+  ),
   'gbdraw/web/index.html': '<main>baseline</main>\n',
   'gbdraw/web/js/app/editor.js': (
     "import { runDiagramGeneration } from '../services/diagram-generation.js';\n"
@@ -802,22 +856,20 @@ const BUDGET_FIXTURE = Object.freeze({
 const FUTURE_GUARD_PATHS = Object.freeze([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   '.github/pull_request_template.md',
-  'tools/web-architecture-evaluation.mjs',
   'tools/web-architecture-rules.json',
-  'tools/web-architecture-violations.json',
-  'tests/web/architecture-ratchet-fixtures.test.mjs'
-]);
-const FUTURE_CHECKER_IMPLEMENTATION_PATHS = Object.freeze([
-  'tools/web-architecture-evaluation.mjs'
+  'tools/web-architecture-violations.json'
 ]);
 const FUTURE_AUTHORITY_PATHS = Object.freeze([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   'tools/web-architecture-rules.json',
   'tools/web-architecture-violations.json'
 ]);
-const reservedPathContent = (path) => path.endsWith('.json')
-  ? '{}\n'
-  : `// reserved fixture for ${path}\n`;
+const reservedPathContent = (path) => {
+  if (path === 'tools/web-architecture-rules.json') {
+    return '{"schemaVersion":1,"rules":[]}\n';
+  }
+  return path.endsWith('.json') ? '{}\n' : `// reserved fixture for ${path}\n`;
+};
 
 const writeFixtureFile = (root, path, content) => {
   const target = join(root, path);
@@ -1151,7 +1203,8 @@ test('checker implementation and authority files cannot change together', () => 
   const implementationPaths = [
     'tools/check-web-change-budget.mjs',
     'tools/web-change-source.mjs',
-    'tools/web-architecture-detectors.mjs'
+    'tools/web-architecture-detectors.mjs',
+    'tools/web-architecture-evaluation.mjs'
   ];
   const authorityPaths = [
     'tools/web-change-policy.json',
@@ -1179,7 +1232,7 @@ test('all checker implementations are separated from reserved future authority',
     'tools/check-web-change-budget.mjs',
     'tools/web-change-source.mjs',
     'tools/web-architecture-detectors.mjs',
-    ...FUTURE_CHECKER_IMPLEMENTATION_PATHS
+    'tools/web-architecture-evaluation.mjs'
   ];
 
   implementationPaths.forEach((implementationPath) => {

--- a/tests/web/architecture-ratchet-fixtures.test.mjs
+++ b/tests/web/architecture-ratchet-fixtures.test.mjs
@@ -1,0 +1,488 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { WEB_ARCHITECTURE_DETECTORS } from '../../tools/web-architecture-detectors.mjs';
+import {
+  classifyArchitectureAuthorityDelta,
+  classifyArchitectureRuleObservation,
+  validateArchitectureRuleRegistry,
+  WEB_ARCHITECTURE_RULE_SCHEMA
+} from '../../tools/web-architecture-evaluation.mjs';
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const AVAILABLE_ENFORCEMENTS = Object.freeze({
+  availableEnforcements: Object.freeze(['hard', 'report-only'])
+});
+
+const canonicalRule = (overrides = {}) => ({
+  key: 'canonical-path.render-request',
+  kind: 'single-canonical-entry-edge',
+  detector: 'canonical-path.render-request.v1',
+  allowedEdges: [{
+    from: 'app/run-analysis.js',
+    to: 'services/session-request.js'
+  }],
+  exactActiveEdgeCount: 1,
+  enforcement: 'hard',
+  baselineEligible: false,
+  ...overrides
+});
+
+const semanticRule = (overrides = {}) => ({
+  key: 'semantic-owner.render-request',
+  kind: 'single-semantic-owner',
+  detector: 'semantic-owner.render-request.v1',
+  allowedDefinitionPaths: ['services/session-request.js'],
+  exactDefinitionCount: 1,
+  enforcement: 'hard',
+  baselineEligible: false,
+  ...overrides
+});
+
+const registry = (rules = [canonicalRule(), semanticRule()]) => ({
+  schemaVersion: 1,
+  rules
+});
+const clone = (value) => JSON.parse(JSON.stringify(value));
+const validationCodes = (value, catalog = WEB_ARCHITECTURE_DETECTORS, options = {}) => (
+  validateArchitectureRuleRegistry(value, catalog, options).errors.map(({ code }) => code)
+);
+
+test('schema version 1 accepts only the two discriminated initial rule kinds', () => {
+  assert.deepEqual(WEB_ARCHITECTURE_RULE_SCHEMA, {
+    schemaVersion: 1,
+    maximumRuleCount: 3,
+    kinds: ['single-canonical-entry-edge', 'single-semantic-owner'],
+    enforcementModes: ['frozen', 'hard', 'report-only']
+  });
+  assert.deepEqual(
+    validateArchitectureRuleRegistry(
+      registry(),
+      WEB_ARCHITECTURE_DETECTORS,
+      AVAILABLE_ENFORCEMENTS
+    ),
+    { valid: true, errors: [] }
+  );
+});
+
+test('strict schema rejects unknown, executable-looking, duplicate, and unsorted data', () => {
+  const cases = [
+    {
+      name: 'unknown top-level field',
+      value: { ...registry(), predicate: 'process.exit(0)' },
+      code: 'unknown-field'
+    },
+    {
+      name: 'wrong kind-specific field',
+      value: registry([{
+        ...semanticRule(),
+        allowedEdges: canonicalRule().allowedEdges
+      }]),
+      code: 'unknown-field'
+    },
+    {
+      name: 'wildcard path',
+      value: registry([semanticRule({ allowedDefinitionPaths: ['services/*.js'] })]),
+      code: 'invalid-web-module-path'
+    },
+    {
+      name: 'JavaScript-looking path',
+      value: registry([semanticRule({
+        allowedDefinitionPaths: ['services/session-request.js;process.exit.js']
+      })]),
+      code: 'invalid-web-module-path'
+    },
+    {
+      name: 'repository-prefixed path',
+      value: registry([semanticRule({
+        allowedDefinitionPaths: ['gbdraw/web/js/services/session-request.js']
+      })]),
+      code: 'invalid-web-module-path'
+    },
+    {
+      name: 'duplicate path',
+      value: registry([semanticRule({
+        allowedDefinitionPaths: [
+          'services/session-request.js',
+          'services/session-request.js'
+        ]
+      })]),
+      code: 'duplicate-value'
+    },
+    {
+      name: 'duplicate rule key',
+      value: registry([semanticRule(), semanticRule()]),
+      code: 'duplicate-rule-key'
+    },
+    {
+      name: 'unsupported enforcement',
+      value: registry([semanticRule({ enforcement: 'disabled' })]),
+      code: 'unsupported-enforcement'
+    },
+    {
+      name: 'unsupported definition count',
+      value: registry([semanticRule({ exactDefinitionCount: 2 })]),
+      code: 'invalid-definition-count'
+    },
+    {
+      name: 'unsorted rules',
+      value: registry([semanticRule(), canonicalRule()]),
+      code: 'unsorted-rules'
+    },
+    {
+      name: 'more than three rules',
+      value: registry([
+        canonicalRule(),
+        semanticRule({ key: 'semantic-owner.alpha' }),
+        semanticRule({ key: 'semantic-owner.beta' }),
+        semanticRule({ key: 'semantic-owner.gamma' })
+      ]),
+      code: 'too-many-rules'
+    }
+  ];
+
+  cases.forEach(({ name, value, code }) => {
+    assert.ok(validationCodes(value).includes(code), name);
+  });
+});
+
+test('canonical edge schema requires nonempty unique sorted edges and one active edge', () => {
+  const edgeA = { from: 'app/alternate.js', to: 'services/session-request.js' };
+  const edgeB = { from: 'app/run-analysis.js', to: 'services/session-request.js' };
+  const cases = [
+    [canonicalRule({ allowedEdges: [] }), 'empty-array'],
+    [canonicalRule({ allowedEdges: [edgeA, edgeA] }), 'duplicate-edge'],
+    [canonicalRule({ allowedEdges: [edgeB, edgeA] }), 'unsorted-edges'],
+    [canonicalRule({ exactActiveEdgeCount: 0 }), 'invalid-active-edge-count'],
+    [canonicalRule({ exactActiveEdgeCount: 2 }), 'invalid-active-edge-count']
+  ];
+
+  cases.forEach(([rule, code]) => {
+    assert.ok(validationCodes(registry([rule])).includes(code));
+  });
+});
+
+test('detector compatibility and staged enforcement fail closed', () => {
+  const wrongCategoryCatalog = {
+    ...WEB_ARCHITECTURE_DETECTORS,
+    'semantic-owner.render-request.v1': {
+      ...WEB_ARCHITECTURE_DETECTORS['semantic-owner.render-request.v1'],
+      subjectCategory: 'canonical-entry-edge'
+    }
+  };
+  const missingEncoderCatalog = {
+    ...WEB_ARCHITECTURE_DETECTORS,
+    'semantic-owner.render-request.v1': {
+      subjectCategory: 'definition-path'
+    }
+  };
+  assert.ok(validationCodes(
+    registry([semanticRule({ detector: 'semantic-owner.unknown.v1' })])
+  ).includes('unknown-detector'));
+  assert.ok(validationCodes(
+    registry([semanticRule()]),
+    wrongCategoryCatalog
+  ).includes('detector-kind-mismatch'));
+  assert.ok(validationCodes(
+    registry([semanticRule()]),
+    missingEncoderCatalog
+  ).includes('missing-subject-encoder'));
+  assert.ok(validationCodes(
+    registry([semanticRule({ enforcement: 'frozen', baselineEligible: true })]),
+    WEB_ARCHITECTURE_DETECTORS,
+    AVAILABLE_ENFORCEMENTS
+  ).includes('unavailable-enforcement'));
+  assert.ok(validationCodes(
+    registry([semanticRule({ baselineEligible: true })])
+  ).includes('invalid-hard-eligibility'));
+});
+
+test('single-canonical-entry observation separates preauthorization from active edges', () => {
+  const rule = canonicalRule({
+    allowedEdges: [
+      { from: 'app/alternate.js', to: 'services/session-request.js' },
+      { from: 'app/run-analysis.js', to: 'services/session-request.js' }
+    ]
+  });
+  const edge = (from, to = 'services/session-request.js') => ({
+    from,
+    to,
+    subject: `${from} -> ${to}`
+  });
+
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    observedEdges: [edge('app/run-analysis.js')]
+  }).observation, 'CONFORMING');
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    observedEdges: []
+  }).observation, 'ABSENT_REQUIRED');
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    observedEdges: [edge('app/unapproved.js')]
+  }).observation, 'DIVERGENT');
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    observedEdges: [edge('app/alternate.js'), edge('app/run-analysis.js')]
+  }).observation, 'DIVERGENT');
+});
+
+test('single-owner observation requires one allowed active definition', () => {
+  const rule = semanticRule({
+    allowedDefinitionPaths: [
+      'services/future-session-request.js',
+      'services/session-request.js'
+    ]
+  });
+  const definition = (path, count = 1) => ({ path, count, subject: path });
+
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    definitionCount: 1,
+    observedDefinitions: [definition('services/session-request.js')]
+  }).observation, 'CONFORMING');
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    definitionCount: 0,
+    observedDefinitions: []
+  }).observation, 'ABSENT_REQUIRED');
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    definitionCount: 1,
+    observedDefinitions: [definition('services/unapproved.js')]
+  }).observation, 'DIVERGENT');
+  assert.equal(classifyArchitectureRuleObservation(rule, {
+    definitionCount: 2,
+    observedDefinitions: [definition('services/session-request.js', 2)]
+  }).observation, 'DIVERGENT');
+});
+
+test('authority delta reports every planned direction without treating removal as contraction', () => {
+  const base = registry([semanticRule({
+    allowedDefinitionPaths: [
+      'services/future-session-request.js',
+      'services/session-request.js'
+    ]
+  })]);
+  const contraction = registry([semanticRule()]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(base, contraction).directions, [
+    'CONTRACTION'
+  ]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(contraction, base).directions, [
+    'EXPANSION'
+  ]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(registry([]), contraction).directions, [
+    'EXPANSION'
+  ]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(contraction, registry([])).directions, [
+    'RELAXATION'
+  ]);
+
+  const reportOnly = registry([semanticRule({
+    enforcement: 'report-only',
+    baselineEligible: true
+  })]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(contraction, reportOnly).directions, [
+    'RELAXATION'
+  ]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(reportOnly, contraction).directions, [
+    'TIGHTENING'
+  ]);
+
+  const reinterpreted = registry([semanticRule({ detector: 'semantic-owner.render-request.v2' })]);
+  assert.deepEqual(classifyArchitectureAuthorityDelta(contraction, reinterpreted).directions, [
+    'REINTERPRETATION'
+  ]);
+});
+
+test('evaluation leaves frozen inputs unchanged and returns stable plain data', () => {
+  const deepFreeze = (value) => {
+    if (value && typeof value === 'object') {
+      Object.values(value).forEach(deepFreeze);
+      Object.freeze(value);
+    }
+    return value;
+  };
+  const value = deepFreeze(registry());
+  const before = JSON.stringify(value);
+  const first = validateArchitectureRuleRegistry(
+    value,
+    WEB_ARCHITECTURE_DETECTORS,
+    AVAILABLE_ENFORCEMENTS
+  );
+  const second = validateArchitectureRuleRegistry(
+    value,
+    WEB_ARCHITECTURE_DETECTORS,
+    AVAILABLE_ENFORCEMENTS
+  );
+  assert.deepEqual(first, second);
+  assert.equal(JSON.stringify(value), before);
+  assert.equal(Object.getPrototypeOf(first), Object.prototype);
+  assert.equal(Object.getPrototypeOf(first.errors), Array.prototype);
+});
+
+const TRUSTED_FIXTURE_FILES = Object.freeze({
+  'package.json': '{"private":true}\n',
+  'tools/check-web-change-budget.mjs': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs'),
+    'utf8'
+  ),
+  'tools/web-architecture-detectors.mjs': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/web-architecture-detectors.mjs'),
+    'utf8'
+  ),
+  'tools/web-architecture-evaluation.mjs': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/web-architecture-evaluation.mjs'),
+    'utf8'
+  ),
+  'tools/web-change-policy.json': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/web-change-policy.json'),
+    'utf8'
+  ),
+  'tools/web-change-source.mjs': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
+    'utf8'
+  ),
+  'gbdraw/web/js/app/run-analysis.js': (
+    "import { runDiagramGeneration } from '../services/diagram-generation.js';\n"
+    + "import { buildCanonicalRenderRequest } from '../services/session-request.js';\n"
+    + 'export const run = () => {\n'
+    + '  const request = buildCanonicalRenderRequest();\n'
+    + '  return runDiagramGeneration(request);\n'
+    + '};\n'
+  ),
+  'gbdraw/web/js/services/diagram-generation.js': (
+    'export const runDiagramGeneration = () => 1;\n'
+  ),
+  'gbdraw/web/js/services/session-request.js': (
+    'export const buildCanonicalRenderRequest = () => ({});\n'
+  )
+});
+
+const writeFixtureFile = (root, path, content) => {
+  const target = join(root, path);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, 'utf8');
+};
+
+const withTrustedCheckerRepository = (mutateHead, runCase, baseFiles = {}) => {
+  const root = mkdtempSync(join(tmpdir(), 'gbdraw-architecture-ratchet-'));
+  try {
+    Object.entries({ ...TRUSTED_FIXTURE_FILES, ...baseFiles }).forEach(([path, content]) => {
+      writeFixtureFile(root, path, content);
+    });
+    const git = (args) => spawnSync('git', args, {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    assert.equal(git(['init', '--quiet']).status, 0);
+    assert.equal(git(['config', 'user.email', 'ratchet@example.invalid']).status, 0);
+    assert.equal(git(['config', 'user.name', 'Ratchet Fixture']).status, 0);
+    assert.equal(git(['add', '.']).status, 0);
+    assert.equal(git(['commit', '--quiet', '-m', 'trusted base']).status, 0);
+    const base = git(['rev-parse', 'HEAD']).stdout.trim();
+    mutateHead((path, content) => writeFixtureFile(root, path, content));
+    assert.equal(git(['add', '-A']).status, 0);
+    assert.equal(git(['commit', '--quiet', '-m', 'candidate head']).status, 0);
+    const head = git(['rev-parse', 'HEAD']).stdout.trim();
+    assert.equal(git(['checkout', '--quiet', '--detach', base]).status, 0);
+    const result = spawnSync(process.execPath, [
+      'tools/check-web-change-budget.mjs',
+      '--base', base,
+      '--head', head
+    ], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    runCase({
+      base,
+      head,
+      status: result.status,
+      output: `${result.stdout || ''}${result.stderr || ''}`
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+const writeRules = (write, value) => write(
+  'tools/web-architecture-rules.json',
+  `${JSON.stringify(value, null, 2)}\n`
+);
+
+test('trusted checker admits an isolated clean-base candidate registry as inert data', () => {
+  withTrustedCheckerRepository(
+    (write) => writeRules(write, registry()),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Classification: EXPANSION/);
+      assert.match(output, /canonical-path\.render-request against untouched base: CONFORMING/);
+      assert.match(output, /semantic-owner\.render-request against untouched base: CONFORMING/);
+      assert.match(output, /Result: \*\*PASS\*\*/);
+    }
+  );
+});
+
+test('trusted checker rejects malformed candidate JSON', () => {
+  withTrustedCheckerRepository(
+    (write) => write('tools/web-architecture-rules.json', '{"schemaVersion":1,"rules":['),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Cannot parse tools\/web-architecture-rules\.json/);
+      assert.match(output, /Result: \*\*FAIL\*\*/);
+    }
+  );
+});
+
+test('trusted checker rejects an authority contraction that excludes active head source', () => {
+  const baseRules = registry([semanticRule({
+    allowedDefinitionPaths: [
+      'services/future-session-request.js',
+      'services/session-request.js'
+    ]
+  })]);
+  const candidateRules = registry([semanticRule({
+    allowedDefinitionPaths: ['services/future-session-request.js']
+  })]);
+  withTrustedCheckerRepository(
+    (write) => writeRules(write, candidateRules),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Classification: CONTRACTION/);
+      assert.match(output, /authority contraction or tightening is DIVERGENT on head source data/);
+    },
+    { 'tools/web-architecture-rules.json': `${JSON.stringify(baseRules, null, 2)}\n` }
+  );
+});
+
+test('trusted checker never executes a proposed head detector during self-authorization', () => {
+  withTrustedCheckerRepository(
+    (write) => {
+      writeRules(write, registry([semanticRule({
+        allowedDefinitionPaths: ['app/secondary.js']
+      })]));
+      write(
+        'gbdraw/web/js/app/secondary.js',
+        'export const buildCanonicalRenderRequest = () => ({});\n'
+      );
+      write(
+        'tools/web-architecture-detectors.mjs',
+        'throw new Error("MALICIOUS HEAD DETECTOR EXECUTED");\n'
+      );
+    },
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.doesNotMatch(output, /MALICIOUS HEAD DETECTOR EXECUTED/);
+      assert.match(output, /claims a clean base but is DIVERGENT/);
+      assert.match(output, /architecture rule authority changes must be isolated/);
+      assert.match(output, /production runtime files and Web guard\/CI files changed together/);
+    }
+  );
+});

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -7,9 +7,15 @@ import {
   detectPrivilegedWebCapabilities,
   detectReportOnlySourceFacts,
   isWebSessionSourcePath,
+  WEB_ARCHITECTURE_DETECTORS,
   WEB_PRIVILEGED_CAPABILITY_KEYS,
   WEB_PRIVILEGED_IMPORT_TARGETS
 } from './web-architecture-detectors.mjs';
+import {
+  classifyArchitectureAuthorityDelta,
+  classifyArchitectureRuleObservation,
+  validateArchitectureRuleRegistry
+} from './web-architecture-evaluation.mjs';
 
 const runGit = (root, args, options = {}) => execFileSync(
   'git',
@@ -121,13 +127,14 @@ const addedBinaryRuntimePaths = productionPaths.filter((path) => {
 });
 const changedVendorPaths = productionPaths.filter((path) => path.startsWith('gbdraw/web/vendor/'));
 const policyPath = 'tools/web-change-policy.json';
+const architectureRulesPath = 'tools/web-architecture-rules.json';
 const guardPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   '.github/pull_request_template.md',
   'tools/check-web-change-budget.mjs',
   'tools/web-architecture-detectors.mjs',
   'tools/web-architecture-evaluation.mjs',
-  'tools/web-architecture-rules.json',
+  architectureRulesPath,
   'tools/web-architecture-violations.json',
   'tools/web-change-source.mjs',
   policyPath,
@@ -146,7 +153,7 @@ const checkerImplementationPaths = new Set([
 ]);
 const authorityPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
-  'tools/web-architecture-rules.json',
+  architectureRulesPath,
   'tools/web-architecture-violations.json',
   policyPath,
   '.github/workflows/test.yml',
@@ -288,6 +295,154 @@ const allProductionSources = new Map(allProductionJavaScriptPaths.map((path) => 
   readHeadFile(path) || ''
 ]));
 
+const emptyRuleRegistry = () => ({ schemaVersion: 1, rules: [] });
+const candidateArchitectureErrors = [];
+const candidateArchitectureObservations = [];
+let architectureAuthorityDelta = Object.freeze({
+  classification: 'UNCHANGED',
+  directions: Object.freeze([]),
+  changes: Object.freeze([])
+});
+
+const parseArchitectureRuleRegistry = (source, revision) => {
+  if (source === null) return { registry: emptyRuleRegistry(), error: null };
+  try {
+    return { registry: JSON.parse(source), error: null };
+  } catch (error) {
+    return {
+      registry: null,
+      error: `Cannot parse ${architectureRulesPath} at ${revision}: ${error.message}`
+    };
+  }
+};
+
+const architectureRuleValidationOptions = Object.freeze({
+  availableEnforcements: Object.freeze(['hard', 'report-only'])
+});
+const formatRuleValidationErrors = (label, validation) => validation.errors.map((error) => (
+  `${label} ${error.path} [${error.code}]: ${error.message}`
+));
+const listRevisionProductionJavaScriptPaths = (revision) => runGit(repositoryRoot, [
+  'ls-tree', '-r', '--name-only', revision, '--', 'gbdraw/web/js'
+]).split('\n').filter((path) => /\.[cm]?js$/.test(path));
+const productionSourcesAtRevision = (revision) => new Map(
+  listRevisionProductionJavaScriptPaths(revision).map((path) => [
+    path.slice('gbdraw/web/js/'.length),
+    readRevisionFile(revision, path) || ''
+  ])
+);
+
+const baseArchitectureRulesSource = readRevisionFile(base, architectureRulesPath);
+const proposedArchitectureRulesSource = readHeadFile(architectureRulesPath);
+if (baseArchitectureRulesSource !== null || proposedArchitectureRulesSource !== null) {
+  const parsedBase = parseArchitectureRuleRegistry(baseArchitectureRulesSource, base);
+  const parsedCandidate = parseArchitectureRuleRegistry(
+    proposedArchitectureRulesSource,
+    head || 'working tree'
+  );
+  if (parsedBase.error) candidateArchitectureErrors.push(parsedBase.error);
+  if (parsedCandidate.error) candidateArchitectureErrors.push(parsedCandidate.error);
+
+  if (parsedBase.registry && parsedCandidate.registry) {
+    const baseValidation = validateArchitectureRuleRegistry(
+      parsedBase.registry,
+      WEB_ARCHITECTURE_DETECTORS,
+      architectureRuleValidationOptions
+    );
+    const candidateValidation = validateArchitectureRuleRegistry(
+      parsedCandidate.registry,
+      WEB_ARCHITECTURE_DETECTORS,
+      architectureRuleValidationOptions
+    );
+    candidateArchitectureErrors.push(
+      ...formatRuleValidationErrors('base registry', baseValidation),
+      ...formatRuleValidationErrors('candidate registry', candidateValidation)
+    );
+
+    if (baseValidation.valid && candidateValidation.valid) {
+      architectureAuthorityDelta = classifyArchitectureAuthorityDelta(
+        parsedBase.registry,
+        parsedCandidate.registry
+      );
+      if (architectureAuthorityDelta.changes.length) {
+        const companionPaths = [...changed.keys()]
+          .filter((path) => path !== architectureRulesPath)
+          .sort();
+        if (companionPaths.length) {
+          candidateArchitectureErrors.push(
+            'architecture rule authority changes must be isolated from other changed paths: '
+            + companionPaths.join(', ')
+          );
+        }
+
+        const baseSources = productionSourcesAtRevision(base);
+        const candidateRules = new Map(parsedCandidate.registry.rules.map((rule) => [rule.key, rule]));
+        const changedRuleKeys = [...new Set(
+          architectureAuthorityDelta.changes.map(({ rule }) => rule)
+        )].sort();
+        changedRuleKeys.forEach((ruleKey) => {
+          const rule = candidateRules.get(ruleKey);
+          if (!rule) return;
+          const detector = WEB_ARCHITECTURE_DETECTORS[rule.detector];
+          let baseObservation;
+          try {
+            baseObservation = classifyArchitectureRuleObservation(
+              rule,
+              detector.detect(baseSources)
+            );
+          } catch (error) {
+            candidateArchitectureErrors.push(
+              `${rule.key} trusted-base detection failed: ${error.message}`
+            );
+            return;
+          }
+          candidateArchitectureObservations.push(
+            `${rule.key} against untouched base: ${baseObservation.observation} `
+            + `(${baseObservation.observedCount}/${baseObservation.requiredCount})`
+          );
+          if (
+            (rule.enforcement === 'hard' || rule.baselineEligible === false)
+            && baseObservation.observation !== 'CONFORMING'
+          ) {
+            candidateArchitectureErrors.push(
+              `${rule.key} claims a clean base but is ${baseObservation.observation}`
+            );
+          }
+
+          const directions = new Set(architectureAuthorityDelta.changes
+            .filter((change) => change.rule === ruleKey)
+            .map(({ direction }) => direction));
+          if (![...directions].some((direction) => (
+            direction === 'CONTRACTION' || direction === 'TIGHTENING'
+          ))) return;
+          let headObservation;
+          try {
+            headObservation = classifyArchitectureRuleObservation(
+              rule,
+              detector.detect(allProductionSources)
+            );
+          } catch (error) {
+            candidateArchitectureErrors.push(
+              `${rule.key} trusted-head-data detection failed: ${error.message}`
+            );
+            return;
+          }
+          candidateArchitectureObservations.push(
+            `${rule.key} against head source data: ${headObservation.observation} `
+            + `(${headObservation.observedCount}/${headObservation.requiredCount})`
+          );
+          if (headObservation.observation !== 'CONFORMING') {
+            candidateArchitectureErrors.push(
+              `${rule.key} authority contraction or tightening is ${headObservation.observation} `
+              + 'on head source data'
+            );
+          }
+        });
+      }
+    }
+  }
+}
+
 const detectedCapabilities = detectPrivilegedWebCapabilities(allProductionSources);
 const capabilityCoverageViolations = (candidatePolicy) => {
   const violations = [];
@@ -426,6 +581,9 @@ if (proposedPolicyExclusions.length) {
 if (missingPolicyKeys.length) {
   integrityViolations.push('proposed privileged capability policy is missing base allowlist keys');
 }
+integrityViolations.push(...candidateArchitectureErrors.map((error) => (
+  `candidate architecture rules: ${error}`
+)));
 const enforcedViolations = [
   ...integrityViolations,
   ...budgetViolations
@@ -439,6 +597,8 @@ const report = [
   `- Base: \`${base}\``,
   `- Head: \`${head || 'working tree'}\``,
   `- Privileged allowlist revision: \`${policyRevision}\``,
+  `- Architecture rule base: ${baseArchitectureRulesSource === null ? 'absent' : `\`${base}\``}`,
+  `- Architecture rule candidate: ${proposedArchitectureRulesSource === null ? 'absent' : `\`${head || 'working tree'}\``}`,
   '- Policy guide: `docs/internal/WEB_CHANGE_POLICY.md`',
   `- Selected profile: ${selectedProfileName}`,
   `- Production file limit: ${selectedProfile.productionFiles}`,
@@ -494,6 +654,21 @@ const report = [
   '## Added privileged allowlist keys',
   '',
   ...list(addedPolicyKeys),
+  '',
+  '## Candidate architecture authority delta',
+  '',
+  `- Classification: ${architectureAuthorityDelta.classification}`,
+  ...list(architectureAuthorityDelta.changes.map(({ rule, field, direction }) => (
+    `${direction} ${rule} (${field})`
+  ))),
+  '',
+  '## Candidate architecture admission observations',
+  '',
+  ...list(candidateArchitectureObservations),
+  '',
+  '## Candidate architecture rule errors',
+  '',
+  ...list(candidateArchitectureErrors),
   '',
   '## Report-only cache/token/handle/journal/protocol/manager names',
   '',

--- a/tools/web-architecture-evaluation.mjs
+++ b/tools/web-architecture-evaluation.mjs
@@ -1,0 +1,505 @@
+const SCHEMA_VERSION = 1;
+const MAXIMUM_RULE_COUNT = 3;
+const RULE_KINDS = Object.freeze([
+  'single-canonical-entry-edge',
+  'single-semantic-owner'
+]);
+const ENFORCEMENT_MODES = Object.freeze(['frozen', 'hard', 'report-only']);
+const SUBJECT_CATEGORY_BY_KIND = Object.freeze({
+  'single-canonical-entry-edge': 'canonical-entry-edge',
+  'single-semantic-owner': 'definition-path'
+});
+const COMMON_RULE_FIELDS = Object.freeze([
+  'baselineEligible',
+  'detector',
+  'enforcement',
+  'key',
+  'kind'
+]);
+const KIND_FIELDS = Object.freeze({
+  'single-canonical-entry-edge': Object.freeze([
+    'allowedEdges',
+    'exactActiveEdgeCount'
+  ]),
+  'single-semantic-owner': Object.freeze([
+    'allowedDefinitionPaths',
+    'exactDefinitionCount'
+  ])
+});
+const RULE_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+const DETECTOR_ID_PATTERN = /^[a-z][a-z0-9-]*(?:\.[a-z0-9-]+)*\.v[1-9][0-9]*$/;
+const WEB_MODULE_PATH_PATTERN = /^[A-Za-z0-9_-]+(?:\/[A-Za-z0-9_.-]+)*\.[cm]?js$/;
+const DIRECTION_ORDER = Object.freeze([
+  'EXPANSION',
+  'RELAXATION',
+  'REINTERPRETATION',
+  'CONTRACTION',
+  'TIGHTENING'
+]);
+
+const compareText = (left, right) => left < right ? -1 : left > right ? 1 : 0;
+const isRecord = (value) => value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value)
+  && [Object.prototype, null].includes(Object.getPrototypeOf(value));
+const stableUnique = (values) => [...new Set(values)].sort(compareText);
+const edgeKey = ({ from, to }) => `${from}\u0000${to}`;
+const compareEdges = (left, right) => compareText(left.from, right.from)
+  || compareText(left.to, right.to);
+const displayEdge = ({ from, to }) => `${from} -> ${to}`;
+const ruleMap = (registry) => new Map((registry?.rules || []).map((rule) => [rule.key, rule]));
+const fieldSet = (kind) => new Set([...COMMON_RULE_FIELDS, ...(KIND_FIELDS[kind] || [])]);
+const stableDifference = (left, right, key = (value) => value) => {
+  const rightKeys = new Set(right.map(key));
+  return left.filter((value) => !rightKeys.has(key(value)));
+};
+
+const addError = (errors, code, path, message) => {
+  errors.push(Object.freeze({ code, path, message }));
+};
+
+const validateExactFields = (value, expectedFields, path, errors) => {
+  Object.keys(value).sort(compareText).forEach((field) => {
+    if (!expectedFields.has(field)) {
+      addError(errors, 'unknown-field', `${path}.${field}`, `Unknown field ${field}`);
+    }
+  });
+  [...expectedFields].sort(compareText).forEach((field) => {
+    if (!Object.hasOwn(value, field)) {
+      addError(errors, 'missing-field', `${path}.${field}`, `Missing required field ${field}`);
+    }
+  });
+};
+
+const isWebModulePath = (value) => typeof value === 'string'
+  && WEB_MODULE_PATH_PATTERN.test(value)
+  && !value.startsWith('gbdraw/web/js/')
+  && !value.includes('//')
+  && !value.split('/').some((segment) => segment === '.' || segment === '..');
+
+const validateWebModulePath = (value, path, errors) => {
+  if (!isWebModulePath(value)) {
+    addError(
+      errors,
+      'invalid-web-module-path',
+      path,
+      'Expected a normalized JavaScript module path relative to gbdraw/web/js/'
+    );
+  }
+};
+
+const validateSortedUniqueStrings = (values, path, errors) => {
+  if (!Array.isArray(values)) {
+    addError(errors, 'invalid-array', path, 'Expected an array');
+    return;
+  }
+  const seen = new Set();
+  let previous = null;
+  values.forEach((value, index) => {
+    validateWebModulePath(value, `${path}[${index}]`, errors);
+    if (typeof value !== 'string') return;
+    if (seen.has(value)) {
+      addError(errors, 'duplicate-value', `${path}[${index}]`, `Duplicate value ${value}`);
+    }
+    if (previous !== null && compareText(previous, value) > 0) {
+      addError(errors, 'unsorted-array', path, 'Values must use ascending canonical order');
+    }
+    seen.add(value);
+    previous = value;
+  });
+};
+
+const validateSortedUniqueEdges = (edges, path, errors) => {
+  if (!Array.isArray(edges)) {
+    addError(errors, 'invalid-array', path, 'Expected an array');
+    return;
+  }
+  if (!edges.length) {
+    addError(errors, 'empty-array', path, 'At least one allowed edge is required');
+  }
+  const seen = new Set();
+  let previous = null;
+  edges.forEach((edge, index) => {
+    const edgePath = `${path}[${index}]`;
+    if (!isRecord(edge)) {
+      addError(errors, 'invalid-edge', edgePath, 'Expected an edge object');
+      return;
+    }
+    validateExactFields(edge, new Set(['from', 'to']), edgePath, errors);
+    validateWebModulePath(edge.from, `${edgePath}.from`, errors);
+    validateWebModulePath(edge.to, `${edgePath}.to`, errors);
+    if (typeof edge.from !== 'string' || typeof edge.to !== 'string') return;
+    const key = edgeKey(edge);
+    if (seen.has(key)) {
+      addError(errors, 'duplicate-edge', edgePath, `Duplicate edge ${displayEdge(edge)}`);
+    }
+    if (previous !== null && compareEdges(previous, edge) > 0) {
+      addError(errors, 'unsorted-edges', path, 'Edges must use canonical (from, to) order');
+    }
+    seen.add(key);
+    previous = edge;
+  });
+};
+
+const validateStableSubjectEncoder = (rule, detector, path, errors) => {
+  if (!detector || typeof detector.encodeSubject !== 'function') {
+    addError(
+      errors,
+      'missing-subject-encoder',
+      `${path}.detector`,
+      `Detector ${rule.detector} must provide a stable subject encoder`
+    );
+    return;
+  }
+  const definitionPaths = Array.isArray(rule.allowedDefinitionPaths)
+    ? rule.allowedDefinitionPaths
+    : [];
+  const edges = Array.isArray(rule.allowedEdges) ? rule.allowedEdges : [];
+  const candidates = rule.kind === 'single-semantic-owner'
+    ? definitionPaths.map((modulePath) => ({ path: modulePath }))
+    : edges.filter(isRecord).map(({ from, to }) => ({ from, to }));
+  candidates.forEach((candidate, index) => {
+    try {
+      const frozenCandidate = Object.freeze({ ...candidate });
+      const first = detector.encodeSubject(frozenCandidate);
+      const second = detector.encodeSubject(frozenCandidate);
+      if (typeof first !== 'string' || !first || first !== second) {
+        addError(
+          errors,
+          'unstable-subject-encoder',
+          `${path}.detector`,
+          `Detector ${rule.detector} did not return a stable nonempty subject for item ${index}`
+        );
+      }
+    } catch (error) {
+      addError(
+        errors,
+        'invalid-subject-encoder',
+        `${path}.detector`,
+        `Detector ${rule.detector} subject encoder failed: ${error.message}`
+      );
+    }
+  });
+};
+
+export const validateArchitectureRuleRegistry = (
+  registry,
+  detectorCatalog,
+  { availableEnforcements = ENFORCEMENT_MODES } = {}
+) => {
+  const errors = [];
+  if (!isRecord(registry)) {
+    addError(errors, 'invalid-registry', '$', 'Expected a rule registry object');
+    return Object.freeze({ valid: false, errors: Object.freeze(errors) });
+  }
+  validateExactFields(registry, new Set(['rules', 'schemaVersion']), '$', errors);
+  if (registry.schemaVersion !== SCHEMA_VERSION) {
+    addError(
+      errors,
+      'unsupported-schema-version',
+      '$.schemaVersion',
+      `Expected schemaVersion ${SCHEMA_VERSION}`
+    );
+  }
+  if (!Array.isArray(registry.rules)) {
+    addError(errors, 'invalid-rules', '$.rules', 'Expected a rules array');
+    return Object.freeze({ valid: false, errors: Object.freeze(errors) });
+  }
+  if (registry.rules.length > MAXIMUM_RULE_COUNT) {
+    addError(
+      errors,
+      'too-many-rules',
+      '$.rules',
+      `Schema version ${SCHEMA_VERSION} permits at most ${MAXIMUM_RULE_COUNT} rules`
+    );
+  }
+
+  const available = new Set(availableEnforcements);
+  const seenKeys = new Set();
+  let previousKey = null;
+  registry.rules.forEach((rule, index) => {
+    const path = `$.rules[${index}]`;
+    if (!isRecord(rule)) {
+      addError(errors, 'invalid-rule', path, 'Expected a rule object');
+      return;
+    }
+    const kind = rule.kind;
+    validateExactFields(rule, fieldSet(kind), path, errors);
+    if (typeof rule.key !== 'string' || !RULE_KEY_PATTERN.test(rule.key)) {
+      addError(errors, 'invalid-rule-key', `${path}.key`, 'Expected a canonical rule key');
+    } else {
+      if (seenKeys.has(rule.key)) {
+        addError(errors, 'duplicate-rule-key', `${path}.key`, `Duplicate rule key ${rule.key}`);
+      }
+      if (previousKey !== null && compareText(previousKey, rule.key) > 0) {
+        addError(errors, 'unsorted-rules', '$.rules', 'Rules must use ascending key order');
+      }
+      seenKeys.add(rule.key);
+      previousKey = rule.key;
+    }
+    if (!RULE_KINDS.includes(kind)) {
+      addError(errors, 'unsupported-rule-kind', `${path}.kind`, `Unsupported rule kind ${kind}`);
+    }
+    if (typeof rule.detector !== 'string' || !DETECTOR_ID_PATTERN.test(rule.detector)) {
+      addError(errors, 'invalid-detector-id', `${path}.detector`, 'Expected a versioned detector ID');
+    }
+    if (!ENFORCEMENT_MODES.includes(rule.enforcement)) {
+      addError(
+        errors,
+        'unsupported-enforcement',
+        `${path}.enforcement`,
+        `Unsupported enforcement mode ${rule.enforcement}`
+      );
+    } else if (!available.has(rule.enforcement)) {
+      addError(
+        errors,
+        'unavailable-enforcement',
+        `${path}.enforcement`,
+        `Enforcement mode ${rule.enforcement} is recognized but unavailable`
+      );
+    }
+    if (typeof rule.baselineEligible !== 'boolean') {
+      addError(errors, 'invalid-baseline-eligibility', `${path}.baselineEligible`, 'Expected a boolean');
+    }
+    if (rule.enforcement === 'hard' && rule.baselineEligible !== false) {
+      addError(
+        errors,
+        'invalid-hard-eligibility',
+        `${path}.baselineEligible`,
+        'Hard rules cannot be baseline eligible'
+      );
+    }
+    if (rule.enforcement === 'frozen' && rule.baselineEligible !== true) {
+      addError(
+        errors,
+        'invalid-frozen-eligibility',
+        `${path}.baselineEligible`,
+        'Frozen rules must be baseline eligible'
+      );
+    }
+
+    if (kind === 'single-semantic-owner') {
+      validateSortedUniqueStrings(rule.allowedDefinitionPaths, `${path}.allowedDefinitionPaths`, errors);
+      if (rule.exactDefinitionCount !== 1) {
+        addError(
+          errors,
+          'invalid-definition-count',
+          `${path}.exactDefinitionCount`,
+          'Schema version 1 requires exactDefinitionCount: 1'
+        );
+      }
+    } else if (kind === 'single-canonical-entry-edge') {
+      validateSortedUniqueEdges(rule.allowedEdges, `${path}.allowedEdges`, errors);
+      if (rule.exactActiveEdgeCount !== 1) {
+        addError(
+          errors,
+          'invalid-active-edge-count',
+          `${path}.exactActiveEdgeCount`,
+          'Schema version 1 requires exactActiveEdgeCount: 1'
+        );
+      }
+    }
+
+    const detector = detectorCatalog?.[rule.detector];
+    if (!detector) {
+      addError(
+        errors,
+        'unknown-detector',
+        `${path}.detector`,
+        `Detector ${rule.detector} is not present in the trusted catalog`
+      );
+      return;
+    }
+    const expectedCategory = SUBJECT_CATEGORY_BY_KIND[kind];
+    if (expectedCategory && detector.subjectCategory !== expectedCategory) {
+      addError(
+        errors,
+        'detector-kind-mismatch',
+        `${path}.detector`,
+        `Rule kind ${kind} requires detector subject category ${expectedCategory}`
+      );
+    }
+    if (typeof detector.detect !== 'function') {
+      addError(
+        errors,
+        'missing-detector-function',
+        `${path}.detector`,
+        `Detector ${rule.detector} must provide source-fact extraction`
+      );
+    }
+    validateStableSubjectEncoder(rule, detector, path, errors);
+  });
+
+  return Object.freeze({
+    valid: errors.length === 0,
+    errors: Object.freeze(errors)
+  });
+};
+
+export const classifyArchitectureRuleObservation = (rule, detectorOutput) => {
+  if (rule.kind === 'single-semantic-owner') {
+    const definitions = Array.isArray(detectorOutput?.observedDefinitions)
+      ? detectorOutput.observedDefinitions
+      : [];
+    const definitionCount = Number.isInteger(detectorOutput?.definitionCount)
+      ? detectorOutput.definitionCount
+      : definitions.reduce((total, definition) => total + Number(definition.count || 0), 0);
+    const allowed = new Set(rule.allowedDefinitionPaths);
+    const unapprovedSubjects = stableUnique(definitions
+      .filter(({ path }) => !allowed.has(path))
+      .map(({ subject, path }) => subject || path));
+    const subjects = stableUnique(definitions.map(({ subject, path }) => subject || path));
+    const observation = definitionCount === 0
+      ? 'ABSENT_REQUIRED'
+      : definitionCount !== rule.exactDefinitionCount || unapprovedSubjects.length
+        ? 'DIVERGENT'
+        : 'CONFORMING';
+    return Object.freeze({
+      observation,
+      subjects: Object.freeze(subjects),
+      unapprovedSubjects: Object.freeze(unapprovedSubjects),
+      observedCount: definitionCount,
+      requiredCount: rule.exactDefinitionCount
+    });
+  }
+
+  if (rule.kind === 'single-canonical-entry-edge') {
+    const edges = Array.isArray(detectorOutput?.observedEdges)
+      ? detectorOutput.observedEdges
+      : [];
+    const allowed = new Set(rule.allowedEdges.map(edgeKey));
+    const subjects = stableUnique(edges.map((edge) => edge.subject || displayEdge(edge)));
+    const unapprovedSubjects = stableUnique(edges
+      .filter((edge) => !allowed.has(edgeKey(edge)))
+      .map((edge) => edge.subject || displayEdge(edge)));
+    const observation = edges.length === 0
+      ? 'ABSENT_REQUIRED'
+      : edges.length !== rule.exactActiveEdgeCount || unapprovedSubjects.length
+        ? 'DIVERGENT'
+        : 'CONFORMING';
+    return Object.freeze({
+      observation,
+      subjects: Object.freeze(subjects),
+      unapprovedSubjects: Object.freeze(unapprovedSubjects),
+      observedCount: edges.length,
+      requiredCount: rule.exactActiveEdgeCount
+    });
+  }
+
+  throw new Error(`Unsupported rule kind ${rule.kind}`);
+};
+
+const enforcementDirection = (before, after) => {
+  if (before === after) return null;
+  if (
+    (before === 'hard' && ['frozen', 'report-only'].includes(after))
+    || (before === 'frozen' && after === 'report-only')
+  ) return 'RELAXATION';
+  if (
+    (before === 'report-only' && ['frozen', 'hard'].includes(after))
+    || (before === 'frozen' && after === 'hard')
+  ) return 'TIGHTENING';
+  throw new Error(`Unsupported enforcement transition ${before} -> ${after}`);
+};
+
+const addChange = (changes, rule, field, direction, before, after) => {
+  changes.push(Object.freeze({ rule, field, direction, before, after }));
+};
+
+export const classifyArchitectureAuthorityDelta = (baseRegistry, candidateRegistry) => {
+  const beforeByKey = ruleMap(baseRegistry);
+  const afterByKey = ruleMap(candidateRegistry);
+  const keys = stableUnique([...beforeByKey.keys(), ...afterByKey.keys()]);
+  const changes = [];
+
+  keys.forEach((key) => {
+    const before = beforeByKey.get(key);
+    const after = afterByKey.get(key);
+    if (!before) {
+      addChange(changes, key, 'rule', 'EXPANSION', null, after);
+      return;
+    }
+    if (!after) {
+      addChange(changes, key, 'rule', 'RELAXATION', before, null);
+      return;
+    }
+    if (before.kind !== after.kind) {
+      addChange(changes, key, 'kind', 'REINTERPRETATION', before.kind, after.kind);
+    }
+    if (before.detector !== after.detector) {
+      addChange(
+        changes,
+        key,
+        'detector',
+        'REINTERPRETATION',
+        before.detector,
+        after.detector
+      );
+    }
+    const enforcement = enforcementDirection(before.enforcement, after.enforcement);
+    if (enforcement) {
+      addChange(
+        changes,
+        key,
+        'enforcement',
+        enforcement,
+        before.enforcement,
+        after.enforcement
+      );
+    }
+    if (before.baselineEligible !== after.baselineEligible) {
+      addChange(
+        changes,
+        key,
+        'baselineEligible',
+        after.baselineEligible ? 'RELAXATION' : 'TIGHTENING',
+        before.baselineEligible,
+        after.baselineEligible
+      );
+    }
+    if (before.kind !== after.kind) return;
+    if (after.kind === 'single-semantic-owner') {
+      stableDifference(
+        after.allowedDefinitionPaths,
+        before.allowedDefinitionPaths
+      ).forEach((value) => {
+        addChange(changes, key, 'allowedDefinitionPaths', 'EXPANSION', null, value);
+      });
+      stableDifference(
+        before.allowedDefinitionPaths,
+        after.allowedDefinitionPaths
+      ).forEach((value) => {
+        addChange(changes, key, 'allowedDefinitionPaths', 'CONTRACTION', value, null);
+      });
+    } else if (after.kind === 'single-canonical-entry-edge') {
+      stableDifference(after.allowedEdges, before.allowedEdges, edgeKey)
+        .sort(compareEdges)
+        .forEach((value) => {
+          addChange(changes, key, 'allowedEdges', 'EXPANSION', null, value);
+        });
+      stableDifference(before.allowedEdges, after.allowedEdges, edgeKey)
+        .sort(compareEdges)
+        .forEach((value) => {
+          addChange(changes, key, 'allowedEdges', 'CONTRACTION', value, null);
+        });
+    }
+  });
+
+  const directions = DIRECTION_ORDER.filter((direction) => (
+    changes.some((change) => change.direction === direction)
+  ));
+  return Object.freeze({
+    classification: directions.length === 0
+      ? 'UNCHANGED'
+      : directions.length === 1 ? directions[0] : 'MIXED',
+    directions: Object.freeze(directions),
+    changes: Object.freeze(changes)
+  });
+};
+
+export const WEB_ARCHITECTURE_RULE_SCHEMA = Object.freeze({
+  schemaVersion: SCHEMA_VERSION,
+  maximumRuleCount: MAXIMUM_RULE_COUNT,
+  kinds: RULE_KINDS,
+  enforcementModes: ENFORCEMENT_MODES
+});


### PR DESCRIPTION
## Purpose

Implement PR C from the architecture fitness-function ratchet plan. This adds strict validation for an optional inert Web architecture-rule registry without creating or activating that registry.

The trusted-base checker now validates candidate rule data with detectors from the trusted base. Proposed head detector code is never imported or executed.

## Verification

Local evidence for head `ff31ec107572c48c461878d889f02614da367e5c` against base `f1c39ba6a7284531eacee4458112be7035c3f2c2`:

- `node tools/check-web-change-budget.mjs`: PASS; no production files, dependency changes, authority delta, or violations.
- `node --test tests/web/architecture-contracts.test.mjs`: PASS as part of the complete Web test run.
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs`: 12 passed, 0 failed.
- `node --test tests/web/*.test.mjs`: 272 passed, 0 failed.
- `git diff --check`: PASS.
- Node syntax checks for both tools and both changed test files: PASS.

GitHub CI evidence for the same head and base:

- `Tests`: PASS, run `32165157990`, https://github.com/satoshikawato/gbdraw/actions/runs/32165157990
- `Web change budget`: PASS, run `32165157990`, job `95803052457`, https://github.com/satoshikawato/gbdraw/actions/runs/32165157990/job/95803052457
- `Web base policy (trusted base)`: PASS, run `32165158416`, job `95803104204`, https://github.com/satoshikawato/gbdraw/actions/runs/32165158416/job/95803104204
- `Workers Builds: gbdraw`: PASS, external deployment check.

The initial workflow runs were cancelled automatically when the `architecture-change` label started replacement runs under the configured concurrency groups. They are not used as acceptance evidence.

## Architecture impact

Select exactly one:

- [ ] This is not architecture-bearing. Rationale:
- [x] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior: inert candidate architecture-rule schema validation and trusted-base admission evaluation.
- Why this changed-capability scope is complete: the diff contains the pure mechanics owner, the existing checker orchestration, fixture-heavy tests, cross-cutting contracts, and the policy explanation. The detector, runtime, authority files, privileged policy, workflows, and dependencies are unchanged.
- Semantic owners before: `{ tools/check-web-change-budget.mjs: Git/file I/O, guard orchestration, reporting; tools/web-architecture-detectors.mjs: source-fact extraction; tools/web-change-policy.json: privileged-path authority }`. No rule-schema or authority-delta evaluator existed.
- Semantic owners after: `{ tools/web-architecture-evaluation.mjs: pure schema, observation, and authority-delta mechanics; tools/check-web-change-budget.mjs: Git/file I/O, trusted-base orchestration, reporting; tools/web-architecture-detectors.mjs: source-fact extraction; tools/web-change-policy.json: privileged-path authority }`.
- Canonical production paths before: `∅` for this guard-only capability. Existing Web production paths are unchanged.
- Canonical production paths after: `∅` for this guard-only capability. Candidate validation has one guard path: `check-web-change-budget.mjs -> trusted detector facts + web-architecture-evaluation.mjs`.
- Compatibility paths before, with stable IDs: `∅`.
- Compatibility paths after, with stable IDs: `∅`.
- Superseded owner/path removed: none; this is a new guard capability. No second checker or detector was added.
- New module classification: `tools/web-architecture-evaluation.mjs` is the single owner of the new pure evaluation capability. `tests/web/architecture-ratchet-fixtures.test.mjs` is test-only evidence.
- Persisted-compatibility evidence and removal condition: not applicable; no persisted format changed.
- Performance/scientific-output evidence, when material: not applicable; no runtime or scientific output changed.
- Deterministic checker evidence: strict discriminated-schema fixtures, exact one-active-edge cases, unavailable `frozen` rejection, detector-kind compatibility, all authority directions, invalid contraction rejection, evaluator purity contracts, malformed JSON rejection, and a malicious head detector fixture that would throw if executed.
- Maintainer architecture decision comment permalink, required before merge: https://github.com/satoshikawato/gbdraw/pull/356#issuecomment-5331943166

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.

Reviewed debt-vector result for the changed capability:

- Semantic-owner excess: before `0`, after `0`, delta `0`.
- Canonical-path excess: before `0`, after `0`, delta `0`.
- Compatibility burden: before `0`, after `0`, delta `0`.

## Maintainer review packet

- Target branch: `dev`.
- Base SHA: `f1c39ba6a7284531eacee4458112be7035c3f2c2`.
- Reviewed candidate head SHA: `ff31ec107572c48c461878d889f02614da367e5c`.
- Production files: none.
- Guard files: `tools/check-web-change-budget.mjs`, `tools/web-architecture-evaluation.mjs`.
- Test files: `tests/web/architecture-contracts.test.mjs`, `tests/web/architecture-ratchet-fixtures.test.mjs`.
- Documentation files: `docs/internal/WEB_CHANGE_POLICY.md`.
- Intended authority files: none.
- Privileged policy changes: none.
- Workflow changes: none.
- Dependency changes: none.
- Accepted-violation or frozen-rule mechanics: none.
- Requested review: confirm the declared changed-capability scope is complete, `delta(OE) <= 0`, `delta(PE) <= 0`, `delta(CB) <= 0`, and the trusted-base boundary never executes proposed head detector code.
- Approval action: the maintainer posted the required structured decision for the final head SHA at https://github.com/satoshikawato/gbdraw/pull/356#issuecomment-5331943166. This PR body is evidence, not approval.
