### PR TITLE
docs: require exact architecture debt deltas

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,15 +11,45 @@ Select exactly one:
 
 For an architecture-bearing change:
 
-- Capability or behavior:
 - Why this changed-capability scope is complete:
-- Semantic owners before:
-- Semantic owners after:
-- Canonical production paths before:
-- Canonical production paths after:
-- Compatibility paths before, with stable IDs:
-- Compatibility paths after, with stable IDs:
-- Superseded owner/path removed:
+
+Humans must declare the complete changed-scope sets and arithmetic below. Add a
+row for every changed capability, behavior, or compatibility namespace. Use
+`none` for an empty set.
+
+Owner-excess rows (repeat for every changed capability):
+
+| Row ID | Capability | Semantic owners before | O before | T before | OE before | Semantic owners after | O after | T after | OE after | delta(OE) |
+| --- | --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: |
+| OE-1 |  |  |  |  |  |  |  |  |  |  |
+
+Path-excess rows (repeat for every changed behavior):
+
+| Row ID | Behavior | Canonical production paths before | P before | PE before | Canonical production paths after | P after | PE after | delta(PE) |
+| --- | --- | --- | ---: | ---: | --- | ---: | ---: | ---: |
+| PE-1 |  |  |  |  |  |  |  |  |
+
+Compatibility-burden rows (repeat for every changed compatibility namespace):
+
+| Row ID | Namespace | Compatibility path stable IDs before | CB before | Compatibility path stable IDs after | CB after | delta(CB) |
+| --- | --- | --- | ---: | --- | ---: | ---: |
+| CB-1 |  |  |  |  |  |  |
+
+Changed-scope totals:
+
+- `OE before -> OE after; delta(OE) = <integer>`:
+- `PE before -> PE after; delta(PE) = <integer>`:
+- `CB before -> CB after; delta(CB) = <integer>`:
+
+List superseded sets separately:
+
+- Superseded semantic owners:
+- Superseded canonical production paths:
+- Superseded compatibility paths, with stable IDs:
+
+The sets and O, T, and P inputs must reproduce every row and total.
+`<= 0`, `non-positive`, or `yes` alone is insufficient evidence.
+
 - New module classification:
 - Persisted-compatibility evidence and removal condition:
 - Performance/scientific-output evidence, when material:

--- a/docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md
+++ b/docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md
@@ -222,23 +222,75 @@ decision within a file, and an unregistered decision may have no deterministic
 marker. Machine reports must name the observation they actually count, such as
 registered definition locations or observed canonical entry edges.
 
+### Exact changed-scope arithmetic
+
+Humans select the changed capabilities, behaviors, compatibility namespaces,
+and complete before and after sets. Static analysis may provide observations
+for that review, but it cannot infer complete repository-wide `OE`, `PE`, or
+`CB` values.
+
+Declare one owner-excess row for every changed capability. Each row has a stable
+row ID, the semantic owner sets before and after, `O before`, `T before`, `O
+after`, and `T after`. The declared sets and inputs must reproduce:
+
+\[
+OE_{before} = \max(0, O_{before} - T_{before})
+\]
+
+\[
+OE_{after} = \max(0, O_{after} - T_{after})
+\]
+
+\[
+\operatorname{delta}(OE) = OE_{after} - OE_{before}
+\]
+
+Declare one path-excess row for every changed behavior. Each row has a stable
+row ID, the canonical production path sets before and after, `P before`, and `P
+after`. The declared sets and inputs must reproduce `PE before`, `PE after`, and
+`delta(PE)` using the path-excess formula above.
+
+Declare one compatibility-burden row for every changed compatibility namespace.
+Each compatibility path has a stable ID. The before and after ID sets must
+reproduce `CB before`, `CB after`, and `delta(CB) = CB after - CB before`.
+
+Sum every declared row for each component to obtain the exact changed-scope
+totals:
+
+```text
+OE before -> OE after; delta(OE) = OE after - OE before
+PE before -> PE after; delta(PE) = PE after - PE before
+CB before -> CB after; delta(CB) = CB after - CB before
+```
+
+Every displayed value and delta is an integer. Multiple changed capabilities,
+behaviors, or compatibility namespaces require multiple rows; sum those rows
+explicitly. If a component has no changed rows, declare `none` and record `0 ->
+0; delta = 0` for that component.
+
 ## Required author evidence
 
