### PR TITLE
Fix Linear Arrange in rows and row-label column semantics

### DIFF
--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -3627,6 +3627,7 @@ export const exportSession = async (
       const adoptedCommitted = isAdoptedCanonicalSession(committed);
       const projected = projectCanonicalSessionRequest({
         ...committed,
+        storedConfig,
         sessionResourceTable: adoptedCommitted ? activeSessionResourceTable : null,
         deferResourceContent: adoptedCommitted,
         adoptCanonicalPayloads: adoptedCommitted

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -35,6 +35,10 @@ import {
   parseLinearTrackSlotSpecs
 } from '../app/linear-track-slots.js';
 import {
+  linearRecordPositionTokens,
+  reconcileLinearRecordLayout
+} from '../app/linear-record-layout.js';
+import {
   isRecordMajorDepthFileMatrix,
   normalizeRecordMajorDepthFileRows,
   parseDepthTrackIndexIdentity
@@ -1619,20 +1623,9 @@ const buildComparisons = ({
   return comparisons;
 };
 
-const resolvedLinearRecordRows = (sequences, layoutRows) => {
-  const rowsByUid = new Map(
-    (Array.isArray(layoutRows) ? layoutRows : [])
-      .map((entry) => [String(entry?.uid || ''), Number(entry?.row)])
-  );
-  return (Array.isArray(sequences) ? sequences : []).map((sequence, index) => {
-    const row = rowsByUid.get(String(sequence?.uid || ''));
-    return Number.isInteger(row) && row > 0 ? row : index + 1;
-  });
-};
-
 export const linearRecordLayoutHasSharedRow = (sequences, layoutRows) => {
   const seenRows = new Set();
-  return resolvedLinearRecordRows(sequences, layoutRows).some((row) => {
+  return reconcileLinearRecordLayout(sequences, layoutRows).some(({ row }) => {
     if (seenRows.has(row)) return true;
     seenRows.add(row);
     return false;
@@ -1642,13 +1635,12 @@ export const linearRecordLayoutHasSharedRow = (sequences, layoutRows) => {
 const buildLayout = (state, filesData) => {
   if (state.mode.value === 'linear') {
     if (!state.linearRecordLayoutEnabled?.value) return {};
-    const resolvedRows = resolvedLinearRecordRows(
-      filesData.linearSeqs,
-      state.linearRecordRows
-    );
     return {
       recordGapPx: Math.max(0, Number(state.linearRecordGap?.value) || 0),
-      multiRecordPositions: resolvedRows.map((row, index) => `#${index + 1}@${row}`)
+      multiRecordPositions: linearRecordPositionTokens(
+        filesData.linearSeqs,
+        state.linearRecordRows
+      )
     };
   }
   if (!state.form.multi_record_canvas) return {};
@@ -2893,6 +2885,137 @@ const projectedOutputPrefix = (
     : '';
 };
 
+const multiRecordPositionParts = (token) => {
+  const value = String(token).trim();
+  const split = value.lastIndexOf('@');
+  return {
+    value,
+    selector: value.slice(0, split).trim(),
+    rowText: value.slice(split + 1).trim()
+  };
+};
+
+const parseMultiRecordPositionToken = (token) => {
+  const { selector, rowText } = multiRecordPositionParts(token);
+  return { selector, row: Number(rowText) };
+};
+
+const parseLinearRecordPositionToken = (token) => {
+  const { value, selector, rowText } = multiRecordPositionParts(token);
+  if (!value || (value.match(/@/g) || []).length !== 1 || !selector) {
+    throw new Error(
+      `Canonical Linear layout entry '${value}' must use '<selector>@<row>'.`
+    );
+  }
+  if (!/^[+-]?\d+$/.test(rowText)) {
+    throw new Error(
+      `Canonical Linear layout entry '${value}' must use a positive integer row.`
+    );
+  }
+  const row = Number(rowText);
+  if (!Number.isInteger(row) || row <= 0) {
+    throw new Error(
+      `Canonical Linear layout entry '${value}' must use a positive integer row.`
+    );
+  }
+  return { selector, row };
+};
+
+const canonicalLinearRecordId = (record) => {
+  const selector = record?.region?.selector || record?.selector;
+  return selector?.kind === 'recordId' ? String(selector.value) : null;
+};
+
+const linearPositionRecordIndex = (selector, records, recordIds) => {
+  const value = String(selector);
+  if (value.startsWith('#')) {
+    const indexText = value.slice(1).trim();
+    if (!/^[+-]?\d+$/.test(indexText)) {
+      throw new Error(`Canonical Linear layout selector '${value}' is invalid.`);
+    }
+    const recordIndex = Number(indexText) - 1;
+    if (recordIndex >= 0 && recordIndex < records.length) return recordIndex;
+    throw new Error(
+      `Canonical Linear layout selector '${value}' is out of range for `
+      + `${records.length} render record(s).`
+    );
+  }
+  const matches = recordIds.flatMap((recordId, index) => (
+    recordId === value ? [index] : []
+  ));
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) {
+    throw new Error(
+      `Canonical Linear layout selector '${value}' matches multiple render records.`
+    );
+  }
+  return null;
+};
+
+const completeStoredLinearRecordRows = (sequences, storedRows) => {
+  if (!Array.isArray(storedRows)) return null;
+  const rowsByUid = new Map(storedRows.map((entry) => [
+    String(entry?.uid || ''),
+    Number(entry?.row)
+  ]));
+  if (!sequences.every((sequence) => {
+    const row = rowsByUid.get(String(sequence?.uid || ''));
+    return Number.isInteger(row) && row > 0;
+  })) return null;
+  return sequences.map((sequence) => ({
+    uid: sequence?.uid || '',
+    row: rowsByUid.get(String(sequence?.uid || ''))
+  }));
+};
+
+const projectLinearRecordRows = (tokens, records, sequences, storedRows) => {
+  if (tokens.length === 0) return [];
+  if (tokens.length !== records.length || sequences.length !== records.length) {
+    throw new Error(
+      `Canonical Linear layout must provide exactly ${records.length} entry(ies).`
+    );
+  }
+  const recordIds = records.map(canonicalLinearRecordId);
+  const persistedRows = completeStoredLinearRecordRows(sequences, storedRows);
+  const rowsByRecordIndex = new Map();
+  const unresolvedSelectors = [];
+  const seenSelectors = new Set();
+  for (const token of tokens) {
+    const { selector, row } = parseLinearRecordPositionToken(token);
+    if (seenSelectors.has(selector)) {
+      throw new Error(
+        `Canonical Linear layout selector '${selector}' was specified more than once.`
+      );
+    }
+    seenSelectors.add(selector);
+    const recordIndex = linearPositionRecordIndex(selector, records, recordIds);
+    if (recordIndex === null) {
+      unresolvedSelectors.push(selector);
+      continue;
+    }
+    if (rowsByRecordIndex.has(recordIndex)) {
+      throw new Error(
+        `Canonical Linear layout selector '${selector}' maps to a duplicate render record.`
+      );
+    }
+    rowsByRecordIndex.set(recordIndex, row);
+  }
+  if (unresolvedSelectors.length > 0) {
+    if (persistedRows) return persistedRows;
+    throw new Error(
+      `Canonical Linear layout selector '${unresolvedSelectors[0]}' `
+      + 'cannot be mapped to a render record.'
+    );
+  }
+  if (rowsByRecordIndex.size !== records.length) {
+    throw new Error('Canonical Linear layout must include every render record exactly once.');
+  }
+  return sequences.map((sequence, index) => ({
+    uid: sequence?.uid || '',
+    row: rowsByRecordIndex.get(index)
+  }));
+};
+
 export const projectCanonicalSessionRequest = ({
   renderRequest,
   resources: canonicalResources,
@@ -3652,22 +3775,19 @@ export const projectCanonicalSessionRequest = ({
       ? (tracks.linearTrackAxisIndex ?? null)
       : null,
     linear_track_slots: projectedLinearTrackSlots,
-    multi_record_positions: (renderRequest.layout?.multiRecordPositions || []).map((token) => {
-      const split = String(token).lastIndexOf('@');
-      return { selector: String(token).slice(0, split), row: Number(String(token).slice(split + 1)) };
-    })
+    multi_record_positions: (renderRequest.layout?.multiRecordPositions || [])
+      .map(parseMultiRecordPositionToken)
   };
   const linearLayout = renderRequest.mode === 'linear' && renderRequest.schema >= 2
     ? {
         enabled: Object.keys(renderRequest.layout || {}).length > 0,
         recordGap: renderRequest.layout?.recordGapPx ?? 24,
-        rows: (renderRequest.layout?.multiRecordPositions || []).map((token, index) => {
-          const split = String(token).lastIndexOf('@');
-          return {
-            uid: files.linearSeqs[index]?.uid || '',
-            row: Number(String(token).slice(split + 1)) || index + 1
-          };
-        })
+        rows: projectLinearRecordRows(
+          renderRequest.layout?.multiRecordPositions || [],
+          records,
+          files.linearSeqs,
+          storedConfig?.linearRecordLayout?.rows
+        )
       }
     : undefined;
   const projectedBlacklistText = Array.isArray(overrides.label_blacklist)

--- a/tests/test_linear_multi_record_layout.py
+++ b/tests/test_linear_multi_record_layout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import xml.etree.ElementTree as ET
 
@@ -343,6 +344,139 @@ def test_api_renders_record_local_widths_and_grid_metadata() -> None:
     assert svg.count("data-record-row=") == 4
     assert 'data-record-row="0"' in svg
     assert 'data-record-column="1"' in svg
+
+
+def test_row_definition_gutter_preserves_shared_row_biological_geometry() -> None:
+    lengths = (1000, 800, 600)
+    namespace = {"svg": "http://www.w3.org/2000/svg"}
+    cfg = apply_config_overrides(
+        None,
+        {
+            "labels.linear.scope": "none",
+            "canvas.show_gc": False,
+            "canvas.show_skew": False,
+            "canvas.linear.keep_definition_left_aligned": True,
+        },
+    )
+
+    def render(*, labeled: bool) -> dict[str, object]:
+        records = _records(*lengths)
+        if labeled:
+            records[0].annotations["gbdraw_record_label"] = "Species alpha"
+            records[0].annotations["gbdraw_record_subtitle"] = "strain beta"
+        root = ET.fromstring(
+            assemble_linear_diagram_from_records(
+                records,
+                cfg=cfg,
+                layout=LinearMultiRecordOptions(
+                    record_gap_px=24,
+                    multi_record_positions=("#1@1", "#2@1", "#3@1"),
+                ),
+                legend="none",
+            ).tostring()
+        )
+        biological_groups = sorted(
+            (
+                group
+                for group in root.findall(".//svg:g", namespace)
+                if "data-record-index" in group.attrib
+            ),
+            key=lambda group: int(group.attrib["data-record-index"]),
+        )
+        widths = []
+        for group in biological_groups:
+            axis = next(
+                line
+                for line in group.findall("./svg:line", namespace)
+                if float(line.attrib["y1"]) == float(line.attrib["y2"]) == 0.0
+            )
+            widths.append(float(axis.attrib["x2"]) - float(axis.attrib["x1"]))
+        record_x = tuple(_translate(group)[0] for group in biological_groups)
+        return {
+            "root": root,
+            "placements": tuple(
+                (
+                    int(group.attrib["data-record-row"]),
+                    int(group.attrib["data-record-column"]),
+                )
+                for group in biological_groups
+            ),
+            "sequence_widths": tuple(widths),
+            "px_per_bp": tuple(
+                width / len(record.seq) for width, record in zip(widths, records)
+            ),
+            "record_x": record_x,
+            "view_box": tuple(
+                float(value) for value in root.attrib["viewBox"].split()
+            ),
+        }
+
+    unlabeled = render(labeled=False)
+    labeled = render(labeled=True)
+
+    assert unlabeled["placements"] == labeled["placements"] == (
+        (0, 0),
+        (0, 1),
+        (0, 2),
+    )
+    assert unlabeled["px_per_bp"][0] > 0
+    assert unlabeled["px_per_bp"] == pytest.approx(
+        (unlabeled["px_per_bp"][0],) * 3
+    )
+    assert labeled["px_per_bp"] == pytest.approx(unlabeled["px_per_bp"])
+    assert labeled["sequence_widths"] == pytest.approx(
+        unlabeled["sequence_widths"]
+    )
+    unlabeled_x = unlabeled["record_x"]
+    labeled_x = labeled["record_x"]
+    assert tuple(x - labeled_x[0] for x in labeled_x) == pytest.approx(
+        tuple(x - unlabeled_x[0] for x in unlabeled_x)
+    )
+
+    labeled_root = labeled["root"]
+    definition_groups = tuple(
+        group
+        for group in labeled_root.findall(".//svg:g", namespace)
+        if group.attrib.get("data-gbdraw-role")
+        in {"record-definition", "record-definition-row"}
+    )
+    assert definition_groups
+    assert all(
+        {"data-record-row", "data-record-column"}.isdisjoint(group.attrib)
+        for group in definition_groups
+    )
+    row_definition = next(
+        group
+        for group in definition_groups
+        if group.attrib.get("data-gbdraw-role") == "record-definition-row"
+    )
+    row_text = row_definition.findall("./svg:text", namespace)
+    assert ["".join(text.itertext()) for text in row_text] == [
+        "Species alpha",
+        "strain beta",
+    ]
+    assert all(
+        text.attrib.get("text-anchor") == "start" and float(text.attrib["x"]) == 0.0
+        for text in row_text
+    )
+
+    composition = json.loads(labeled_root.attrib["data-gbdraw-composition"])
+    primary_bounds = composition["primary"]["finalBounds"]
+    edge_padding = composition["spacing"]["edgePaddingPx"]
+    view_box_left, _view_box_top, view_box_width, _view_box_height = labeled[
+        "view_box"
+    ]
+    view_box_right = view_box_left + view_box_width
+    assert primary_bounds["x"] - view_box_left == pytest.approx(edge_padding)
+    assert view_box_right - (
+        primary_bounds["x"] + primary_bounds["width"]
+    ) == pytest.approx(edge_padding)
+    assert _translate(row_definition)[0] == pytest.approx(primary_bounds["x"])
+
+    gutter_growth = view_box_width - unlabeled["view_box"][2]
+    record_shift = labeled_x[0] - unlabeled_x[0]
+    assert gutter_growth > 0
+    assert gutter_growth == pytest.approx(record_shift)
 
 
 def test_bottom_legend_follows_last_resolved_row() -> None:

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -100,11 +100,59 @@ const svgSourceIdentity = (content) => ({
 
 const svgComparisonSummary = (content) => {
   const source = String(content || '');
+  const attribute = (tag, name) => (
+    tag.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1] ?? null
+  );
+  const endpointCounts = new Map();
+  const pairwiseTags = source.match(
+    /<path\b[^>]*data-gbdraw-pairwise-match-id="[^"]*"[^>]*>/g
+  ) || [];
+  for (const tag of pairwiseTags) {
+    const queryText = attribute(tag, 'data-query-record-index');
+    const subjectText = attribute(tag, 'data-subject-record-index');
+    if (queryText === null || subjectText === null) continue;
+    const query = Number(queryText);
+    const subject = Number(subjectText);
+    if (!Number.isInteger(query) || !Number.isInteger(subject)) continue;
+    const key = `${query}->${subject}`;
+    endpointCounts.set(key, Number(endpointCounts.get(key) || 0) + 1);
+  }
   return {
     comparisonGroups: (source.match(/<g[^>]*\bid="comparison\d+"/g) || []).length,
     pairwiseMatches: (source.match(/data-gbdraw-pairwise-match-id=/g) || []).length,
-    comparisonLegends: (source.match(/data-gbdraw-role="comparison-legend"/g) || []).length
+    comparisonLegends: (source.match(/data-gbdraw-role="comparison-legend"/g) || []).length,
+    endpointCounts: [...endpointCounts.entries()]
+      .map(([edge, matches]) => ({ edge, matches }))
+      .sort((left, right) => {
+        const [leftQuery, leftSubject] = left.edge.split('->').map(Number);
+        const [rightQuery, rightSubject] = right.edge.split('->').map(Number);
+        return leftQuery - rightQuery || leftSubject - rightSubject;
+      })
   };
+};
+
+const EXPECTED_VIBRIO_COMPARISON_SUMMARY = {
+  comparisonGroups: 16,
+  pairwiseMatches: 633,
+  comparisonLegends: 2,
+  endpointCounts: [
+    { edge: '0->3', matches: 59 },
+    { edge: '0->4', matches: 14 },
+    { edge: '1->3', matches: 16 },
+    { edge: '1->4', matches: 80 },
+    { edge: '3->5', matches: 53 },
+    { edge: '3->6', matches: 15 },
+    { edge: '4->5', matches: 13 },
+    { edge: '4->6', matches: 75 },
+    { edge: '5->7', matches: 72 },
+    { edge: '5->8', matches: 13 },
+    { edge: '6->7', matches: 14 },
+    { edge: '6->8', matches: 79 },
+    { edge: '7->9', matches: 51 },
+    { edge: '7->10', matches: 12 },
+    { edge: '8->9', matches: 9 },
+    { edge: '8->10', matches: 58 }
+  ]
 };
 
 const svgLinearGeometrySummary = (content) => {
@@ -808,6 +856,7 @@ const assertRecoverableErrorState = async (page, diagnostic, originalPreview) =>
 test.describe.configure({ mode: 'serial' });
 
 test('real Vibrio preview regenerates twice through staged binary resources', async ({
+  browser,
   page,
   context
 }, testInfo) => {
@@ -951,11 +1000,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   const loadedComparisonSummary = svgComparisonSummary(loaded.originalPreview);
   const firstComparisonSummary = svgComparisonSummary(firstGeneratedSvg);
   const secondComparisonSummary = svgComparisonSummary(secondGeneratedSvg);
-  expect(loadedComparisonSummary).toEqual({
-    comparisonGroups: 16,
-    pairwiseMatches: 633,
-    comparisonLegends: 2
-  });
+  expect(loadedComparisonSummary).toEqual(EXPECTED_VIBRIO_COMPARISON_SUMMARY);
   expect(firstComparisonSummary).toEqual(loadedComparisonSummary);
   expect(secondComparisonSummary).toEqual(firstComparisonSummary);
   for (const [stage, svg] of [
@@ -1343,6 +1388,96 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     });
   }
 
+  const preSaveActiveIntent = await activeIntentSummary(page);
+  const sessionDownloadPromise = page.waitForEvent('download', { timeout: 300_000 });
+  await page.getByRole('button', { name: 'Save Session' }).click();
+  const savedSessionPath = await (await sessionDownloadPromise).path();
+  expect(savedSessionPath).toBeTruthy();
+
+  const restoredContext = await browser.newContext({
+    baseURL: 'http://127.0.0.1:4173'
+  });
+  let savedSessionRoundTrip;
+  try {
+    const restoredPage = await restoredContext.newPage();
+    const restoredPageErrors = [];
+    const restoredConsoleErrors = [];
+    restoredPage.on('pageerror', (error) => {
+      restoredPageErrors.push(String(error?.message || error));
+    });
+    restoredPage.on('console', (message) => {
+      if (message.type() === 'error') restoredConsoleErrors.push(message.text());
+    });
+    await openApp(restoredPage, { waitForPalette: false });
+    const chooserPromise = restoredPage.waitForEvent('filechooser');
+    await restoredPage.getByRole('button', { name: 'Load Session' }).click();
+    const loadDialogPromise = restoredPage.waitForEvent('dialog', { timeout: 300_000 });
+    await (await chooserPromise).setFiles(savedSessionPath);
+    const loadDialog = await loadDialogPromise;
+    expect(loadDialog.message()).toBe('Session loaded successfully!');
+    await loadDialog.accept();
+
+    const restoredActiveIntent = await activeIntentSummary(restoredPage);
+    expect(restoredActiveIntent).toEqual(preSaveActiveIntent);
+    const restoredLoadedSvg = await restoredPage.evaluate(() => {
+      const app = window.__GBDRAW_APP__;
+      return String(app.results?.[app.selectedResultIndex]?.content || '');
+    });
+    expect(svgComparisonSummary(restoredLoadedSvg))
+      .toEqual(EXPECTED_VIBRIO_COMPARISON_SUMMARY);
+    expect(svgLinearGeometrySummary(restoredLoadedSvg))
+      .toEqual(EXPECTED_VIBRIO_LINEAR_GEOMETRY);
+
+    await restoredPage.evaluate(() => {
+      window.__GBDRAW_VIBRIO_RESTORED_RUN__ = { done: false, result: null, error: '' };
+      window.__GBDRAW_APP__.runAnalysis().then((result) => {
+        Object.assign(window.__GBDRAW_VIBRIO_RESTORED_RUN__, { done: true, result });
+      }).catch((error) => {
+        Object.assign(window.__GBDRAW_VIBRIO_RESTORED_RUN__, {
+          done: true,
+          error: String(error?.message || error)
+        });
+      });
+    });
+    await restoredPage.waitForFunction(
+      () => window.__GBDRAW_VIBRIO_RESTORED_RUN__?.done === true,
+      null,
+      { timeout: 900_000 }
+    );
+    const restoredGeneration = await restoredPage.evaluate(() => {
+      const app = window.__GBDRAW_APP__;
+      const run = window.__GBDRAW_VIBRIO_RESTORED_RUN__;
+      return {
+        result: run.result,
+        error: run.error,
+        errorSummary: String(app.errorLog?.summary || ''),
+        svg: String(app.results?.[app.selectedResultIndex]?.content || '')
+      };
+    });
+    expect(restoredGeneration).toMatchObject({
+      result: { status: 'ok' },
+      error: '',
+      errorSummary: ''
+    });
+    expect(svgComparisonSummary(restoredGeneration.svg))
+      .toEqual(EXPECTED_VIBRIO_COMPARISON_SUMMARY);
+    expect(svgLinearGeometrySummary(restoredGeneration.svg))
+      .toEqual(EXPECTED_VIBRIO_LINEAR_GEOMETRY);
+    expect(restoredPageErrors).toEqual([]);
+    expect(restoredConsoleErrors).toEqual([]);
+    savedSessionRoundTrip = {
+      activeIntentSha256: restoredActiveIntent.sha256,
+      loadedPreviewIdentity: svgSourceIdentity(restoredLoadedSvg),
+      generatedIdentity: svgSourceIdentity(restoredGeneration.svg),
+      loadedPreviewExactBytesEqual: restoredLoadedSvg === secondGeneratedSvg,
+      generatedExactBytesEqual: restoredGeneration.svg === secondGeneratedSvg,
+      comparisonSummary: svgComparisonSummary(restoredGeneration.svg),
+      linearGeometry: svgLinearGeometrySummary(restoredGeneration.svg)
+    };
+  } finally {
+    await restoredContext.close();
+  }
+
   const report = {
     load: {
       previewMetrics,
@@ -1393,6 +1528,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
         artifactFingerprints[0] === artifactFingerprints[1]
     },
     historyRoundTrip,
+    savedSessionRoundTrip,
     structural,
     worker: afterPing
   };
@@ -1413,6 +1549,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     secondPhaseAttribution: report.generations.secondPhaseAttribution,
     structural: report.structural,
     deterministicOutput: report.deterministicOutput,
-    historyRoundTrip: report.historyRoundTrip
+    historyRoundTrip: report.historyRoundTrip,
+    savedSessionRoundTrip: report.savedSessionRoundTrip
   })}`);
 });

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -107,6 +107,74 @@ const svgComparisonSummary = (content) => {
   };
 };
 
+const svgLinearGeometrySummary = (content) => {
+  const groupTags = String(content || '').match(/<g\b[^>]*>/g) || [];
+  const attribute = (tag, name) => (
+    tag.match(new RegExp(`\\b${name}="([^"]*)"`))?.[1] ?? null
+  );
+  const placements = groupTags
+    .filter((tag) => (
+      attribute(tag, 'data-record-index') !== null
+      && attribute(tag, 'data-record-row') !== null
+      && attribute(tag, 'data-record-column') !== null
+    ))
+    .map((tag) => ({
+      record: Number(attribute(tag, 'data-record-index')),
+      row: Number(attribute(tag, 'data-record-row')),
+      column: Number(attribute(tag, 'data-record-column'))
+    }))
+    .sort((left, right) => left.record - right.record);
+  const rowNumbers = [...new Set(placements.map(({ row }) => row))]
+    .sort((left, right) => left - right);
+  const recordsByRow = rowNumbers.map((row) => placements
+    .filter((placement) => placement.row === row)
+    .sort((left, right) => left.column - right.column)
+    .map(({ record }) => record));
+  const definitionGroups = groupTags.filter((tag) => (
+    ['record-definition', 'record-definition-row'].includes(
+      attribute(tag, 'data-gbdraw-role')
+    )
+  ));
+  return {
+    biologicalGroups: placements.length,
+    rows: rowNumbers.length,
+    rowSizes: recordsByRow.map((records) => records.length),
+    placements,
+    recordsByRow,
+    definitionPseudoPlacements: definitionGroups.filter((tag) => (
+      attribute(tag, 'data-record-row') !== null
+      || attribute(tag, 'data-record-column') !== null
+    )).length
+  };
+};
+
+const EXPECTED_VIBRIO_LINEAR_GEOMETRY = {
+  biologicalGroups: 11,
+  rows: 5,
+  rowSizes: [3, 2, 2, 2, 2],
+  placements: [
+    { record: 0, row: 0, column: 0 },
+    { record: 1, row: 0, column: 1 },
+    { record: 2, row: 0, column: 2 },
+    { record: 3, row: 1, column: 0 },
+    { record: 4, row: 1, column: 1 },
+    { record: 5, row: 2, column: 0 },
+    { record: 6, row: 2, column: 1 },
+    { record: 7, row: 3, column: 0 },
+    { record: 8, row: 3, column: 1 },
+    { record: 9, row: 4, column: 0 },
+    { record: 10, row: 4, column: 1 }
+  ],
+  recordsByRow: [
+    [0, 1, 2],
+    [3, 4],
+    [5, 6],
+    [7, 8],
+    [9, 10]
+  ],
+  definitionPseudoPlacements: 0
+};
+
 const installCanonicalRequestCapture = (page) => page.evaluate(() => {
   const previousPostMessage = Worker.prototype.postMessage;
   window.__GBDRAW_VIBRIO_CANONICAL_REQUESTS__ = [];
@@ -890,6 +958,16 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   });
   expect(firstComparisonSummary).toEqual(loadedComparisonSummary);
   expect(secondComparisonSummary).toEqual(firstComparisonSummary);
+  for (const [stage, svg] of [
+    ['loaded preview', loaded.originalPreview],
+    ['first generation', firstGeneratedSvg],
+    ['second generation', secondGeneratedSvg]
+  ]) {
+    expect(
+      svgLinearGeometrySummary(svg),
+      `Unexpected semantic Linear geometry in ${stage}.`
+    ).toEqual(EXPECTED_VIBRIO_LINEAR_GEOMETRY);
+  }
   const generatedFeatureCatalogDigest = await featureCatalogDigest(page);
 
   const activity = second.worker;

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -125,6 +125,194 @@ const installDiagramRequestObserver = async (page) => {
   });
 };
 
+const generateFromVisibleControl = async (page) => {
+  const previousRunCount = await page.evaluate(() => (
+    window.__GBDRAW_DIAGRAM_RUNS__?.length || 0
+  ));
+  const generate = page.getByRole('button', { name: 'Generate Diagram' });
+  await expect(generate).toBeEnabled();
+  await generate.click();
+  await expect.poll(() => page.evaluate((runCount) => ({
+    processing: Boolean(window.__GBDRAW_APP__?.processing),
+    runCount: window.__GBDRAW_DIAGRAM_RUNS__?.length || 0,
+    error: window.__GBDRAW_APP__?.errorLog?.summary || ''
+  }), previousRunCount), { timeout: 180000 }).toEqual({
+    processing: false,
+    runCount: previousRunCount + 1,
+    error: ''
+  });
+  await expect(page.getByRole('region', { name: 'Result Preview' })).toBeVisible();
+  await expect(generate).toBeEnabled();
+};
+
+const linearPlacementEvidence = (page) => page.evaluate(() => {
+  const summarize = (svg) => {
+    const placements = [...svg.querySelectorAll(
+      '[data-record-index][data-record-row][data-record-column]'
+    )].map((group) => ({
+      record: Number(group.getAttribute('data-record-index')),
+      row: Number(group.getAttribute('data-record-row')),
+      column: Number(group.getAttribute('data-record-column'))
+    })).sort((left, right) => left.record - right.record);
+    const definitions = [...svg.querySelectorAll(
+      '[data-gbdraw-role="record-definition"], [data-gbdraw-role="record-definition-row"]'
+    )];
+    return {
+      placements,
+      definitionPseudoPlacements: definitions.filter((group) => (
+        group.hasAttribute('data-record-row')
+        || group.hasAttribute('data-record-column')
+      )).length
+    };
+  };
+  const app = window.__GBDRAW_APP__;
+  const selected = app.results[Number(app.selectedResultIndex || 0)];
+  const selectedSvg = new DOMParser().parseFromString(selected.content, 'image/svg+xml')
+    .documentElement;
+  const mountedSvg = document.querySelector(
+    '[role="region"][aria-label="Result Preview"] svg'
+  );
+  if (!mountedSvg) throw new Error('Expected the selected Result Preview SVG to be mounted.');
+  const request = window.__GBDRAW_DIAGRAM_RUNS__.at(-1);
+  return {
+    request: {
+      records: request.records.length,
+      comparisons: request.comparisons.length,
+      positions: request.layout.multiRecordPositions
+    },
+    selected: summarize(selectedSvg),
+    mounted: summarize(mountedSvg)
+  };
+});
+
+test.describe('Linear shared-row recovery', () => {
+  test.describe.configure({ retries: 0 });
+
+  test('authors, saves, reloads, and continues a three-record shared row', async ({ browser, page }) => {
+    test.setTimeout(300000);
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', (error) => pageErrors.push(String(error?.message || error)));
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text());
+    });
+    await installDiagramRequestObserver(page);
+    await openApp(page, { waitForPalette: false });
+
+    await page.getByRole('button', { name: 'Linear', exact: true }).click();
+    const addSequence = page.getByRole('button', { name: 'Add sequence' }).first();
+    await addSequence.click();
+    await addSequence.click();
+    await expect(page.getByRole('group', { name: /^Linear sequence \d+$/ })).toHaveCount(3);
+
+    const sources = [
+      makeComparisonGenbank('SharedRowA', 'atg'),
+      makeComparisonGenbank('SharedRowB', 'gct'),
+      makeComparisonGenbank('SharedRowC', 'tta')
+    ];
+    for (const [index, content] of sources.entries()) {
+      const chooserPromise = page.waitForEvent('filechooser');
+      await page.getByRole('group', { name: `Linear sequence ${index + 1}` })
+        .getByRole('button', { name: 'Choose GenBank File' })
+        .click();
+      await (await chooserPromise).setFiles({
+        name: `shared-row-${index + 1}.gbk`,
+        mimeType: 'text/plain',
+        buffer: Buffer.from(content)
+      });
+    }
+    await page.getByRole('button', { name: 'Record options for sequence 1' }).click();
+    await page.getByRole('textbox', { name: 'Definition for sequence 1' })
+      .fill('<i>Vibrio</i> shared-row label', { timeout: 10000 });
+
+    await openLinearAdvancedComparison(page);
+    await page.getByRole('checkbox', { name: 'Arrange linear records in rows' }).check();
+    const rowInputs = page.getByRole('spinbutton', {
+      name: /^Linear record row for sequence \d+$/
+    });
+    await expect(rowInputs).toHaveCount(3);
+    for (let index = 0; index < 3; index += 1) {
+      await rowInputs.nth(index).fill('1');
+    }
+    expect(await rowInputs.evaluateAll((inputs) => inputs.map((input) => input.value)))
+      .toEqual(['1', '1', '1']);
+    await page.getByRole('button', { name: 'Set no comparison' }).click();
+
+    await generateFromVisibleControl(page);
+    const expectedPlacement = [
+      { record: 0, row: 0, column: 0 },
+      { record: 1, row: 0, column: 1 },
+      { record: 2, row: 0, column: 2 }
+    ];
+    const initial = await linearPlacementEvidence(page);
+    expect(initial.request).toEqual({
+      records: 3,
+      comparisons: 0,
+      positions: ['#1@1', '#2@1', '#3@1']
+    });
+    expect(initial.selected).toEqual({
+      placements: expectedPlacement,
+      definitionPseudoPlacements: 0
+    });
+    expect(initial.mounted).toEqual(initial.selected);
+
+    const sessionDownloadPromise = page.waitForEvent('download', { timeout: 120000 });
+    const titleDialogPromise = page.waitForEvent('dialog', { timeout: 10000 });
+    const saveClickPromise = page.getByRole('button', { name: 'Save Session' }).click();
+    const titleDialog = await titleDialogPromise;
+    expect(titleDialog.message()).toBe('Session title');
+    await titleDialog.accept('linear-shared-row-recovery');
+    await saveClickPromise;
+    const sessionPath = await (await sessionDownloadPromise).path();
+    expect(sessionPath).toBeTruthy();
+
+    const restoredContext = await browser.newContext({
+      baseURL: 'http://127.0.0.1:4173'
+    });
+    try {
+      const restoredPage = await restoredContext.newPage();
+      const restoredPageErrors = [];
+      const restoredConsoleErrors = [];
+      restoredPage.on('pageerror', (error) => (
+        restoredPageErrors.push(String(error?.message || error))
+      ));
+      restoredPage.on('console', (message) => {
+        if (message.type() === 'error') restoredConsoleErrors.push(message.text());
+      });
+      await installDiagramRequestObserver(restoredPage);
+      await openApp(restoredPage, { waitForPalette: false });
+      const chooserPromise = restoredPage.waitForEvent('filechooser');
+      await restoredPage.getByRole('button', { name: 'Load Session' }).click();
+      const loadDialogPromise = restoredPage.waitForEvent('dialog', { timeout: 120000 });
+      await (await chooserPromise).setFiles(sessionPath);
+      const loadDialog = await loadDialogPromise;
+      expect(loadDialog.message()).toBe('Session loaded successfully!');
+      await loadDialog.accept();
+
+      await openLinearAdvancedComparison(restoredPage);
+      const restoredRows = restoredPage.getByRole('spinbutton', {
+        name: /^Linear record row for sequence \d+$/
+      });
+      expect(await restoredRows.evaluateAll((inputs) => inputs.map((input) => input.value)))
+        .toEqual(['1', '1', '1']);
+      await generateFromVisibleControl(restoredPage);
+      const restored = await linearPlacementEvidence(restoredPage);
+      expect(restored.request).toEqual(initial.request);
+      expect(restored.selected).toEqual(initial.selected);
+      expect(restored.mounted).toEqual(restored.selected);
+
+      await generateFromVisibleControl(restoredPage);
+      expect(await linearPlacementEvidence(restoredPage)).toEqual(restored);
+      expect(restoredPageErrors).toEqual([]);
+      expect(restoredConsoleErrors).toEqual([]);
+    } finally {
+      await restoredContext.close();
+    }
+    expect(pageErrors).toEqual([]);
+    expect(consoleErrors).toEqual([]);
+  });
+});
+
 test('Similarity-group popup selects every OG match without a focus outline', async ({ page }) => {
   await openApp(page, { waitForPalette: false });
 

--- a/tests/web/linear-record-layout.test.mjs
+++ b/tests/web/linear-record-layout.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { cp, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import test from 'node:test';
 import { pathToFileURL } from 'node:url';
 
 const repoRoot = process.cwd();
@@ -19,12 +20,61 @@ const {
   setLinearRecordRow
 } = await import(pathToFileURL(join(tempRoot, 'linear-record-layout.js')));
 
-const sequences = [{ uid: 'a' }, { uid: 'b' }, { uid: 'c' }];
-const layout = reconcileLinearRecordLayout(sequences, [{ uid: 'a', row: 1 }, { uid: 'b', row: 1 }]);
-assert.deepEqual(layout, [{ uid: 'a', row: 1 }, { uid: 'b', row: 1 }, { uid: 'c', row: 3 }]);
-setLinearRecordRow(layout, 'c', 2);
-assert.deepEqual(linearRecordPositionTokens(sequences, layout), ['#1@1', '#2@1', '#3@2']);
+const freshSequences = () => [{ uid: 'a' }, { uid: 'b' }, { uid: 'c' }];
 
-const moved = moveLinearRecordInRow(sequences, layout, 'b', -1);
-assert.deepEqual(sequences.map((sequence) => sequence.uid), ['b', 'a', 'c']);
-assert.deepEqual(moved.map((entry) => entry.uid), ['b', 'a', 'c']);
+test('shared rows remain UID-keyed while records are added and removed', () => {
+  const sequences = freshSequences();
+  const originalEntries = [{ uid: 'a', row: 1 }, { uid: 'b', row: 1 }];
+  const layout = reconcileLinearRecordLayout(sequences, originalEntries);
+  assert.deepEqual(layout, [
+    { uid: 'a', row: 1 },
+    { uid: 'b', row: 1 },
+    { uid: 'c', row: 3 }
+  ]);
+  assert.deepEqual(originalEntries, [{ uid: 'a', row: 1 }, { uid: 'b', row: 1 }]);
+
+  setLinearRecordRow(layout, 'c', 1);
+  assert.deepEqual(linearRecordPositionTokens(sequences, layout), [
+    '#1@1', '#2@1', '#3@1'
+  ]);
+  const withNewRecord = reconcileLinearRecordLayout(
+    [...sequences, { uid: 'd' }],
+    layout
+  );
+  assert.deepEqual(withNewRecord, [
+    { uid: 'a', row: 1 },
+    { uid: 'b', row: 1 },
+    { uid: 'c', row: 1 },
+    { uid: 'd', row: 4 }
+  ]);
+  assert.deepEqual(
+    reconcileLinearRecordLayout([sequences[0], sequences[2]], withNewRecord),
+    [{ uid: 'a', row: 1 }, { uid: 'c', row: 1 }]
+  );
+});
+
+test('an invalid row preserves only the edited UID row', () => {
+  const layout = [
+    { uid: 'a', row: 1 },
+    { uid: 'b', row: 2 },
+    { uid: 'c', row: 1 }
+  ];
+  setLinearRecordRow(layout, 'b', 0);
+  assert.deepEqual(layout, [
+    { uid: 'a', row: 1 },
+    { uid: 'b', row: 2 },
+    { uid: 'c', row: 1 }
+  ]);
+});
+
+test('moving within a row changes card order without changing membership', () => {
+  const sequences = freshSequences();
+  const layout = sequences.map(({ uid }) => ({ uid, row: 1 }));
+  const moved = moveLinearRecordInRow(sequences, layout, 'b', -1);
+  assert.deepEqual(sequences.map((sequence) => sequence.uid), ['b', 'a', 'c']);
+  assert.deepEqual(moved, [
+    { uid: 'b', row: 1 },
+    { uid: 'a', row: 1 },
+    { uid: 'c', row: 1 }
+  ]);
+});

--- a/tests/web/session-export-validation.test.mjs
+++ b/tests/web/session-export-validation.test.mjs
@@ -38,6 +38,9 @@ const {
 const { buildCanonicalRenderRequest } = await import(
   '../../gbdraw/web/js/services/session-request.js'
 );
+const { resolveLinearComparisonPlan } = await import(
+  '../../gbdraw/web/js/app/linear-comparisons.js'
+);
 const { state } = await import('../../gbdraw/web/js/state.js');
 
 let inputReads = 0;
@@ -198,3 +201,118 @@ assert.ok(inputReads > 0, 'saving must bind the active input file');
 assert.equal(compressionAttempts, 1);
 assert.equal(downloadedBlobs, 1);
 assert.ok(downloadedBlob instanceof Blob);
+
+const linearFile = (name, recordId) => {
+  const text = [
+    `LOCUS       ${recordId.padEnd(16)} 12 bp    DNA     linear`,
+    `DEFINITION  ${recordId}.`,
+    `ACCESSION   ${recordId}`,
+    'ORIGIN',
+    '        1 atgcatgcatgc',
+    '//',
+    ''
+  ].join('\n');
+  const bytes = new TextEncoder().encode(text);
+  return {
+    live: {
+      name,
+      type: 'application/genbank',
+      size: bytes.byteLength,
+      lastModified: 1,
+      async arrayBuffer() { return bytes.buffer.slice(0); }
+    },
+    serialized: {
+      name,
+      type: 'application/genbank',
+      size: bytes.byteLength,
+      lastModified: 1,
+      encoding: 'base64',
+      data: btoa(text)
+    }
+  };
+};
+const linearA = linearFile('record-a.gbk', 'RecordA');
+const linearB = linearFile('record-b.gbk', 'RecordB');
+state.mode.value = 'linear';
+state.lInputType.value = 'gb';
+state.results.value = [];
+state.featureCatalog.value = null;
+state.form.normalize_length = false;
+state.linearSeqs.splice(0, state.linearSeqs.length,
+  {
+    uid: 'record-a',
+    gb: linearA.live,
+    gff: null,
+    fasta: null,
+    depth: null,
+    losat_gencode: 1,
+    definition: '',
+    record_subtitle: '',
+    region_record_id: '',
+    region_start: null,
+    region_end: null,
+    region_reverse: false
+  },
+  {
+    uid: 'record-b',
+    gb: linearB.live,
+    gff: null,
+    fasta: null,
+    depth: null,
+    losat_gencode: 1,
+    definition: '',
+    record_subtitle: '',
+    region_record_id: '',
+    region_start: null,
+    region_end: null,
+    region_reverse: false
+  }
+);
+state.linearRecordLayoutEnabled.value = true;
+state.linearRecordRows.splice(0, state.linearRecordRows.length,
+  { uid: 'record-a', row: 2 },
+  { uid: 'record-b', row: 1 }
+);
+state.linearComparisonPlan.mode = 'none';
+state.linearComparisonPlan.defaultSource = 'losat';
+state.linearComparisonPlan.edges.splice(0, state.linearComparisonPlan.edges.length);
+const linearCommitted = buildCanonicalRenderRequest({
+  state,
+  filesData: {
+    linearSeqs: [
+      { ...state.linearSeqs[0], gb: linearA.serialized },
+      { ...state.linearSeqs[1], gb: linearB.serialized }
+    ],
+    linearComparisons: []
+  },
+  comparisonPlanSnapshot: resolveLinearComparisonPlan({
+    plan: state.linearComparisonPlan,
+    sequences: state.linearSeqs,
+    layout: state.linearRecordRows,
+    losatProgram: state.losatProgram.value,
+    blastpMode: state.losat.blastp.mode
+  })
+});
+adoptCanonicalRenderArtifacts(linearCommitted, { adoptOwnedRequest: true });
+linearCommitted.renderRequest.records.forEach((record) => {
+  record.selector = null;
+  record.region = null;
+});
+linearCommitted.renderRequest.layout.multiRecordPositions = [
+  'RecordB@1',
+  'RecordA@2'
+];
+
+const linearSaved = await exportSession('source-record-id-layout');
+assert.equal(linearSaved.status, 'saved');
+const linearSession = JSON.parse(gunzipSync(
+  Buffer.from(await linearSaved.blob.arrayBuffer())
+).toString('utf8'));
+assert.deepEqual(linearSession.renderRequest.layout.multiRecordPositions, [
+  'RecordB@1',
+  'RecordA@2'
+]);
+assert.deepEqual(linearSession.config.linearRecordLayout.rows, [
+  { uid: 'record-a', row: 2 },
+  { uid: 'record-b', row: 1 }
+]);

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -1933,6 +1933,20 @@ assert.deepEqual(
   ),
   { first: 2, second: 1, third: 1 }
 );
+for (const multiRecordPositions of [null, []]) {
+  const emptyRowsProjection = projectCanonicalSessionRequest({
+    ...reorderedRowsCanonical,
+    renderRequest: {
+      ...reorderedRowsCanonical.renderRequest,
+      layout: {
+        ...reorderedRowsCanonical.renderRequest.layout,
+        multiRecordPositions
+      }
+    }
+  });
+  assert.deepEqual(emptyRowsProjection.config.linearRecordLayout.rows, []);
+  assert.deepEqual(emptyRowsProjection.config.adv.multi_record_positions, []);
+}
 const recordIdRowsCanonical = {
   ...reorderedRowsCanonical,
   renderRequest: {
@@ -1962,6 +1976,146 @@ assert.deepEqual(recordIdRowsProjection.config.adv.multi_record_positions, [
   { selector: 'Record3', row: 1 },
   { selector: 'Record1', row: 2 }
 ]);
+const paddedIndexRowsCanonical = {
+  ...reorderedRowsCanonical,
+  renderRequest: {
+    ...reorderedRowsCanonical.renderRequest,
+    layout: {
+      ...reorderedRowsCanonical.renderRequest.layout,
+      multiRecordPositions: [' #02 @ 1 ', ' #03 @ 1 ', ' #01 @ 2 ']
+    }
+  }
+};
+assert.deepEqual(
+  Object.fromEntries(
+    projectCanonicalSessionRequest(paddedIndexRowsCanonical)
+      .config.linearRecordLayout.rows
+      .map((entry) => [entry.uid, entry.row])
+  ),
+  { first: 2, second: 1, third: 1 }
+);
+const unresolvedRecordIdRowsCanonical = {
+  ...reorderedRowsCanonical,
+  renderRequest: {
+    ...reorderedRowsCanonical.renderRequest,
+    records: reorderedRowsCanonical.renderRequest.records.map((record) => ({
+      ...record,
+      selector: null,
+      region: null
+    })),
+    layout: {
+      ...reorderedRowsCanonical.renderRequest.layout,
+      multiRecordPositions: ['Record2@1', 'Record3@1', 'Record1@2']
+    }
+  }
+};
+const sourceRecordIdRowsCanonical = {
+  ...unresolvedRecordIdRowsCanonical,
+  renderRequest: {
+    ...unresolvedRecordIdRowsCanonical.renderRequest,
+    records: unresolvedRecordIdRowsCanonical.renderRequest.records.map(
+      (record, index) => ({
+        ...record,
+        source: { kind: 'genbank', resourceId: `source-record-${index + 1}` }
+      })
+    )
+  },
+  resources: Object.fromEntries([0, 1, 2].map((index) => {
+    const text = genbankText.replaceAll('WEBTEST', `Record${index + 1}`);
+    return [`source-record-${index + 1}`, {
+      kind: 'genbank',
+      name: `source-record-${index + 1}.gbk`,
+      encoding: 'base64',
+      size: new TextEncoder().encode(text).byteLength,
+      data: btoa(text)
+    }];
+  }))
+};
+assert.throws(
+  () => projectCanonicalSessionRequest(sourceRecordIdRowsCanonical),
+  /selector 'Record2' cannot be mapped to a render record/
+);
+assert.throws(
+  () => projectCanonicalSessionRequest(unresolvedRecordIdRowsCanonical),
+  /selector 'Record2' cannot be mapped to a render record/
+);
+assert.deepEqual(
+  Object.fromEntries(
+    projectCanonicalSessionRequest({
+      ...unresolvedRecordIdRowsCanonical,
+      storedConfig: {
+        linearRecordLayout: {
+          rows: [
+            { uid: 'first', row: 2 },
+            { uid: 'second', row: 1 },
+            { uid: 'third', row: 1 }
+          ]
+        }
+      }
+    }).config.linearRecordLayout.rows.map((entry) => [entry.uid, entry.row])
+  ),
+  { first: 2, second: 1, third: 1 }
+);
+const ambiguousRecordIdRowsCanonical = {
+  ...recordIdRowsCanonical,
+  renderRequest: {
+    ...recordIdRowsCanonical.renderRequest,
+    records: recordIdRowsCanonical.renderRequest.records.map((record, index) => ({
+      ...record,
+      selector: {
+        kind: 'recordId',
+        value: index < 2 ? 'DuplicateRecord' : 'Record3'
+      }
+    })),
+    layout: {
+      ...recordIdRowsCanonical.renderRequest.layout,
+      multiRecordPositions: ['DuplicateRecord@1', 'Record3@1', '#1@2']
+    }
+  }
+};
+assert.throws(
+  () => projectCanonicalSessionRequest(ambiguousRecordIdRowsCanonical),
+  /selector 'DuplicateRecord' matches multiple render records/
+);
+assert.throws(
+  () => projectCanonicalSessionRequest({
+    ...reorderedRowsCanonical,
+    renderRequest: {
+      ...reorderedRowsCanonical.renderRequest,
+      layout: { multiRecordPositions: ['#2@1'] }
+    }
+  }),
+  /must provide exactly 3 entry\(ies\)/
+);
+assert.throws(
+  () => projectCanonicalSessionRequest({
+    ...reorderedRowsCanonical,
+    renderRequest: {
+      ...reorderedRowsCanonical.renderRequest,
+      layout: { multiRecordPositions: ['#1@-2', '#2@1', '#3@1'] }
+    }
+  }),
+  /must use a positive integer row/
+);
+assert.throws(
+  () => projectCanonicalSessionRequest({
+    ...reorderedRowsCanonical,
+    renderRequest: {
+      ...reorderedRowsCanonical.renderRequest,
+      layout: { multiRecordPositions: ['Unknown@1', '#99@1', '#1@2'] }
+    },
+    storedConfig: {
+      linearRecordLayout: {
+        rows: [
+          { uid: 'first', row: 2 },
+          { uid: 'second', row: 1 },
+          { uid: 'third', row: 1 }
+        ]
+      }
+    }
+  }),
+  /selector '#99' is out of range/
+);
 
 state.linearRecordRows.splice(0, state.linearRecordRows.length,
   { uid: 'first', row: 1 }, { uid: 'second', row: 1 }, { uid: 'third', row: 2 });

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -1902,6 +1902,69 @@ assert.deepEqual(arrangedCanonical.renderRequest.layout, {
   recordGapPx: 30,
   multiRecordPositions: ['#1@1', '#2@1', '#3@2']
 });
+assert.equal(arrangedCanonical.renderRequest.records.length, 3);
+assert.equal(new Set(
+  arrangedCanonical.renderRequest.layout.multiRecordPositions.map(
+    (token) => String(token).split('@', 1)[0]
+  )
+).size, 3);
+
+state.linearRecordRows.splice(0, state.linearRecordRows.length,
+  { uid: 'first', row: 2 }, { uid: 'second', row: 1 }, { uid: 'third', row: 1 });
+const reorderedRowsCanonical = buildCanonicalRenderRequest({
+  state,
+  filesData: linearFilesData,
+  comparisonPlanSnapshot: resolveLinearComparisonPlan({
+    plan: createDefaultLinearComparisonPlan(),
+    sequences: linearFilesData.linearSeqs,
+    layout: state.linearRecordRows
+  })
+});
+assert.deepEqual(reorderedRowsCanonical.renderRequest.layout, {
+  recordGapPx: 30,
+  multiRecordPositions: ['#2@1', '#3@1', '#1@2']
+});
+assert.deepEqual(reorderedRowsCanonical.renderRequest.comparisons, []);
+assert.deepEqual(
+  Object.fromEntries(
+    projectCanonicalSessionRequest(reorderedRowsCanonical)
+      .config.linearRecordLayout.rows
+      .map((entry) => [entry.uid, entry.row])
+  ),
+  { first: 2, second: 1, third: 1 }
+);
+const recordIdRowsCanonical = {
+  ...reorderedRowsCanonical,
+  renderRequest: {
+    ...reorderedRowsCanonical.renderRequest,
+    records: reorderedRowsCanonical.renderRequest.records.map((record, index) => ({
+      ...record,
+      selector: { kind: 'recordId', value: `Record${index + 1}` },
+      region: null
+    })),
+    layout: {
+      ...reorderedRowsCanonical.renderRequest.layout,
+      multiRecordPositions: ['Record2@1', 'Record3@1', 'Record1@2']
+    }
+  }
+};
+const recordIdRowsProjection = projectCanonicalSessionRequest(recordIdRowsCanonical);
+assert.deepEqual(
+  Object.fromEntries(
+    recordIdRowsProjection.config.linearRecordLayout.rows.map(
+      (entry) => [entry.uid, entry.row]
+    )
+  ),
+  { first: 2, second: 1, third: 1 }
+);
+assert.deepEqual(recordIdRowsProjection.config.adv.multi_record_positions, [
+  { selector: 'Record2', row: 1 },
+  { selector: 'Record3', row: 1 },
+  { selector: 'Record1', row: 2 }
+]);
+
+state.linearRecordRows.splice(0, state.linearRecordRows.length,
+  { uid: 'first', row: 1 }, { uid: 'second', row: 1 }, { uid: 'third', row: 2 });
 
 state.losatProgram.value = 'blastp';
 state.losat.blastp.mode = 'pairwise';


### PR DESCRIPTION
## Purpose

Restore Linear Arrange in rows authoring and Session continuation. Canonical multi_record_position tokens now follow normalized row order and retain record-card order within each row. Session projection resolves each selector to its sequence UID instead of treating token position as record identity.

The existing row-definition gutter remains separate from biological placements. Regression coverage now proves that definition metadata creates no pseudo-record, consumes no biological column, and does not change sequence scaling.

The guard commit records the pre-correction failure: interleaved rows were emitted as #1@2,#2@1,#3@1 instead of #2@1,#3@1,#1@2.

## Verification

- Guard commit 977577394bfdbcc632727bbce8082ab8725962bf: the focused Node command failed in tests/web/session-request.test.mjs with the token-order mismatch above, while the row-state contract passed.
- Fix commit 2ebf26c8: the same focused Node command passes.
- JavaScript contracts: 72/72 top-level Web Node tests pass; directly affected session, export-validation, and layout owners pass.
- Python contracts: 43/43 focused layout and interface tests pass.
- Linear browser contract: 17/17 tests pass with retries 0, including visible 1,1,1 authoring, Save, fresh Load, and repeated Generate.
- Vibrio browser contract: 1/1 passes with retries 0. It finds 11 biological groups in rows 3,2,2,2,2, no definition pseudo-placement, all 16 expected comparison endpoint pairs, and equivalent Save to fresh Load to Generate semantics.
- Full non-slow Python suite: 2942 passed, 17 skipped, 11 deselected.
- Architecture contracts: 85/85 pass.
- Ruff, python -m build, and git diff --check pass.
- Exact-head Web change budget with the architecture-change profile: PASS, size review CLEAR, zero cycles, no authority or canonical-path violations.
- Functional smoke discovered 99 tests. The parallel local run passed 95; one unrelated SVG child-process launch returned status null under 16-worker contention, and three tests in that serial file did not run. That file passes 4/4 with the repository CI worker count of 1 and retries 0. Exact-head CI is pending.

## Architecture impact

Select exactly one:

- [ ] This is not architecture-bearing. Rationale:
- [x] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior: Linear shared-row request construction and current Session restoration.
- Why this changed-capability scope is complete: The first failing checkpoint was canonical request construction/projection. The correction stays in the request and Session owners; browser row state, Python selector resolution, layout solving, and SVG composition already preserve the required geometry.
- Semantic owners before: gbdraw/web/js/app/linear-record-layout.js owned UID row reconciliation; gbdraw/web/js/services/session-request.js owned request assembly plus a local row default/order projection and token-index Session restoration; gbdraw/web/js/services/config.js orchestrated Session export.
- Semantic owners after: The same three owners remain. session-request.js delegates row normalization and ordering to linear-record-layout.js and maps parsed selectors back to record identity; config.js only supplies the stored configuration needed by that projection.
- Canonical production paths before: Generate to run-analysis.js to session-request.js to local row defaults and card-order tokens. Session projection treated token order as record order before writing UID rows.
- Canonical production paths after: Generate to run-analysis.js to session-request.js to linearRecordPositionTokens(), yielding normalized row/order tokens. Session projection maps selector to record index to sequence UID, using complete persisted UID rows only when a source-only record ID cannot be recovered from the biology resource.
- Compatibility paths before, with stable IDs: LIN-COMPAT-01 supported #n@row and unique-record-ID selectors; LIN-COMPAT-02 persisted the existing Session render request and editable UID rows; LIN-COMPAT-03 kept No comparison, uploaded comparison, and LOSAT independent from row placement.
- Compatibility paths after, with stable IDs: LIN-COMPAT-01, LIN-COMPAT-02, and LIN-COMPAT-03 remain supported with no schema or grammar change. Empty or null positions still project to an empty row list.
- Superseded owner/path removed: The local resolvedLinearRecordRows ordering/default implementation and positional token-index restoration were removed.
- New module classification: None. No module, dependency, state store, parser owner, renderer, or schema was added.
- Persisted-compatibility evidence and removal condition: Existing #n and unique-record-ID Session forms pass projection and fresh-load tests. Source-only record IDs use complete persisted UID rows from the same current Session; incomplete evidence fails explicitly. No temporary compatibility branch or scheduled removal was added.
- Performance/scientific-output evidence, when material: Python geometry and rendering code are unchanged. Focused geometry tests preserve px_per_bp, biological widths, relative X distances, and contiguous columns with and without row labels. Vibrio retains 11 records, five rows, and all expected comparison endpoints.
- Deterministic checker evidence: WEB_ARCHITECTURE_CHANGE=true node tools/check-web-change-budget.mjs --base origin/dev --head HEAD passes on 2ebf26c8 with size review CLEAR, no import cycles, unchanged registered authority, and conforming render-request canonical path and semantic owner.
- Maintainer architecture decision comment permalink, required before merge:

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.
