### PR TITLE
docs: clarify maintainer-led contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,121 @@
 # Contributing to gbdraw
 
-Thanks for your interest in improving gbdraw. This guide covers the practical
-steps for reporting a bug, proposing a change, and getting a pull request
-merged.
+Thank you for your interest in gbdraw. gbdraw is a maintainer-led open-source
+project. Use, inspection, bug reports, reproducible examples, research and
+publication use cases, scientific and domain review, testing in additional
+environments, documentation corrections, and focused proposals are welcome.
+
+The maintainer retains final authority over product behavior, scientific and
+technical terminology, architecture, scope, compatibility policy, and
+releases. Bug reports, reproducible examples, and questions about existing
+behavior may be opened directly. Small documentation corrections may also go
+directly to a pull request. Anything larger must begin with an issue and wait
+for explicit agreement on the intended behavior and whether a pull request is
+the appropriate next step.
+
+External pull requests are optional proposals, not the project's default
+development path or an entitlement to merge. An accepted idea may be revised,
+split, independently implemented, or adopted without merging the submitted
+patch. Contributing does not imply roadmap priority, repository access, a
+merge, or maintainer status.
+
+## Most useful contributions
+
+The project particularly values:
+
+- reproducible bug reports;
+- exact commands or Python examples;
+- minimal, shareable inputs that expose an edge case;
+- concrete research or publication workflows;
+- review of scientific terminology and figure semantics;
+- verification on platforms, browsers, and datasets not covered by the
+  maintainer;
+- focused documentation corrections; and
+- small, agreed changes with regression tests.
+
+A feature request is evidence for a product decision. It is not a commitment
+to implement the feature or accept a particular design.
+
+## Governance and decision rights
+
+User reports and external review inform the project, but gbdraw is not governed
+by contributor voting or consensus. The maintainer decides:
+
+- whether a problem belongs within gbdraw's scope;
+- authoritative user-facing behavior;
+- scientific and technical terminology;
+- public API, CLI, session, and file-format contracts;
+- architecture and dependency changes;
+- compatibility and deprecation policy;
+- release contents and timing; and
+- whether a change is maintainable enough to merge.
+
+A technically functioning change may still be declined if it would introduce:
+
+- ambiguous behavior;
+- a parallel implementation path;
+- duplicated semantic ownership;
+- an unjustified compatibility burden;
+- excessive maintenance cost;
+- an unsupported scientific interpretation; or
+- scope drift.
 
 ## Before you start
 
 - Search [existing issues](https://github.com/satoshikawato/gbdraw/issues)
-  and [pull requests](https://github.com/satoshikawato/gbdraw/pulls) first;
-  someone may already be working on the same thing.
-- For a substantial change (a new CLI option, a new track type, a rendering
-  behavior change), open an issue describing the problem before writing code.
-  Small fixes and documentation corrections can go straight to a pull
-  request.
-- Read [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
+  and [pull requests](https://github.com/satoshikawato/gbdraw/pulls) first.
+- Bug reports, reproducible examples, and questions about existing behavior
+  may be opened without prior approval.
+- Small typo, broken-link, and narrowly scoped documentation corrections may
+  go directly to a pull request.
+- Start anything larger with an issue. Do not begin implementation until the
+  maintainer explicitly confirms both the intended behavior and that a pull
+  request is an appropriate next step. Agreement that a problem belongs in
+  gbdraw does not approve a particular design.
+- Obtain prior agreement for changes to rendering geometry, public APIs, CLI
+  options, persisted formats, dependencies, architecture, or feature scope.
+- Unsolicited large features, broad refactors, generated rewrites, and
+  architecture changes may be closed without line-by-line review.
+- Read [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md). It applies to issues,
+  pull requests, and other project interactions.
+
+These boundaries keep reports and evidence easy to share while avoiding
+substantial work on an approach the project cannot maintain.
 
 ## Reporting a bug
 
 Open a [GitHub issue](https://github.com/satoshikawato/gbdraw/issues/new) with:
 
 - the `gbdraw` version (`gbdraw -h` prints it) and installation method
-  (Bioconda, PyPI, or source),
-- the exact command or Python snippet you ran,
-- what you expected versus what happened, and
-- a minimal input file, or a small excerpt from one, when the issue depends
-  on specific input data.
+  (Bioconda, PyPI, or source);
+- the affected interface (Web, CLI, or Python) and diagram mode (Circular or
+  Linear), when relevant;
+- the exact command or Python snippet you ran;
+- what you expected and what happened instead;
+- the operating system or browser for environment-specific failures;
+- whether the problem is reproducible with the current stable release; and
+- a minimal input file or small excerpt, when possible.
+
+Do not upload confidential, restricted, or otherwise non-shareable genomic
+data. A synthetic or redacted input that preserves the failure is welcome.
+
+## Proposing a change
+
+Begin with the user problem rather than a preferred implementation. Describe:
+
+- the affected interface and diagram mode;
+- the current behavior;
+- the expected behavior;
+- a minimal example;
+- why existing options are insufficient;
+- possible effects on existing figures, saved sessions, requests, commands,
+  or Python code;
+- relevant scientific terminology or interpretation; and
+- plausible behavioral alternatives when more than one answer is reasonable.
+
+Substantial implementation must wait for maintainer confirmation. Agreement
+that a problem exists is not approval of a patch. The maintainer may first ask
+for a smaller evidence-producing change or an explicit behavior decision.
 
 ## Development setup
 
@@ -66,9 +157,19 @@ pytest tests/ -v -k "test_circular_basic"
 pytest tests/ -v -m "circular"      # or -m "linear"
 ```
 
-If your change affects the web app, see
-[`gbdraw/web/CLAUDE.md`](./gbdraw/web/CLAUDE.md) for the JavaScript test
-suite and Playwright checks.
+For Web changes, run the focused JavaScript tests and the relevant browser
+scenario. Browser tests that depend on the packaged application require the
+generated browser wheel:
+
+```bash
+node --test tests/web/<focused-test>.test.mjs
+python tools/prepare_browser_wheel.py
+npx playwright test tests/web/<focused-test>.playwright.spec.js
+```
+
+The JavaScript Playwright specifications require Node's `@playwright/test`.
+When only Python Playwright is available, use an equivalent focused browser
+check rather than omitting browser verification.
 
 ## Changing rendered SVG output
 
@@ -89,85 +190,103 @@ git diff -- tests/reference_outputs/
 pytest tests/test_output_comparison.py::TestOutputComparison -v
 ```
 
-Do not update reference outputs to make a failing test pass without first
-confirming the new geometry is correct; the reference files are the
-project's record of intended rendering behavior.
+Do not update reference outputs merely to make a failing test pass. First
+confirm that the new geometry is intentional and correct; the reference files
+record the project's intended rendering behavior.
 
 ## Changing documentation
 
-Public documentation has four routes: [Tutorials](./docs/TUTORIALS/README.md),
+Use [`docs/DOCS.md`](./docs/DOCS.md) as the stable index for
+[Tutorials](./docs/TUTORIALS/README.md),
 [Technical documentation](./docs/REFERENCE/README.md),
-[FAQ](./docs/FAQ.md), and [Gallery](./docs/GALLERY.md). See
-[`docs/DOCS.md`](./docs/DOCS.md) for the index and the
-[current implementation plan](./docs/internal/DOCUMENTATION_SIMPLIFICATION_IMPLEMENTATION_PLAN_2026-08-09.md)
-for the ownership and evidence rules.
+[FAQ](./docs/FAQ.md), and [Gallery](./docs/GALLERY.md).
 
-Use the fewest pages that answer distinct reader questions. Before adding a
-public page, identify the reader question, the existing owner, and whether the
-change should keep, merge, delete, or create a page. A separate GUI, CLI, or
-Python test scenario does not require a separate public page. Technical
-documentation owns exact contracts; FAQ answers choices and troubleshooting by
-linking to those contracts.
+Before adding a page, identify which existing document owns the reader's
+question. A new interface or test scenario does not automatically require a
+new top-level page. Technical documentation owns exact contracts; FAQ pages
+answer choices and troubleshooting by linking to those contracts. Internal
+plans, audits, and executable evidence registries belong under
+`docs/internal/`.
 
 Tutorial commands, public code blocks, and internal evidence scenarios are
-checked against the current CLI, GUI, and Python API:
+checked against the current CLI, Web, and Python interfaces:
 
 ```bash
 pytest tests/ -v -k documentation
 ```
 
-Extend an existing owner before adding a new top-level document. Internal
-plans, audits, and executable evidence registries belong in `docs/internal/`,
-not alongside user-facing pages.
-
 ## Style
 
-- Python: type hints throughout (`from __future__ import annotations`),
-  `snake_case` for functions/modules, `PascalCase` for classes,
+- Python: use type hints throughout (`from __future__ import annotations`),
+  `snake_case` for functions and modules, `PascalCase` for classes,
   `UPPER_SNAKE_CASE` for constants, and the `logging` module for diagnostics
-  (no bare `print`).
-- Prefer extending an existing configurator, drawer, or group module over
-  adding a new parallel code path; see the Architecture section of
-  [`CLAUDE.md`](./CLAUDE.md) for how the CLI, Web UI, and Python API are
-  meant to converge on shared internals.
-- Don't add speculative options, fallbacks, or abstractions for
-  hypothetical future use; keep changes scoped to the problem at hand.
+  instead of bare `print` calls.
+- Extend an existing configurator, drawer, group, or typed boundary instead of
+  adding a parallel path. The CLI, Web, and Python interfaces should converge
+  on shared internals.
+- Do not add speculative options, fallbacks, or abstractions for hypothetical
+  future use. Keep changes within the agreed problem.
+- Architecture-bearing changes must follow the
+  [architecture fitness-function ratchet](./docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md)
+  and remove superseded owners and paths in the same change.
 
 ## Branch roles
 
-- Work-branch base: the latest merged `origin/dev`.
-- Pull-request target: `dev`.
-- Integration branch: `dev`.
-- Release branch: `main`.
+- Approved work starts from the latest merged `dev`.
+- Pull requests target `dev`.
+- `dev` is the integration branch.
+- `main` is the release branch.
+- Promotion from `dev` to `main` is performed by the maintainer.
 
-Agent-authored work branches must start from `origin/dev` without tracking
-`dev` or `main`. Maintainers promote `dev` to `main` through a pull request
-after the integration checks pass. Feature work must not target `main`
-directly.
+For a fork, keep your fork as `origin`, add this repository as `upstream`, and
+create a non-tracking work branch from `upstream/dev`:
+
+```bash
+git remote add upstream https://github.com/satoshikawato/gbdraw.git
+git fetch upstream
+git switch --no-track -c <branch-name> upstream/dev
+```
+
+If this repository is already your `origin`, use:
+
+```bash
+git fetch origin
+git switch --no-track -c <branch-name> origin/dev
+```
 
 ## Submitting a pull request
 
-1. Fetch `origin` and create a non-tracking work branch from `origin/dev`:
+Submit a non-trivial pull request only after its scope has been agreed in the
+corresponding issue. Then:
+
+1. Create a branch from the latest merged `dev` as described above.
+2. Keep the patch limited to the agreed problem. Avoid unrelated cleanup,
+   speculative abstractions, and drive-by refactors.
+3. Add regression tests for the agreed behavior.
+4. Run the relevant local checks, including at minimum:
 
    ```bash
-   git fetch origin
-   git switch --no-track -c <branch-name> origin/dev
+   ruff check gbdraw/
+   pytest tests/ -v -m "not slow"
    ```
 
-2. Make your change with tests that cover it (a bug fix without a
-   regression test is unlikely to be merged).
-3. Run `ruff check gbdraw/` and `pytest tests/ -v -m "not slow"` locally.
-4. Open a pull request against `dev` describing what changed and why.
-   Link the issue it resolves, if any.
-5. Complete exactly one declaration under `Architecture impact` in the pull
-   request template. Architecture-bearing changes must include the concrete
-   before and after sets required by the
+5. Target `dev` and link the agreed issue.
+6. Explain the problem, agreed behavior, implementation boundary, validation,
+   compatibility effects, scientific-output effects, and any intentional
+   rendering changes.
+7. Complete exactly one declaration under `Architecture impact` in the
+   [pull request template](./.github/pull_request_template.md).
+8. For an architecture-bearing change, provide the complete before and after
+   sets and other evidence required by the
    [architecture fitness-function ratchet](./docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md).
-6. For an architecture-bearing change, before merge, record the permalink to
-   the architecture owner's structured decision for the exact final head SHA.
-   The author declaration is evidence, not approval; a later commit requires a
-   new owner decision.
-7. Wait for all required CI checks to pass before merge.
+9. If SVG output changes, review the actual output and the reference diff, and
+   identify every intentional rendering change.
+
+Passing CI is necessary but not sufficient for merge. The maintainer also
+evaluates product behavior, scientific meaning, architecture, compatibility,
+scope, and long-term maintenance cost. A pull request may be narrowed, split,
+substantially revised, or replaced by a separate implementation. A valid
+proposal may be adopted without merging the submitted patch.
 
 By contributing, you agree that your contribution is licensed under the
 project's [MIT License](./LICENSE.txt).


### PR DESCRIPTION
## Purpose

Rewrite CONTRIBUTING.md so gbdraw is clearly presented as a maintainer-led open-source project. The guide now prioritizes reproducible evidence and domain review, requires prior scope agreement for non-trivial implementation, and clarifies that pull requests are proposals rather than guaranteed merges.

## Verification

- git diff --check
- python -m pytest tests/ -v -k documentation --maxfail=1 (73 passed, 2904 deselected)
- verified obsolete internal-plan and Agent-authored references are absent
- verified all local links in CONTRIBUTING.md resolve

## Product behavior semantics

- **Semantics:** NONE
- **PR role:** IMPLEMENTATION
- **Change intent:** NOT_APPLICABLE
- **Basis:** none
- **Rationale:** Documentation policy only; rendering, APIs, CLI behavior, persisted formats, and scientific output are unchanged.

## Architecture impact

- [x] This is not architecture-bearing. Rationale: The change is confined to CONTRIBUTING.md and does not alter any semantic owner, production path, compatibility path, dependency, or public runtime contract.
- [ ] This is architecture-bearing; the evidence below is complete.