-The pull-request author records concrete before and after sets for every changed
-capability. Each declaration must include:
+The pull-request author records the exact changed-scope rows and totals. Each
+declaration must include:
 
 - the capability or behavior and why the selected scope is complete;
-- semantic owners before and after;
-- canonical production paths before and after;
-- compatibility paths before and after, using stable IDs;
-- every superseded owner or path removed in the same change;
+- semantic owner sets, `O`, `T`, `OE`, and `delta(OE)` before and after for each
+  changed capability;
+- canonical production path sets, `P`, `PE`, and `delta(PE)` before and after for
+  each changed behavior;
+- compatibility path stable-ID sets, `CB`, and `delta(CB)` before and after for
+  each changed compatibility namespace;
+- the exact changed-scope totals obtained by summing all declared rows;
+- superseded semantic owners, canonical production paths, and compatibility
+  paths in three separate lists;
 - the classification of each new module;
 - persisted-compatibility, performance, scientific-output, and deterministic
   checker evidence when applicable.
 
 Use `none` for an empty set. Do not replace these sets with unsupported
-repository-wide totals. The completeness rationale matters because a favorable
-delta over an incomplete capability scope can hide a parallel owner or path.
+repository-wide totals. `<= 0`, `non-positive`, or `yes` alone is insufficient
+evidence. The completeness rationale matters because a favorable delta over an
+incomplete capability scope can hide a parallel owner or path and is invalid.
 
 The declaration is evidence, not approval. The architecture owner reviews the
 exact proposed head as described under [Manual architecture review](#manual-architecture-review).
@@ -280,6 +332,11 @@ AND every superseded owner or path is removed in the same change
 AND the declared changed-capability scope is complete
 ```
 
+These inequalities define acceptance, not the evidence format. The author and
+maintainer must record the exact before value, after value, and integer delta
+for all three components. They must also list the superseded sets instead of
+recording only `yes`.
+
 A new capability may begin with one new semantic owner without increasing owner
 excess. It must also begin with one canonical path.
 
@@ -297,12 +354,18 @@ totals.
 Capability: render request construction
 Owners before:
   {services/session-request.js, app/legacy-request.js}
+O before: 2
+T before: 1
+OE before: 1
 Owners after:
   {services/session-request.js}
+O after: 1
+T after: 1
+OE after: 0
 Superseded owner removed:
   app/legacy-request.js
 Review result:
-  delta(OE) = -1 for this capability
+  OE 1 -> 0; delta(OE) = -1
 ```
 
 Moving an owner can preauthorize the destination in inert authority, but the
@@ -314,12 +377,16 @@ runtime change must remove the old owner when it activates the new one.
 Behavior: Generate reaches render-request construction
 Paths before:
   {app/run-analysis.js -> services/session-request.js}
+P before: 1
+PE before: 0
 Paths after:
   {app/generate.js -> services/session-request.js}
+P after: 1
+PE after: 0
 Superseded path removed:
   app/run-analysis.js -> services/session-request.js
 Review result:
-  delta(PE) = 0 for this behavior
+  PE 0 -> 0; delta(PE) = 0
 ```
 
 The authority may list both edges during a staged move. Source must still have
@@ -331,12 +398,14 @@ exactly one active edge.
 Schema namespace: saved-session
 Compatibility paths before:
   {saved-session:v4-to-v5}
+CB before: 1
 Compatibility paths after:
   none
+CB after: 0
 Removed path:
   saved-session:v4-to-v5
 Review result:
-  delta(CB) = -1 for this namespace
+  CB 1 -> 0; delta(CB) = -1
 ```
 
 A new compatibility ID requires the persisted-format evidence named in the
@@ -657,13 +726,24 @@ head and posts this structured comment manually:
 ```markdown
 Architecture decision: APPROVED
 Reviewed head SHA: <full commit SHA>
-Reviewed capability scope:
-- <capability and stable before/after set references>
-Decision:
-- delta(OE) <= 0
-- delta(PE) <= 0
-- delta(CB) <= 0, or: <persisted-compatibility exception and evidence>
-- superseded owners and paths removed: yes
+Reviewed changed-scope rows:
+- OE row <ID>: owners before <set> -> owners after <set>; O before <integer> -> O after <integer>; T before <integer> -> T after <integer>; OE before <integer> -> OE after <integer>; delta(OE) = <integer>
+- PE row <ID>: paths before <set> -> paths after <set>; P before <integer> -> P after <integer>; PE before <integer> -> PE after <integer>; delta(PE) = <integer>
+- CB row <ID>: stable IDs before <set> -> stable IDs after <set>; CB before <integer> -> CB after <integer>; delta(CB) = <integer>
+Changed-scope totals:
+- OE before <integer> -> OE after <integer>; delta(OE) = <integer>
+- PE before <integer> -> PE after <integer>; delta(PE) = <integer>
+- CB before <integer> -> CB after <integer>; delta(CB) = <integer>
+Superseded semantic owners:
+- <none, or exact set>
+Superseded canonical production paths:
+- <none, or exact set>
+Superseded compatibility paths, with stable IDs:
+- <none, or exact stable-ID set>
+Scope completeness decision:
+- <why the declared changed-scope rows and sets are complete>
+Persisted-compatibility exception:
+- <none, or exact exception and evidence>
 Limitations:
 - <none, or explicit non-authorizing limitation>
 ```

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -724,6 +724,38 @@ test('the PR template retains architecture evidence anchors', () => {
   });
 });
 
