### PR TITLE
Fix lazy WSSV FASTA reads during generation

### DIFF
--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -638,9 +638,6 @@ const logPostGbdrawTimings = (entries) => {
   console.groupEnd();
 };
 const extractLosatFastaFast = async ({ file, text, fmt, regionSpec, recordSelector, reverseFlag }) => {
-  if (typeof text !== 'string' && !file?.text) {
-    throw new Error('Input file is not available for browser FASTA extraction.');
-  }
   const sourceText = typeof text === 'string' ? text : await readFileText(file);
   const records = fmt === 'genbank' ? parseGenbankRecordsFast(sourceText) : parseFastaRecordsFast(sourceText);
   const selected = selectParsedRecord(records, recordSelector);
@@ -652,9 +649,6 @@ const extractLosatFastaFast = async ({ file, text, fmt, regionSpec, recordSelect
   };
 };
 const extractAllLosatFastaFast = async ({ file, text, fmt }) => {
-  if (typeof text !== 'string' && !file?.text) {
-    throw new Error('Input file is not available for browser FASTA extraction.');
-  }
   const sourceText = typeof text === 'string' ? text : await readFileText(file);
   const records = fmt === 'genbank' ? parseGenbankRecordsFast(sourceText) : parseFastaRecordsFast(sourceText);
   if (!records.length) throw new Error('No records found for circular conservation reference.');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test:playwright": "playwright test",
     "test:web:functional-smoke": "playwright test --config=playwright.functional.config.js",
     "test:web:perf-smoke": "playwright test --config=playwright.perf.config.js",
-    "test:web:vibrio-generate": "playwright test --config=playwright.vibrio.config.js"
+    "test:web:vibrio-generate": "playwright test --config=playwright.vibrio.config.js",
+    "test:web:wssv-generate": "playwright test --config=playwright.wssv.config.js"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",

--- a/playwright.wssv.config.js
+++ b/playwright.wssv.config.js
@@ -1,0 +1,17 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+const baseConfig = require('./playwright.config.js');
+
+module.exports = defineConfig({
+  ...baseConfig,
+  testDir: './tests/web/contracts',
+  testMatch: 'wssv-full-generation.serial.spec.js',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  timeout: 1_200_000,
+  use: {
+    ...baseConfig.use,
+    trace: 'retain-on-failure'
+  }
+});

--- a/tests/web/contracts/wssv-full-generation.serial.spec.js
+++ b/tests/web/contracts/wssv-full-generation.serial.spec.js
@@ -1,0 +1,274 @@
+const { test, expect } = require('@playwright/test');
+const {
+  getDiagramWorkerActivity,
+  openApp
+} = require('../helpers/app-lifecycle.cjs');
+
+const SESSION_URL = '/gbdraw/web/gallery/sessions/WSSV_genome_comparison.gbdraw-session.json';
+const EXPECTED_FILES = [
+  'CN01.fasta',
+  'WSSV-TW.fasta',
+  'WSSV-CN.fasta',
+  'WSSV-TH.fasta',
+  'JP01A.fasta',
+  'JP01B.fasta',
+  'Pc2020.fasta',
+  'E1.fasta',
+  '0722-1.fasta',
+  'CN03.fasta',
+  'CN04.fasta',
+  'WSSV-AU.fasta',
+  'EU129.fa',
+  'GCF7.fa',
+  'MES-753.fa',
+  'Shantou2019.fa',
+  'POMZ1.fa',
+  'POMZ4.fa',
+  'MG18PR-0187-N40S.fa',
+  'Angostura2013.fa'
+];
+const EXPECTED_LABELS = [
+  'CN01',
+  'WSSV-TW',
+  'WSSV-CN',
+  'WSSV-TH',
+  'JP01A',
+  'JP01B',
+  'Pc2020',
+  'E1',
+  '0722-1',
+  'CN03',
+  'CN04',
+  'WSSV-AU',
+  'EU129',
+  'GCF7',
+  'MES-753',
+  'Shantou2019',
+  'POMZ1',
+  'POMZ4',
+  'MG18PR-0187-N40S',
+  'Angostura2013'
+];
+const EXPECTED_COLORS = [
+  '#6e91b7',
+  '#f4a251',
+  '#77b26f',
+  '#e67577',
+  '#8fc4c0',
+  '#f0d369',
+  '#be92b2',
+  '#ffafb7',
+  '#ae8e7c',
+  '#c6bebb',
+  '#6e91b7',
+  '#f4a251',
+  '#e67577',
+  '#8fc4c0',
+  '#bcb4ca',
+  '#f0d369',
+  '#be92b2',
+  '#ffafb7',
+  '#ae8e7c',
+  '#c6bebb'
+];
+
+const installWssvProbe = (page) => page.addInitScript(() => {
+  const metrics = [];
+  window.__GBDRAW_WSSV_PROBE__ = {
+    metrics,
+    losatCalls: 0,
+    snapshot() {
+      return {
+        metrics: metrics.map((metric) => ({ ...metric })),
+        losatCalls: this.losatCalls
+      };
+    }
+  };
+  window.__GBDRAW_TEST_HOOKS__ = {
+    onStructuralMetric(metric) {
+      metrics.push({ ...metric });
+    }
+  };
+  window.__GBDRAW_LOSAT_EXECUTOR__ = async () => {
+    window.__GBDRAW_WSSV_PROBE__.losatCalls += 1;
+    throw new Error('WSSV replay must not execute LOSAT outside its verified cache.');
+  };
+});
+
+test.describe.configure({ mode: 'serial' });
+
+test('bundled WSSV session regenerates 20 conservation rings from lazy FASTAs', async ({
+  browser
+}, testInfo) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const externalRequests = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (!['127.0.0.1', 'localhost'].includes(url.hostname)) {
+      externalRequests.push(request.url());
+    }
+  });
+  page.on('dialog', (dialog) => dialog.accept());
+
+  try {
+    await installWssvProbe(page);
+    await openApp(page);
+
+    const imported = await page.evaluate(async (sessionUrl) => {
+      const response = await fetch(sessionUrl);
+      if (!response.ok) throw new Error(`Could not load WSSV session: ${response.status}`);
+      const file = new File(
+        [await response.text()],
+        'WSSV_genome_comparison.gbdraw-session.json',
+        { type: 'application/json' }
+      );
+      const result = await window.__GBDRAW_APP__.importSession({
+        target: { files: [file], value: '' }
+      });
+      const { state } = await import('/gbdraw/web/js/state.js');
+      const sources = state.files.c_conservation_fastas;
+      return {
+        result,
+        previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+        resultCount: window.__GBDRAW_APP__.results.length,
+        selectedResultIndex: window.__GBDRAW_APP__.selectedResultIndex,
+        names: sources.map((source) => source.name),
+        metadataOnly: sources.map((source) => ({
+          frozen: Object.isFrozen(source),
+          ownFields: ['text', 'arrayBuffer', 'data', 'resourceId']
+            .filter((field) => Object.hasOwn(source, field))
+        })),
+        metrics: window.__GBDRAW_WSSV_PROBE__.snapshot().metrics
+      };
+    }, SESSION_URL);
+
+    expect(imported.result?.status).toBe('ok');
+    expect(imported.previewVisible).toBe(true);
+    expect(imported.resultCount).toBe(1);
+    expect(imported.selectedResultIndex).toBe(0);
+    expect(imported.names).toEqual(EXPECTED_FILES);
+    expect(imported.metadataOnly).toEqual(
+      EXPECTED_FILES.map(() => ({ frozen: true, ownFields: [] }))
+    );
+    expect(imported.metrics.filter(({ name, resourceId }) => (
+      name === 'base64DecodeCount'
+      && (
+        resourceId === 'record-1-genbank'
+        || String(resourceId || '').startsWith('conservation-losat-fasta-files-')
+      )
+    ))).toHaveLength(21);
+    expect(await getDiagramWorkerActivity(page)).toMatchObject({
+      constructions: 0,
+      initializations: 0,
+      helpers: 0,
+      runs: 0
+    });
+
+    const generated = await page.evaluate(async () => {
+      const app = window.__GBDRAW_APP__;
+      const startedAt = performance.now();
+      const result = await app.runAnalysis();
+      const elapsedMs = performance.now() - startedAt;
+      const selected = app.results?.[app.selectedResultIndex];
+      const content = String(selected?.content || '');
+      const documentRoot = new DOMParser().parseFromString(content, 'image/svg+xml');
+      const {
+        isCommittedSvgResult,
+        isCommittedSvgResultMounted
+      } = await import('/gbdraw/web/js/services/svg-result-ingestion.js');
+      const slots = [...documentRoot.querySelectorAll(
+        '[data-gbdraw-slot-renderer="sequence_conservation"]'
+      )];
+      return {
+        result,
+        elapsedMs,
+        errorLog: app.errorLog,
+        resultCount: app.results.length,
+        selectedResultIndex: app.selectedResultIndex,
+        selectedName: String(selected?.name || ''),
+        committedResult: isCommittedSvgResult(selected),
+        mountedResult: isCommittedSvgResultMounted(selected),
+        previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
+        slots: slots.map((slot) => ({
+          id: slot.getAttribute('data-gbdraw-slot-id'),
+          sourceIndex: Number(slot.getAttribute('data-source-index')),
+          label: slot.getAttribute('data-track-label'),
+          color: slot.getAttribute('data-track-color')
+        })),
+        renderedMatchCount: documentRoot.querySelectorAll(
+          '[data-gbdraw-match-id]'
+        ).length,
+        comparisonLegendCount: documentRoot.querySelectorAll(
+          '[data-gbdraw-role="comparison-legend"]'
+        ).length,
+        unsafeContent: /<script|foreignObject|\son\w+\s*=|javascript:/i.test(content),
+        oldMissingFileMessage: content.includes(
+          'Input file is not available for browser FASTA extraction.'
+        ),
+        probe: window.__GBDRAW_WSSV_PROBE__.snapshot()
+      };
+    });
+
+    expect(generated.result).toEqual({ status: 'ok' });
+    expect(generated.errorLog).toBeNull();
+    expect(generated.resultCount).toBe(1);
+    expect(generated.selectedResultIndex).toBe(0);
+    expect(generated.selectedName).toBe('out.svg');
+    expect(generated.committedResult).toBe(true);
+    expect(generated.mountedResult).toBe(true);
+    expect(generated.previewVisible).toBe(true);
+    expect(generated.slots).toEqual(EXPECTED_LABELS.map((label, index) => ({
+      id: `conservation_${index + 1}`,
+      sourceIndex: index,
+      label,
+      color: EXPECTED_COLORS[index]
+    })));
+    expect(generated.renderedMatchCount).toBeGreaterThan(0);
+    expect(generated.comparisonLegendCount).toBe(1);
+    expect(generated.unsafeContent).toBe(false);
+    expect(generated.oldMissingFileMessage).toBe(false);
+    expect(generated.probe.losatCalls).toBe(0);
+    expect(externalRequests).toEqual([]);
+
+    const fastaTextReads = generated.probe.metrics.filter(({ name, resourceId }) => (
+      name === 'resourceTextReadCount'
+      && String(resourceId || '').startsWith('conservation-losat-fasta-files-')
+    ));
+    expect(fastaTextReads.map(({ resourceId }) => resourceId)).toEqual(
+      EXPECTED_FILES.map((_, index) => `conservation-losat-fasta-files-${index + 1}`)
+    );
+    expect(generated.probe.metrics.filter(({ name, resourceId }) => (
+      name === 'base64DecodeCount'
+      && (
+        resourceId === 'record-1-genbank'
+        || String(resourceId || '').startsWith('conservation-losat-fasta-files-')
+      )
+    ))).toHaveLength(21);
+
+    const worker = await getDiagramWorkerActivity(page);
+    expect(worker.constructions).toBe(1);
+    expect(worker.initializations).toBe(1);
+    expect(worker.runs).toBe(1);
+    expect(worker.settledInitializations).toBe(1);
+    expect(worker.settledRuns).toBe(1);
+    expect(worker.instances).toHaveLength(1);
+    expect(worker.instances[0].terminated).toBe(false);
+
+    const evidence = {
+      elapsedMs: generated.elapsedMs,
+      resourceTextReads: fastaTextReads.length,
+      ringCount: generated.slots.length,
+      renderedMatchCount: generated.renderedMatchCount,
+      losatCalls: generated.probe.losatCalls,
+      worker
+    };
+    await testInfo.attach('wssv-full-generation-evidence.json', {
+      body: Buffer.from(JSON.stringify(evidence, null, 2)),
+      contentType: 'application/json'
+    });
+    console.log(`WSSV full-generation evidence: ${JSON.stringify(evidence)}`);
+  } finally {
+    await context.close();
+  }
+});

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -171,6 +171,10 @@ const { createHistorySnapshotService } = await import(
   '../../gbdraw/web/js/services/history-snapshot.js'
 );
 const {
+  adoptCurrentSessionResources,
+  createSessionResourceFileView
+} = await import('../../gbdraw/web/js/services/session-resource-backing.js');
+const {
   featureStateFromCatalog
 } = await import('../../gbdraw/web/js/services/feature-catalog.js');
 const { normalizeLinearSeqList, state } = await import('../../gbdraw/web/js/state.js');
