### PR TITLE
Fetch full history for trusted promotion checks

### DIFF
--- a/.github/workflows/web-base-policy.yml
+++ b/.github/workflows/web-base-policy.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
@@ -33,7 +33,7 @@ jobs:
       - name: Fetch PR head as Git data
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: git fetch --no-tags --depth=1 origin "$HEAD_SHA"
+        run: git fetch --no-tags origin "$HEAD_SHA"
 
       - name: Check Web policy from trusted base
         env:

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -696,9 +696,10 @@ test('PR workflows separate normal tests from trusted base-policy execution', ()
   assert.match(BASE_POLICY_WORKFLOW, /permissions:\n  contents: read/);
   assert.match(BASE_POLICY_WORKFLOW, /name: Web base policy \(trusted base\)/);
   assert.match(BASE_POLICY_WORKFLOW, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.match(BASE_POLICY_WORKFLOW, /fetch-depth: 0/);
   assert.match(BASE_POLICY_WORKFLOW, /persist-credentials: false/);
   assert.equal([...BASE_POLICY_WORKFLOW.matchAll(/uses: actions\/checkout@/g)].length, 1);
-  assert.match(BASE_POLICY_WORKFLOW, /git fetch --no-tags --depth=1 origin "\$HEAD_SHA"/);
+  assert.match(BASE_POLICY_WORKFLOW, /git fetch --no-tags origin "\$HEAD_SHA"/);
   assert.match(
     BASE_POLICY_WORKFLOW,
     /node tools\/check-web-change-budget\.mjs --base "\$BASE_SHA" --head "\$HEAD_SHA"/


### PR DESCRIPTION
## Purpose

Give the trusted `pull_request_target` Web policy job the complete Git history required by the promotion ancestry check introduced in #379.

The trusted workflow continues to check out the exact base SHA, runs only the checker from that trusted base, uses read-only contents permission, and fetches the candidate head only as Git data. It does not check out or execute candidate code.

This PR is the isolated workflow-activation stage. It does not change checker implementation, policy authority, Web runtime, or rendering behavior.

## Verification

- `node tests/web/architecture-contracts.test.mjs`: 91 pass, 0 fail.
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs`: pass.
- `node --test tests/web/web-promotion-context.test.mjs`: pass.
- `node tools/check-web-change-budget.mjs`: ordinary context, `Result: PASS`; production files changed: none; guard files changed: the trusted workflow and its contract test only.
- `node --check tools/check-web-change-budget.mjs`: pass.
- `git diff --check`: pass.
- Local Node 18 note: the outer `node --test tests/web/architecture-contracts.test.mjs` runner terminated its test-file child after about 10 seconds without an individual assertion failure; direct execution of the same test file completed all 91 assertions successfully. PR CI uses the repository's Node 20 workflow and is the authoritative runner check.

## Architecture impact

Select exactly one:

- [ ] This is not architecture-bearing. Rationale:
- [x] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior: trusted-base Git history acquisition for exact base/head ancestry validation.
- Why this changed-capability scope is complete: `.github/workflows/web-base-policy.yml` remains the only `pull_request_target` owner and continues to invoke the one trusted-base checker. The only behavior change is replacing shallow base/head acquisition with complete history; the contract test fixes this requirement and the no-candidate-execution boundary.
- Semantic owners before: trusted policy execution and Git acquisition `{.github/workflows/web-base-policy.yml}`; ancestry decision `{tools/check-web-change-budget.mjs}`.
- Semantic owners after: trusted policy execution and full-history Git acquisition `{.github/workflows/web-base-policy.yml}`; ancestry decision `{tools/check-web-change-budget.mjs}`.
- Canonical production paths before: `{trusted exact-base checkout at depth 1 -> candidate head fetch at depth 1 as Git data -> trusted checker}`, which cannot prove older `main` ancestry across an aggregate `dev` history.
- Canonical production paths after: `{trusted exact-base checkout with full history -> candidate head fetch without shallow restriction as Git data -> trusted checker}`, which supplies the one ancestry decision owner with the required commit graph.
- Compatibility paths before, with stable IDs: none.
- Compatibility paths after, with stable IDs: none.
- Superseded owner/path removed: the two shallow acquisition settings are removed in the same change; there is no parallel shallow fallback.
- New module classification: none.
- Persisted-compatibility evidence and removal condition: not applicable.
- Performance/scientific-output evidence, when material: not applicable; no Web runtime or scientific output changes.
- Deterministic checker evidence: the workflow contract requires `fetch-depth: 0`, an unshallowed head fetch, one trusted checkout, read-only permission, exact base checkout, and no candidate checkout or execution; all 91 architecture contracts pass.
- Maintainer architecture decision comment permalink, required before merge: pending manual review of exact head `ea3125f5ad6ba6b0eab5f7f57bec8b4482bd151a`.

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.

Changed-scope ratchet: `OE 0 -> 0`, `PE 0 -> 0`, `CB 0 -> 0`.

## Maintainer review packet

Exact head: `ea3125f5ad6ba6b0eab5f7f57bec8b4482bd151a`

Ready-to-post decision after manual review:

```text
Architecture decision: APPROVED
Reviewed head SHA: ea3125f5ad6ba6b0eab5f7f57bec8b4482bd151a
Reviewed capability scope:
- Trusted-base Git history acquisition for exact base/head ancestry validation; the complete before/after owner and path sets are recorded in the PR body.
Decision:
- delta(OE) <= 0
- delta(PE) <= 0
- delta(CB) <= 0
- superseded owners and paths removed: yes
Limitations:
- None. Candidate code remains data-only and is never checked out or executed by the trusted workflow.
```