+test('the PR template requires exact changed-scope architecture debt arithmetic', () => {
+  [
+    'Owner-excess rows (repeat for every changed capability)',
+    'O before',
+    'T before',
+    'OE before',
+    'O after',
+    'T after',
+    'OE after',
+    'Path-excess rows (repeat for every changed behavior)',
+    'P before',
+    'PE before',
+    'P after',
+    'PE after',
+    'Compatibility-burden rows (repeat for every changed compatibility namespace)',
+    'Compatibility path stable IDs before',
+    'CB before',
+    'Compatibility path stable IDs after',
+    'CB after',
+    'Changed-scope totals',
+    'OE before -> OE after; delta(OE) = <integer>',
+    'PE before -> PE after; delta(PE) = <integer>',
+    'CB before -> CB after; delta(CB) = <integer>',
+    'Superseded semantic owners',
+    'Superseded canonical production paths',
+    'Superseded compatibility paths, with stable IDs',
+    '`<= 0`, `non-positive`, or `yes` alone is insufficient evidence.'
+  ].forEach((anchor) => {
+    assert.ok(PULL_REQUEST_TEMPLATE.includes(anchor), `Missing exact-debt anchor: ${anchor}`);
+  });
+});
+
 test('normal CI uses dev as the staging push branch', () => {
   assert.match(
     TEST_WORKFLOW,


### PR DESCRIPTION
## Purpose

Require architecture-bearing PRs and maintainer decisions to report exact changed-scope OE, PE, and CB before/after values with integer deltas. Human reviewers still declare the complete semantic-owner, canonical-path, and compatibility-path sets; the process does not claim repository-wide static inference.

## Verification

- Base/head: `1ae5447783a77ef53d134de5ad395f819b43d33c` -> `92cd77ff3796675081d9358a762afcc71619bf9f`.
- Focused guard RED (expected, before implementation): after adding only the new exact-debt contract test, it failed against the unchanged base template with `Missing exact-debt anchor: Owner-excess rows (repeat for every changed capability)`.
- Focused guard GREEN: after updating the documentation and template, the same unchanged contract passed (1 passed, 85 skipped).
- Full architecture-contract suite: 86 passed.
- Web policy check against `origin/dev..HEAD`: PASS; size review CLEAR.

## Architecture impact

- [x] This is not architecture-bearing. Rationale: this guard/process-only change edits documentation, the PR template, and its contract test. It does not change product semantic owners, canonical production paths, compatibility paths, architecture authority, or checker semantics.
- [ ] This is architecture-bearing; the evidence below is complete.