### PR TITLE
Avoid duplicate architecture tests in Browser CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,9 @@ jobs:
 
       - name: Run Web JavaScript tests
         run: |
-          node --test tests/web/*.test.mjs
+          find tests/web -maxdepth 1 -type f \
+            -name '*.test.mjs' ! -name 'architecture-contracts.test.mjs' \
+            -print0 | xargs -0 node --test
           node --test --test-concurrency=1 tests/web/contracts/vibrio-sequence-source-coverage.test.mjs
           node tests/web/session-request.test.mjs --project-session gbdraw/web/gallery/sessions/hepatoplasmataceae_orthogroup.gbdraw-session.json.gz
           node tests/web/session-request.test.mjs --project-session gbdraw/web/gallery/sessions/tobacco-chloroplast.gbdraw-session.json


### PR DESCRIPTION
## Summary

- keep the dedicated architecture-contract test invocation unchanged
- exclude that same file from the later broad Browser unit-test invocation
- preserve all remaining Web JavaScript and specialized Gallery session checks

## Why

Under Node.js 20, `architecture-contracts.test.mjs` passes on its own but can terminate with a file-level `ERR_TEST_FAILURE` when it is executed a second time as part of the broad `tests/web/*.test.mjs` batch. The failure reproduces on `origin/dev`; it is not caused by PR #365 production code.

## Verification

- Browser Web unit batch excluding the already-tested architecture file: 69/69 passed
- dedicated architecture contracts: 83/83 passed
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD`: PASS
- production files touched: 0
