### PR TITLE
Keep custom skew colors across Session Load and Generate

### DIFF
--- a/gbdraw/web/js/app/svg-styles.js
+++ b/gbdraw/web/js/app/svg-styles.js
@@ -20,6 +20,7 @@ import { PAIRWISE_LEGEND_SELECTOR, parseTransformXY } from './legend/utils.js';
 import { serializeCleanSvg } from '../services/svg-serialization.js';
 import { getFeatureOverride } from '../services/feature-override-identity.js';
 import { getGroupsByBaseIds } from '../services/svg-result-normalization.js';
+import { resolveTrackSlotSkewColorValue } from './track-slot-colors.js';
 
 export { getGroupsByBaseIds } from '../services/svg-result-normalization.js';
 
@@ -147,15 +148,39 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions, preview
     );
     if (skewGroups.length > 0) {
       skewGroups.forEach((skewGroup) => {
+        const slotId = String(skewGroup.getAttribute('data-gbdraw-slot-id') || '').trim();
+        const customSlotsEnabled = mode.value === 'circular'
+          ? adv.circular_track_slots_enabled
+          : adv.linear_track_slots_enabled;
+        const slots = mode.value === 'circular'
+          ? adv.circular_track_slots
+          : adv.linear_track_slots;
+        const slot = customSlotsEnabled && Array.isArray(slots)
+          ? slots.find((candidate) => (
+              candidate?.enabled !== false &&
+              candidate?.renderer === 'dinucleotide_skew' &&
+              String(candidate?.id || '').trim() === slotId
+            ))
+          : null;
+        const positiveColor = resolveTrackSlotSkewColorValue({
+          slot,
+          key: 'positive_color',
+          currentColors: colors
+        });
+        const negativeColor = resolveTrackSlotSkewColorValue({
+          slot,
+          key: 'negative_color',
+          currentColors: colors
+        });
         const skewPaths = skewGroup.querySelectorAll('path');
         let pathIndex = 0;
         skewPaths.forEach((path) => {
           const fill = path.getAttribute('fill');
           if (fill && fill !== 'white' && fill !== 'none') {
-            if (pathIndex === 0 && colors.skew_high) {
-              if (setColorAttributeIfChanged(path, 'fill', colors.skew_high)) updatedCount++;
-            } else if (pathIndex === 1 && colors.skew_low) {
-              if (setColorAttributeIfChanged(path, 'fill', colors.skew_low)) updatedCount++;
+            if (pathIndex === 0) {
+              if (setColorAttributeIfChanged(path, 'fill', positiveColor)) updatedCount++;
+            } else if (pathIndex === 1) {
+              if (setColorAttributeIfChanged(path, 'fill', negativeColor)) updatedCount++;
             }
             pathIndex++;
           }

--- a/gbdraw/web/js/app/track-slot-colors.js
+++ b/gbdraw/web/js/app/track-slot-colors.js
@@ -12,7 +12,7 @@ const FINAL_SKEW_COLOR_FALLBACKS = Object.freeze({
 });
 
 const unwrapRef = (value) => {
-  if (value && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, 'value')) {
+  if (value && typeof value === 'object' && 'value' in value) {
     return value.value;
   }
   return value;

--- a/tests/web/contracts/session-custom-skew-colors.playwright.spec.js
+++ b/tests/web/contracts/session-custom-skew-colors.playwright.spec.js
@@ -1,0 +1,326 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { gunzipSync } = require('node:zlib');
+const { openApp } = require('../helpers/app-lifecycle.cjs');
+
+test.describe.configure({ retries: 0 });
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const sourceSessionPath = join(
+  repoRoot,
+  'gbdraw',
+  'web',
+  'gallery',
+  'sessions',
+  'HmmtDNA_ATskew.gbdraw-session.json'
+);
+const sourceSession = JSON.parse(readFileSync(sourceSessionPath, 'utf8'));
+const AT_SLOT_ID = 'a_skew_2';
+const AT_POSITIVE = '#deaf6e';
+const AT_NEGATIVE = '#7294e3';
+
+const expectedAtParams = {
+  nt: 'AT',
+  positive_color: AT_POSITIVE,
+  negative_color: AT_NEGATIVE,
+  legend_label: 'AT skew'
+};
+
+const installRequestObserver = async (page) => {
+  await page.addInitScript(() => {
+    window.__GBDRAW_CUSTOM_SKEW_REQUESTS__ = [];
+    const NativeWorker = window.Worker;
+    window.Worker = new Proxy(NativeWorker, {
+      construct(target, args) {
+        const worker = Reflect.construct(target, args, target);
+        if (!String(args[0] || '').includes('diagram-generation-worker.js')) return worker;
+        const nativePostMessage = worker.postMessage.bind(worker);
+        worker.postMessage = (message, transfer) => {
+          if (message?.type === 'run' && message?.payload?.request) {
+            window.__GBDRAW_CUSTOM_SKEW_REQUESTS__.push(
+              JSON.parse(JSON.stringify(message.payload.request))
+            );
+          }
+          if (transfer === undefined) return nativePostMessage(message);
+          return nativePostMessage(message, transfer);
+        };
+        return worker;
+      }
+    });
+  });
+};
+
+const collectErrors = (page) => {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(`page: ${error.message}`));
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(`console: ${message.text()}`);
+  });
+  return errors;
+};
+
+const loadSessionThroughUi = async (page, sessionPath) => {
+  const chooserPromise = page.waitForEvent('filechooser');
+  await page.getByRole('button', { name: 'Load Session' }).click();
+  const chooser = await chooserPromise;
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 180_000 });
+  await chooser.setFiles(sessionPath);
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+  await expect.poll(() => page.evaluate(() => ({
+    mode: window.__GBDRAW_APP__?.mode,
+    processing: window.__GBDRAW_APP__?.processing,
+    slotIds: (window.__GBDRAW_APP__?.adv?.circular_track_slots || [])
+      .map((slot) => slot.id)
+  })), { timeout: 180_000 }).toEqual({
+    mode: 'circular',
+    processing: false,
+    slotIds: ['features', 'gc_content', 'gc_skew', AT_SLOT_ID, 'ticks']
+  });
+};
+
+const openCustomTrackSlots = async (page) => {
+  const panel = page.locator('#circular-custom-track-slots-panel');
+  if (!await panel.isVisible()) {
+    await page.getByRole('button', { name: 'Custom Track Slots' }).click();
+  }
+  await expect(panel).toBeVisible();
+};
+
+const expectExplicitAtControls = async (page) => {
+  await openCustomTrackSlots(page);
+  const group = page.getByRole('group', { name: `Circular track slot ${AT_SLOT_ID}` });
+  await expect(group).toBeVisible();
+  await expect(group.getByLabel('Track dinucleotide')).toHaveValue('AT');
+  await expect(group.getByLabel('Track legend label')).toHaveValue('AT skew');
+  await expect(group.locator('input[type="color"][title="Positive skew color"]'))
+    .toHaveValue(AT_POSITIVE);
+  await expect(group.locator('input[type="color"][title="Negative skew color"]'))
+    .toHaveValue(AT_NEGATIVE);
+  await expect(group.getByText('Custom +', { exact: true })).toBeVisible();
+  await expect(group.getByText('Custom -', { exact: true })).toBeVisible();
+  return group;
+};
+
+const activeAtParams = (page) => page.evaluate((slotId) => {
+  const slot = window.__GBDRAW_APP__.adv.circular_track_slots
+    .find((candidate) => candidate.id === slotId);
+  return JSON.parse(JSON.stringify(slot?.params || null));
+}, AT_SLOT_ID);
+
+const requestEvidence = (request) => {
+  const slots = request?.diagramOptions?.tracks?.circularTrackSlots || [];
+  const at = slots.find((slot) => slot.id === AT_SLOT_ID);
+  const gc = slots.find((slot) => slot.id === 'gc_skew');
+  return {
+    schema: request?.schema,
+    at: at && {
+      id: at.id,
+      renderer: at.renderer,
+      params: at.params
+    },
+    gc: gc && {
+      id: gc.id,
+      renderer: gc.renderer,
+      params: gc.params
+    }
+  };
+};
+
+const expectRenderedAtColors = (evidence) => {
+  expect(evidence.result).toEqual(evidence.mounted);
+  expect(evidence.result.atFills).toContain(AT_POSITIVE);
+  expect(evidence.result.atFills).toContain(AT_NEGATIVE);
+  expect(evidence.result.gcFills).toContain(evidence.paletteSkew.positive);
+  expect(evidence.result.gcFills).toContain(evidence.paletteSkew.negative);
+  expect(evidence.result.atFills).not.toEqual(evidence.result.gcFills);
+  expect(evidence.result.atLegend).toEqual({
+    positive: AT_POSITIVE,
+    negative: AT_NEGATIVE
+  });
+};
+
+const generateThroughUi = async (page) => {
+  const requestCount = await page.evaluate(() => (
+    window.__GBDRAW_CUSTOM_SKEW_REQUESTS__.length
+  ));
+  await page.getByRole('button', { name: 'Generate Diagram' }).click();
+  await expect.poll(() => page.evaluate((previousCount) => ({
+    processing: window.__GBDRAW_APP__.processing,
+    requestCount: window.__GBDRAW_CUSTOM_SKEW_REQUESTS__.length,
+    error: window.__GBDRAW_APP__.errorLog
+  }), requestCount), { timeout: 300_000 }).toEqual({
+    processing: false,
+    requestCount: requestCount + 1,
+    error: null
+  });
+  return page.evaluate(() => ({
+    request: JSON.parse(JSON.stringify(window.__GBDRAW_CUSTOM_SKEW_REQUESTS__.at(-1))),
+    svg: (() => {
+      const normalizeColor = (value) => String(value || '').trim().toLowerCase();
+      const inspectSvg = (svg) => {
+        if (!svg) throw new Error('Expected an SVG Result.');
+        const trackFills = (slotId) => {
+          const group = svg.querySelector(`[data-gbdraw-slot-id="${CSS.escape(slotId)}"]`);
+          if (!group) throw new Error(`Missing rendered track slot ${slotId}.`);
+          return [...new Set([group, ...group.querySelectorAll('[fill]')]
+            .map((element) => normalizeColor(element.getAttribute('fill')))
+            .filter((value) => value && value !== 'none'))].sort();
+        };
+        const legendFill = (label) => {
+          const text = [...svg.querySelectorAll('text')]
+            .find((element) => String(element.textContent || '').trim() === label);
+          if (!text) throw new Error(`Missing legend label ${label}.`);
+          let group = text.parentElement;
+          while (group && group !== svg) {
+            const fill = [...group.querySelectorAll('[fill]')]
+              .map((element) => normalizeColor(element.getAttribute('fill')))
+              .find((value) => value && value !== 'none');
+            if (fill) return fill;
+            group = group.parentElement;
+          }
+          throw new Error(`Missing legend fill for ${label}.`);
+        };
+        return {
+          atFills: trackFills('a_skew_2'),
+          gcFills: trackFills('gc_skew'),
+          atLegend: {
+            positive: legendFill('AT skew (+)'),
+            negative: legendFill('AT skew (-)')
+          }
+        };
+      };
+      const app = window.__GBDRAW_APP__;
+      const selected = app.results?.[app.selectedResultIndex];
+      const resultSvg = new DOMParser().parseFromString(
+        String(selected?.content || ''),
+        'image/svg+xml'
+      ).documentElement;
+      const mountedSvg = app.svgContainer?.querySelector?.('svg') || null;
+      return {
+        result: inspectSvg(resultSvg),
+        mounted: inspectSvg(mountedSvg),
+        paletteSkew: {
+          positive: normalizeColor(app.currentColors?.skew_high),
+          negative: normalizeColor(app.currentColors?.skew_low)
+        }
+      };
+    })()
+  }));
+};
+
+const changePaletteThroughUi = async (page) => {
+  const colorsPanel = page.locator('details').filter({
+    has: page.locator('summary[aria-label="Colors"]')
+  });
+  if (!await colorsPanel.getAttribute('open')) {
+    await colorsPanel.locator('summary[aria-label="Colors"]').click();
+  }
+  const palette = page.getByLabel('Palette', { exact: true });
+  await expect(palette).toBeVisible();
+  const current = await palette.inputValue();
+  const options = await palette.locator('option').evaluateAll((elements) => (
+    elements.map((element) => element.value)
+  ));
+  const next = options.find((value) => value && value !== current);
+  expect(next).toBeTruthy();
+  await palette.selectOption(next);
+  await expect(palette).toHaveValue(next);
+  return next;
+};
+
+const saveSessionThroughUi = async (page) => {
+  const downloadPromise = page.waitForEvent('download', { timeout: 180_000 });
+  page.once('dialog', (dialog) => dialog.accept('custom-skew-round-trip'));
+  await page.getByRole('button', { name: 'Save Session' }).click();
+  const download = await downloadPromise;
+  const path = await download.path();
+  expect(path).toBeTruthy();
+  const saved = JSON.parse(gunzipSync(readFileSync(path)).toString('utf8'));
+  return { path, saved };
+};
+
+test('explicit AT-skew colors survive schema-5 Load, Generate, Save, fresh Load, and continued Generate', async ({
+  browser,
+  page
+}) => {
+  test.setTimeout(600_000);
+  expect(sourceSession.renderRequest.schema).toBe(5);
+  expect(requestEvidence(sourceSession.renderRequest).at.params).toEqual(expectedAtParams);
+
+  const initialErrors = collectErrors(page);
+  await installRequestObserver(page);
+  await openApp(page);
+  await loadSessionThroughUi(page, sourceSessionPath);
+  await expectExplicitAtControls(page);
+  expect(await activeAtParams(page)).toEqual(expectedAtParams);
+
+  const firstGenerate = await generateThroughUi(page);
+  expect(requestEvidence(firstGenerate.request)).toEqual({
+    schema: 6,
+    at: {
+      id: AT_SLOT_ID,
+      renderer: 'dinucleotide_skew',
+      params: expectedAtParams
+    },
+    gc: {
+      id: 'gc_skew',
+      renderer: 'dinucleotide_skew',
+      params: {}
+    }
+  });
+  expectRenderedAtColors(firstGenerate.svg);
+
+  await changePaletteThroughUi(page);
+  expect(await activeAtParams(page)).toEqual(expectedAtParams);
+  const paletteGenerate = await generateThroughUi(page);
+  expect(requestEvidence(paletteGenerate.request).at.params).toEqual(expectedAtParams);
+  expectRenderedAtColors(paletteGenerate.svg);
+
+  const { path: savedPath, saved } = await saveSessionThroughUi(page);
+  expect(saved.renderRequest.schema).toBe(6);
+  expect(requestEvidence(saved.renderRequest).at.params).toEqual(expectedAtParams);
+  expect(
+    saved.config.adv.circular_track_slots.find((slot) => slot.id === AT_SLOT_ID).params
+  ).toEqual(expectedAtParams);
+
+  const freshContext = await browser.newContext();
+  const freshPage = await freshContext.newPage();
+  const freshErrors = collectErrors(freshPage);
+  await installRequestObserver(freshPage);
+  await openApp(freshPage);
+  await loadSessionThroughUi(freshPage, savedPath);
+  const freshAtGroup = await expectExplicitAtControls(freshPage);
+  expect(await activeAtParams(freshPage)).toEqual(expectedAtParams);
+
+  const freshGenerate = await generateThroughUi(freshPage);
+  expect(requestEvidence(freshGenerate.request).at.params).toEqual(expectedAtParams);
+  expectRenderedAtColors(freshGenerate.svg);
+
+  const continuedGenerate = await generateThroughUi(freshPage);
+  expect(requestEvidence(continuedGenerate.request).at.params).toEqual(expectedAtParams);
+  expectRenderedAtColors(continuedGenerate.svg);
+
+  await freshAtGroup.getByTitle('Inherit positive skew color').click();
+  await expect(freshAtGroup.getByText('Inherited +', { exact: true })).toBeVisible();
+  const inheritedPositive = await freshAtGroup
+    .locator('input[type="color"][title="Positive skew color"]')
+    .inputValue();
+  expect(inheritedPositive).not.toBe(AT_POSITIVE);
+  const clearedParams = await activeAtParams(freshPage);
+  expect(clearedParams).toEqual({
+    nt: 'AT',
+    negative_color: AT_NEGATIVE,
+    legend_label: 'AT skew'
+  });
+  const inheritedGenerate = await generateThroughUi(freshPage);
+  expect(requestEvidence(inheritedGenerate.request).at.params).toEqual(clearedParams);
+  expect(inheritedGenerate.svg.result.atFills).toContain(inheritedPositive);
+  expect(inheritedGenerate.svg.result.atLegend.positive).toBe(inheritedPositive);
+
+  expect(initialErrors).toEqual([]);
+  expect(freshErrors).toEqual([]);
+  await freshContext.close();
+});

--- a/tests/web/track-slot-colors.test.mjs
+++ b/tests/web/track-slot-colors.test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+
+const canvasContext = {
+  _fillStyle: '#000000',
+  get fillStyle() {
+    return this._fillStyle;
+  },
+  set fillStyle(value) {
+    const normalized = String(value || '').toLowerCase();
+    if (/^#[0-9a-f]{6}$/.test(normalized)) this._fillStyle = normalized;
+    if (normalized === 'tomato') this._fillStyle = '#ff6347';
+  }
+};
+globalThis.document = {
+  createElement: () => ({ getContext: () => canvasContext })
+};
+
+const {
+  normalizeColorInputValue,
+  resolveInheritedSkewSlotColor,
+  resolveTrackSlotSkewColorValue
+} = await import('../../gbdraw/web/js/app/track-slot-colors.js');
+
+const vueRefPrototype = {};
+Object.defineProperty(vueRefPrototype, 'value', {
+  get() {
+    return this._value;
+  }
+});
+const vueRef = (value) => Object.assign(Object.create(vueRefPrototype), { _value: value });
+
+const currentColors = vueRef({
+  skew_high: '#112233',
+  skew_low: '#445566'
+});
+const paletteDefinitions = vueRef({
+  ocean: { skew_high: '#abcdef', skew_low: '#fedcba' },
+  default: { skew_high: '#123456', skew_low: '#654321' }
+});
+const selectedPalette = vueRef('ocean');
+const explicitSlot = {
+  params: {
+    positive_color: '#abc',
+    negative_color: 'tomato'
+  }
+};
+const untouchedParams = structuredClone(explicitSlot.params);
+
+assert.equal(normalizeColorInputValue('#abc'), '#aabbcc');
+assert.equal(normalizeColorInputValue('tomato'), '#ff6347');
+assert.equal(normalizeColorInputValue('not-a-color'), null);
+assert.equal(resolveTrackSlotSkewColorValue({
+  slot: explicitSlot,
+  key: 'positive_color',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#aabbcc');
+assert.equal(resolveTrackSlotSkewColorValue({
+  slot: explicitSlot,
+  key: 'negative_color',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#ff6347');
+assert.deepEqual(explicitSlot.params, untouchedParams);
+
+const inheritedSlot = { params: {} };
+assert.equal(resolveTrackSlotSkewColorValue({
+  slot: inheritedSlot,
+  key: 'positive_color',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#112233');
+assert.equal(resolveTrackSlotSkewColorValue({
+  slot: inheritedSlot,
+  key: 'negative_color',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#445566');
+
+delete explicitSlot.params.positive_color;
+assert.equal(resolveTrackSlotSkewColorValue({
+  slot: explicitSlot,
+  key: 'positive_color',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#112233');
+assert.deepEqual(inheritedSlot.params, {});
+
+assert.equal(resolveTrackSlotSkewColorValue({
+  slot: { params: { positive_color: 'not-a-color' } },
+  key: 'positive_color',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#112233');
+assert.equal(resolveInheritedSkewSlotColor({
+  key: 'positive_color',
+  currentColors: vueRef({}),
+  paletteDefinitions,
+  selectedPalette
+}), '#abcdef');
+assert.equal(resolveInheritedSkewSlotColor({
+  key: 'negative_color',
+  currentColors: {},
+  paletteDefinitions: {},
+  selectedPalette: 'missing'
+}), '#ad72e3');
+assert.equal(resolveInheritedSkewSlotColor({
+  key: 'unknown',
+  currentColors,
+  paletteDefinitions,
+  selectedPalette
+}), '#777777');


### PR DESCRIPTION
## Summary

- preserve explicit per-slot skew colors when palette styling is applied to the mounted SVG preview
- reuse the existing track-slot color resolver instead of independently recoloring every skew group
- make inherited-color resolution unwrap Vue refs correctly, including after an explicit color is cleared
- add a retry-free browser contract for schema-5 Load through schema-6 Generate, palette changes, Save, fresh Load, repeated Generate, SVG/legend agreement, and clear-to-inherit behavior

## RESTORE evidence

- Base: `963058f3a43ec285e81726115bac8e0c828c2990`
- Guard commit: `ddab0169`
- Correction commit / head: `d15956a55be92b1c15f54b4a4dcca2eacef61f32`
- Pre-correction: `npx playwright test tests/web/contracts/session-custom-skew-colors.playwright.spec.js --config=playwright.functional.config.js --retries=0` failed because the selected Result contained `#deaf6e/#7294e3` while the mounted `a_skew_2` preview had palette fills `#f6a8f1/#bd96df`.
- Post-correction: the unchanged command passed `1/1`.

## Verification

- `node --test --test-concurrency=1 tests/web/track-slot-colors.test.mjs tests/web/session-request.test.mjs tests/web/gallery-session-migration.test.mjs` — 3 passed
- `python -m pytest tests/test_circular_track_slots.py tests/test_gallery_session_semantics.py -q` — 120 passed
- `npm run test:web:gallery-publication` — 9 passed
- `npm run test:web:functional-smoke` — 100 passed
- top-level Web JavaScript tests — 72 passed
- `python -m pytest tests/ -q -m "not slow"` — 2,953 passed, 17 skipped, 11 deselected
- `node --test tests/web/architecture-contracts.test.mjs` — 85 passed
- `node tools/check-web-change-budget.mjs --base 963058f3a43ec285e81726115bac8e0c828c2990 --head HEAD` — PASS, Size review CLEAR
- `ruff check gbdraw/` — passed
- `git diff --check 963058f3a43ec285e81726115bac8e0c828c2990...HEAD` — passed

## Architecture declaration

- Capability: effective custom skew color resolution in the Web editor and mounted preview.
- Complete scope: custom slot controls resolve displayed colors in `app/track-slot-colors.js`; mounted palette styling consumes that result in `app/svg-styles.js`; request construction and Python rendering were verified correct and are unchanged.
- Semantic owners before: `{app/track-slot-colors.js, app/svg-styles.js independent all-skew palette override}`.
- Semantic owners after: `{app/track-slot-colors.js}`; `app/svg-styles.js` delegates per-slot resolution.
- Canonical production path before: `{active slot -> canonical schema-6 request -> Python SVG; mounted preview -> independent global skew palette override}`.
- Canonical production path after: `{active slot -> canonical schema-6 request -> Python SVG -> mounted preview -> existing slot color resolver}`.
- Compatibility paths before: `{render-request:schema-5-reader}`.
- Compatibility paths after: `{render-request:schema-5-reader}`.
- Superseded path removed: unconditional mounted-preview recoloring of every `dinucleotide_skew` group.
- New production modules, schemas, compatibility readers, dependencies, reactive state, or watchers: none.
- `delta(OE) <= 0`, `delta(PE) <= 0`, `delta(CB) = 0` for the changed capability.

## Assets

The committed HmmtDNA Session and SVG already contain the intended explicit colors and pass Gallery publication parity. No Gallery, Session, SVG, thumbnail, tutorial, reference-output, or other generated artifact was changed.
