### PR TITLE
Allow content-neutral main merge promotions

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -2719,7 +2719,8 @@ test('promotion reports runtime and guard aggregation without weakening ordinary
     const promotion = executePromotion({ execute, root, base, head });
     assert.equal(promotion.status, 0, promotion.output);
     assert.match(promotion.output, /Change context: PROMOTION/);
-    assert.match(promotion.output, /Promotion source ancestry: PASS/);
+    assert.match(promotion.output, /Promotion source coverage: PASS/);
+    assert.match(promotion.output, /Promotion coverage basis: DIRECT_ANCESTRY/);
     assert.match(promotion.output, /Promotion aggregation observations: 1/);
     assert.match(
       promotionReportSection(promotion.output, 'Promotion aggregation observations'),
@@ -2861,7 +2862,75 @@ test('promotion still rejects an invalid architecture registry', () => {
   });
 });
 
-test('promotion fails when dev does not contain the current main head', () => {
+test('promotion accepts a content-neutral main merge commit without a sync PR', () => {
+  withChangeBudgetRepository(({ commit, execute, git, root, write }) => {
+    const common = git(['rev-parse', 'HEAD']).stdout.trim();
+    write('gbdraw/web/js/app/editor.js', 'export const editExistingOwner = () => 2;\n');
+    const promotedDevHead = commit('prior promoted dev head');
+
+    assert.equal(git(['checkout', '--quiet', '--detach', common]).status, 0);
+    assert.equal(
+      git(['merge', '--quiet', '--no-ff', '-m', 'merge prior dev promotion', promotedDevHead]).status,
+      0
+    );
+    const base = git(['rev-parse', 'HEAD']).stdout.trim();
+    assert.equal(git(['merge-base', '--is-ancestor', base, promotedDevHead]).status, 1);
+    assert.equal(
+      git(['rev-parse', `${base}^{tree}`]).stdout.trim(),
+      git(['rev-parse', `${promotedDevHead}^{tree}`]).stdout.trim()
+    );
+
+    assert.equal(git(['checkout', '--quiet', '--detach', promotedDevHead]).status, 0);
+    write('gbdraw/web/js/app/secondary.js', 'export const editSecondaryOwner = () => 2;\n');
+    const head = commit('continue dev after promotion');
+
+    const promotion = executePromotion({ execute, root, base, head });
+    assert.equal(promotion.status, 0, promotion.output);
+    assert.match(promotion.output, /Promotion source coverage: PASS/);
+    assert.match(promotion.output, /Promotion coverage basis: MERGE_PARENT_TREE/);
+    assert.equal(
+      promotionReportSection(promotion.output, 'Blocking violations').trim(),
+      '- None'
+    );
+  });
+});
+
+test('promotion rejects a main merge commit with main-only tree content', () => {
+  withChangeBudgetRepository(({ commit, execute, git, root, write }) => {
+    const common = git(['rev-parse', 'HEAD']).stdout.trim();
+    write('gbdraw/web/js/app/editor.js', 'export const editExistingOwner = () => 2;\n');
+    const promotedDevHead = commit('prior promoted dev head');
+
+    assert.equal(git(['checkout', '--quiet', '--detach', common]).status, 0);
+    assert.equal(
+      git(['merge', '--quiet', '--no-ff', '-m', 'merge prior dev promotion', promotedDevHead]).status,
+      0
+    );
+    write('.github/workflows/test.yml', 'name: main-only resolution\n');
+    assert.equal(git(['add', '.github/workflows/test.yml']).status, 0);
+    assert.equal(git(['commit', '--quiet', '--amend', '--no-edit']).status, 0);
+    const base = git(['rev-parse', 'HEAD']).stdout.trim();
+    assert.notEqual(
+      git(['rev-parse', `${base}^{tree}`]).stdout.trim(),
+      git(['rev-parse', `${promotedDevHead}^{tree}`]).stdout.trim()
+    );
+
+    assert.equal(git(['checkout', '--quiet', '--detach', promotedDevHead]).status, 0);
+    write('gbdraw/web/js/app/secondary.js', 'export const editSecondaryOwner = () => 2;\n');
+    const head = commit('continue dev without main-only content');
+
+    const promotion = executePromotion({ execute, root, base, head });
+    assert.equal(promotion.status, 1, promotion.output);
+    assert.match(promotion.output, /Promotion source coverage: FAIL/);
+    assert.match(promotion.output, /Promotion coverage basis: MAIN_CONTENT_MISSING/);
+    assert.match(
+      promotion.output,
+      /The promotion source does not contain the current main content\. Merge or rebase main into dev, then rerun the promotion\./
+    );
+  });
+});
+
+test('promotion fails when dev does not contain current main content', () => {
   withChangeBudgetRepository(({ commit, execute, git, root, write }) => {
     const common = git(['rev-parse', 'HEAD']).stdout.trim();
     write('gbdraw/web/js/app/editor.js', 'export const editExistingOwner = () => 2;\n');
@@ -2873,10 +2942,11 @@ test('promotion fails when dev does not contain the current main head', () => {
 
     const promotion = executePromotion({ execute, root, base, head });
     assert.equal(promotion.status, 1, promotion.output);
-    assert.match(promotion.output, /Promotion source ancestry: FAIL/);
+    assert.match(promotion.output, /Promotion source coverage: FAIL/);
+    assert.match(promotion.output, /Promotion coverage basis: MAIN_CONTENT_MISSING/);
     assert.match(
       promotion.output,
-      /The promotion source does not contain the current main head\. Merge or rebase main into dev, then rerun the promotion\./
+      /The promotion source does not contain the current main content\. Merge or rebase main into dev, then rerun the promotion\./
     );
   });
 });

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1002,9 +1002,11 @@ const withChangeBudgetRepository = (runCase) => {
         encoding: 'utf8',
         env: {
           ...process.env,
+          GITHUB_ACTIONS: '',
           GITHUB_EVENT_NAME: '',
           GITHUB_EVENT_PATH: '',
           GITHUB_REPOSITORY: '',
+          GITHUB_STEP_SUMMARY: '',
           ...environment
         },
         stdio: ['ignore', 'pipe', 'pipe']

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -67,30 +67,57 @@ const changeContext = classifyWebChangeContext({
   headSha: head
 });
 
-const promotionSourceAncestry = (() => {
-  if (!changeContext.isPromotion) return { status: 'NOT_APPLICABLE', violation: '' };
-  const result = spawnSync(
+const promotionSourceCoverage = (() => {
+  if (!changeContext.isPromotion) {
+    return { status: 'NOT_APPLICABLE', basis: 'NOT_APPLICABLE', violation: '' };
+  }
+  const probeGit = (args) => spawnSync(
     'git',
-    ['-C', repositoryRoot, 'merge-base', '--is-ancestor', base, head],
+    ['-C', repositoryRoot, ...args],
     { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
   );
-  if (result.status === 0) return { status: 'PASS', violation: '' };
-  if (result.status === 1) {
-    return {
-      status: 'FAIL',
-      violation: (
-        'The promotion source does not contain the current main head. '
-        + 'Merge or rebase main into dev, then rerun the promotion.'
-      )
-    };
-  }
-  return {
+  const error = () => ({
     status: 'ERROR',
+    basis: 'UNVERIFIED',
     violation: (
-      'Promotion source ancestry could not be verified. '
+      'Promotion source coverage could not be verified. '
       + 'Fetch complete base and head history, then rerun the promotion.'
     )
-  };
+  });
+  const failure = () => ({
+    status: 'FAIL',
+    basis: 'MAIN_CONTENT_MISSING',
+    violation: (
+      'The promotion source does not contain the current main content. '
+      + 'Merge or rebase main into dev, then rerun the promotion.'
+    )
+  });
+
+  const directAncestry = probeGit(['merge-base', '--is-ancestor', base, head]);
+  if (directAncestry.status === 0) {
+    return { status: 'PASS', basis: 'DIRECT_ANCESTRY', violation: '' };
+  }
+  if (directAncestry.status !== 1) return error();
+
+  const parentResult = probeGit(['rev-list', '--parents', '-n', '1', base]);
+  if (parentResult.status !== 0) return error();
+  const [baseCommit, ...baseParents] = parentResult.stdout.trim().split(/\s+/);
+  if (baseCommit !== base || baseParents.length < 2) return failure();
+
+  const baseTreeResult = probeGit(['rev-parse', `${base}^{tree}`]);
+  if (baseTreeResult.status !== 0) return error();
+  const baseTree = baseTreeResult.stdout.trim();
+  for (const parent of baseParents) {
+    const parentAncestry = probeGit(['merge-base', '--is-ancestor', parent, head]);
+    if (parentAncestry.status !== 0 && parentAncestry.status !== 1) return error();
+    if (parentAncestry.status === 1) continue;
+    const parentTreeResult = probeGit(['rev-parse', `${parent}^{tree}`]);
+    if (parentTreeResult.status !== 0) return error();
+    if (parentTreeResult.stdout.trim() === baseTree) {
+      return { status: 'PASS', basis: 'MERGE_PARENT_TREE', violation: '' };
+    }
+  }
+  return failure();
 })();
 
 const parseDiffLines = (output) => output.trim()
@@ -868,7 +895,7 @@ if (productionNetAdditions > selectedProfile.netAdditions) {
 
 const blockingViolations = [
   ...changeContext.errors,
-  ...(promotionSourceAncestry.violation ? [promotionSourceAncestry.violation] : [])
+  ...(promotionSourceCoverage.violation ? [promotionSourceCoverage.violation] : [])
 ];
 const promotionAggregationObservations = [];
 if (newProductionDependencies.length) {
@@ -1064,7 +1091,8 @@ const report = [
   `- Architecture rule candidate: ${proposedArchitectureRulesSource === null ? 'absent' : `\`${head || 'working tree'}\``}`,
   '- Policy guide: `docs/internal/WEB_CHANGE_POLICY.md`',
   `- Change context: ${changeContext.context}`,
-  `- Promotion source ancestry: ${promotionSourceAncestry.status}`,
+  `- Promotion source coverage: ${promotionSourceCoverage.status}`,
+  `- Promotion coverage basis: ${promotionSourceCoverage.basis}`,
   `- Promotion aggregation observations: ${promotionAggregationObservations.length}`,
   `- Selected profile: ${selectedProfileName}`,
   `- Size-review threshold for production files: ${selectedProfile.productionFiles}`,


### PR DESCRIPTION
## Purpose

Make repeated `dev` to `main` promotions operational without requiring a content-neutral `main` to `dev` synchronization PR after every promotion.

The previous rule required the exact current `main` commit to be an ancestor of `dev`. A normal GitHub merge adds a merge commit only to `main`, even when that merge commit's complete tree is exactly the promoted `dev` tree. The next promotion therefore failed despite `dev` already containing all current `main` content.

The checker now admits a trusted promotion when either:

1. current `main` is a direct ancestor of `dev`; or
2. current `main` is a merge commit, one of its parents is an ancestor of `dev`, and the complete Git tree of current `main` is byte-for-byte identical to that contained parent.

If `main` contains a hotfix, conflict resolution, or any other main-only content, the trees differ and promotion remains blocked with the synchronization remediation. Missing Git history fails closed. Same-repository, exact base/head refs, and exact GitHub event SHA matching are unchanged.

This PR changes only checker implementation and its contract tests. It does not change workflows, authority files, Web runtime, or rendering behavior.

## Verification

- `node tests/web/architecture-contracts.test.mjs`: 96 pass, 0 fail.
- `env GITHUB_ACTIONS=true node tests/web/architecture-contracts.test.mjs`: 96 pass, 0 fail; CI annotations are isolated from checker report assertions.
- The new graph fixtures prove direct ancestry, content-neutral main merge acceptance, main-only merge-tree rejection, and independent main-commit rejection.
- `node --test tests/web/web-promotion-context.test.mjs`: pass.
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs`: pass.
- `node tools/check-web-change-budget.mjs`: ordinary context, production changes none, guard changes checker/test only, result `PASS`, size review `CLEAR`.
- `node --check tools/check-web-change-budget.mjs`: pass.
- `node --check tests/web/architecture-contracts.test.mjs`: pass.
- `git diff --check`: pass.

## Architecture impact

Select exactly one:

- [ ] This is not architecture-bearing. Rationale:
- [x] This is architecture-bearing; the evidence below is complete.

For an architecture-bearing change:

- Capability or behavior: trusted promotion source-content coverage admission for repeated merge-commit promotions.
- Why this changed-capability scope is complete: `tools/check-web-change-budget.mjs` remains the sole Git/file-I/O orchestrator and promotion coverage decision owner. `tools/web-promotion-context.mjs` remains the one pure GitHub-metadata classifier and is unchanged. No workflow or authority owner changes.
- Semantic owners before: promotion metadata classification `{tools/web-promotion-context.mjs}`; direct source-ancestry admission and result `{tools/check-web-change-budget.mjs}`.
- Semantic owners after: promotion metadata classification `{tools/web-promotion-context.mjs}`; direct ancestry or exact merge-parent-tree coverage admission and result `{tools/check-web-change-budget.mjs}`.
- Canonical production paths before: `{strict GitHub classification -> require main commit ancestor of dev -> hard checks -> result}`.
- Canonical production paths after: `{strict GitHub classification -> direct ancestry, else exact merge-parent ancestry plus full-tree equality -> hard checks -> result}`.
- Compatibility paths before, with stable IDs: none.
- Compatibility paths after, with stable IDs: none.
- Superseded owner/path removed: the direct-ancestry-only rejection path is replaced in place. There is no branch-name exception, environment override, or permanent synchronization bypass.
- New module classification: none.
- Persisted-compatibility evidence and removal condition: not applicable.
- Performance/scientific-output evidence, when material: not applicable; no runtime or scientific output change.
- Deterministic checker evidence: 96 integrated architecture contracts, including positive direct and merge-parent-tree cases plus negative main-only merge content and independent main commit cases.
- Maintainer architecture decision comment permalink, required before merge: https://github.com/satoshikawato/gbdraw/pull/383#issuecomment-5421618719 (exact head `fa5f7706a2a5d727ac52bc019e6d2186769aa4da`).

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] Every superseded implementation was removed in this change.
- [x] No accepted deterministic violation was added in this implementation PR.

Changed-scope ratchet: `OE 0 -> 0`, `PE 0 -> 0`, `CB 0 -> 0`.

## Maintainer review packet

Exact head: `fa5f7706a2a5d727ac52bc019e6d2186769aa4da`

Ready-to-post decision after manual review:

```text
Architecture decision: APPROVED
Reviewed head SHA: fa5f7706a2a5d727ac52bc019e6d2186769aa4da
Reviewed capability scope:
- Trusted promotion source-content coverage admission for repeated merge-commit promotions; the complete before/after owner and path sets are recorded in the PR body.
Decision:
- delta(OE) <= 0
- delta(PE) <= 0
- delta(CB) <= 0
- superseded owners and paths removed: yes
Limitations:
- Main-only hotfixes, conflict resolutions, incomplete history, and non-merge divergence remain blocking and require main-to-dev synchronization.
```
