### PR TITLE
Scope dev staging checks to integrated change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,21 @@ jobs:
 
       - name: Check Web change budget
         env:
-          DEV_PROMOTION_RANGE: ${{ github.ref == 'refs/heads/dev' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+          DEV_INTEGRATED_CHANGE: ${{ github.ref == 'refs/heads/dev' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+          DEV_PUSH_BASE: ${{ github.event_name == 'push' && github.event.before || '' }}
+          DEV_PUSH_HEAD: ${{ github.event_name == 'push' && github.sha || '' }}
           WEB_CHANGE_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
           WEB_CHANGE_HEAD: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
           WEB_ARCHITECTURE_CHANGE: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'architecture-change') }}
         run: |
-          if [[ "$DEV_PROMOTION_RANGE" == "true" ]]; then
-            git fetch origin main
-            BASE_SHA="$(git merge-base origin/main HEAD)"
-            HEAD_SHA="$(git rev-parse HEAD)"
+          if [[ "$DEV_INTEGRATED_CHANGE" == "true" ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+              BASE_SHA="$DEV_PUSH_BASE"
+              HEAD_SHA="$DEV_PUSH_HEAD"
+            else
+              BASE_SHA="$(git rev-parse HEAD^1)"
+              HEAD_SHA="$(git rev-parse HEAD)"
+            fi
             node tools/check-web-change-budget.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
           else
             node tools/check-web-change-budget.mjs

--- a/docs/internal/WEB_CHANGE_POLICY.md
+++ b/docs/internal/WEB_CHANGE_POLICY.md
@@ -40,6 +40,20 @@ The required status names remain `Web change budget` and
 Actions emits one bounded warning annotation when size review is required; the
 step summary contains the complete measurements and reasons.
 
+## CI diff scope
+
+Pull request checks compare the pull request base SHA with its head SHA. A push
+to `dev` checks only the change integrated by that push, from
+`github.event.before` to `github.sha`. A manual `dev` staging run has no push
+payload, so it checks the current merge commit from its first parent to `HEAD`.
+These ranges determine only the change presented to the Web checker. The full
+staging matrix continues to run from the current `dev` checkout.
+
+This scope prevents independently reviewed changes already on `dev` from being
+reclassified as one combined runtime-and-guard change. It does not add a
+promotion exception or alter any blocking rule, threshold, authority source, or
+checker behavior.
+
 ## Guard separation
 
 Except for the pure policy contraction described below, Web runtime files cannot

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -734,7 +734,7 @@ test('normal CI uses dev as the staging push branch', () => {
   assert.equal([...TEST_WORKFLOW.matchAll(/^    if:/gm)].length, 2);
 });
 
-test('dev staging runs check the complete promotion range explicitly', () => {
+test('dev staging Web checks scope only the newly integrated change', () => {
   const step = TEST_WORKFLOW.match(
     /      - name: Check Web change budget\n[\s\S]*?(?=\n      - name: Check Web architecture contracts)/
   )?.[0];
@@ -742,11 +742,21 @@ test('dev staging runs check the complete promotion range explicitly', () => {
 
   assert.match(
     step,
-    /DEV_PROMOTION_RANGE: \$\{\{ github\.ref == 'refs\/heads\/dev' && \(github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'\) \}\}/
+    /DEV_INTEGRATED_CHANGE: \$\{\{ github\.ref == 'refs\/heads\/dev' && \(github\.event_name == 'push' \|\| github\.event_name == 'workflow_dispatch'\) \}\}/
   );
-  assert.match(step, /git fetch origin main/);
-  assert.match(step, /BASE_SHA="\$\(git merge-base origin\/main HEAD\)"/);
+  assert.match(
+    step,
+    /DEV_PUSH_BASE: \$\{\{ github\.event_name == 'push' && github\.event\.before \|\| '' \}\}/
+  );
+  assert.match(
+    step,
+    /DEV_PUSH_HEAD: \$\{\{ github\.event_name == 'push' && github\.sha \|\| '' \}\}/
+  );
+  assert.match(step, /BASE_SHA="\$DEV_PUSH_BASE"/);
+  assert.match(step, /HEAD_SHA="\$DEV_PUSH_HEAD"/);
+  assert.match(step, /BASE_SHA="\$\(git rev-parse HEAD\^1\)"/);
   assert.match(step, /HEAD_SHA="\$\(git rev-parse HEAD\)"/);
+  assert.doesNotMatch(step, /git fetch origin main|git merge-base origin\/main HEAD/);
   assert.match(
     step,
     /node tools\/check-web-change-budget\.mjs --base "\$BASE_SHA" --head "\$HEAD_SHA"/


### PR DESCRIPTION
## Purpose

- Scope the Web change-budget check on a push to `dev` to the newly integrated change while keeping the complete staging matrix on the current `dev` checkout.
- Use `github.event.before` to `github.sha` for a `dev` push and the current merge commit's first parent to `HEAD` for a manual `dev` staging run.
- Preserve ordinary pull-request base/head checking and every blocking checker rule.

The failed post-merge Tests run was [32830257400](https://github.com/satoshikawato/gbdraw/actions/runs/32830257400), Web change budget job [97747113687](https://github.com/satoshikawato/gbdraw/actions/runs/32830257400/job/97747113687), at `dev@3c31eb44564768fd7991034b96353d9b04cc25e6`.

- Old cumulative scope: `34752fe9cd846a805c6a478640f5ae9be1858c1c` to `3c31eb44564768fd7991034b96353d9b04cc25e6`.
- Newly integrated scope for that merge: `101a376ec3add9e7e212fc822001264ee0d59a7b` to `3c31eb44564768fd7991034b96353d9b04cc25e6`.
- This PR scope: `3c31eb44564768fd7991034b96353d9b04cc25e6` to `6db20d0e23547b18bf23f2a961da4c5cbd11a693`.

The old range combined independently merged runtime and guard/checker changes and failed the runtime/guard and checker/authority composition rules. The corrected integrated range passes the unchanged checker with no blocking violations.

All existing dependent staging jobs remain enabled and continue to check out the current commit: Core, Recipes standard, Gallery, Browser, Playwright functional, Playwright performance, supported-version acceptance, Slow, Lint, and LOSAT cache browser acceptance.

## Verification

- Guard-first focused FAIL before the workflow correction: `node --test --test-name-pattern='dev staging Web checks scope only the newly integrated change' tests/web/architecture-contracts.test.mjs` (exit 1).
- Same focused command after the workflow correction: PASS (1/1 file-level test target).
- `node --test tests/web/architecture-contracts.test.mjs`: PASS (85/85).
- `node tools/check-web-change-budget.mjs --base 101a376ec3add9e7e212fc822001264ee0d59a7b --head 3c31eb44564768fd7991034b96353d9b04cc25e6`: PASS, size review CLEAR, no blocking violations.
- `node tools/check-web-change-budget.mjs --base 3c31eb44564768fd7991034b96353d9b04cc25e6 --head 6db20d0e23547b18bf23f2a961da4c5cbd11a693`: PASS, zero production churn, no blocking violations.
- Workflow YAML parse: PASS.
- `git diff --check origin/dev...HEAD`: PASS.
- Diff audit: only `.github/workflows/test.yml`, `tests/web/architecture-contracts.test.mjs`, and `docs/internal/WEB_CHANGE_POLICY.md` changed. `tools/check-web-change-budget.mjs`, all product code, and product behavior are unchanged. No promotion exception was added.

## Architecture impact

Select exactly one:

- [x] This is not architecture-bearing. Rationale: this guard-only change narrows CI diff selection; it does not add, remove, move, duplicate, or redefine a semantic owner, canonical production path, compatibility path, public contract, persisted representation, or product runtime behavior.
- [ ] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior:
- Why this changed-capability scope is complete:
- Semantic owners before:
- Semantic owners after:
- Canonical production paths before:
- Canonical production paths after:
- Compatibility paths before, with stable IDs:
- Compatibility paths after, with stable IDs:
- Superseded owner/path removed:
- New module classification:
- Persisted-compatibility evidence and removal condition:
- Performance/scientific-output evidence, when material:
- Deterministic checker evidence:
- Maintainer architecture decision comment permalink, required before merge:

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.

This PR is intentionally guard-only. No merge was performed; work stops after PR preparation.
