### PR TITLE
Add a shadow fast PR gate and true Web smoke coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,6 @@ jobs:
 
   core:
     name: Core (Python ${{ matrix.python-version }})
-    needs: web-change-budget
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -90,9 +89,38 @@ jobs:
         if: always()
         run: git diff --exit-code -- tests/reference_outputs/
 
+  core-pr:
+    name: Core PR (Python 3.11)
+    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install core test dependencies
+        run: python -m pip install -e ".[export]" pytest pytest-timeout pytest-xdist Pillow
+
+      - name: Run core tests
+        run: >-
+          python -m pytest tests/
+          -m "not slow and not (recipe or gallery or browser)"
+          -n auto --dist loadfile
+          --durations=30
+
+      - name: Verify reference outputs are unchanged
+        if: always()
+        run: git diff --exit-code -- tests/reference_outputs/
+
   recipes-standard:
     name: Recipes standard (Python 3.11)
-    needs: web-change-budget
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -117,7 +145,6 @@ jobs:
 
   gallery:
     name: Gallery (Python 3.11)
-    needs: web-change-budget
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -142,7 +169,6 @@ jobs:
 
   browser:
     name: Browser (Python 3.11)
-    needs: web-change-budget
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -192,9 +218,64 @@ jobs:
           -m "slow and browser"
           --durations=30
 
+  web-pr-smoke:
+    name: Web PR smoke
+    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install Web PR smoke dependencies
+        run: |
+          python -m pip install -e ".[dev]"
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Prepare browser wheel
+        run: python tools/prepare_browser_wheel.py
+
+      - name: Run fast Web JavaScript contracts
+        run: >-
+          find tests/web -maxdepth 1 -type f
+          -name '*.test.mjs' ! -name 'architecture-contracts.test.mjs'
+          ! -name 'gallery-session-publication.test.mjs'
+          -print0 | xargs -0 node --test
+
+      - name: Run non-slow Python browser tests
+        run: >-
+          python -m pytest tests/
+          -m "browser and not slow"
+          --durations=30
+
+      - name: Run Playwright PR smoke
+        run: npm run test:web:pr-smoke
+
+      - name: Upload Playwright PR smoke traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-pr-smoke-traces-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   playwright-functional:
     name: Playwright functional
-    needs: web-change-budget
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -224,7 +305,7 @@ jobs:
         run: python tools/prepare_browser_wheel.py
 
       - name: Run Playwright functional tests
-        run: npm run test:web:functional-smoke
+        run: npm run test:web:functional-full
 
       - name: Upload Playwright functional traces
         if: failure()
@@ -237,7 +318,6 @@ jobs:
 
   playwright-performance:
     name: Playwright performance
-    needs: web-change-budget
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -280,7 +360,6 @@ jobs:
 
   acceptance-supported-main:
     name: ${{ matrix.surface }} acceptance (Python ${{ matrix.python-version }})
