### PR TITLE
[verification only] Prove PR gate blocks a fast failure

### DIFF
--- a/tests/test_pr_gate_cutover_probe.py
+++ b/tests/test_pr_gate_cutover_probe.py
@@ -1,0 +1,3 @@
+def test_pr_gate_blocks_a_failed_fast_job() -> None:
+    """Intentional failure for the isolated hosted branch-protection probe."""
+    raise AssertionError("intentional PR / gate cutover probe; do not merge")


### PR DESCRIPTION
## Verification-only pull request — do not merge

This isolated pull request verifies the new `dev` required path after the add-before-remove cutover. It adds one intentionally failing test and does not modify production code or any existing test.

Expected hosted result:

- `Core PR (Python 3.11)` fails on `tests/test_pr_gate_cutover_probe.py`.
- `PR / gate` fails because a mandatory fast dependency did not succeed.
- `Web base policy (trusted base)` remains successful.
- `dev` branch protection blocks merge based on the two required contexts.

The pull request will be closed after the evidence is captured. It must never be merged.

## Purpose

Prove that a deliberate fast-job failure blocks `PR / gate` after the required-check cutover.

## Verification

Hosted evidence only; local failure is intentional.

## Product behavior semantics

- **Semantics:** `NONE`
- **PR role:** `EVIDENCE_ONLY`
- **Change intent:** `NOT_APPLICABLE`
- **Basis:** `none`
- **Rationale:** No production behavior changes.

## Architecture impact

- [x] This is not architecture-bearing. Rationale: isolated failing-test evidence only.
- [ ] This is architecture-bearing; the evidence below is complete.