@@ -291,6 +295,27 @@ const committedFeatureState = () => structuredClone({
   resultGenerationKey: state.resultGenerationKey.value,
   lastRunInfo: state.lastRunInfo.value
 });
+
+const encodedResource = (kind, name, text) => {
+  const bytes = new TextEncoder().encode(text);
+  return {
+    kind,
+    name,
+    type: 'text/plain',
+    size: bytes.byteLength,
+    lastModified: 0,
+    encoding: 'base64',
+    data: Buffer.from(bytes).toString('base64')
+  };
+};
+
+const sha256Text = async (text) => {
+  const digest = new Uint8Array(await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(text)
+  ));
+  return [...digest].map((value) => value.toString(16).padStart(2, '0')).join('');
+};
 
 test('audit-5 owner: direct simple createRunAnalysis path is worker-only and catalog-transactional', async () => {
   const structuralMetrics = {};
@@ -657,6 +682,321 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   assert.deepEqual(state.adv.multi_record_positions, discoveryStateBeforeRollback.positions);
   assert.deepEqual(state.circularRecordDiscovery, discoveryStateBeforeRollback.discovery);
   state.semanticFileWatchersSuppressed.value = false;
+});
+
+test('FASTA extraction delegates lazy resources to the shared reader', async () => {
+  const resourceMetrics = [];
+  const previousTestHooks = globalThis.__GBDRAW_TEST_HOOKS__;
+  globalThis.__GBDRAW_TEST_HOOKS__ = {
+    onStructuralMetric(metric) {
+      resourceMetrics.push({ ...metric });
+    }
+  };
+  const referenceText = [
+    'LOCUS       REF 8 bp DNA',
+    'ORIGIN',
+    '        1 acgtacgt',
+    '//',
+    ''
+  ].join('\n');
+  const referenceFasta = '>REF\nACGTACGT\n';
+  const comparisonText = '>CMP\nTTTTAAAA\n';
+  const resourceTable = adoptCurrentSessionResources({
+    reference: encodedResource('genbank', 'reference.gb', referenceText),
+    comparison: encodedResource('conservation-fasta-file', 'comparison.fa', comparisonText)
+  });
+  const referenceView = createSessionResourceFileView(resourceTable, 'reference');
+  const comparisonView = createSessionResourceFileView(resourceTable, 'comparison');
+  const lazyFields = ['text', 'arrayBuffer', 'data', 'resourceId'];
+  for (const file of [referenceView, comparisonView]) {
+    assert.equal(Object.isFrozen(file), true);
+    lazyFields.forEach((field) => assert.equal(Object.hasOwn(file, field), false));
+  }
+
+  state.mode.value = 'circular';
+  state.cInputType.value = 'gb';
+  state.form.prefix = 'lazy-circular';
+  state.form.show_depth = false;
+  state.form.multi_record_canvas = false;
+  state.adv.circular_track_slots_enabled = false;
+  state.adv.circular_track_slots = [];
+  Object.assign(state.adv, {
+    min_bitscore: 0,
+    evalue: '1e-2',
+    identity: 0,
+    alignment_length: 0
+  });
+  Object.assign(state.circularConservation, {
+    enabled: true,
+    source: 'losat',
+    losat_program: 'blastn',
+    subject_gencode: 1,
+    reference: 'auto',
+    labels: '',
+    ring_width: 5,
+    ring_gap: 2
+  });
+  state.circularConservation.series.splice(0, state.circularConservation.series.length, {
+    sourceKey: `${comparisonView.name}|${comparisonView.size}|0|0`,
+    fileName: comparisonView.name,
+    sourceIndex: 0,
+    label: 'Lazy comparison',
+    color: '#123456',
+    losat_gencode: 1
+  });
+  state.files.c_gb = referenceView;
+  state.files.c_gff = null;
+  state.files.c_fasta = null;
+  state.files.c_depth = null;
+  state.files.c_conservation_blasts = [];
+  state.files.c_conservation_fastas = [comparisonView];
+  state.files.c_conservation_sequence_sources = [];
+  state.annotationSets.splice(0);
+  state.circularRecordList.value = [];
+  Object.assign(state.circularRecordDiscovery, {
+    status: 'idle', error: '', inputType: '', primaryFile: null, pairedFile: null
+  });
+
+  const queryCanonicalHash = await sha256Text(comparisonText);
+  const subjectCanonicalHash = await sha256Text(referenceFasta);
+  const cachePayload = {
+    cacheSchema: 2,
+    identityKind: 'nucleotide',
+    program: 'blastn',
+    outfmt: '6',
+    args: ['--task', 'megablast'],
+    queryCanonicalHash,
+    subjectCanonicalHash,
+    flow: 'circular-conservation'
+  };
+  const cacheKey = await sha256Text(JSON.stringify(cachePayload));
+  state.losatCache.value = new Map([[cacheKey, {
+    schema: 2,
+    kind: 'raw-losat',
+    identityKind: 'nucleotide',
+    text: 'CMP\tREF\t100\t8\t0\t0\t1\t8\t1\t8\t1e-20\t40\n',
+    program: 'blastn',
+    flow: 'circular-conservation',
+    outfmt: '6',
+    args: ['--task', 'megablast'],
+    queryCanonicalHash,
+    subjectCanonicalHash
+  }]]);
+  state.losatDerivedCache.value = new Map();
+
+  const runner = wireGeneratedArtifactRuntimeOwner(createRunAnalysis({
+    ...generatedArtifactHandleOptions,
+    state,
+    serializeCanonicalFiles: () => serializeActiveRenderFiles(state.mode.value, state),
+    canonicalSessionVersion: SESSION_VERSION,
+    adoptCanonicalRenderArtifacts: () => {},
+    prepareLinearRecordCatalog: async () => ({
+      catalog: { mode: 'linear', status: 'ready', records: [] },
+      error: ''
+    }),
+    prepareCandidateCommit: ({
+      results,
+      catalog,
+      featureColorOverrides,
+      featureStrokeOverrides
+    }) => ({
+      results: structuredClone(results),
+      featureState: featureStateFromCatalog(catalog),
+      featureColorOverrides: structuredClone(featureColorOverrides),
+      featureStrokeOverrides: structuredClone(featureStrokeOverrides)
+    }),
+    resetPreviewViewport: () => {}
+  }));
+
+  let losatCalls = 0;
+  let capturedSequences = [];
+  const previousLosatExecutor = globalThis.__GBDRAW_LOSAT_EXECUTOR__;
+  globalThis.__GBDRAW_LOSAT_EXECUTOR__ = async (jobs, options) => {
+    losatCalls += 1;
+    capturedSequences = Array.from(options.sequences.values());
+    return jobs.map((job) => ({
+      cacheKey: job.cacheKey,
+      text: 'SECOND\tTHIRD\t100\t4\t0\t0\t1\t4\t1\t4\t1e-10\t20\n'
+    }));
+  };
+
+  try {
+    const circularResult = result('lazy-circular.svg', 'lazy-circular');
+    workerResponses.push(response(circularResult, validCatalog(circularResult.name)));
+    assert.deepEqual(
+      await runner.runAnalysis(),
+      { status: 'ok' },
+      JSON.stringify(state.errorLog.value)
+    );
+    assert.equal(losatCalls, 0, 'verified circular cache entries must prevent LOSAT execution');
+    assert.deepEqual(
+      resourceMetrics.filter(({ name }) => name === 'resourceTextReadCount')
+        .map(({ resourceId }) => resourceId),
+      ['reference', 'comparison']
+    );
+    assert.equal(
+      workerMessages.filter(({ type }) => type === 'run').at(-1)
+        .payload.request.diagramOptions.conservationLabels[0],
+      'Lazy comparison'
+    );
+
+    const invalidFile = Object.freeze({
+      name: 'missing.gb', type: 'text/plain', size: 0, lastModified: 0
+    });
+    state.files.c_gb = invalidFile;
+    state.circularRecordList.value = [
+      { selector: '#1', record_id: 'missing', record_length: 1 }
+    ];
+    Object.assign(state.circularRecordDiscovery, {
+      status: 'ready',
+      error: '',
+      inputType: 'gb',
+      primaryFile: invalidFile,
+      pairedFile: null
+    });
+    assert.deepEqual(await runner.runAnalysis(), { status: 'error' });
+    assert.match(
+      state.errorLog.value?.summary || '',
+      /A File-like object with arrayBuffer\(\) or text\(\) is required/
+    );
+
+    resourceMetrics.splice(0);
+    const linearTable = adoptCurrentSessionResources({
+      multi: encodedResource('genbank', 'multi.gb', [
+        'LOCUS       FIRST 8 bp DNA',
+        'ORIGIN',
+        '        1 aaaaaaaa',
+        '//',
+        'LOCUS       SECOND 8 bp DNA',
+        'ORIGIN',
+        '        1 aaccggtt',
+        '//',
+        ''
+      ].join('\n')),
+      third: encodedResource('genbank', 'third.gb', [
+        'LOCUS       THIRD 8 bp DNA',
+        'ORIGIN',
+        '        1 ttttaaaa',
+        '//',
+        ''
+      ].join('\n'))
+    });
+    const multiView = createSessionResourceFileView(linearTable, 'multi');
+    const thirdView = createSessionResourceFileView(linearTable, 'third');
+    state.mode.value = 'linear';
+    state.lInputType.value = 'gb';
+    state.form.prefix = 'lazy-linear';
+    state.form.show_depth = false;
+    state.form.linear_track_layout = 'middle';
+    state.adv.linear_track_slots_enabled = false;
+    state.adv.linear_track_slots = [];
+    state.adv.comparison_height = null;
+    state.linearRecordLayoutEnabled.value = false;
+    state.linearRecordRows.splice(0);
+    state.linearSeqs.splice(0, state.linearSeqs.length, {
+      uid: 'multi',
+      gb: multiView,
+      gff: null,
+      fasta: null,
+      depth: null,
+      blast: null,
+      losat_gencode: 1,
+      losat_filename: '',
+      definition: '',
+      record_subtitle: '',
+      region_record_id: 'SECOND',
+      region_start: 2,
+      region_end: 5,
+      region_reverse: true
+    }, {
+      uid: 'third',
+      gb: thirdView,
+      gff: null,
+      fasta: null,
+      depth: null,
+      blast: null,
+      losat_gencode: 1,
+      losat_filename: '',
+      definition: '',
+      record_subtitle: '',
+      region_record_id: 'THIRD',
+      region_start: null,
+      region_end: null,
+      region_reverse: false
+    });
+    Object.assign(state.linearComparisonPlan, {
+      mode: 'selected',
+      defaultSource: 'losat'
+    });
+    state.linearComparisonPlan.edges.splice(0, state.linearComparisonPlan.edges.length, {
+      id: 'lazy-linear-edge',
+      queryUid: 'multi',
+      subjectUid: 'third',
+      included: true,
+      source: 'losat',
+      file: null,
+      fileActive: false,
+      losatFilename: '',
+      losatFilenameActive: false
+    });
+    state.files.linearCanonicalComparisons = [];
+    state.losatProgram.value = 'blastn';
+    state.losat.blastn.task = 'megablast';
+    state.losat.executionMode = 'serial';
+    state.losatCache.value = new Map();
+
+    const comparisonPlanSnapshot = resolveLinearComparisonPlan({
+      plan: state.linearComparisonPlan,
+      sequences: state.linearSeqs,
+      layout: [],
+      losatProgram: state.losatProgram.value,
+      blastpMode: state.losat.blastp.mode
+    });
+    const linearResult = result('lazy-linear.svg', 'lazy-linear');
+    workerHelperResponses.push({
+      ok: true,
+      result: {
+        tsv: 'SECOND\tTHIRD\t100\t4\t0\t0\t1\t4\t1\t4\t1e-10\t20\n'
+      }
+    });
+    workerResponses.push(response(linearResult, validCatalog(linearResult.name)));
+    assert.deepEqual(
+      await runner.runAnalysis(comparisonPlanSnapshot),
+      { status: 'ok' },
+      JSON.stringify({ error: state.errorLog.value, lastWorker: workerMessages.at(-1) })
+    );
+    assert.equal(losatCalls, 1);
+    assert.ok(capturedSequences.includes('>SECOND\nACCG\n'));
+    assert.ok(capturedSequences.includes('>THIRD\nTTTTAAAA\n'));
+    const conversionRequest = workerMessages.findLast((message) => (
+      message.type === 'helper' &&
+      message.operation === 'convertLosatNucleotideToDisplayTsv'
+    ));
+    assert.deepEqual(conversionRequest?.payload.queryViewTransform, {
+      length: 4,
+      reverse: true
+    });
+    assert.equal(
+      resourceMetrics.filter(({ name }) => name === 'resourceByteReadCount').length,
+      2
+    );
+    assert.equal(
+      resourceMetrics.filter(({ name }) => name === 'resourceTextReadCount').length,
+      0,
+      'the explicit staged text fast path must not materialize file text again'
+    );
+  } finally {
+    if (previousTestHooks === undefined) {
+      delete globalThis.__GBDRAW_TEST_HOOKS__;
+    } else {
+      globalThis.__GBDRAW_TEST_HOOKS__ = previousTestHooks;
+    }
+    if (previousLosatExecutor === undefined) {
+      delete globalThis.__GBDRAW_LOSAT_EXECUTOR__;
+    } else {
+      globalThis.__GBDRAW_LOSAT_EXECUTOR__ = previousLosatExecutor;
+    }
+  }
 });
 
 test('Linear mode none ignores dormant comparison state while active depth and annotations render', async () => {

--- a/tests/web/wssv-gallery-fastas.test.mjs
+++ b/tests/web/wssv-gallery-fastas.test.mjs
@@ -1,22 +1,35 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 
 import { buildRestoredMatchSequenceSources } from '../../gbdraw/web/js/app/match-sequences.js';
+import { readFileText } from '../../gbdraw/web/js/services/file-content-cache.js';
+import {
+  adoptCurrentSessionResources,
+  sessionResourceSource
+} from '../../gbdraw/web/js/services/session-resource-backing.js';
 import { projectCanonicalSessionRequest } from '../../gbdraw/web/js/services/session-request.js';
-
 
 const sessionPath = new URL(
   '../../gbdraw/web/gallery/sessions/WSSV_genome_comparison.gbdraw-session.json',
   import.meta.url
 );
 const session = JSON.parse(await readFile(sessionPath, 'utf8'));
+const resourceMetrics = [];
+globalThis.__GBDRAW_TEST_HOOKS__ = {
+  onStructuralMetric(metric) {
+    resourceMetrics.push({ ...metric });
+  }
+};
+const sessionResourceTable = adoptCurrentSessionResources(session.resources);
 const projection = projectCanonicalSessionRequest({
   renderRequest: session.renderRequest,
   resources: session.resources,
   webFiles: session.webFiles,
   legacyFiles: session.files,
   storedConfig: session.config,
-  fileBindings: session.cliInvocation?.fileBindings
+  fileBindings: session.cliInvocation?.fileBindings,
+  sessionResourceTable
 });
 
 const expectedComparisons = [
@@ -72,18 +85,19 @@ assert.deepEqual(
   ]
 );
 
-const withText = (file) => ({
-  ...file,
-  text: async () => Buffer.from(file.data, 'base64').toString('utf8')
-});
+const lazyViews = [projection.files.c_gb, ...projection.files.c_conservation_fastas];
+for (const file of lazyViews) {
+  assert.equal(Object.isFrozen(file), true);
+  for (const field of ['text', 'arrayBuffer', 'data', 'resourceId']) {
+    assert.equal(Object.hasOwn(file, field), false, `${file.name} exposed ${field}`);
+  }
+}
+assert.equal(resourceMetrics.length, 0, 'resource projection must remain metadata-only');
+
 const restoredSources = await buildRestoredMatchSequenceSources({
   mode: projection.mode,
   cInputType: projection.inputType,
-  files: {
-    ...projection.files,
-    c_gb: withText(projection.files.c_gb),
-    c_conservation_fastas: projection.files.c_conservation_fastas.map(withText)
-  },
+  files: projection.files,
   circularConservation: session.config.circularConservation
 });
 const comparisons = restoredSources.filter(
@@ -101,4 +115,40 @@ assert.deepEqual(
 assert.deepEqual(
   comparisons.map((source) => source.sourceIndex),
   Array.from({ length: 20 }, (_, index) => index)
+);
+
+const expectedResourceIds = session.webFiles.conservationLosatFastaSources;
+assert.deepEqual(
+  projection.files.c_conservation_fastas.map((file) => (
+    sessionResourceSource(file)?.resourceId
+  )),
+  expectedResourceIds
+);
+assert.equal(
+  sessionResourceSource(projection.files.c_gb)?.resourceId,
+  session.renderRequest.records[0].source.resourceId
+);
+assert.deepEqual(
+  projection.files.c_conservation_fastas.map((file) => sessionResourceSource(file)?.descriptor),
+  expectedResourceIds.map((resourceId) => session.resources[resourceId])
+);
+
+const fastaTexts = await Promise.all(
+  projection.files.c_conservation_fastas.map((file) => readFileText(file))
+);
+const displayedCacheEntries = session.losatCache.entries.filter((entry) => (
+  entry.flow === 'circular-conservation' && entry.display === true
+));
+assert.equal(displayedCacheEntries.length, 20);
+assert.deepEqual(
+  fastaTexts.map((text) => createHash('sha256').update(text).digest('hex')),
+  displayedCacheEntries.map((entry) => entry.queryCanonicalHash)
+);
+assert.equal(
+  resourceMetrics.filter(({ name }) => name === 'resourceTextReadCount').length,
+  21
+);
+assert.equal(
+  resourceMetrics.filter(({ name }) => name === 'base64DecodeCount').length,
+  21
 );


### PR DESCRIPTION
## Summary

- Route both browser FASTA extraction paths through `readFileText()` when no explicit string is provided.
- Cover circular conservation and linear sequence preparation with frozen metadata-only session resource views.
- Add the sole isolated full-browser WSSV generation test and its npm entry point.

This implements PR 1 from the Interactive Gallery session replay remediation plan at commit `0fee522c936dc58ba8a9d7a44830449efd8ea5fd`.

Plan documents:

- `docs/internal/INTERACTIVE_GALLERY_SESSION_REPLAY_REMEDIATION_PLAN_2026-08-22.md`
- `docs/internal/INTERACTIVE_GALLERY_SESSION_REPLAY_PR_01_WSSV_LAZY_RESOURCE_READ.md`

PR 2 publication and CI work and PR 3 tutorial media work remain out of scope.

## Failure reproduced

The final regression tests failed with the two pre-fix guards in place. The public `createRunAnalysis()` path reported `Input file is not available for browser FASTA extraction.`, and the browser test restored the saved WSSV preview but returned an error from Generate. Both tests passed after removing the guards.

## Implementation

`extractLosatFastaFast()` and `extractAllLosatFastaFast()` now use the existing explicit-string fast path and otherwise call `readFileText(file)`. Parsing, record selection, region handling, reverse transforms, ordering, and session data are unchanged.

The retained browser test imports the bundled WSSV session through the public application lifecycle, confirms that import stays lazy and Worker-free, runs Generate, and checks the 20 ordered conservation rings. It rejects unexpected LOSAT execution and external requests.

## Architecture evidence

```text
Owners before = {
  services/file-content-cache.js::readFileText,
  app/run-analysis.js::extractLosatFastaFast capability guard,
  app/run-analysis.js::extractAllLosatFastaFast capability guard
}

Owners after = {
  services/file-content-cache.js::readFileText
}

Canonical path before = FASTA extraction -> narrower .text guard -> shared reader
Canonical path after  = FASTA extraction -> shared reader

Compatibility paths before = none
Compatibility paths after  = none
Superseded paths removed    = both .text guards
New production modules/dependencies = none
```

Production code changes are limited to deleting the two guards, six lines in total. The Playwright spec and config are verification infrastructure, not new semantic owners.

## Verification

- `node --test tests/web/session-resource-backing.test.mjs tests/web/file-content-cache.test.mjs tests/web/wssv-gallery-fastas.test.mjs tests/web/run-analysis-simple-path.test.mjs`: 4 passed
- `python -m pytest tests/test_wssv_gallery_fastas.py -q`: 2 passed
- `python tools/prepare_browser_wheel.py`: passed; generated wheel remained ignored
- `npm run test:web:wssv-generate`: 1 passed in 15.8 seconds
  - Generate elapsed time: 8,553.9 ms
  - Conservation rings: 20
  - Rendered matches: 6,096
  - Lazy FASTA text reads: 20
  - LOSAT calls: 0
  - Diagram Worker constructions: 1
- `npm run test:web:functional-smoke`: 98 passed
- `node tools/check-web-change-budget.mjs`: passed; production modules, edges, cycles, owners, and dependencies did not increase
- `python -m pytest tests/ -v -m "not slow"`: 2,946 passed, 17 skipped, 11 deselected in 621.61 seconds
  - Four existing Biopython qualifier-length warnings were reported by session compatibility tests.

## Scope audit

No changes were made to `file-content-cache.js`, `session-resource-backing.js`, session or request schemas, Gallery sessions, SVGs, thumbnails, reference outputs, `package-lock.json`, or the plan documents. No generated artifact is included.

The dedicated WSSV spec is the only WSSV full-render owner. PR 2 may call `npm run test:web:wssv-generate` from CI and add the shared SVG parity assertion in this spec, but should not move or duplicate it.