-    needs: web-change-budget
     if: >-
       (github.event_name == 'pull_request' && github.base_ref == 'main') ||
       (github.event_name == 'push' &&
@@ -329,7 +408,6 @@ jobs:
 
   slow-main:
     name: Slow (Python ${{ matrix.python-version }})
-    needs: web-change-budget
     if: >-
       (github.event_name == 'pull_request' && github.base_ref == 'main') ||
       (github.event_name == 'push' &&
@@ -371,7 +449,6 @@ jobs:
 
   lint:
     name: Lint
-    needs: web-change-budget
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -392,7 +469,6 @@ jobs:
 
   losat-cache-browser-acceptance:
     name: LOSAT cache browser acceptance
-    needs: web-change-budget
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -424,3 +500,29 @@ jobs:
 
       - name: Run LOSAT cache migration browser acceptance
         run: python tests/run_losat_cache_browser_acceptance.py
+
+  pr-gate:
+    name: PR / gate
+    needs:
+      - web-change-budget
+      - core-pr
+      - recipes-standard
+      - gallery
+      - lint
+      - web-pr-smoke
+    if: >-
+      always() &&
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Require all fast PR evidence
+        run: |
+          set -euo pipefail
+          test "${{ needs.web-change-budget.result }}" = "success"
+          test "${{ needs.core-pr.result }}" = "success"
+          test "${{ needs.recipes-standard.result }}" = "success"
+          test "${{ needs.gallery.result }}" = "success"
+          test "${{ needs.lint.result }}" = "success"
+          test "${{ needs.web-pr-smoke.result }}" = "success"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "Playwright test dependencies for the gbdraw web UI.",
   "scripts": {
     "test:playwright": "playwright test",
-    "test:web:functional-smoke": "playwright test --config=playwright.functional.config.js",
+    "test:web:functional-full": "playwright test --config=playwright.functional.config.js",
+    "test:web:pr-smoke": "playwright test --config=playwright.pr-smoke.config.js",
+    "test:web:functional-smoke": "npm run test:web:functional-full",
     "test:web:perf-smoke": "playwright test --config=playwright.perf.config.js",
     "test:web:gallery-publication": "playwright test --config=playwright.gallery-publication.config.js",
     "test:web:vibrio-generate": "playwright test --config=playwright.vibrio.config.js"

--- a/playwright.pr-smoke.config.js
+++ b/playwright.pr-smoke.config.js
@@ -1,0 +1,20 @@
+// @ts-check
+const { defineConfig } = require('@playwright/test');
+const baseConfig = require('./playwright.config.js');
+
+module.exports = defineConfig({
+  ...baseConfig,
+  testIgnore: [
+    /.*performance\.playwright\.spec\.js/,
+    /losat-cache-migration\.playwright\.spec\.js/
+  ],
+  grep: /@pr-smoke/,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+  use: {
+    ...baseConfig.use,
+    trace: 'retain-on-failure'
+  },
+  projects: baseConfig.projects.filter(({ name }) => name === 'chromium')
+});

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -56,6 +56,26 @@ const BASE_POLICY_WORKFLOW = readFileSync(
   join(REPOSITORY_ROOT, '.github/workflows/web-base-policy.yml'),
   'utf8'
 );
+const PACKAGE_SCRIPTS = JSON.parse(readFileSync(
+  join(REPOSITORY_ROOT, 'package.json'),
+  'utf8'
+)).scripts;
+const FUNCTIONAL_PLAYWRIGHT_CONFIG = readFileSync(
+  join(REPOSITORY_ROOT, 'playwright.functional.config.js'),
+  'utf8'
+);
+const PR_SMOKE_PLAYWRIGHT_CONFIG = readFileSync(
+  join(REPOSITORY_ROOT, 'playwright.pr-smoke.config.js'),
+  'utf8'
+);
+const WORKFLOW_SOURCES = readdirSync(
+  join(REPOSITORY_ROOT, '.github/workflows'),
+  { withFileTypes: true }
+).filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+  .map((entry) => readFileSync(
+    join(REPOSITORY_ROOT, '.github/workflows', entry.name),
+    'utf8'
+  ));
 const PULL_REQUEST_TEMPLATE = readFileSync(
   join(REPOSITORY_ROOT, '.github/pull_request_template.md'),
   'utf8'
@@ -87,6 +107,19 @@ const walkJavaScriptFiles = (directory) => readdirSync(directory, { withFileType
     if (entry.isDirectory()) return walkJavaScriptFiles(path);
     return entry.isFile() && entry.name.endsWith('.js') ? [path] : [];
   });
+
+const PLAYWRIGHT_SPEC_SOURCES = walkJavaScriptFiles(
+  join(REPOSITORY_ROOT, 'tests/web')
+).filter((path) => path.endsWith('.playwright.spec.js'))
+  .map((path) => readFileSync(path, 'utf8'));
+
+const workflowJob = (jobId) => {
+  const job = TEST_WORKFLOW.match(
+    new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
+  )?.[0];
+  assert.ok(job, `${jobId} job must exist`);
+  return job;
+};
 
 const productionSources = new Map(
   walkJavaScriptFiles(JAVASCRIPT_ROOT).map((path) => [
@@ -708,6 +741,134 @@ test('PR workflows separate normal tests from trusted base-policy execution', ()
     BASE_POLICY_WORKFLOW,
     /(?:checkout|run):[^\n]*pull_request\.head|ref:.*pull_request\.head|git (?:checkout|switch) /
   );
+  assert.doesNotMatch(BASE_POLICY_WORKFLOW, /Core PR \(Python 3\.11\)|Web PR smoke|PR \/ gate/);
+});
+
+test('PR-to-dev fast candidates and aggregate fail closed over the mandatory evidence', () => {
+  const corePr = workflowJob('core-pr');
+  assert.match(corePr, /\n    name: Core PR \(Python 3\.11\)\n/);
+  assert.match(
+    corePr,
+    /if: github\.event_name == 'pull_request' && github\.base_ref == 'dev'/
+  );
+  assert.match(corePr, /-m "not slow and not \(recipe or gallery or browser\)"/);
+  assert.match(corePr, /git diff --exit-code -- tests\/reference_outputs\//);
+  assert.doesNotMatch(corePr, /matrix:/);
+
+  const webPrSmoke = workflowJob('web-pr-smoke');
+  assert.match(webPrSmoke, /\n    name: Web PR smoke\n/);
+  assert.match(
+    webPrSmoke,
+    /if: github\.event_name == 'pull_request' && github\.base_ref == 'dev'/
+  );
+  assert.match(webPrSmoke, /timeout-minutes: 5/);
+  assert.equal([...webPrSmoke.matchAll(/uses: actions\/checkout@/g)].length, 1);
+  assert.equal([...webPrSmoke.matchAll(/npm ci/g)].length, 1);
+  assert.equal([...webPrSmoke.matchAll(/playwright install --with-deps chromium/g)].length, 1);
+  assert.equal([...webPrSmoke.matchAll(/python tools\/prepare_browser_wheel\.py/g)].length, 1);
+  assert.match(webPrSmoke, /Run fast Web JavaScript contracts/);
+  assert.match(webPrSmoke, /! -name 'gallery-session-publication\.test\.mjs'/);
+  assert.match(webPrSmoke, /-m "browser and not slow"/);
+  assert.match(webPrSmoke, /npm run test:web:pr-smoke/);
+  assert.match(webPrSmoke, /if: failure\(\)[\s\S]+path: test-results\//);
+  assert.doesNotMatch(
+    webPrSmoke,
+    /functional-full|perf-smoke|losat-cache|gallery-publication|Vibrio/
+  );
+
+  const gate = workflowJob('pr-gate');
+  assert.match(gate, /\n    name: PR \/ gate\n/);
+  const dependencies = gate.match(
+    /\n    needs:\n((?:      - [a-z0-9-]+\n)+)/
+  )?.[1].trim().split('\n').map((line) => line.replace('- ', '').trim());
+  assert.deepEqual(dependencies, [
+    'web-change-budget',
+    'core-pr',
+    'recipes-standard',
+    'gallery',
+    'lint',
+    'web-pr-smoke'
+  ]);
+  assert.match(
+    gate,
+    /if: >-\n      always\(\) &&\n      github\.event_name == 'pull_request' &&\n      github\.base_ref == 'dev'/
+  );
+  dependencies.forEach((jobId) => {
+    assert.ok(
+      gate.includes(`test "\${{ needs.${jobId}.result }}" = "success"`),
+      `${jobId} must fail the aggregate unless it succeeds`
+    );
+  });
+  assert.doesNotMatch(gate, /gh api|curl|check-web-change-budget|pull_request_target/);
+});
+
+test('PR smoke selection is explicit while the full functional inventory stays wide', () => {
+  assert.equal(
+    PACKAGE_SCRIPTS['test:web:functional-full'],
+    'playwright test --config=playwright.functional.config.js'
+  );
+  assert.equal(
+    PACKAGE_SCRIPTS['test:web:pr-smoke'],
+    'playwright test --config=playwright.pr-smoke.config.js'
+  );
+  assert.equal(
+    PACKAGE_SCRIPTS['test:web:functional-smoke'],
+    'npm run test:web:functional-full'
+  );
+  assert.doesNotMatch(FUNCTIONAL_PLAYWRIGHT_CONFIG, /\bgrep\s*:/);
+  assert.match(FUNCTIONAL_PLAYWRIGHT_CONFIG, /performance\\\.playwright\\\.spec\\\.js/);
+  assert.match(FUNCTIONAL_PLAYWRIGHT_CONFIG, /losat-cache-migration/);
+
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /grep: \/@pr-smoke\//);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /retries: 0/);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /workers: 1/);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /reporter: 'list'/);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /trace: 'retain-on-failure'/);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /name === 'chromium'/);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /performance\\\.playwright\\\.spec\\\.js/);
+  assert.match(PR_SMOKE_PLAYWRIGHT_CONFIG, /losat-cache-migration/);
+  assert.doesNotMatch(
+    `${PACKAGE_SCRIPTS['test:web:pr-smoke']}\n${PR_SMOKE_PLAYWRIGHT_CONFIG}`,
+    /pass-with-no-tests/
+  );
+
+  const selectedCount = PLAYWRIGHT_SPEC_SOURCES.reduce(
+    (count, source) => count + [...source.matchAll(/tag: ['"]@pr-smoke['"]/g)].length,
+    0
+  );
+  assert.ok(selectedCount >= 6 && selectedCount <= 10, `selected ${selectedCount} smoke tests`);
+});
+
+test('PR 1 preserves legacy check identities and does not add policy owners or mutators', () => {
+  [
+    'Web change budget',
+    'Core (Python ${{ matrix.python-version }})',
+    'Recipes standard (Python 3.11)',
+    'Gallery (Python 3.11)',
+    'Browser (Python 3.11)',
+    'Playwright functional',
+    'Playwright performance',
+    'Lint',
+    'LOSAT cache browser acceptance'
+  ].forEach((displayName) => {
+    assert.ok(TEST_WORKFLOW.includes(`name: ${displayName}`), `Missing legacy job: ${displayName}`);
+  });
+  assert.match(TEST_WORKFLOW, /python-version: \["3\.10", "3\.11", "3\.12"\]/);
+  assert.match(BASE_POLICY_WORKFLOW, /name: Web base policy \(trusted base\)/);
+  assert.doesNotMatch(TEST_WORKFLOW, /needs: web-change-budget/);
+  assert.equal(
+    existsSync(join(REPOSITORY_ROOT, '.github/workflows/dev-staging.yml')),
+    false
+  );
+  assert.equal(
+    existsSync(join(REPOSITORY_ROOT, '.github/workflows/gallery-readiness.yml')),
+    false
+  );
+  assert.doesNotMatch(TEST_WORKFLOW, /dev-staging\.yml|gallery-readiness\.yml/);
+  assert.doesNotMatch(
+    WORKFLOW_SOURCES.join('\n'),
+    /branches\/[^"]+\/protection|required_status_checks|\/rulesets(?:\b|\/)/
+  );
 });
 
 test('the PR template retains architecture evidence anchors', () => {
@@ -764,7 +925,6 @@ test('normal CI uses dev as the staging push branch', () => {
   );
   assert.doesNotMatch(TEST_WORKFLOW, /branches: \[[^\]]*"develop"/);
   assert.match(TEST_WORKFLOW, /\n  workflow_dispatch:\n/);
-  assert.equal([...TEST_WORKFLOW.matchAll(/^    if:/gm)].length, 2);
 });
 
 test('dev staging Web checks scope only the newly integrated change', () => {

--- a/tests/web/contracts/active-result-edit-transaction.playwright.spec.js
+++ b/tests/web/contracts/active-result-edit-transaction.playwright.spec.js
@@ -235,7 +235,7 @@ test.describe('active Result Feature fill transaction', () => {
     expect(await page.evaluate(() => window.__GBDRAW_APP__.errorLog || null)).toBeNull();
   };
 
-  test('visible tRNA fill scope remains coherent through History, Session, Generate, and SVG export', async ({
+  test('visible tRNA fill scope remains coherent through History, Session, Generate, and SVG export', { tag: '@pr-smoke' }, async ({
     page,
     browser
   }, testInfo) => {

--- a/tests/web/contracts/session-custom-skew-colors.playwright.spec.js
+++ b/tests/web/contracts/session-custom-skew-colors.playwright.spec.js
@@ -242,7 +242,7 @@ const saveSessionThroughUi = async (page) => {
   return { path, saved };
 };
 
-test('explicit AT-skew colors survive schema-5 Load, Generate, Save, fresh Load, and continued Generate', async ({
+test('explicit AT-skew colors survive schema-5 Load, Generate, Save, fresh Load, and continued Generate', { tag: '@pr-smoke' }, async ({
   browser,
   page
 }) => {

--- a/tests/web/depth-track-session.playwright.spec.js
+++ b/tests/web/depth-track-session.playwright.spec.js
@@ -19,7 +19,7 @@ const repeatRegionGenbankPath = join(repoRoot, 'tests/test_inputs/NC_001454.1.gb
 const sparseGenbankAPath = join(repoRoot, 'tests/test_inputs/BGC0000708.gbk');
 const sparseGenbankBPath = join(repoRoot, 'tests/test_inputs/BGC0000709.gbk');
 
-test('diagram Worker startup leaves no main-thread Python runtime', async ({ page }) => {
+test('diagram Worker startup leaves no main-thread Python runtime', { tag: '@pr-smoke' }, async ({ page }) => {
   test.setTimeout(180000);
   const genbank = readFileSync(hmmtDnaPath, 'utf8');
   await openApp(page);
@@ -944,7 +944,7 @@ test('Definition line colors preserve raw values and present named, Auto, and No
   expect(result.editedNameRaw).toBe('#00ff00');
 });
 
-test('Invalid Annotation slot is rejected before worker startup and preserves committed state', async ({ page }) => {
+test('Invalid Annotation slot is rejected before worker startup and preserves committed state', { tag: '@pr-smoke' }, async ({ page }) => {
   await page.addInitScript(() => {
     const nativePostMessage = Worker.prototype.postMessage;
     window.__GBDRAW_DIAGRAM_RUN_MESSAGES__ = 0;

--- a/tests/web/export-lazy-loading.playwright.spec.js
+++ b/tests/web/export-lazy-loading.playwright.spec.js
@@ -89,7 +89,7 @@ const expectNoPdfOrInteractiveRequests = (requestCount) => {
   expect(requestCount(STANDALONE_ASSET_PATH)).toBe(0);
 };
 
-test('startup and non-PDF exports do not load PDF or interactive payloads', async ({
+test('startup and non-PDF exports do not load PDF or interactive payloads', { tag: '@pr-smoke' }, async ({
   page
 }) => {
   const requestCount = installRequestCounter(page);

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -669,7 +669,7 @@ test('Normalize Record Lengths rejects a shared Linear row and remains recoverab
   });
 });
 
-test('No comparison completes a real render without touching dormant comparison work', async ({ page }) => {
+test('No comparison completes a real render without touching dormant comparison work', { tag: '@pr-smoke' }, async ({ page }) => {
   test.setTimeout(300000);
   await installDiagramRequestObserver(page);
   await page.addInitScript(() => {

--- a/tests/web/right-drawer.playwright.spec.js
+++ b/tests/web/right-drawer.playwright.spec.js
@@ -60,7 +60,7 @@ test('a remembered unavailable Similarity groups tab reopens as Features', async
   ).toBe('features');
 });
 
-test('individual Feature, Label, and Legend edits update the mounted SVG', async ({
+test('individual Feature, Label, and Legend edits update the mounted SVG', { tag: '@pr-smoke' }, async ({
   page
 }) => {
   const imported = await loadGallerySession(


### PR DESCRIPTION
## Purpose

Add a shadow fast admission path for pull requests targeting `dev` without changing live branch protection. The normal `pull_request` workflow now emits `Core PR (Python 3.11)`, `Web PR smoke`, and a fail-closed `PR / gate`.

User-visible impact: none. Product runtime, Python behavior, scientific output, and reference output bytes are unchanged.

- Start SHA: `efcb3e31b0c31eb7d8dbf1a912bb2f6d08b564e5`
- Head SHA: `e41e764fff2ed6435058baf3484459c3827dd15d`

`PR / gate` requires these candidate-side jobs:

- `Web change budget`
- `Core PR (Python 3.11)`
- `Recipes standard (Python 3.11)`
- `Gallery (Python 3.11)`
- `Lint`
- `Web PR smoke`

`Web base policy (trusted base)` remains independent in `.github/workflows/web-base-policy.yml`.

## Baseline

### Branch protection and check identity

The GitHub API reported classic branch protection on both branches. No repository ruleset was active.

| Branch | Owner | Strict | Required checks and app IDs |
| --- | --- | --- | --- |
| `dev` | Classic branch protection | `true` | `Web change budget`, `Web base policy (trusted base)`, `Core (Python 3.10)`, `Core (Python 3.11)`, `Core (Python 3.12)`, `Recipes standard (Python 3.11)`, `Gallery (Python 3.11)`, `Browser (Python 3.11)`, `Playwright functional`, `Playwright performance`, `Lint`, `LOSAT cache browser acceptance`; all app ID `15368` |
| `main` | Classic branch protection | `false` | The same 12 checks, six supported-version acceptance checks, and `Slow (Python 3.10/3.11/3.12)` use app ID `15368`; `CodeQL` uses app ID `57789` |

Recent successful evidence:

- `dev`: [Web change budget](https://github.com/satoshikawato/gbdraw/actions/runs/32950096664/job/98119351095), [Web base policy (trusted base)](https://github.com/satoshikawato/gbdraw/actions/runs/32950096644/job/98119350787), [Playwright functional](https://github.com/satoshikawato/gbdraw/actions/runs/32950096664/job/98119821188)
- `main`: [Playwright functional](https://github.com/satoshikawato/gbdraw/actions/runs/32954034110/job/98132312474), [CodeQL](https://github.com/satoshikawato/gbdraw/runs/98119336794)

### Workflow graph before this change

`test.yml` triggers on pushes to `main`, `refactoring`, and `dev`; pull requests to `dev` and `main`; and manual dispatch. Pull-request activity types are `opened`, `synchronize`, `reopened`, `labeled`, and `unlabeled`.

| Job ID | Display name | Job condition | Previous `needs` |
| --- | --- | --- | --- |
| `web-change-budget` | `Web change budget` | none | none |
| `core` | `Core (Python ${{ matrix.python-version }})` | none | `web-change-budget` |
| `recipes-standard` | `Recipes standard (Python 3.11)` | none | `web-change-budget` |
| `gallery` | `Gallery (Python 3.11)` | none | `web-change-budget` |
| `browser` | `Browser (Python 3.11)` | none | `web-change-budget` |
| `playwright-functional` | `Playwright functional` | none | `web-change-budget` |
| `playwright-performance` | `Playwright performance` | none | `web-change-budget` |
| `acceptance-supported-main` | `${{ matrix.surface }} acceptance (Python ${{ matrix.python-version }})` | main PR, main/dev push, or dev dispatch | `web-change-budget` |
| `slow-main` | `Slow (Python ${{ matrix.python-version }})` | main PR, main/dev push, or dev dispatch | `web-change-budget` |
| `lint` | `Lint` | none | `web-change-budget` |
| `losat-cache-browser-acceptance` | `LOSAT cache browser acceptance` | none | `web-change-budget` |

The old PR-to-`dev` critical path serialized every leaf behind `Web change budget`. `Browser`, `Playwright functional`, `Playwright performance`, and `LOSAT cache browser acceptance` each repeated Python, Node, browser, and wheel setup where applicable.

### Playwright baseline

The current `origin/dev` command discovered 16 functional spec files and 101 tests. The full config used one CI worker, two retries, and `trace: on-first-retry`.

The recent [hosted functional job](https://github.com/satoshikawato/gbdraw/actions/runs/32950096664/job/98119821188) ran 101 tests with one worker:

| Measurement | Duration |
| --- | ---: |
| Checkout through prepared browser wheel | 1m 15s |
| Functional Playwright step | 9m 13s |
| Whole functional job | 10m 33s |

## Verification

### Commands

| Before | After |
| --- | --- |
| `test:web:functional-smoke` ran the full functional config | `test:web:functional-full` names the full command directly |
| no PR smoke command | `test:web:pr-smoke` selects explicit `@pr-smoke` tags |
| no transition alias | `test:web:functional-smoke` temporarily calls `test:web:functional-full` |
| `Playwright functional` called the misleading command name | `Playwright functional` calls `test:web:functional-full` |

The transition-only alias remains full coverage. It does not point at the PR smoke selection and is scheduled for removal after active callers have moved.

### Smoke selection

The selected tests are unchanged existing journeys. Only `@pr-smoke` metadata was added.

| Existing test | File | Critical boundary represented | Hosted duration |
| --- | --- | --- | ---: |
| `visible tRNA fill scope remains coherent through History, Session, Generate, and SVG export` | `tests/web/contracts/active-result-edit-transaction.playwright.spec.js` | Circular Generate, visible edit, Undo/Redo, session continuity, SVG export | 23.0s |
| `explicit AT-skew colors survive schema-5 Load, Generate, Save, fresh Load, and continued Generate` | `tests/web/contracts/session-custom-skew-colors.playwright.spec.js` | Input load, Generate, save/load continuity, continued Generate | 36.0s |
| `diagram Worker startup leaves no main-thread Python runtime` | `tests/web/depth-track-session.playwright.spec.js` | App boot, browser wheel and Worker readiness, HmmtDNA input, small Circular Generate | 12.7s |
| `Invalid Annotation slot is rejected before worker startup and preserves committed state` | `tests/web/depth-track-session.playwright.spec.js` | Invalid-input recovery and committed-state preservation | 2.7s |
| `startup and non-PDF exports do not load PDF or interactive payloads` | `tests/web/export-lazy-loading.playwright.spec.js` | App boot and SVG/non-PDF export path | 1.4s |
| `No comparison completes a real render without touching dormant comparison work` | `tests/web/linear-multi-record.playwright.spec.js` | Representative synthetic input and small Linear Generate | 14.9s |
| `individual Feature, Label, and Legend edits update the mounted SVG` | `tests/web/right-drawer.playwright.spec.js` | Visible Feature, Label, and Legend edits | 12.0s |

Inventory preservation:

- Full spec files: 16 before, 16 after
- Full tests: 101 before, 101 after
- Deleted tests: 0
- Newly skipped tests: 0
- Smoke tests: 7 in 6 files
- Smoke retries: 0
- Smoke CI workers: 1
- Smoke trace mode: `retain-on-failure`

Local results:

- `npm ci`: passed
- `npx playwright test --config=playwright.pr-smoke.config.js --list`: 7 tests in 6 files
- `npm run test:web:pr-smoke`: 7 passed in 1.0m, retry 0
- `npm run test:web:functional-full -- --list`: 101 tests in 16 files
- Fast Web JavaScript contracts used by `Web PR smoke`: 71 passed in 3.75s
- `python -m pytest tests/ -m "browser and not slow" --durations=30`: 13 passed, 2964 deselected in 37.11s
- `node --test tests/web/architecture-contracts.test.mjs`: 99 passed
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs`: passed
- `node tools/check-web-change-budget.mjs --base origin/dev`: PASS, size review CLEAR, production diff 0
- Workflow YAML parse: 14 jobs
- `git diff --check`: passed
- `actionlint`: not installed locally; no dependency was added

### Combined setup and graph changes

`Web PR smoke` performs checkout, Python 3.11 setup, Node 20 setup, dependency installation, one Chromium installation, and one browser-wheel preparation. The same job then runs fast JavaScript contracts, non-slow Python browser tests, and the seven Playwright smoke tests. Full functional, performance, slow offline packaging, LOSAT acceptance, Vibrio, and Gallery publication checks remain outside this candidate job.

The obsolete `needs: web-change-budget` edge was removed from `core`, `recipes-standard`, `gallery`, `browser`, `playwright-functional`, `playwright-performance`, `acceptance-supported-main`, `slow-main`, `lint`, and `losat-cache-browser-acceptance`. None consumes checker output or needs checker ordering for correctness. No old ordering dependency was retained.

The new `pr-gate` dependency list is intentional: the aggregate must wait for each mandatory fast result and reject every result other than `success`.

### Hosted verification

The first [hosted Tests run](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297) succeeded at head `e41e764fff2ed6435058baf3484459c3827dd15d`. These are single-run measurements, not percentile claims.

| Check | Result | Hosted duration |
| --- | --- | ---: |
| [Web base policy (trusted base)](https://github.com/satoshikawato/gbdraw/actions/runs/32978584499/job/98209294344) | success, still owned by the separate trusted-base workflow | 1m 36s |
| [Web change budget](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296512) | success | 3m 35s |
| [Core PR (Python 3.11)](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296811) | success | 4m 7s |
| [Recipes standard (Python 3.11)](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296701) | success | 3m 6s |
| [Gallery (Python 3.11)](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296279) | success | 5m 4s |
| [Lint](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296728) | success | 37s |
| [Web PR smoke](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296712) | success, 7 passed with retry 0 | 3m 46s |
| [PR / gate](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98211049698) | success after all six mandatory results were successful | 2s; completed 5m 13s after workflow start |
| [Playwright functional](https://github.com/satoshikawato/gbdraw/actions/runs/32978585297/job/98209296751) | success, 101 passed with one worker | 14m 44s |

`Web PR smoke` spent 1m 37s from job setup through its one prepared browser wheel, 4s on fast JavaScript contracts, 13s on non-slow Python browser tests, and 1m 47s on the seven Playwright tests. Playwright reported 7 passed in 1.8m and no retry. The full functional job separately discovered and passed all 101 tests; its Playwright step took 12m 16s.

The independent jobs started at 14:10:02-14:10:04 UTC. `Web change budget` did not complete until 14:13:37 UTC, so the new candidates and legacy leaves demonstrably did not wait for it. All 12 legacy `dev` required contexts were generated and succeeded, including the old full browser, functional, performance, and LOSAT jobs.

The post-run GitHub API read matches the baseline exactly: `dev` remains classic protection with `strict: true` and the same 12 checks at app ID `15368`; `main` remains classic protection with `strict: false`, the same 21 app-ID-`15368` checks, and `CodeQL` at app ID `57789`. The repository ruleset list remains empty. No protection or ruleset mutation was made.

GitHub reports the PR as `MERGEABLE` at this head under the current legacy protection. At the time of the read, `mergeStateStatus` was `UNSTABLE` while the non-required `Gallery browser (Vibrio)` check was still running; every legacy required context was already successful.

### Rollback

Revert commit `e41e764fff2ed6435058baf3484459c3827dd15d`. The legacy required jobs and trusted-base workflow are still present, so rollback does not require a branch-protection change.

## Product behavior semantics

- **Semantics:** `NONE`
- **PR role:** `EVIDENCE_ONLY`
- **Change intent:** `NOT_APPLICABLE`
- **Basis:** `none`
- **Rationale:** The change affects CI scheduling, check aggregation, and test selection only. It does not change reachable product behavior.

Human reviewer comment:

```text
SEMANTIC-DISPOSITION:
  NO_USER_VISIBLE_DIFFERENCE

BASIS:
  CI-only change; production and scientific-output diff is zero.
```

## Architecture impact

Select exactly one:

- [x] This is not architecture-bearing. General CI execution remains owned by `.github/workflows/test.yml`; no second workflow owner was added, and no production semantic owner, canonical production path, or compatibility path changed.
- [ ] This is architecture-bearing; the evidence below is complete.

- New module classification: `playwright.pr-smoke.config.js` is a test-only configuration module that reuses the existing Playwright base config.
- Persisted-compatibility evidence and removal condition: not applicable.
- Performance/scientific-output evidence: product/runtime/scientific-output diff 0; full Playwright inventory remains 101 tests.
- Deterministic checker evidence: Web change budget PASS/CLEAR; architecture contracts 99 passed.
- Maintainer architecture decision comment permalink: not required for this non-architecture-bearing change.

- [x] No second parser, normalizer, state mirror, lifecycle owner, or canonical pipeline was added.
- [x] No superseded production implementation exists in this change.
- [x] No accepted deterministic violation was added.
