### PR TITLE
ci: enforce declared Web architecture rules

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -28,6 +28,11 @@ import {
   WEB_PRIVILEGED_IMPORT_TARGETS
 } from '../../tools/web-architecture-detectors.mjs';
 import {
+  classifyArchitectureRuleObservation,
+  evaluateArchitectureRuleResult,
+  validateArchitectureRuleRegistry
+} from '../../tools/web-architecture-evaluation.mjs';
+import {
   literalImportSpecifiers,
   maskJavaScript
 } from '../../tools/web-change-source.mjs';
@@ -59,6 +64,15 @@ const WEB_ARCHITECTURE_EVALUATION_SOURCE = readFileSync(
   join(REPOSITORY_ROOT, 'tools/web-architecture-evaluation.mjs'),
   'utf8'
 );
+const WEB_ARCHITECTURE_DETECTOR_SOURCE = readFileSync(
+  join(REPOSITORY_ROOT, 'tools/web-architecture-detectors.mjs'),
+  'utf8'
+);
+const WEB_ARCHITECTURE_RULES_SOURCE = readFileSync(
+  join(REPOSITORY_ROOT, 'tools/web-architecture-rules.json'),
+  'utf8'
+);
+const WEB_ARCHITECTURE_RULES = JSON.parse(WEB_ARCHITECTURE_RULES_SOURCE);
 const WEB_CHANGE_BUDGET_SOURCE = readFileSync(
   join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs'),
   'utf8'
@@ -254,15 +268,6 @@ test('production rendering crosses the canonical request and Worker boundary', (
     occurrenceOwners(/\brunDiagramGeneration\s*\(/g),
     new Map([['app/run-analysis.js', 1]])
   );
-  assert.deepEqual(
-    occurrenceOwners(/\bbuildCanonicalRenderRequest\s*\(/g),
-    new Map([
-      ['app/run-analysis.js', 1],
-      ['services/config.js', 1],
-      ['services/gallery-session-migration.js', 1]
-    ])
-  );
-  assert.deepEqual(directImports.get('app/run-analysis.js')?.has('services/session-request.js'), true);
   assert.deepEqual(directImports.get('app/run-analysis.js')?.has('services/diagram-generation.js'), true);
   assert.match(
     productionSources.get('app/run-analysis.js'),
@@ -568,32 +573,30 @@ test('versioned architecture detectors expose stable normalized subjects', () =>
   );
 });
 
-test('versioned architecture detectors characterize the untouched source tree', () => {
-  assert.deepEqual(
-    WEB_ARCHITECTURE_DETECTORS['semantic-owner.render-request.v1']
-      .detect(productionSources),
-    {
-      definitionCount: 1,
-      observedDefinitions: [{
-        path: 'services/session-request.js',
-        count: 1,
-        subject: 'services/session-request.js'
-      }],
-      subjects: ['services/session-request.js']
-    }
-  );
-  assert.deepEqual(
-    WEB_ARCHITECTURE_DETECTORS['canonical-path.render-request.v1']
-      .detect(productionSources),
-    {
-      observedEdges: [{
-        from: 'app/run-analysis.js',
-        to: 'services/session-request.js',
-        subject: 'app/run-analysis.js -> services/session-request.js'
-      }],
-      subjects: ['app/run-analysis.js -> services/session-request.js']
-    }
-  );
+test('declared architecture rules actively govern the current source tree', () => {
+  assert.deepEqual(validateArchitectureRuleRegistry(
+    WEB_ARCHITECTURE_RULES,
+    WEB_ARCHITECTURE_DETECTORS,
+    { availableEnforcements: ['hard', 'report-only'] }
+  ), { valid: true, errors: [] });
+
+  const results = WEB_ARCHITECTURE_RULES.rules.map((rule) => {
+    const detector = WEB_ARCHITECTURE_DETECTORS[rule.detector];
+    const observed = classifyArchitectureRuleObservation(rule, detector.detect(productionSources));
+    return {
+      key: rule.key,
+      ...evaluateArchitectureRuleResult({
+        observation: observed.observation,
+        mode: rule.enforcement.replace('-', '_').toUpperCase(),
+        baselineRelation: 'NOT_APPLICABLE',
+        authorityResolution: 'NOT_APPLICABLE'
+      })
+    };
+  });
+  assert.deepEqual(results.map(({ key, decision }) => ({ key, decision })), [
+    { key: 'canonical-path.render-request', decision: 'PASS' },
+    { key: 'semantic-owner.render-request', decision: 'PASS' }
+  ]);
 });
 
 test('pure architecture evaluation owns no I/O, source detection, or authority data', () => {
@@ -609,6 +612,24 @@ test('pure architecture evaluation owns no I/O, source detection, or authority d
   assert.doesNotMatch(WEB_ARCHITECTURE_EVALUATION_SOURCE, /^#!|process\.argv/);
 });
 
+test('registered architecture authority and executable matching have separate owners', () => {
+  assert.deepEqual(Object.keys(WEB_ARCHITECTURE_RULES), ['schemaVersion', 'rules']);
+  assert.doesNotMatch(
+    WEB_CHANGE_BUDGET_SOURCE,
+    /app\/run-analysis\.js|services\/session-request\.js/
+  );
+  assert.doesNotMatch(
+    WEB_ARCHITECTURE_EVALUATION_SOURCE,
+    /app\/run-analysis\.js|services\/session-request\.js/
+  );
+  assert.doesNotMatch(
+    WEB_ARCHITECTURE_DETECTOR_SOURCE,
+    /\ballowedEdges\b|\ballowedDefinitionPaths\b|\bexactActiveEdgeCount\b|\bexactDefinitionCount\b|\bbaselineEligible\b/
+  );
+  assert.match(WEB_ARCHITECTURE_DETECTOR_SOURCE, /RENDER_REQUEST_DEFINITION_PATTERN/);
+  assert.match(WEB_ARCHITECTURE_DETECTOR_SOURCE, /RENDER_REQUEST_CALL_PATTERN/);
+});
+
 test('the Web checker remains the sole evaluator orchestrator and CLI entry point', () => {
   assert.match(
     WEB_CHANGE_BUDGET_SOURCE,
@@ -617,7 +638,8 @@ test('the Web checker remains the sole evaluator orchestrator and CLI entry poin
   [
     'validateArchitectureRuleRegistry',
     'classifyArchitectureAuthorityDelta',
-    'classifyArchitectureRuleObservation'
+    'classifyArchitectureRuleObservation',
+    'evaluateArchitectureRuleResult'
   ].forEach((name) => {
     assert.match(WEB_CHANGE_BUDGET_SOURCE, new RegExp(`\\b${name}\\s*\\(`));
   });
@@ -775,15 +797,18 @@ const WEB_ARCHITECTURE_RATCHET_FIXTURES = join(
 );
 const BUDGET_POLICY = Object.freeze({
   allowedPrivilegedImporters: {
-    'services/diagram-generation.js': ['app/editor.js'],
+    'services/diagram-generation.js': ['app/editor.js', 'app/run-analysis.js'],
+    'services/session-request.js': ['app/run-analysis.js'],
     'workers/diagram-generation-worker.js': []
   },
   allowedPrivilegedOwners: {
     'Diagram Worker': [
       'app/editor.js',
       'app/future-owner.js',
+      'app/run-analysis.js',
       'services/diagram-generation.js'
-    ]
+    ],
+    'Render request': ['app/run-analysis.js']
   }
 });
 const BUDGET_PROFILES = Object.freeze([
@@ -828,6 +853,7 @@ const BUDGET_FIXTURE = Object.freeze({
     WEB_ARCHITECTURE_EVALUATION_MODULE,
     'utf8'
   ),
+  'tools/web-architecture-rules.json': WEB_ARCHITECTURE_RULES_SOURCE,
   'tools/web-change-source.mjs': readFileSync(
     join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
     'utf8'
@@ -843,6 +869,14 @@ const BUDGET_FIXTURE = Object.freeze({
     + 'export const editExistingOwner = () => runDiagramGeneration();\n'
   ),
   'gbdraw/web/js/app/future-owner.js': 'export const futureOwnerPlaceholder = () => 1;\n',
+  'gbdraw/web/js/app/run-analysis.js': (
+    "import { runDiagramGeneration } from '../services/diagram-generation.js';\n"
+    + "import { buildCanonicalRenderRequest } from '../services/session-request.js';\n"
+    + 'export const run = () => {\n'
+    + '  const request = buildCanonicalRenderRequest();\n'
+    + '  return runDiagramGeneration(request);\n'
+    + '};\n'
+  ),
   'gbdraw/web/js/app/secondary.js': 'export const editSecondaryOwner = () => 1;\n',
   'gbdraw/web/js/app/budget-lines.js': budgetLineSource(),
   'gbdraw/web/js/services/diagram-generation.js': (
@@ -851,13 +885,19 @@ const BUDGET_FIXTURE = Object.freeze({
   'gbdraw/web/js/services/session-file.js': (
     'export const readSession = () => ({ version: 1 });\n'
   ),
+  'gbdraw/web/js/services/session-request.js': (
+    'export const buildCanonicalRenderRequest = () => ({});\n'
+  ),
   'gbdraw/web/vendor/library.js': 'globalThis.vendorLibrary = true;\n'
 });
 const FUTURE_GUARD_PATHS = Object.freeze([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   '.github/pull_request_template.md',
-  'tools/web-architecture-rules.json',
   'tools/web-architecture-violations.json'
+]);
+const PROTECTED_ARCHITECTURE_GUARD_PATHS = Object.freeze([
+  ...FUTURE_GUARD_PATHS,
+  'tools/web-architecture-rules.json'
 ]);
 const FUTURE_AUTHORITY_PATHS = Object.freeze([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
@@ -1004,6 +1044,300 @@ const assertRevisionChangeBudgetFailure = (mutate, expectedPatterns) => {
     assertNonWaivableRevisionFailure(execute, base, head, expectedPatterns);
   });
 };
+
+const TRUSTED_ARCHITECTURE_FIXTURE_FILES = Object.freeze({
+  'package.json': '{"private":true}\n',
+  'tools/check-web-change-budget.mjs': readFileSync(CHANGE_BUDGET_CHECKER, 'utf8'),
+  'tools/web-architecture-detectors.mjs': readFileSync(
+    WEB_ARCHITECTURE_DETECTOR_MODULE,
+    'utf8'
+  ),
+  'tools/web-architecture-evaluation.mjs': readFileSync(
+    WEB_ARCHITECTURE_EVALUATION_MODULE,
+    'utf8'
+  ),
+  'tools/web-architecture-rules.json': WEB_ARCHITECTURE_RULES_SOURCE,
+  'tools/web-change-policy.json': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/web-change-policy.json'),
+    'utf8'
+  ),
+  'tools/web-change-source.mjs': readFileSync(
+    join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
+    'utf8'
+  ),
+  'gbdraw/web/js/app/run-analysis.js': (
+    "import { runDiagramGeneration } from '../services/diagram-generation.js';\n"
+    + "import { buildCanonicalRenderRequest } from '../services/session-request.js';\n"
+    + 'export const run = () => {\n'
+    + '  const request = buildCanonicalRenderRequest();\n'
+    + '  return runDiagramGeneration(request);\n'
+    + '};\n'
+  ),
+  'gbdraw/web/js/services/diagram-generation.js': (
+    'export const runDiagramGeneration = () => 1;\n'
+  ),
+  'gbdraw/web/js/services/session-request.js': (
+    'export const buildCanonicalRenderRequest = () => ({});\n'
+  )
+});
+
+const canonicalCallerSource = (
+  "import { runDiagramGeneration } from '../services/diagram-generation.js';\n"
+  + "import { buildCanonicalRenderRequest } from '../services/session-request.js';\n"
+  + 'export const run = () => {\n'
+  + '  const request = buildCanonicalRenderRequest();\n'
+  + '  return runDiagramGeneration(request);\n'
+  + '};\n'
+);
+const rulesSource = (mutate) => {
+  const rules = JSON.parse(WEB_ARCHITECTURE_RULES_SOURCE);
+  mutate(rules);
+  return `${JSON.stringify(rules, null, 2)}\n`;
+};
+const canonicalRule = (rules) => rules.rules.find(
+  ({ key }) => key === 'canonical-path.render-request'
+);
+const preauthorizedCanonicalRulesSource = rulesSource((rules) => {
+  canonicalRule(rules).allowedEdges = [
+    { from: 'app/alternate.js', to: 'services/session-request.js' },
+    { from: 'app/run-analysis.js', to: 'services/session-request.js' }
+  ];
+});
+const reportOnlyCanonicalRulesSource = rulesSource((rules) => {
+  canonicalRule(rules).enforcement = 'report-only';
+});
+
+const withTrustedArchitectureRepository = (mutateHead, runCase, baseFiles = {}) => {
+  const root = mkdtempSync(join(tmpdir(), 'gbdraw-architecture-ratchet-'));
+  try {
+    Object.entries({ ...TRUSTED_ARCHITECTURE_FIXTURE_FILES, ...baseFiles })
+      .forEach(([path, content]) => writeFixtureFile(root, path, content));
+    const git = (args) => spawnSync('git', args, {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    assert.equal(git(['init', '--quiet']).status, 0);
+    assert.equal(git(['config', 'user.email', 'ratchet@example.invalid']).status, 0);
+    assert.equal(git(['config', 'user.name', 'Ratchet Fixture']).status, 0);
+    assert.equal(git(['add', '.']).status, 0);
+    assert.equal(git(['commit', '--quiet', '-m', 'trusted base']).status, 0);
+    const base = git(['rev-parse', 'HEAD']).stdout.trim();
+    mutateHead((path, content) => writeFixtureFile(root, path, content));
+    assert.equal(git(['add', '-A']).status, 0);
+    assert.equal(git(['commit', '--quiet', '-m', 'candidate head']).status, 0);
+    const head = git(['rev-parse', 'HEAD']).stdout.trim();
+    assert.equal(git(['checkout', '--quiet', '--detach', base]).status, 0);
+    const result = spawnSync(process.execPath, [
+      'tools/check-web-change-budget.mjs',
+      '--base', base,
+      '--head', head
+    ], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    runCase({
+      base,
+      head,
+      status: result.status,
+      output: `${result.stdout || ''}${result.stderr || ''}`
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+};
+
+test('active base rules accept one canonical entry edge', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('fixture-note.txt', 'unchanged architecture\n'),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(
+        output,
+        /canonical-path\.render-request .* observation=CONFORMING .* decision=PASS/
+      );
+      assert.match(
+        output,
+        /semantic-owner\.render-request .* registeredDefinitionLocations=1/
+      );
+    }
+  );
+});
+
+test('active hard rule fails when the canonical entry edge is absent', () => {
+  withTrustedArchitectureRepository(
+    (write) => write(
+      'gbdraw/web/js/app/run-analysis.js',
+      'export const run = () => 1;\n'
+    ),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(
+        output,
+        /canonical-path\.render-request .* observation=ABSENT_REQUIRED .* decision=FAIL/
+      );
+    }
+  );
+});
+
+test('active hard rule rejects an unapproved canonical entry edge', () => {
+  withTrustedArchitectureRepository(
+    (write) => {
+      write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n');
+      write('gbdraw/web/js/app/alternate.js', canonicalCallerSource);
+    },
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(
+        output,
+        /canonical-path\.render-request \| subject=app\/alternate\.js -> services\/session-request\.js \| observation=DIVERGENT .* decision=FAIL/
+      );
+    }
+  );
+});
+
+test('two simultaneously active preauthorized edges fail in stable subject order', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('gbdraw/web/js/app/alternate.js', canonicalCallerSource),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      const alternate = output.indexOf(
+        'canonical-path.render-request | subject=app/alternate.js -> services/session-request.js'
+      );
+      const current = output.indexOf(
+        'canonical-path.render-request | subject=app/run-analysis.js -> services/session-request.js'
+      );
+      const semantic = output.indexOf('semantic-owner.render-request | subject=');
+      assert.ok(alternate >= 0 && alternate < current && current < semantic, output);
+      assert.match(output.slice(alternate, semantic), /observation=DIVERGENT[\s\S]+decision=FAIL/);
+    },
+    { 'tools/web-architecture-rules.json': preauthorizedCanonicalRulesSource }
+  );
+});
+
+test('an inactive preauthorized edge does not fail', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('fixture-note.txt', 'preauthorization remains inactive\n'),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(
+        output,
+        /canonical-path\.render-request .* observation=CONFORMING .* decision=PASS/
+      );
+    },
+    { 'tools/web-architecture-rules.json': preauthorizedCanonicalRulesSource }
+  );
+});
+
+test('report-only rules report absence without consulting an accepted store or failing', () => {
+  withTrustedArchitectureRepository(
+    (write) => write(
+      'gbdraw/web/js/app/run-analysis.js',
+      'export const run = () => 1;\n'
+    ),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(
+        output,
+        /canonical-path\.render-request .* observation=ABSENT_REQUIRED .* mode=REPORT_ONLY .* decision=REPORT/
+      );
+      assert.match(output, /Result: \*\*PASS\*\*/);
+    },
+    {
+      'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource,
+      'tools/web-architecture-violations.json': 'not valid JSON and must not be loaded\n'
+    }
+  );
+});
+
+test('hard rules do not consult an accepted-violation store', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('fixture-note.txt', 'hard rule remains conforming\n'),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.doesNotMatch(output, /Cannot parse tools\/web-architecture-violations\.json/);
+      assert.match(output, /Result: \*\*PASS\*\*/);
+    },
+    { 'tools/web-architecture-violations.json': 'not valid JSON and must not be loaded\n' }
+  );
+});
+
+test('trusted checker rejects malformed proposed rule JSON as inert data', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('tools/web-architecture-rules.json', '{"schemaVersion":1,"rules":['),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Cannot parse tools\/web-architecture-rules\.json/);
+      assert.match(output, /Result: \*\*FAIL\*\*/);
+    }
+  );
+});
+
+test('a proposed detector that throws is never loaded or executed', () => {
+  withTrustedArchitectureRepository(
+    (write) => write(
+      'tools/web-architecture-detectors.mjs',
+      'throw new Error("MALICIOUS HEAD DETECTOR EXECUTED");\n'
+    ),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.doesNotMatch(output, /MALICIOUS HEAD DETECTOR EXECUTED/);
+      assert.match(output, /canonical-path\.render-request .* decision=PASS/);
+    }
+  );
+});
+
+test('proposed detector ID and implementation cannot alter trusted source observation', () => {
+  const proposedRules = rulesSource((rules) => {
+    canonicalRule(rules).detector = 'canonical-path.render-request.v999';
+  });
+  withTrustedArchitectureRepository(
+    (write) => {
+      write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n');
+      write('gbdraw/web/js/app/alternate.js', canonicalCallerSource);
+      write('tools/web-architecture-rules.json', proposedRules);
+      write(
+        'tools/web-architecture-detectors.mjs',
+        'throw new Error("MALICIOUS HEAD DETECTOR EXECUTED");\n'
+      );
+    },
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.doesNotMatch(output, /MALICIOUS HEAD DETECTOR EXECUTED/);
+      assert.match(output, /unknown-detector/);
+      assert.match(
+        output,
+        /canonical-path\.render-request .* observation=DIVERGENT .* decision=FAIL/
+      );
+    }
+  );
+});
+
+test('mutually conforming proposed rules and source cannot replace base authority', () => {
+  const proposedRules = rulesSource((rules) => {
+    canonicalRule(rules).allowedEdges = [{
+      from: 'app/alternate.js',
+      to: 'services/session-request.js'
+    }];
+  });
+  withTrustedArchitectureRepository(
+    (write) => {
+      write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n');
+      write('gbdraw/web/js/app/alternate.js', canonicalCallerSource);
+      write('tools/web-architecture-rules.json', proposedRules);
+    },
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(
+        output,
+        /canonical-path\.render-request \| subject=app\/alternate\.js -> services\/session-request\.js \| observation=DIVERGENT .* decision=FAIL/
+      );
+      assert.match(output, /architecture rule authority changes must be isolated/);
+      assert.match(output, /Result: \*\*FAIL\*\*/);
+    }
+  );
+});
 
 test('fixed profiles enforce exact production-file boundaries', () => {
   BUDGET_PROFILES.forEach((profile) => {
@@ -1187,8 +1521,8 @@ test('reserved future guard paths need not exist before their rollout', () => {
   assert.match(result.output, /Result: \*\*PASS\*\*/);
 });
 
-test('runtime cannot co-change with any reserved future guard path', () => {
-  FUTURE_GUARD_PATHS.forEach((guardPath) => {
+test('runtime cannot co-change with any protected architecture guard path', () => {
+  PROTECTED_ARCHITECTURE_GUARD_PATHS.forEach((guardPath) => {
     assertNonWaivableWorkingTreeFailure((write) => {
       write(
         'gbdraw/web/js/services/session-file.js',
@@ -1250,7 +1584,7 @@ test('all checker implementations are separated from reserved future authority',
   });
 });
 
-test('the evaluator implementation and ratchet fixture classifications stay disjoint', () => {
+test('evaluator fixtures stay implementation-only while active rule authority stays isolated', () => {
   const evaluatorAndFixture = runChangeBudgetCase((write) => {
     write(
       'tools/web-architecture-evaluation.mjs',
@@ -1273,7 +1607,11 @@ test('the evaluator implementation and ratchet fixture classifications stay disj
       reservedPathContent('tools/web-architecture-rules.json')
     );
   });
-  assert.equal(fixtureAndAuthority.status, 0, fixtureAndAuthority.output);
+  assert.equal(fixtureAndAuthority.status, 1, fixtureAndAuthority.output);
+  assert.match(
+    fixtureAndAuthority.output,
+    /architecture rule authority changes must be isolated/
+  );
 });
 
 test('the reserved PR template is guard-only', () => {
@@ -1299,7 +1637,11 @@ test('the reserved PR template is guard-only', () => {
       reservedPathContent('tools/web-architecture-rules.json')
     );
   });
-  assert.equal(templateAndAuthority.status, 0, templateAndAuthority.output);
+  assert.equal(templateAndAuthority.status, 1, templateAndAuthority.output);
+  assert.match(
+    templateAndAuthority.output,
+    /architecture rule authority changes must be isolated/
+  );
 });
 
 test('an unregistered path acquires no guard or authority classification', () => {

--- a/tests/web/architecture-ratchet-fixtures.test.mjs
+++ b/tests/web/architecture-ratchet-fixtures.test.mjs
@@ -1,26 +1,15 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
 import test from 'node:test';
-import { fileURLToPath } from 'node:url';
 
 import { WEB_ARCHITECTURE_DETECTORS } from '../../tools/web-architecture-detectors.mjs';
 import {
   classifyArchitectureAuthorityDelta,
   classifyArchitectureRuleObservation,
+  evaluateArchitectureRuleResult,
   validateArchitectureRuleRegistry,
   WEB_ARCHITECTURE_RULE_SCHEMA
 } from '../../tools/web-architecture-evaluation.mjs';
 
-const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const AVAILABLE_ENFORCEMENTS = Object.freeze({
   availableEnforcements: Object.freeze(['hard', 'report-only'])
 });
@@ -54,7 +43,6 @@ const registry = (rules = [canonicalRule(), semanticRule()]) => ({
   schemaVersion: 1,
   rules
 });
-const clone = (value) => JSON.parse(JSON.stringify(value));
 const validationCodes = (value, catalog = WEB_ARCHITECTURE_DETECTORS, options = {}) => (
   validateArchitectureRuleRegistry(value, catalog, options).errors.map(({ code }) => code)
 );
@@ -300,6 +288,84 @@ test('authority delta reports every planned direction without treating removal a
   ]);
 });
 
+test('hard and report-only decisions use the five-field result envelope', () => {
+  const cases = [
+    ['HARD', 'CONFORMING', 'PASS'],
+    ['HARD', 'DIVERGENT', 'FAIL'],
+    ['HARD', 'ABSENT_REQUIRED', 'FAIL'],
+    ['REPORT_ONLY', 'CONFORMING', 'PASS'],
+    ['REPORT_ONLY', 'DIVERGENT', 'REPORT'],
+    ['REPORT_ONLY', 'ABSENT_REQUIRED', 'REPORT']
+  ];
+
+  cases.forEach(([mode, observation, decision]) => {
+    const semanticInputs = Object.freeze({
+      observation,
+      mode,
+      baselineRelation: 'NOT_APPLICABLE',
+      authorityResolution: 'NOT_APPLICABLE'
+    });
+    assert.deepEqual(evaluateArchitectureRuleResult(semanticInputs), {
+      ...semanticInputs,
+      decision
+    });
+  });
+});
+
+test('hard and report-only evaluation rejects accepted-store relations', () => {
+  for (const mode of ['HARD', 'REPORT_ONLY']) {
+    for (const baselineRelation of ['ACCEPTED', 'NEW', 'FIXED']) {
+      assert.throws(() => evaluateArchitectureRuleResult({
+        observation: 'DIVERGENT',
+        mode,
+        baselineRelation,
+        authorityResolution: 'NOT_APPLICABLE'
+      }), /requires baselineRelation NOT_APPLICABLE/);
+    }
+    for (const authorityResolution of ['RETAINED', 'EXACT_CONTRACTION', 'INVALID_CHANGE']) {
+      assert.throws(() => evaluateArchitectureRuleResult({
+        observation: 'DIVERGENT',
+        mode,
+        baselineRelation: 'NOT_APPLICABLE',
+        authorityResolution
+      }), /requires authorityResolution NOT_APPLICABLE/);
+    }
+  }
+});
+
+test('malformed four-input evaluation combinations fail closed', () => {
+  const valid = {
+    observation: 'CONFORMING',
+    mode: 'HARD',
+    baselineRelation: 'NOT_APPLICABLE',
+    authorityResolution: 'NOT_APPLICABLE'
+  };
+  const unsupported = [
+    ['observation', 'UNKNOWN_OBSERVATION'],
+    ['mode', 'UNKNOWN_MODE'],
+    ['baselineRelation', 'UNKNOWN_BASELINE'],
+    ['authorityResolution', 'UNKNOWN_AUTHORITY']
+  ];
+
+  unsupported.forEach(([field, value]) => {
+    assert.throws(
+      () => evaluateArchitectureRuleResult({ ...valid, [field]: value }),
+      new RegExp(`Unsupported architecture rule ${field}`)
+    );
+  });
+  assert.throws(
+    () => evaluateArchitectureRuleResult({ ...valid, mode: 'FROZEN' }),
+    /mode FROZEN is unavailable/
+  );
+  assert.throws(
+    () => evaluateArchitectureRuleResult({ ...valid, decision: 'PASS' }),
+    /requires exactly/
+  );
+  const { authorityResolution: _omitted, ...missingField } = valid;
+  assert.throws(() => evaluateArchitectureRuleResult(missingField), /requires exactly/);
+  assert.throws(() => evaluateArchitectureRuleResult(null), /semantic input object/);
+});
+
 test('evaluation leaves frozen inputs unchanged and returns stable plain data', () => {
   const deepFreeze = (value) => {
     if (value && typeof value === 'object') {
@@ -324,165 +390,4 @@ test('evaluation leaves frozen inputs unchanged and returns stable plain data', 
   assert.equal(JSON.stringify(value), before);
   assert.equal(Object.getPrototypeOf(first), Object.prototype);
   assert.equal(Object.getPrototypeOf(first.errors), Array.prototype);
-});
-
-const TRUSTED_FIXTURE_FILES = Object.freeze({
-  'package.json': '{"private":true}\n',
-  'tools/check-web-change-budget.mjs': readFileSync(
-    join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs'),
-    'utf8'
-  ),
-  'tools/web-architecture-detectors.mjs': readFileSync(
-    join(REPOSITORY_ROOT, 'tools/web-architecture-detectors.mjs'),
-    'utf8'
-  ),
-  'tools/web-architecture-evaluation.mjs': readFileSync(
-    join(REPOSITORY_ROOT, 'tools/web-architecture-evaluation.mjs'),
-    'utf8'
-  ),
-  'tools/web-change-policy.json': readFileSync(
-    join(REPOSITORY_ROOT, 'tools/web-change-policy.json'),
-    'utf8'
-  ),
-  'tools/web-change-source.mjs': readFileSync(
-    join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
-    'utf8'
-  ),
-  'gbdraw/web/js/app/run-analysis.js': (
-    "import { runDiagramGeneration } from '../services/diagram-generation.js';\n"
-    + "import { buildCanonicalRenderRequest } from '../services/session-request.js';\n"
-    + 'export const run = () => {\n'
-    + '  const request = buildCanonicalRenderRequest();\n'
-    + '  return runDiagramGeneration(request);\n'
-    + '};\n'
-  ),
-  'gbdraw/web/js/services/diagram-generation.js': (
-    'export const runDiagramGeneration = () => 1;\n'
-  ),
-  'gbdraw/web/js/services/session-request.js': (
-    'export const buildCanonicalRenderRequest = () => ({});\n'
-  )
-});
-
-const writeFixtureFile = (root, path, content) => {
-  const target = join(root, path);
-  mkdirSync(dirname(target), { recursive: true });
-  writeFileSync(target, content, 'utf8');
-};
-
-const withTrustedCheckerRepository = (mutateHead, runCase, baseFiles = {}) => {
-  const root = mkdtempSync(join(tmpdir(), 'gbdraw-architecture-ratchet-'));
-  try {
-    Object.entries({ ...TRUSTED_FIXTURE_FILES, ...baseFiles }).forEach(([path, content]) => {
-      writeFixtureFile(root, path, content);
-    });
-    const git = (args) => spawnSync('git', args, {
-      cwd: root,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe']
-    });
-    assert.equal(git(['init', '--quiet']).status, 0);
-    assert.equal(git(['config', 'user.email', 'ratchet@example.invalid']).status, 0);
-    assert.equal(git(['config', 'user.name', 'Ratchet Fixture']).status, 0);
-    assert.equal(git(['add', '.']).status, 0);
-    assert.equal(git(['commit', '--quiet', '-m', 'trusted base']).status, 0);
-    const base = git(['rev-parse', 'HEAD']).stdout.trim();
-    mutateHead((path, content) => writeFixtureFile(root, path, content));
-    assert.equal(git(['add', '-A']).status, 0);
-    assert.equal(git(['commit', '--quiet', '-m', 'candidate head']).status, 0);
-    const head = git(['rev-parse', 'HEAD']).stdout.trim();
-    assert.equal(git(['checkout', '--quiet', '--detach', base]).status, 0);
-    const result = spawnSync(process.execPath, [
-      'tools/check-web-change-budget.mjs',
-      '--base', base,
-      '--head', head
-    ], {
-      cwd: root,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe']
-    });
-    runCase({
-      base,
-      head,
-      status: result.status,
-      output: `${result.stdout || ''}${result.stderr || ''}`
-    });
-  } finally {
-    rmSync(root, { recursive: true, force: true });
-  }
-};
-
-const writeRules = (write, value) => write(
-  'tools/web-architecture-rules.json',
-  `${JSON.stringify(value, null, 2)}\n`
-);
-
-test('trusted checker admits an isolated clean-base candidate registry as inert data', () => {
-  withTrustedCheckerRepository(
-    (write) => writeRules(write, registry()),
-    ({ status, output }) => {
-      assert.equal(status, 0, output);
-      assert.match(output, /Classification: EXPANSION/);
-      assert.match(output, /canonical-path\.render-request against untouched base: CONFORMING/);
-      assert.match(output, /semantic-owner\.render-request against untouched base: CONFORMING/);
-      assert.match(output, /Result: \*\*PASS\*\*/);
-    }
-  );
-});
-
-test('trusted checker rejects malformed candidate JSON', () => {
-  withTrustedCheckerRepository(
-    (write) => write('tools/web-architecture-rules.json', '{"schemaVersion":1,"rules":['),
-    ({ status, output }) => {
-      assert.equal(status, 1, output);
-      assert.match(output, /Cannot parse tools\/web-architecture-rules\.json/);
-      assert.match(output, /Result: \*\*FAIL\*\*/);
-    }
-  );
-});
-
-test('trusted checker rejects an authority contraction that excludes active head source', () => {
-  const baseRules = registry([semanticRule({
-    allowedDefinitionPaths: [
-      'services/future-session-request.js',
-      'services/session-request.js'
-    ]
-  })]);
-  const candidateRules = registry([semanticRule({
-    allowedDefinitionPaths: ['services/future-session-request.js']
-  })]);
-  withTrustedCheckerRepository(
-    (write) => writeRules(write, candidateRules),
-    ({ status, output }) => {
-      assert.equal(status, 1, output);
-      assert.match(output, /Classification: CONTRACTION/);
-      assert.match(output, /authority contraction or tightening is DIVERGENT on head source data/);
-    },
-    { 'tools/web-architecture-rules.json': `${JSON.stringify(baseRules, null, 2)}\n` }
-  );
-});
-
-test('trusted checker never executes a proposed head detector during self-authorization', () => {
-  withTrustedCheckerRepository(
-    (write) => {
-      writeRules(write, registry([semanticRule({
-        allowedDefinitionPaths: ['app/secondary.js']
-      })]));
-      write(
-        'gbdraw/web/js/app/secondary.js',
-        'export const buildCanonicalRenderRequest = () => ({});\n'
-      );
-      write(
-        'tools/web-architecture-detectors.mjs',
-        'throw new Error("MALICIOUS HEAD DETECTOR EXECUTED");\n'
-      );
-    },
-    ({ status, output }) => {
-      assert.equal(status, 1, output);
-      assert.doesNotMatch(output, /MALICIOUS HEAD DETECTOR EXECUTED/);
-      assert.match(output, /claims a clean base but is DIVERGENT/);
-      assert.match(output, /architecture rule authority changes must be isolated/);
-      assert.match(output, /production runtime files and Web guard\/CI files changed together/);
-    }
-  );
 });

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -14,6 +14,7 @@ import {
 import {
   classifyArchitectureAuthorityDelta,
   classifyArchitectureRuleObservation,
+  evaluateArchitectureRuleResult,
   validateArchitectureRuleRegistry
 } from './web-architecture-evaluation.mjs';
 
@@ -298,6 +299,9 @@ const allProductionSources = new Map(allProductionJavaScriptPaths.map((path) => 
 const emptyRuleRegistry = () => ({ schemaVersion: 1, rules: [] });
 const candidateArchitectureErrors = [];
 const candidateArchitectureObservations = [];
+const activeArchitectureErrors = [];
+const activeArchitectureFailures = [];
+const activeArchitectureRows = [];
 let architectureAuthorityDelta = Object.freeze({
   classification: 'UNCHANGED',
   directions: Object.freeze([]),
@@ -331,6 +335,18 @@ const productionSourcesAtRevision = (revision) => new Map(
     readRevisionFile(revision, path) || ''
   ])
 );
+const intendedRuleSubjects = (rule, detector) => (
+  rule.kind === 'single-semantic-owner'
+    ? rule.allowedDefinitionPaths.map((path) => detector.encodeSubject({ path }))
+    : rule.allowedEdges.map((edge) => detector.encodeSubject(edge))
+).sort();
+const registeredLocationSummary = (rule, detectorOutput, observation) => (
+  rule.kind === 'single-semantic-owner'
+    ? `registeredDefinitionLocations=${new Set(
+      (detectorOutput.observedDefinitions || []).map(({ path }) => path)
+    ).size}; observedDefinitions=${observation.observedCount}/${observation.requiredCount}`
+    : `observedCanonicalEntryEdges=${observation.observedCount}/${observation.requiredCount}`
+);
 
 const baseArchitectureRulesSource = readRevisionFile(base, architectureRulesPath);
 const proposedArchitectureRulesSource = readHeadFile(architectureRulesPath);
@@ -340,105 +356,154 @@ if (baseArchitectureRulesSource !== null || proposedArchitectureRulesSource !== 
     proposedArchitectureRulesSource,
     head || 'working tree'
   );
-  if (parsedBase.error) candidateArchitectureErrors.push(parsedBase.error);
+  if (parsedBase.error) activeArchitectureErrors.push(parsedBase.error);
   if (parsedCandidate.error) candidateArchitectureErrors.push(parsedCandidate.error);
 
-  if (parsedBase.registry && parsedCandidate.registry) {
-    const baseValidation = validateArchitectureRuleRegistry(
+  const baseValidation = parsedBase.registry
+    ? validateArchitectureRuleRegistry(
       parsedBase.registry,
       WEB_ARCHITECTURE_DETECTORS,
       architectureRuleValidationOptions
-    );
-    const candidateValidation = validateArchitectureRuleRegistry(
+    )
+    : null;
+  const candidateValidation = parsedCandidate.registry
+    ? validateArchitectureRuleRegistry(
       parsedCandidate.registry,
       WEB_ARCHITECTURE_DETECTORS,
       architectureRuleValidationOptions
+    )
+    : null;
+  if (baseValidation) {
+    activeArchitectureErrors.push(
+      ...formatRuleValidationErrors('base registry', baseValidation)
     );
+  }
+  if (candidateValidation) {
     candidateArchitectureErrors.push(
-      ...formatRuleValidationErrors('base registry', baseValidation),
       ...formatRuleValidationErrors('candidate registry', candidateValidation)
     );
+  }
 
-    if (baseValidation.valid && candidateValidation.valid) {
-      architectureAuthorityDelta = classifyArchitectureAuthorityDelta(
-        parsedBase.registry,
-        parsedCandidate.registry
-      );
-      if (architectureAuthorityDelta.changes.length) {
-        const companionPaths = [...changed.keys()]
-          .filter((path) => path !== architectureRulesPath)
-          .sort();
-        if (companionPaths.length) {
+  if (baseValidation?.valid) {
+    [...parsedBase.registry.rules]
+      .sort((left, right) => left.key.localeCompare(right.key))
+      .forEach((rule) => {
+        const detector = WEB_ARCHITECTURE_DETECTORS[rule.detector];
+        try {
+          const detectorOutput = detector.detect(allProductionSources);
+          const observation = classifyArchitectureRuleObservation(rule, detectorOutput);
+          const result = evaluateArchitectureRuleResult({
+            observation: observation.observation,
+            mode: rule.enforcement.replace('-', '_').toUpperCase(),
+            baselineRelation: 'NOT_APPLICABLE',
+            authorityResolution: 'NOT_APPLICABLE'
+          });
+          const subjects = observation.subjects.length
+            ? [...observation.subjects].sort()
+            : intendedRuleSubjects(rule, detector);
+          const locationSummary = registeredLocationSummary(
+            rule,
+            detectorOutput,
+            observation
+          );
+          (subjects.length ? subjects : ['<none>']).forEach((subject) => {
+            activeArchitectureRows.push(
+              `${rule.key} | subject=${subject} | observation=${result.observation} `
+              + `| mode=${result.mode} | baselineRelation=${result.baselineRelation} `
+              + `| authorityResolution=${result.authorityResolution} `
+              + `| decision=${result.decision} | ${locationSummary}`
+            );
+          });
+          if (result.decision === 'FAIL') {
+            activeArchitectureFailures.push(
+              `${rule.key} is ${result.observation} under ${result.mode}`
+            );
+          }
+        } catch (error) {
+          activeArchitectureErrors.push(`${rule.key}: ${error.message}`);
+        }
+      });
+  }
+
+  if (baseValidation?.valid && candidateValidation?.valid) {
+    architectureAuthorityDelta = classifyArchitectureAuthorityDelta(
+      parsedBase.registry,
+      parsedCandidate.registry
+    );
+    if (architectureAuthorityDelta.changes.length) {
+      const companionPaths = [...changed.keys()]
+        .filter((path) => path !== architectureRulesPath)
+        .sort();
+      if (companionPaths.length) {
+        candidateArchitectureErrors.push(
+          'architecture rule authority changes must be isolated from other changed paths: '
+          + companionPaths.join(', ')
+        );
+      }
+
+      const baseSources = productionSourcesAtRevision(base);
+      const candidateRules = new Map(parsedCandidate.registry.rules.map((rule) => [rule.key, rule]));
+      const changedRuleKeys = [...new Set(
+        architectureAuthorityDelta.changes.map(({ rule }) => rule)
+      )].sort();
+      changedRuleKeys.forEach((ruleKey) => {
+        const rule = candidateRules.get(ruleKey);
+        if (!rule) return;
+        const detector = WEB_ARCHITECTURE_DETECTORS[rule.detector];
+        let baseObservation;
+        try {
+          baseObservation = classifyArchitectureRuleObservation(
+            rule,
+            detector.detect(baseSources)
+          );
+        } catch (error) {
           candidateArchitectureErrors.push(
-            'architecture rule authority changes must be isolated from other changed paths: '
-            + companionPaths.join(', ')
+            `${rule.key} trusted-base detection failed: ${error.message}`
+          );
+          return;
+        }
+        candidateArchitectureObservations.push(
+          `${rule.key} against untouched base: ${baseObservation.observation} `
+          + `(${baseObservation.observedCount}/${baseObservation.requiredCount})`
+        );
+        if (
+          (rule.enforcement === 'hard' || rule.baselineEligible === false)
+          && baseObservation.observation !== 'CONFORMING'
+        ) {
+          candidateArchitectureErrors.push(
+            `${rule.key} claims a clean base but is ${baseObservation.observation}`
           );
         }
 
-        const baseSources = productionSourcesAtRevision(base);
-        const candidateRules = new Map(parsedCandidate.registry.rules.map((rule) => [rule.key, rule]));
-        const changedRuleKeys = [...new Set(
-          architectureAuthorityDelta.changes.map(({ rule }) => rule)
-        )].sort();
-        changedRuleKeys.forEach((ruleKey) => {
-          const rule = candidateRules.get(ruleKey);
-          if (!rule) return;
-          const detector = WEB_ARCHITECTURE_DETECTORS[rule.detector];
-          let baseObservation;
-          try {
-            baseObservation = classifyArchitectureRuleObservation(
-              rule,
-              detector.detect(baseSources)
-            );
-          } catch (error) {
-            candidateArchitectureErrors.push(
-              `${rule.key} trusted-base detection failed: ${error.message}`
-            );
-            return;
-          }
-          candidateArchitectureObservations.push(
-            `${rule.key} against untouched base: ${baseObservation.observation} `
-            + `(${baseObservation.observedCount}/${baseObservation.requiredCount})`
+        const directions = new Set(architectureAuthorityDelta.changes
+          .filter((change) => change.rule === ruleKey)
+          .map(({ direction }) => direction));
+        if (![...directions].some((direction) => (
+          direction === 'CONTRACTION' || direction === 'TIGHTENING'
+        ))) return;
+        let headObservation;
+        try {
+          headObservation = classifyArchitectureRuleObservation(
+            rule,
+            detector.detect(allProductionSources)
           );
-          if (
-            (rule.enforcement === 'hard' || rule.baselineEligible === false)
-            && baseObservation.observation !== 'CONFORMING'
-          ) {
-            candidateArchitectureErrors.push(
-              `${rule.key} claims a clean base but is ${baseObservation.observation}`
-            );
-          }
-
-          const directions = new Set(architectureAuthorityDelta.changes
-            .filter((change) => change.rule === ruleKey)
-            .map(({ direction }) => direction));
-          if (![...directions].some((direction) => (
-            direction === 'CONTRACTION' || direction === 'TIGHTENING'
-          ))) return;
-          let headObservation;
-          try {
-            headObservation = classifyArchitectureRuleObservation(
-              rule,
-              detector.detect(allProductionSources)
-            );
-          } catch (error) {
-            candidateArchitectureErrors.push(
-              `${rule.key} trusted-head-data detection failed: ${error.message}`
-            );
-            return;
-          }
-          candidateArchitectureObservations.push(
-            `${rule.key} against head source data: ${headObservation.observation} `
-            + `(${headObservation.observedCount}/${headObservation.requiredCount})`
+        } catch (error) {
+          candidateArchitectureErrors.push(
+            `${rule.key} trusted-head-data detection failed: ${error.message}`
           );
-          if (headObservation.observation !== 'CONFORMING') {
-            candidateArchitectureErrors.push(
-              `${rule.key} authority contraction or tightening is ${headObservation.observation} `
-              + 'on head source data'
-            );
-          }
-        });
-      }
+          return;
+        }
+        candidateArchitectureObservations.push(
+          `${rule.key} against head source data: ${headObservation.observation} `
+          + `(${headObservation.observedCount}/${headObservation.requiredCount})`
+        );
+        if (headObservation.observation !== 'CONFORMING') {
+          candidateArchitectureErrors.push(
+            `${rule.key} authority contraction or tightening is ${headObservation.observation} `
+            + 'on head source data'
+          );
+        }
+      });
     }
   }
 }
@@ -584,6 +649,12 @@ if (missingPolicyKeys.length) {
 integrityViolations.push(...candidateArchitectureErrors.map((error) => (
   `candidate architecture rules: ${error}`
 )));
+integrityViolations.push(...activeArchitectureErrors.map((error) => (
+  `active architecture rules: ${error}`
+)));
+integrityViolations.push(...activeArchitectureFailures.map((error) => (
+  `active architecture rules: ${error}`
+)));
 const enforcedViolations = [
   ...integrityViolations,
   ...budgetViolations
@@ -669,6 +740,14 @@ const report = [
   '## Candidate architecture rule errors',
   '',
   ...list(candidateArchitectureErrors),
+  '',
+  '## Active architecture rule results',
+  '',
+  ...list(activeArchitectureRows),
+  '',
+  '## Active architecture rule errors',
+  '',
+  ...list(activeArchitectureErrors),
   '',
   '## Report-only cache/token/handle/journal/protocol/manager names',
   '',

--- a/tools/web-architecture-evaluation.mjs
+++ b/tools/web-architecture-evaluation.mjs
@@ -36,6 +36,30 @@ const DIRECTION_ORDER = Object.freeze([
   'CONTRACTION',
   'TIGHTENING'
 ]);
+const RESULT_FIELDS = Object.freeze([
+  'authorityResolution',
+  'baselineRelation',
+  'mode',
+  'observation'
+]);
+const RESULT_OBSERVATIONS = Object.freeze([
+  'ABSENT_REQUIRED',
+  'CONFORMING',
+  'DIVERGENT'
+]);
+const RESULT_MODES = Object.freeze(['FROZEN', 'HARD', 'REPORT_ONLY']);
+const BASELINE_RELATIONS = Object.freeze([
+  'ACCEPTED',
+  'FIXED',
+  'NEW',
+  'NOT_APPLICABLE'
+]);
+const AUTHORITY_RESOLUTIONS = Object.freeze([
+  'EXACT_CONTRACTION',
+  'INVALID_CHANGE',
+  'NOT_APPLICABLE',
+  'RETAINED'
+]);
 
 const compareText = (left, right) => left < right ? -1 : left > right ? 1 : 0;
 const isRecord = (value) => value !== null
@@ -387,6 +411,60 @@ export const classifyArchitectureRuleObservation = (rule, detectorOutput) => {
   }
 
   throw new Error(`Unsupported rule kind ${rule.kind}`);
+};
+
+export const evaluateArchitectureRuleResult = (semanticInputs) => {
+  if (!isRecord(semanticInputs)) {
+    throw new Error('Architecture rule evaluation requires one semantic input object');
+  }
+  const actualFields = Object.keys(semanticInputs).sort(compareText);
+  if (
+    actualFields.length !== RESULT_FIELDS.length
+    || actualFields.some((field, index) => field !== RESULT_FIELDS[index])
+  ) {
+    throw new Error(
+      `Architecture rule evaluation requires exactly: ${RESULT_FIELDS.join(', ')}`
+    );
+  }
+
+  const {
+    observation,
+    mode,
+    baselineRelation,
+    authorityResolution
+  } = semanticInputs;
+  const supportedValues = [
+    ['observation', observation, RESULT_OBSERVATIONS],
+    ['mode', mode, RESULT_MODES],
+    ['baselineRelation', baselineRelation, BASELINE_RELATIONS],
+    ['authorityResolution', authorityResolution, AUTHORITY_RESOLUTIONS]
+  ];
+  supportedValues.forEach(([field, value, allowed]) => {
+    if (!allowed.includes(value)) {
+      throw new Error(`Unsupported architecture rule ${field}: ${value}`);
+    }
+  });
+
+  if (mode === 'FROZEN') {
+    throw new Error('Architecture rule mode FROZEN is unavailable');
+  }
+  if (baselineRelation !== 'NOT_APPLICABLE') {
+    throw new Error(`${mode} requires baselineRelation NOT_APPLICABLE`);
+  }
+  if (authorityResolution !== 'NOT_APPLICABLE') {
+    throw new Error(`${mode} requires authorityResolution NOT_APPLICABLE`);
+  }
+
+  const decision = observation === 'CONFORMING'
+    ? 'PASS'
+    : mode === 'HARD' ? 'FAIL' : 'REPORT';
+  return Object.freeze({
+    observation,
+    mode,
+    baselineRelation,
+    authorityResolution,
+    decision
+  });
 };
 
 const enforcementDirection = (before, after) => {


### PR DESCRIPTION
## Purpose

Activate the two Web architecture rules declared by PR D without changing the registry. `tools/web-architecture-rules.json` becomes the active owner of registered intended paths, counts, and enforcement modes. The checker reads the trusted base detector, rules, and privileged policy, then evaluates proposed-head source with those base artifacts.

The checker reports the five-field result envelope in stable rule and subject order. `tools/web-architecture-evaluation.mjs` accepts `observation`, `mode`, `baselineRelation`, and `authorityResolution`; it derives `decision` inside the pure evaluation function. PR E supports `HARD` and `REPORT_ONLY`. `FROZEN` fails closed because accepted-store mechanics are unavailable.

The same commit removes the superseded inline current-source assertions. No dual active authority remains. The detector owns executable source matching, the evaluator owns pure mechanics, the checker owns Git/file I/O and reporting, and `tools/web-change-policy.json` remains the privileged path-permission owner.

This change does not add an accepted-violation store. Production source, compatibility paths, Web runtime, rule data, privileged policy, workflows, and dependencies are unchanged.

## Review packet

Exact revisions:

- Base: `dev@fa1b245fa1a8659d9cc5a0e7825e22b98bdd857d`
- Head: `architecture-ratchet-pr-e-activate-rules@c6e93a0e9b2974d41cb7551841e0cd3fbd5afa1f`
- Commit count: 1
- Head parent: `fa1b245fa1a8659d9cc5a0e7825e22b98bdd857d`
- Unchanged rule-registry blob on both revisions: `c557b5f77c725dab44f093ac60d234e7f29393f3`
- PR D promotion prerequisite: #359 merged to `main` as `b6fe14382eaf973a4a01d433527268d0e23d09c5`

Observed diff:

- `M tests/web/architecture-contracts.test.mjs`
- `M tests/web/architecture-ratchet-fixtures.test.mjs`
- `M tools/check-web-change-budget.mjs`
- `M tools/web-architecture-evaluation.mjs`
- 4 files, +701/-297
- No production/runtime, registry, detector, privileged policy, workflow, dependency, or compatibility-path changes.

Authority transition:

- Before: `tests/web/architecture-contracts.test.mjs` directly asserted the `buildCanonicalRenderRequest` occurrence owners and the `app/run-analysis.js -> services/session-request.js` import. The JSON registry was inert.
- After: `tools/web-architecture-rules.json` owns the allowed paths, exact counts, hard modes, and baseline eligibility. The contract test loads the registry, runs the registered detectors, and evaluates the declared rules.
- Removed superseded assertions: the inline `buildCanonicalRenderRequest` owner map and direct `services/session-request.js` import assertion.
- Preserved production path: `app/run-analysis.js -> services/session-request.js`.
- Compatibility paths: `none -> none`.

Exact-head CI:

- [Tests run 32203854552](https://github.com/satoshikawato/gbdraw/actions/runs/32203854552): SUCCESS for head `c6e93a0e9b2974d41cb7551841e0cd3fbd5afa1f`.
- Web change budget in that run: SUCCESS. The head checker reports both registered rules as `CONFORMING/HARD/NOT_APPLICABLE/NOT_APPLICABLE/PASS`, with observed counts `1/1`.
- [Web base policy run 32203854673](https://github.com/satoshikawato/gbdraw/actions/runs/32203854673): SUCCESS for the same base/head pair.
- [Workers Builds](https://dash.cloudflare.com/9e9f747642f00743bd30fde1b78769f5/workers/services/view/gbdraw/production/builds/b4a4cca6-513d-45da-af2b-0a9cc2cfcefc): SUCCESS for `c6e93a0e9b2974d41cb7551841e0cd3fbd5afa1f`.
- CodeQL: no check run is attached to this PR head. No CodeQL result is claimed. If GitHub emits one after Ready, it must complete before merge.
- Runs `32203830786` and `32203830854` were cancelled during label replacement and are excluded from acceptance evidence.

The trusted-base run executes the pre-PR-E checker. It proves that proposed-head code did not replace the trust root, but it does not certify the proposed PR E checker. The head checker behavior is covered by the exact-head Tests run, its unit and fixture tests, and the manual review below.

Implementation-head checks:

- `node tools/check-web-change-budget.mjs --base fa1b245fa1a8659d9cc5a0e7825e22b98bdd857d --head c6e93a0e9b2974d41cb7551841e0cd3fbd5afa1f` (`PASS`)
- `node --test tests/web/architecture-contracts.test.mjs` (73 passed)
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs` (11 passed)
- `node --test tests/web/*.test.mjs` (283 passed)
- `git diff --check fa1b245fa1a8659d9cc5a0e7825e22b98bdd857d...c6e93a0e9b2974d41cb7551841e0cd3fbd5afa1f`

After merge, PR F1 must observe this checker running from the trusted `dev` base. That observation is a condition for F1, not for this PR.

## Architecture impact

Select exactly one:

- [ ] This is not architecture-bearing. Rationale:
- [x] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior: registered render-request semantic-owner and canonical-entry-edge conformance.
- Why this changed-capability scope is complete: PR E changes only activation, decision, orchestration, and test boundaries for the two PR D rules. The detector catalog, rule registry, privileged policy, runtime source, workflows, dependencies, and compatibility paths are unchanged.
- Semantic owners before: `{tests/web/architecture-contracts.test.mjs inline intended constraints}` for active enforcement; `{tools/web-architecture-rules.json}` was inert; `{tools/web-architecture-detectors.mjs}` owned executable matching; `{tools/web-architecture-evaluation.mjs}` owned schema and authority-delta mechanics; `{tools/check-web-change-budget.mjs}` owned orchestration and reporting.
- Semantic owners after: `{tools/web-architecture-rules.json}` owns registered intended paths, counts, and modes; `{tools/web-architecture-detectors.mjs}` owns executable matching; `{tools/web-architecture-evaluation.mjs}` owns schema, observation, authority-delta, and five-field decision mechanics; `{tools/check-web-change-budget.mjs}` owns Git/file I/O, orchestration, and reporting.
- Canonical production paths before: `{app/run-analysis.js -> services/session-request.js}`.
- Canonical production paths after: `{app/run-analysis.js -> services/session-request.js}`.
- Compatibility paths before, with stable IDs: `none`.
- Compatibility paths after, with stable IDs: `none`.
- Superseded owner/path removed: the production-source direct-edge assertion and untouched-source render-request owner/edge assertions were removed. No production path was removed.
- New module classification: `none`.
- Persisted-compatibility evidence and removal condition: not applicable; no persisted representation changed.
- Performance/scientific-output evidence, when material: not applicable; no runtime or rendering code changed.
- Deterministic checker evidence: current hard rules report `CONFORMING/HARD/NOT_APPLICABLE/NOT_APPLICABLE/PASS`; table-driven tests cover all six PR E decisions, malformed inputs, unavailable `FROZEN`, canonical-edge cases, stable ordering, and trusted-boundary attacks.
- Maintainer architecture decision comment permalink, required before merge: [exact-head approval comment](https://github.com/satoshikawato/gbdraw/pull/358#issuecomment-5348446039).

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.
