### PR TITLE
Add trusted exact-SHA promotion evidence verification

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1003,6 +1003,14 @@ const WEB_PROMOTION_CONTEXT_MODULE = join(
   REPOSITORY_ROOT,
   'tools/web-promotion-context.mjs'
 );
+const PROMOTION_READINESS_HELPER = join(
+  REPOSITORY_ROOT,
+  'tools/check-promotion-readiness.mjs'
+);
+const PROMOTION_READINESS_TEST = join(
+  REPOSITORY_ROOT,
+  'tests/web/promotion-readiness.test.mjs'
+);
 const BUDGET_POLICY = Object.freeze({
   allowedPrivilegedImporters: {
     'services/diagram-generation.js': ['app/editor.js', 'app/run-analysis.js'],
@@ -1047,11 +1055,21 @@ const budgetLineSource = (changedLines = 0, appendedLines = 0) => [
   )
 ].join('\n') + '\n';
 const BUDGET_FIXTURE = Object.freeze({
+  '.github/workflows/deploy_web.yml': 'name: baseline deploy\n',
+  '.github/workflows/gallery-publication.yml': 'name: baseline gallery\n',
   '.github/workflows/test.yml': 'name: baseline\n',
   '.github/workflows/web-base-policy.yml': 'name: baseline policy\n',
   'docs/internal/WEB_CHANGE_POLICY.md': '# Baseline Web change policy\n',
   'package.json': '{"private":true}\n',
   'tests/web/architecture-contracts.test.mjs': '// baseline contract\n',
+  'tests/web/promotion-readiness.test.mjs': readFileSync(
+    PROMOTION_READINESS_TEST,
+    'utf8'
+  ),
+  'tools/check-promotion-readiness.mjs': readFileSync(
+    PROMOTION_READINESS_HELPER,
+    'utf8'
+  ),
   'tools/check-web-change-budget.mjs': readFileSync(CHANGE_BUDGET_CHECKER, 'utf8'),
   'tools/web-architecture-detectors.mjs': readFileSync(
     WEB_ARCHITECTURE_DETECTOR_MODULE,
@@ -2199,10 +2217,13 @@ test('checker implementation and authority files cannot change together', () => 
     'tools/web-change-source.mjs',
     'tools/web-architecture-detectors.mjs',
     'tools/web-architecture-evaluation.mjs',
-    'tools/web-promotion-context.mjs'
+    'tools/web-promotion-context.mjs',
+    'tools/check-promotion-readiness.mjs'
   ];
   const authorityPaths = [
     'tools/web-change-policy.json',
+    '.github/workflows/gallery-publication.yml',
+    '.github/workflows/deploy_web.yml',
     '.github/workflows/test.yml',
     '.github/workflows/web-base-policy.yml'
   ];
@@ -2228,7 +2249,8 @@ test('all checker implementations are separated from reserved future authority',
     'tools/web-change-source.mjs',
     'tools/web-architecture-detectors.mjs',
     'tools/web-architecture-evaluation.mjs',
-    'tools/web-promotion-context.mjs'
+    'tools/web-promotion-context.mjs',
+    'tools/check-promotion-readiness.mjs'
   ];
 
   implementationPaths.forEach((implementationPath) => {
@@ -2244,6 +2266,27 @@ test('all checker implementations are separated from reserved future authority',
       }, [/Web checker\/source parser and authority policy\/workflow files changed together/]);
     });
   });
+});
+
+test('promotion helper stays checker-only while evidence workflows stay authority-only', () => {
+  const helperOnly = runChangeBudgetCase((write) => {
+    write(
+      'tools/check-promotion-readiness.mjs',
+      `${BUDGET_FIXTURE['tools/check-promotion-readiness.mjs']}\n// helper changed\n`
+    );
+  });
+  assert.equal(helperOnly.status, 0, helperOnly.output);
+
+  for (const workflowPath of [
+    '.github/workflows/gallery-publication.yml',
+    '.github/workflows/deploy_web.yml'
+  ]) {
+    const workflowOnly = runChangeBudgetCase((write) => {
+      write(workflowPath, `${BUDGET_FIXTURE[workflowPath]}# workflow changed\n`);
+    });
+    assert.equal(workflowOnly.status, 0, workflowOnly.output);
+    assert.match(workflowOnly.output, new RegExp(workflowPath.replaceAll('.', '\\.')));
+  }
 });
 
 test('evaluator fixtures stay implementation-only while active rule authority stays isolated', () => {
@@ -2565,9 +2608,13 @@ test('runtime plus a semantically unchanged policy remains separated', () => {
 test('runtime plus policy contraction rejects every additional guard change', () => {
   const guardCases = [
     ['checker', 'tools/check-web-change-budget.mjs'],
+    ['promotion helper', 'tools/check-promotion-readiness.mjs'],
     ['architecture detectors', 'tools/web-architecture-detectors.mjs'],
     ['source parser', 'tools/web-change-source.mjs'],
     ['architecture contracts', 'tests/web/architecture-contracts.test.mjs'],
+    ['promotion readiness tests', 'tests/web/promotion-readiness.test.mjs'],
+    ['Gallery workflow', '.github/workflows/gallery-publication.yml'],
+    ['deploy workflow', '.github/workflows/deploy_web.yml'],
     ['normal workflow', '.github/workflows/test.yml'],
     ['trusted-base workflow', '.github/workflows/web-base-policy.yml'],
     ['policy documentation', 'docs/internal/WEB_CHANGE_POLICY.md']

--- a/tests/web/promotion-readiness.test.mjs
+++ b/tests/web/promotion-readiness.test.mjs
@@ -1,0 +1,580 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PromotionReadinessError,
+  runPromotionReadinessCli,
+  verifyPromotionResultTree,
+  verifyWorkflowEvidence
+} from '../../tools/check-promotion-readiness.mjs';
+
+const API_ORIGIN = 'https://api.github.com';
+const REPOSITORY = 'satoshikawato/gbdraw';
+const REPOSITORY_API_PATH = '/repos/satoshikawato/gbdraw';
+const HEAD_SHA = '2'.repeat(40);
+const BASE_SHA = '1'.repeat(40);
+const HEAD_TREE_SHA = '3'.repeat(40);
+const OTHER_TREE_SHA = '4'.repeat(40);
+const TEST_WORKFLOW_PATH = '.github/workflows/test.yml';
+const TEST_AGGREGATE = 'Dev staging / gate';
+const GALLERY_WORKFLOW_PATH = '.github/workflows/gallery-publication.yml';
+const GALLERY_AGGREGATE = 'Gallery readiness / gate';
+
+const workflowFixture = ({ path = TEST_WORKFLOW_PATH, id = 501, state = 'active' } = {}) => ({
+  id,
+  path,
+  state,
+  url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/workflows/${id}`
+});
+
+const runFixture = (overrides = {}) => {
+  const id = overrides.id ?? 701;
+  return {
+    id,
+    run_number: 41,
+    run_attempt: 1,
+    workflow_id: 501,
+    path: TEST_WORKFLOW_PATH,
+    event: 'push',
+    head_branch: 'dev',
+    head_sha: HEAD_SHA,
+    repository: { full_name: REPOSITORY },
+    status: 'completed',
+    conclusion: 'success',
+    url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/runs/${id}`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/${id}`,
+    created_at: '2026-08-27T10:00:00Z',
+    updated_at: '2026-08-27T10:10:00Z',
+    ...overrides
+  };
+};
+
+const jobFixture = (overrides = {}) => {
+  const id = overrides.id ?? 801;
+  const runId = overrides.run_id ?? 701;
+  return {
+    id,
+    run_id: runId,
+    head_sha: HEAD_SHA,
+    name: TEST_AGGREGATE,
+    status: 'completed',
+    conclusion: 'success',
+    url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/jobs/${id}`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/${runId}/job/${id}`,
+    ...overrides
+  };
+};
+
+const response = (body, { status = 200, link = null } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: { get: (name) => name.toLowerCase() === 'link' ? link : null },
+  json: async () => body
+});
+
+const nextLink = (source, page) => {
+  const url = new URL(source);
+  url.searchParams.set('page', String(page));
+  return `<${url}>; rel="next"`;
+};
+
+const createFetch = ({
+  workflow = workflowFixture(),
+  workflowStatus = 200,
+  runPages = [[runFixture()]],
+  runTotalCount = runPages.reduce((count, page) => count + page.length, 0),
+  runLinks = [],
+  currentRuns = [runFixture()],
+  jobPages = [[jobFixture()]],
+  jobTotalCount = jobPages.reduce((count, page) => count + page.length, 0),
+  jobLinks = []
+} = {}) => {
+  const calls = [];
+  let currentRunIndex = 0;
+  const fetchImpl = async (source, options) => {
+    const url = new URL(source);
+    calls.push({ url: url.toString(), options });
+    assert.equal(options.headers.Authorization, 'Bearer fixture-token');
+
+    if (/\/actions\/workflows\/[^/]+$/.test(url.pathname)) {
+      return response(
+        workflowStatus === 200 ? workflow : { message: 'Not Found' },
+        { status: workflowStatus }
+      );
+    }
+    if (/\/actions\/workflows\/\d+\/runs$/.test(url.pathname)) {
+      const page = Number(url.searchParams.get('page') || 1);
+      const link = Object.hasOwn(runLinks, page - 1)
+        ? runLinks[page - 1]
+        : page < runPages.length ? nextLink(url, page + 1) : null;
+      return response({
+        total_count: runTotalCount,
+        workflow_runs: runPages[page - 1] ?? []
+      }, { link });
+    }
+    if (/\/actions\/runs\/\d+\/attempts\/\d+\/jobs$/.test(url.pathname)) {
+      const page = Number(url.searchParams.get('page') || 1);
+      const link = Object.hasOwn(jobLinks, page - 1)
+        ? jobLinks[page - 1]
+        : page < jobPages.length ? nextLink(url, page + 1) : null;
+      return response({
+        total_count: jobTotalCount,
+        jobs: jobPages[page - 1] ?? []
+      }, { link });
+    }
+    if (/\/actions\/runs\/\d+$/.test(url.pathname)) {
+      const snapshot = currentRuns[Math.min(currentRunIndex, currentRuns.length - 1)];
+      currentRunIndex += 1;
+      return response(snapshot);
+    }
+    assert.fail(`Unexpected GitHub API request: ${url}`);
+  };
+  fetchImpl.calls = calls;
+  return fetchImpl;
+};
+
+const verify = (overrides = {}) => verifyWorkflowEvidence({
+  repository: REPOSITORY,
+  workflowPath: TEST_WORKFLOW_PATH,
+  expectedEvent: 'push',
+  expectedBranch: 'dev',
+  expectedHeadSha: HEAD_SHA,
+  expectedAggregateName: TEST_AGGREGATE,
+  token: 'fixture-token',
+  fetchImpl: createFetch(),
+  ...overrides
+});
+
+const rejectsWith = async (promise, code, reason) => assert.rejects(promise, (error) => {
+  assert.ok(error instanceof PromotionReadinessError);
+  assert.equal(error.code, code);
+  assert.match(error.message, reason);
+  assert.ok(Number.isFinite(JSON.stringify(error.observed).length));
+  return true;
+});
+
+test('exact Tests and Gallery workflow evidence succeeds with auditable output', async () => {
+  const cases = [
+    [TEST_WORKFLOW_PATH, TEST_AGGREGATE, 501, 701, 801],
+    [GALLERY_WORKFLOW_PATH, GALLERY_AGGREGATE, 502, 702, 802]
+  ];
+  for (const [workflowPath, aggregateName, workflowId, runId, jobId] of cases) {
+    const workflow = workflowFixture({ path: workflowPath, id: workflowId });
+    const run = runFixture({
+      id: runId,
+      workflow_id: workflowId,
+      path: workflowPath,
+      url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/runs/${runId}`,
+      html_url: `https://github.com/${REPOSITORY}/actions/runs/${runId}`
+    });
+    const job = jobFixture({
+      id: jobId,
+      run_id: runId,
+      name: aggregateName,
+      url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/jobs/${jobId}`,
+      html_url: `https://github.com/${REPOSITORY}/actions/runs/${runId}/job/${jobId}`
+    });
+    const fetchImpl = createFetch({
+      workflow,
+      runPages: [[run]],
+      currentRuns: [run],
+      jobPages: [[job]]
+    });
+    const evidence = await verify({
+      workflowPath,
+      expectedAggregateName: aggregateName,
+      fetchImpl
+    });
+    assert.equal(evidence.repository, REPOSITORY);
+    assert.deepEqual(evidence.workflow, { path: workflowPath, id: workflowId, state: 'active' });
+    assert.equal(evidence.run.id, runId);
+    assert.equal(evidence.run.headSha, HEAD_SHA);
+    assert.equal(evidence.aggregateJob.id, jobId);
+    assert.equal(evidence.aggregateJob.name, aggregateName);
+    assert.match(evidence.selection.basis, /newest exact-identity run/);
+    assert.equal(fetchImpl.calls.length, 5);
+  }
+});
+
+test('latest successful rerun attempt is inspected through the attempt-specific endpoint', async () => {
+  const rerun = runFixture({ run_attempt: 2 });
+  const fetchImpl = createFetch({ runPages: [[rerun]], currentRuns: [rerun] });
+  const evidence = await verify({ fetchImpl });
+  assert.equal(evidence.run.attempt, 2);
+  assert.ok(fetchImpl.calls.some(({ url }) => (
+    url.includes('/actions/runs/701/attempts/2/jobs')
+  )));
+  assert.ok(!fetchImpl.calls.some(({ url }) => url.includes('filter=latest')));
+});
+
+test('multiple successful exact-identity runs report every ignored older run ID', async () => {
+  const older = runFixture({
+    id: 700,
+    run_number: 40,
+    created_at: '2026-08-27T09:00:00Z',
+    url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/runs/700`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/700`
+  });
+  const evidence = await verify({
+    fetchImpl: createFetch({ runPages: [[older, runFixture()]] })
+  });
+  assert.deepEqual(evidence.selection.matchingRunIds, [701, 700]);
+  assert.deepEqual(evidence.selection.ignoredOlderRunIds, [700]);
+});
+
+test('run and aggregate evidence on later pages is not missed', async () => {
+  const wrongRun = runFixture({
+    id: 700,
+    run_number: 40,
+    head_sha: '9'.repeat(40),
+    url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/runs/700`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/700`
+  });
+  const leafJob = jobFixture({ id: 800, name: 'leaf' });
+  const fetchImpl = createFetch({
+    runPages: [[wrongRun], [runFixture()]],
+    jobPages: [[leafJob], [jobFixture()]]
+  });
+  const evidence = await verify({ fetchImpl });
+  assert.equal(evidence.run.id, 701);
+  assert.equal(evidence.aggregateJob.id, 801);
+  assert.equal(fetchImpl.calls.filter(({ url }) => url.includes('/workflows/501/runs')).length, 2);
+  assert.equal(fetchImpl.calls.filter(({ url }) => url.includes('/attempts/1/jobs')).length, 2);
+});
+
+test('workflow resolution rejects missing, disabled, and path-mismatched workflows', async () => {
+  await rejectsWith(
+    verify({ fetchImpl: createFetch({ workflowStatus: 404 }) }),
+    'WORKFLOW_NOT_FOUND',
+    /not found/
+  );
+  await rejectsWith(
+    verify({ fetchImpl: createFetch({ workflow: workflowFixture({ state: 'disabled_manually' }) }) }),
+    'WORKFLOW_IDENTITY_MISMATCH',
+    /disabled or does not match/
+  );
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        workflow: workflowFixture({ path: GALLERY_WORKFLOW_PATH })
+      })
+    }),
+    'WORKFLOW_IDENTITY_MISMATCH',
+    /exact workflow path/
+  );
+});
+
+test('unsupported workflow, manual evidence, and wrong aggregate contracts fail before fetch', async () => {
+  await rejectsWith(
+    verify({ workflowPath: '.github/workflows/deploy_web.yml' }),
+    'UNSUPPORTED_WORKFLOW',
+    /not a promotion evidence producer/
+  );
+  await rejectsWith(
+    verify({ expectedEvent: 'workflow_dispatch' }),
+    'UNSUPPORTED_STAGING_IDENTITY',
+    /push runs on dev/
+  );
+  await rejectsWith(
+    verify({ expectedBranch: 'main' }),
+    'UNSUPPORTED_STAGING_IDENTITY',
+    /push runs on dev/
+  );
+  await rejectsWith(
+    verify({ expectedAggregateName: 'Tests' }),
+    'AGGREGATE_CONTRACT_MISMATCH',
+    /does not match the workflow contract/
+  );
+});
+
+test('wrong repository, event, branch, SHA, workflow ID, and absent runs never match', async () => {
+  const cases = [
+    ['wrong repository', { repository: { full_name: 'attacker/gbdraw' } }],
+    ['manual dispatch', { event: 'workflow_dispatch' }],
+    ['wrong event', { event: 'pull_request' }],
+    ['wrong branch', { head_branch: 'main' }],
+    ['wrong SHA', { head_sha: '8'.repeat(40) }],
+    ['wrong workflow ID', { workflow_id: 999 }]
+  ];
+  for (const [, changes] of cases) {
+    await rejectsWith(
+      verify({ fetchImpl: createFetch({ runPages: [[runFixture(changes)]] }) }),
+      'NO_MATCHING_RUN',
+      /No workflow run matches/
+    );
+  }
+  await rejectsWith(
+    verify({ fetchImpl: createFetch({ runPages: [], runTotalCount: 0 }) }),
+    'NO_MATCHING_RUN',
+    /No workflow run matches/
+  );
+});
+
+test('a newer queued or failed run is selected instead of an older success', async () => {
+  const older = runFixture({
+    id: 700,
+    run_number: 40,
+    created_at: '2026-08-27T09:00:00Z',
+    url: `${API_ORIGIN}${REPOSITORY_API_PATH}/actions/runs/700`,
+    html_url: `https://github.com/${REPOSITORY}/actions/runs/700`
+  });
+  for (const [status, conclusion] of [['queued', null], ['completed', 'failure']]) {
+    const newer = runFixture({ status, conclusion });
+    await rejectsWith(
+      verify({
+        fetchImpl: createFetch({
+          runPages: [[older, newer]],
+          currentRuns: [newer]
+        })
+      }),
+      'RUN_NOT_SUCCESSFUL',
+      /Newest exact-identity workflow run/
+    );
+  }
+});
+
+test('cancelled, timed-out, skipped, and conclusion-less current runs fail closed', async () => {
+  for (const conclusion of ['cancelled', 'timed_out', 'skipped', null]) {
+    const run = runFixture({ conclusion });
+    await rejectsWith(
+      verify({ fetchImpl: createFetch({ runPages: [[run]], currentRuns: [run] }) }),
+      'RUN_NOT_SUCCESSFUL',
+      /not completed successfully/
+    );
+  }
+});
+
+test('a newly started current attempt cannot reuse an older successful attempt', async () => {
+  const olderAttempt = runFixture({ run_attempt: 1 });
+  const currentAttempt = runFixture({ run_attempt: 2, status: 'queued', conclusion: null });
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        runPages: [[olderAttempt]],
+        currentRuns: [currentAttempt]
+      })
+    }),
+    'RUN_NOT_SUCCESSFUL',
+    /not completed successfully/
+  );
+});
+
+test('an attempt change during verification invalidates otherwise successful evidence', async () => {
+  const attemptOne = runFixture({ run_attempt: 1 });
+  const attemptTwo = runFixture({ run_attempt: 2 });
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        currentRuns: [attemptOne, attemptTwo]
+      })
+    }),
+    'RUN_ATTEMPT_CHANGED',
+    /changed during evidence verification/
+  );
+});
+
+test('aggregate job must be present exactly once and successful', async () => {
+  await rejectsWith(
+    verify({ fetchImpl: createFetch({ jobPages: [[jobFixture({ name: 'leaf' })]] }) }),
+    'AGGREGATE_JOB_CARDINALITY',
+    /exactly one aggregate job/
+  );
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        jobPages: [[jobFixture(), jobFixture({ id: 802 })]]
+      })
+    }),
+    'AGGREGATE_JOB_CARDINALITY',
+    /exactly one aggregate job/
+  );
+  for (const conclusion of ['skipped', 'cancelled', 'failure']) {
+    await rejectsWith(
+      verify({
+        fetchImpl: createFetch({
+          jobPages: [[jobFixture({ conclusion })]]
+        })
+      }),
+      'AGGREGATE_JOB_NOT_SUCCESSFUL',
+      /not completed successfully/
+    );
+  }
+});
+
+test('malformed run and job metadata fails closed with a bounded reason', async () => {
+  const malformedRunFetch = createFetch();
+  const originalRunResponse = malformedRunFetch;
+  await rejectsWith(
+    verify({
+      fetchImpl: async (source, options) => {
+        const result = await originalRunResponse(source, options);
+        if (String(source).includes('/workflows/501/runs')) {
+          return response({ total_count: '1', workflow_runs: [] });
+        }
+        return result;
+      }
+    }),
+    'MALFORMED_API_RESPONSE',
+    /response shape is malformed/
+  );
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        jobPages: [[{ ...jobFixture(), name: null }]]
+      })
+    }),
+    'MALFORMED_JOB',
+    /job metadata is malformed/
+  );
+});
+
+test('incomplete, malformed, and looping pagination fails closed', async () => {
+  await rejectsWith(
+    verify({ fetchImpl: createFetch({ runTotalCount: 2 }) }),
+    'INCOMPLETE_PAGINATION',
+    /ended before total_count/
+  );
+  await rejectsWith(
+    verify({ fetchImpl: createFetch({ runLinks: ['not-a-link'], runTotalCount: 2 }) }),
+    'MALFORMED_PAGINATION',
+    /Link header is malformed/
+  );
+  const skippedPageUrl = new URL(`${API_ORIGIN}${REPOSITORY_API_PATH}/actions/workflows/501/runs`);
+  skippedPageUrl.searchParams.set('branch', 'dev');
+  skippedPageUrl.searchParams.set('event', 'push');
+  skippedPageUrl.searchParams.set('exclude_pull_requests', 'true');
+  skippedPageUrl.searchParams.set('head_sha', HEAD_SHA);
+  skippedPageUrl.searchParams.set('per_page', '100');
+  skippedPageUrl.searchParams.set('page', '3');
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        runPages: [[runFixture()], [], []],
+        runTotalCount: 2,
+        runLinks: [`<${skippedPageUrl}>; rel="next"`]
+      })
+    }),
+    'INCOMPLETE_PAGINATION',
+    /skipped or reordered a page/
+  );
+  const initialRunsUrl = new URL(`${API_ORIGIN}${REPOSITORY_API_PATH}/actions/workflows/501/runs`);
+  initialRunsUrl.searchParams.set('branch', 'dev');
+  initialRunsUrl.searchParams.set('event', 'push');
+  initialRunsUrl.searchParams.set('exclude_pull_requests', 'true');
+  initialRunsUrl.searchParams.set('head_sha', HEAD_SHA);
+  initialRunsUrl.searchParams.set('per_page', '100');
+  await rejectsWith(
+    verify({
+      fetchImpl: createFetch({
+        runPages: [[runFixture()], []],
+        runTotalCount: 2,
+        runLinks: [`<${initialRunsUrl}>; rel="next"`]
+      })
+    }),
+    'PAGINATION_LOOP',
+    /repeated a page/
+  );
+});
+
+const gitResult = (status = 0, stdout = '', stderr = '') => ({ status, stdout, stderr });
+
+const createGitRunner = ({
+  shallow = false,
+  missing = '',
+  mergeStatus = 0,
+  mergeTree = HEAD_TREE_SHA
+} = {}) => (_repositoryRoot, args) => {
+  if (args.join(' ') === 'rev-parse --is-shallow-repository') {
+    return gitResult(0, `${shallow}\n`);
+  }
+  if (args[0] === 'cat-file') {
+    return missing && args.at(-1).startsWith(missing)
+      ? gitResult(128, '', 'missing object')
+      : gitResult();
+  }
+  if (args[0] === 'rev-parse' && args.includes('--verify')) {
+    return gitResult(0, `${HEAD_TREE_SHA}\n`);
+  }
+  if (args[0] === 'merge-tree') {
+    return gitResult(mergeStatus, mergeStatus ? '' : `${mergeTree}\n`, mergeStatus ? 'CONFLICT' : '');
+  }
+  assert.fail(`Unexpected Git arguments: ${args.join(' ')}`);
+};
+
+test('conflict-free synthetic merge tree equal to the head tree succeeds without mutation commands', () => {
+  const calls = [];
+  const inner = createGitRunner();
+  const evidence = verifyPromotionResultTree({
+    repositoryRoot: '/fixture/repository',
+    baseSha: BASE_SHA,
+    headSha: HEAD_SHA,
+    runGit: (root, args) => {
+      calls.push({ root, args });
+      return inner(root, args);
+    }
+  });
+  assert.equal(evidence.conflictFree, true);
+  assert.equal(evidence.treeMatchesHead, true);
+  assert.equal(evidence.syntheticMergeTreeSha, HEAD_TREE_SHA);
+  assert.deepEqual(calls.at(-1).args, [
+    'merge-tree', '--write-tree', '--no-messages', BASE_SHA, HEAD_SHA
+  ]);
+  assert.ok(calls.every(({ args }) => !['checkout', 'merge', 'switch'].includes(args[0])));
+});
+
+test('shallow history, missing objects, conflicts, and different trees fail closed', () => {
+  const cases = [
+    ['INCOMPLETE_GIT_HISTORY', /Complete Git history/, createGitRunner({ shallow: true })],
+    ['MISSING_GIT_OBJECT', /Complete Git object/, createGitRunner({ missing: BASE_SHA })],
+    ['MERGE_CONFLICT', /not conflict-free/, createGitRunner({ mergeStatus: 1 })],
+    ['RESULT_TREE_MISMATCH', /differs from the dev head tree/, createGitRunner({ mergeTree: OTHER_TREE_SHA })]
+  ];
+  for (const [code, reason, runGit] of cases) {
+    assert.throws(
+      () => verifyPromotionResultTree({
+        repositoryRoot: '/fixture/repository',
+        baseSha: BASE_SHA,
+        headSha: HEAD_SHA,
+        runGit
+      }),
+      (error) => error instanceof PromotionReadinessError
+        && error.code === code
+        && reason.test(error.message)
+    );
+  }
+});
+
+test('invalid SHA arguments are rejected before Git executes', () => {
+  let executed = false;
+  assert.throws(
+    () => verifyPromotionResultTree({
+      repositoryRoot: '/fixture/repository',
+      baseSha: 'HEAD; touch /tmp/injected',
+      headSha: HEAD_SHA,
+      runGit: () => {
+        executed = true;
+        return gitResult();
+      }
+    }),
+    (error) => error instanceof PromotionReadinessError
+      && error.code === 'INVALID_OBJECT_ID'
+  );
+  assert.equal(executed, false);
+});
+
+test('CLI failure returns nonzero with expected identity and bounded diagnostics', async () => {
+  let stdout = '';
+  let stderr = '';
+  const status = await runPromotionReadinessCli({
+    argv: ['workflow-evidence', '--repository', REPOSITORY],
+    env: { GITHUB_TOKEN: 'fixture-token' },
+    stdout: { write: (value) => { stdout += value; } },
+    stderr: { write: (value) => { stderr += value; } }
+  });
+  assert.equal(status, 1);
+  assert.equal(stdout, '');
+  assert.match(stderr, /MISSING_ARGUMENT/);
+  assert.match(stderr, /Expected:/);
+  assert.match(stderr, /Observed:/);
+  assert.ok(!stderr.includes('fixture-token'));
+});

--- a/tools/check-promotion-readiness.mjs
+++ b/tools/check-promotion-readiness.mjs
@@ -1,0 +1,874 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const API_ORIGIN = 'https://api.github.com';
+const API_VERSION = '2026-03-10';
+const PER_PAGE = 100;
+const MAX_PAGES = 10;
+const MAX_SEARCH_RESULTS = PER_PAGE * MAX_PAGES;
+const FULL_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const REPOSITORY_NAME = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})\/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/;
+
+export const PROMOTION_WORKFLOW_CONTRACTS = Object.freeze({
+  '.github/workflows/gallery-publication.yml': 'Gallery readiness / gate',
+  '.github/workflows/test.yml': 'Dev staging / gate'
+});
+
+const isObject = (value) => value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value);
+
+const boundedText = (value, limit = 240) => {
+  if (typeof value !== 'string') return '';
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length <= limit ? normalized : `${normalized.slice(0, limit)}...`;
+};
+
+export class PromotionReadinessError extends Error {
+  constructor(code, reason, { expected = {}, observed = {} } = {}) {
+    super(reason);
+    this.name = 'PromotionReadinessError';
+    this.code = code;
+    this.expected = expected;
+    this.observed = observed;
+  }
+}
+
+const fail = (code, reason, details) => {
+  throw new PromotionReadinessError(code, reason, details);
+};
+
+const positiveInteger = (value) => Number.isSafeInteger(value) && value > 0;
+
+const normalizeObjectId = (value, field, expected = {}) => {
+  if (typeof value !== 'string' || !FULL_OBJECT_ID.test(value)) {
+    fail('INVALID_OBJECT_ID', `${field} must be a full 40- or 64-character hexadecimal object ID.`, {
+      expected,
+      observed: { [field]: typeof value === 'string' ? boundedText(value) : typeof value }
+    });
+  }
+  return value.toLowerCase();
+};
+
+const repositoryParts = (repository) => {
+  if (typeof repository !== 'string' || !REPOSITORY_NAME.test(repository)) {
+    fail('INVALID_REPOSITORY', 'repository must be an exact OWNER/REPOSITORY full name.', {
+      expected: { format: 'OWNER/REPOSITORY' },
+      observed: { repository: boundedText(repository) }
+    });
+  }
+  return repository.split('/').map(encodeURIComponent);
+};
+
+const workflowContract = (workflowPath, expectedAggregateName) => {
+  if (!Object.hasOwn(PROMOTION_WORKFLOW_CONTRACTS, workflowPath)) {
+    fail('UNSUPPORTED_WORKFLOW', 'workflow path is not a promotion evidence producer.', {
+      expected: { workflowPaths: Object.keys(PROMOTION_WORKFLOW_CONTRACTS) },
+      observed: { workflowPath: boundedText(workflowPath) }
+    });
+  }
+  const aggregateName = PROMOTION_WORKFLOW_CONTRACTS[workflowPath];
+  if (expectedAggregateName !== aggregateName) {
+    fail('AGGREGATE_CONTRACT_MISMATCH', 'aggregate job name does not match the workflow contract.', {
+      expected: { workflowPath, aggregateName },
+      observed: { expectedAggregateName: boundedText(expectedAggregateName) }
+    });
+  }
+  return aggregateName;
+};
+
+const responseHeader = (response, name) => {
+  if (response.headers && typeof response.headers.get === 'function') {
+    return response.headers.get(name);
+  }
+  if (isObject(response.headers)) {
+    const entry = Object.entries(response.headers)
+      .find(([key]) => key.toLowerCase() === name.toLowerCase());
+    return entry?.[1] ?? null;
+  }
+  return null;
+};
+
+const requestJson = async ({ url, token, fetchImpl, expected, notFoundCode = '' }) => {
+  let response;
+  try {
+    response = await fetchImpl(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token.trim()}`,
+        'X-GitHub-Api-Version': API_VERSION
+      }
+    });
+  } catch (error) {
+    fail('API_REQUEST_FAILED', 'GitHub Actions API request failed.', {
+      expected,
+      observed: { errorType: boundedText(error?.name || typeof error) }
+    });
+  }
+  if (!isObject(response) || typeof response.ok !== 'boolean'
+      || !Number.isInteger(response.status) || typeof response.json !== 'function') {
+    fail('MALFORMED_API_RESPONSE', 'GitHub Actions API returned a malformed response envelope.', {
+      expected,
+      observed: { responseType: typeof response }
+    });
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (_error) {
+    fail('MALFORMED_API_RESPONSE', 'GitHub Actions API response was not valid JSON.', {
+      expected,
+      observed: { status: response.status }
+    });
+  }
+  if (!response.ok) {
+    const code = response.status === 404 && notFoundCode ? notFoundCode : 'API_REQUEST_FAILED';
+    fail(code, response.status === 404 && notFoundCode
+      ? 'Expected GitHub Actions resource was not found.'
+      : 'GitHub Actions API request did not succeed.', {
+      expected,
+      observed: {
+        status: response.status,
+        message: boundedText(isObject(body) ? body.message : '')
+      }
+    });
+  }
+  return { body, link: responseHeader(response, 'link') };
+};
+
+export const parseLinkHeader = (source) => {
+  if (source === null || source === undefined) return new Map();
+  if (typeof source !== 'string' || !source.trim()) {
+    fail('MALFORMED_PAGINATION', 'GitHub pagination Link header is malformed.', {
+      observed: { link: boundedText(source) }
+    });
+  }
+  const relations = new Map();
+  for (const entry of source.split(/,\s*(?=<)/)) {
+    const match = entry.trim().match(/^<([^<>]+)>;\s*rel="(next|prev|first|last)"$/);
+    if (!match || relations.has(match?.[2])) {
+      fail('MALFORMED_PAGINATION', 'GitHub pagination Link header is malformed.', {
+        observed: { link: boundedText(source) }
+      });
+    }
+    relations.set(match[2], match[1]);
+  }
+  return relations;
+};
+
+const validatePaginationUrl = (source, { pathname, immutableParameters, expected }) => {
+  let url;
+  try {
+    url = new URL(source);
+  } catch (_error) {
+    fail('MALFORMED_PAGINATION', 'GitHub pagination next URL is invalid.', {
+      expected,
+      observed: { nextUrl: boundedText(source) }
+    });
+  }
+  const allowedParameters = new Set([...immutableParameters.keys(), 'page']);
+  const allParameterNames = [...url.searchParams.keys()];
+  const parameterNames = [...new Set(allParameterNames)];
+  const page = url.searchParams.get('page');
+  if (url.origin !== API_ORIGIN || url.pathname !== pathname || url.username || url.password
+      || url.hash || parameterNames.some((name) => !allowedParameters.has(name))
+      || parameterNames.length !== allParameterNames.length
+      || [...immutableParameters].some(([name, value]) => url.searchParams.get(name) !== value)
+      || (page !== null && (!/^\d+$/.test(page) || !Number.isSafeInteger(Number(page))
+        || Number(page) < 1))) {
+    fail('MALFORMED_PAGINATION', 'GitHub pagination next URL changed the evidence query.', {
+      expected,
+      observed: { nextUrl: boundedText(source) }
+    });
+  }
+  return url.toString();
+};
+
+const collectPaginated = async ({
+  initialUrl,
+  pathname,
+  immutableParameters,
+  arrayField,
+  token,
+  fetchImpl,
+  expected
+}) => {
+  let nextUrl = initialUrl;
+  let totalCount = null;
+  const pages = new Set();
+  const itemIds = new Set();
+  const items = [];
+
+  while (nextUrl) {
+    if (pages.size >= MAX_PAGES) {
+      fail('INCOMPLETE_PAGINATION', 'GitHub evidence exceeded the bounded pagination limit.', {
+        expected,
+        observed: { pages: pages.size, limit: MAX_PAGES }
+      });
+    }
+    const validatedUrl = validatePaginationUrl(nextUrl, {
+      pathname,
+      immutableParameters,
+      expected
+    });
+    if (pages.has(validatedUrl)) {
+      fail('PAGINATION_LOOP', 'GitHub evidence pagination repeated a page.', {
+        expected,
+        observed: { nextUrl: boundedText(validatedUrl), pages: pages.size }
+      });
+    }
+    const page = Number(new URL(validatedUrl).searchParams.get('page') || 1);
+    if (page !== pages.size + 1) {
+      fail('INCOMPLETE_PAGINATION', 'GitHub evidence pagination skipped or reordered a page.', {
+        expected,
+        observed: { expectedPage: pages.size + 1, page }
+      });
+    }
+    pages.add(validatedUrl);
+
+    const { body, link } = await requestJson({
+      url: validatedUrl,
+      token,
+      fetchImpl,
+      expected
+    });
+    if (!isObject(body) || !Number.isSafeInteger(body.total_count) || body.total_count < 0
+        || !Array.isArray(body[arrayField])) {
+      fail('MALFORMED_API_RESPONSE', `GitHub ${arrayField} response shape is malformed.`, {
+        expected,
+        observed: {
+          totalCount: body?.total_count,
+          collectionType: Array.isArray(body?.[arrayField]) ? 'array' : typeof body?.[arrayField]
+        }
+      });
+    }
+    if (body.total_count > MAX_SEARCH_RESULTS) {
+      fail('INCOMPLETE_PAGINATION', 'GitHub evidence result count exceeds the bounded search limit.', {
+        expected,
+        observed: { totalCount: body.total_count, limit: MAX_SEARCH_RESULTS }
+      });
+    }
+    if (totalCount === null) totalCount = body.total_count;
+    else if (totalCount !== body.total_count) {
+      fail('INCOMPLETE_PAGINATION', 'GitHub evidence total changed during pagination.', {
+        expected,
+        observed: { initialTotalCount: totalCount, currentTotalCount: body.total_count }
+      });
+    }
+
+    for (const item of body[arrayField]) {
+      if (!isObject(item) || !positiveInteger(item.id) || itemIds.has(item.id)) {
+        fail('MALFORMED_API_RESPONSE', `GitHub ${arrayField} contains malformed or duplicate items.`, {
+          expected,
+          observed: { itemId: item?.id }
+        });
+      }
+      itemIds.add(item.id);
+      items.push(item);
+    }
+    if (items.length > totalCount) {
+      fail('INCOMPLETE_PAGINATION', 'GitHub evidence returned more items than total_count.', {
+        expected,
+        observed: { totalCount, received: items.length }
+      });
+    }
+
+    const relations = parseLinkHeader(link);
+    nextUrl = relations.get('next') || '';
+    if (nextUrl && items.length >= totalCount) {
+      fail('INCOMPLETE_PAGINATION', 'GitHub evidence advertised another page after total_count.', {
+        expected,
+        observed: { totalCount, received: items.length }
+      });
+    }
+  }
+
+  if (items.length !== totalCount) {
+    fail('INCOMPLETE_PAGINATION', 'GitHub evidence pagination ended before total_count.', {
+      expected,
+      observed: { totalCount, received: items.length }
+    });
+  }
+  return items;
+};
+
+const validTimestamp = (value) => typeof value === 'string'
+  && value.length > 0
+  && Number.isFinite(Date.parse(value));
+
+const runIdentity = (run) => ({
+  id: run?.id,
+  runNumber: run?.run_number,
+  runAttempt: run?.run_attempt,
+  workflowId: run?.workflow_id,
+  workflowPath: run?.path,
+  repository: run?.repository?.full_name,
+  event: run?.event,
+  branch: run?.head_branch,
+  headSha: run?.head_sha,
+  status: run?.status,
+  conclusion: run?.conclusion
+});
+
+const validateRun = (run, expected) => {
+  const observed = runIdentity(run);
+  if (!isObject(run) || !positiveInteger(run.id) || !positiveInteger(run.run_number)
+      || !positiveInteger(run.run_attempt) || !positiveInteger(run.workflow_id)
+      || typeof run.path !== 'string' || typeof run.event !== 'string'
+      || typeof run.head_branch !== 'string' || typeof run.head_sha !== 'string'
+      || !isObject(run.repository) || typeof run.repository.full_name !== 'string'
+      || typeof run.status !== 'string'
+      || !(run.conclusion === null || typeof run.conclusion === 'string')
+      || typeof run.url !== 'string' || typeof run.html_url !== 'string'
+      || !validTimestamp(run.created_at) || !validTimestamp(run.updated_at)) {
+    fail('MALFORMED_RUN', 'GitHub workflow run metadata is malformed.', { expected, observed });
+  }
+  return run;
+};
+
+const runMatches = (run, expected) => run.workflow_id === expected.workflowId
+  && run.path === expected.workflowPath
+  && run.repository.full_name === expected.repository
+  && run.event === expected.event
+  && run.head_branch === expected.branch
+  && run.head_sha.toLowerCase() === expected.headSha;
+
+const validateRunUrls = (run, repositoryApiPath, expected) => {
+  const expectedApiUrl = `${API_ORIGIN}${repositoryApiPath}/actions/runs/${run.id}`;
+  const expectedHtmlUrl = `https://github.com/${expected.repository}/actions/runs/${run.id}`;
+  if (run.url !== expectedApiUrl || run.html_url !== expectedHtmlUrl) {
+    fail('RUN_IDENTITY_MISMATCH', 'GitHub workflow run URLs do not match its repository and run ID.', {
+      expected: { ...expected, runApiUrl: expectedApiUrl, runUrl: expectedHtmlUrl },
+      observed: { ...runIdentity(run), runApiUrl: run.url, runUrl: run.html_url }
+    });
+  }
+};
+
+const requireSuccessfulRun = (run, expected) => {
+  if (run.status !== 'completed' || run.conclusion !== 'success') {
+    fail('RUN_NOT_SUCCESSFUL', 'Newest exact-identity workflow run is not completed successfully.', {
+      expected: { ...expected, status: 'completed', conclusion: 'success' },
+      observed: runIdentity(run)
+    });
+  }
+};
+
+const validateJob = (job, run, expected, repositoryApiPath) => {
+  const observed = {
+    id: job?.id,
+    runId: job?.run_id,
+    name: job?.name,
+    headSha: job?.head_sha,
+    status: job?.status,
+    conclusion: job?.conclusion
+  };
+  const expectedApiUrl = `${API_ORIGIN}${repositoryApiPath}/actions/jobs/${job?.id}`;
+  const expectedHtmlUrl = `https://github.com/${expected.repository}/actions/runs/${run.id}/job/${job?.id}`;
+  if (!isObject(job) || !positiveInteger(job.id) || job.run_id !== run.id
+      || typeof job.name !== 'string' || typeof job.head_sha !== 'string'
+      || job.head_sha.toLowerCase() !== expected.headSha || typeof job.status !== 'string'
+      || !(job.conclusion === null || typeof job.conclusion === 'string')
+      || job.url !== expectedApiUrl || typeof job.html_url !== 'string'
+      || job.html_url !== expectedHtmlUrl) {
+    fail('MALFORMED_JOB', 'GitHub workflow job metadata is malformed or identity-mismatched.', {
+      expected: { ...expected, runId: run.id },
+      observed
+    });
+  }
+  return job;
+};
+
+const exactRunSnapshot = ({ run, selectedRun, expected, repositoryApiPath }) => {
+  validateRun(run, expected);
+  validateRunUrls(run, repositoryApiPath, expected);
+  if (!runMatches(run, expected) || run.id !== selectedRun.id
+      || run.run_number !== selectedRun.run_number
+      || run.run_attempt < selectedRun.run_attempt) {
+    fail('RUN_IDENTITY_MISMATCH', 'Current workflow run no longer matches the selected evidence identity.', {
+      expected: { ...expected, runId: selectedRun.id, minimumAttempt: selectedRun.run_attempt },
+      observed: runIdentity(run)
+    });
+  }
+  return run;
+};
+
+export const verifyWorkflowEvidence = async ({
+  repository,
+  workflowPath,
+  expectedEvent = 'push',
+  expectedBranch = 'dev',
+  expectedHeadSha,
+  expectedAggregateName,
+  token,
+  fetchImpl = globalThis.fetch
+}) => {
+  const [owner, repo] = repositoryParts(repository);
+  workflowContract(workflowPath, expectedAggregateName);
+  const headSha = normalizeObjectId(expectedHeadSha, 'expectedHeadSha');
+  const expectedIdentity = {
+    repository,
+    workflowPath,
+    event: 'push',
+    branch: 'dev',
+    headSha,
+    aggregateName: expectedAggregateName
+  };
+  if (expectedEvent !== 'push' || expectedBranch !== 'dev') {
+    fail('UNSUPPORTED_STAGING_IDENTITY', 'Promotion evidence is limited to push runs on dev.', {
+      expected: expectedIdentity,
+      observed: { event: expectedEvent, branch: expectedBranch }
+    });
+  }
+  if (typeof token !== 'string' || !token.trim()) {
+    fail('MISSING_TOKEN', 'A GitHub token with Actions read access is required.', {
+      expected: expectedIdentity,
+      observed: { token: 'missing' }
+    });
+  }
+  if (typeof fetchImpl !== 'function') {
+    fail('MISSING_FETCH', 'A fetch implementation is required.', { expected: expectedIdentity });
+  }
+
+  const repositoryApiPath = `/repos/${owner}/${repo}`;
+  const workflowResolutionUrl = `${API_ORIGIN}${repositoryApiPath}/actions/workflows/${encodeURIComponent(workflowPath)}`;
+  const { body: workflow } = await requestJson({
+    url: workflowResolutionUrl,
+    token,
+    fetchImpl,
+    expected: expectedIdentity,
+    notFoundCode: 'WORKFLOW_NOT_FOUND'
+  });
+  const workflowObserved = {
+    id: workflow?.id,
+    path: workflow?.path,
+    state: workflow?.state,
+    url: workflow?.url
+  };
+  if (!isObject(workflow) || !positiveInteger(workflow.id)
+      || workflow.path !== workflowPath || workflow.state !== 'active'
+      || workflow.url !== `${API_ORIGIN}${repositoryApiPath}/actions/workflows/${workflow.id}`) {
+    fail('WORKFLOW_IDENTITY_MISMATCH', 'Resolved workflow is disabled or does not match the exact workflow path.', {
+      expected: expectedIdentity,
+      observed: workflowObserved
+    });
+  }
+
+  const runExpected = { ...expectedIdentity, workflowId: workflow.id };
+  const runsPath = `${repositoryApiPath}/actions/workflows/${workflow.id}/runs`;
+  const runParameters = new Map([
+    ['branch', 'dev'],
+    ['event', 'push'],
+    ['exclude_pull_requests', 'true'],
+    ['head_sha', headSha],
+    ['per_page', String(PER_PAGE)]
+  ]);
+  const runsUrl = new URL(`${API_ORIGIN}${runsPath}`);
+  runParameters.forEach((value, name) => runsUrl.searchParams.set(name, value));
+  const runs = await collectPaginated({
+    initialUrl: runsUrl.toString(),
+    pathname: runsPath,
+    immutableParameters: runParameters,
+    arrayField: 'workflow_runs',
+    token,
+    fetchImpl,
+    expected: runExpected
+  });
+  runs.forEach((run) => {
+    validateRun(run, runExpected);
+    validateRunUrls(run, repositoryApiPath, runExpected);
+  });
+  const matchingRuns = runs.filter((run) => runMatches(run, runExpected)).sort((left, right) => (
+    Date.parse(right.created_at) - Date.parse(left.created_at)
+    || right.run_number - left.run_number
+    || right.id - left.id
+  ));
+  if (!matchingRuns.length) {
+    fail('NO_MATCHING_RUN', 'No workflow run matches the exact promotion evidence identity.', {
+      expected: runExpected,
+      observed: { runs: runs.slice(0, 5).map(runIdentity), observedCount: runs.length }
+    });
+  }
+  const selectedRun = matchingRuns[0];
+  const currentRunUrl = `${API_ORIGIN}${repositoryApiPath}/actions/runs/${selectedRun.id}`;
+  const { body: currentRunBody } = await requestJson({
+    url: currentRunUrl,
+    token,
+    fetchImpl,
+    expected: { ...runExpected, runId: selectedRun.id }
+  });
+  const currentRun = exactRunSnapshot({
+    run: currentRunBody,
+    selectedRun,
+    expected: runExpected,
+    repositoryApiPath
+  });
+  requireSuccessfulRun(currentRun, runExpected);
+
+  const jobsPath = `${repositoryApiPath}/actions/runs/${currentRun.id}/attempts/${currentRun.run_attempt}/jobs`;
+  const jobParameters = new Map([['per_page', String(PER_PAGE)]]);
+  const jobsUrl = new URL(`${API_ORIGIN}${jobsPath}`);
+  jobParameters.forEach((value, name) => jobsUrl.searchParams.set(name, value));
+  const jobs = await collectPaginated({
+    initialUrl: jobsUrl.toString(),
+    pathname: jobsPath,
+    immutableParameters: jobParameters,
+    arrayField: 'jobs',
+    token,
+    fetchImpl,
+    expected: { ...runExpected, runId: currentRun.id, runAttempt: currentRun.run_attempt }
+  });
+  jobs.forEach((job) => validateJob(job, currentRun, runExpected, repositoryApiPath));
+  const aggregateJobs = jobs.filter((job) => job.name === expectedAggregateName);
+  if (aggregateJobs.length !== 1) {
+    fail('AGGREGATE_JOB_CARDINALITY', 'Expected exactly one aggregate job on the current run attempt.', {
+      expected: {
+        ...runExpected,
+        runId: currentRun.id,
+        runAttempt: currentRun.run_attempt,
+        aggregateMatches: 1
+      },
+      observed: {
+        aggregateMatches: aggregateJobs.length,
+        jobs: jobs.slice(0, 5).map(({ id, name, status, conclusion }) => ({
+          id, name, status, conclusion
+        }))
+      }
+    });
+  }
+  const aggregateJob = aggregateJobs[0];
+  if (aggregateJob.status !== 'completed' || aggregateJob.conclusion !== 'success') {
+    fail('AGGREGATE_JOB_NOT_SUCCESSFUL', 'Aggregate job is not completed successfully.', {
+      expected: { ...runExpected, status: 'completed', conclusion: 'success' },
+      observed: {
+        id: aggregateJob.id,
+        name: aggregateJob.name,
+        status: aggregateJob.status,
+        conclusion: aggregateJob.conclusion
+      }
+    });
+  }
+
+  const { body: finalRunBody } = await requestJson({
+    url: currentRunUrl,
+    token,
+    fetchImpl,
+    expected: { ...runExpected, runId: currentRun.id, runAttempt: currentRun.run_attempt }
+  });
+  const finalRun = exactRunSnapshot({
+    run: finalRunBody,
+    selectedRun: currentRun,
+    expected: runExpected,
+    repositoryApiPath
+  });
+  if (finalRun.run_attempt !== currentRun.run_attempt) {
+    fail('RUN_ATTEMPT_CHANGED', 'Workflow run attempt changed during evidence verification.', {
+      expected: { ...runExpected, runId: currentRun.id, runAttempt: currentRun.run_attempt },
+      observed: runIdentity(finalRun)
+    });
+  }
+  requireSuccessfulRun(finalRun, runExpected);
+
+  return {
+    kind: 'promotion-workflow-evidence',
+    repository,
+    workflow: {
+      path: workflowPath,
+      id: workflow.id,
+      state: workflow.state
+    },
+    run: {
+      id: finalRun.id,
+      number: finalRun.run_number,
+      attempt: finalRun.run_attempt,
+      url: finalRun.html_url,
+      apiUrl: finalRun.url,
+      createdAt: finalRun.created_at,
+      updatedAt: finalRun.updated_at,
+      event: finalRun.event,
+      branch: finalRun.head_branch,
+      headSha,
+      status: finalRun.status,
+      conclusion: finalRun.conclusion
+    },
+    aggregateJob: {
+      id: aggregateJob.id,
+      name: aggregateJob.name,
+      url: aggregateJob.html_url,
+      apiUrl: aggregateJob.url,
+      status: aggregateJob.status,
+      conclusion: aggregateJob.conclusion
+    },
+    selection: {
+      basis: 'newest exact-identity run by created_at, then run_number, then run ID; current attempt revalidated after job inspection',
+      matchingRunIds: matchingRuns.map(({ id }) => id),
+      ignoredOlderRunIds: matchingRuns.slice(1).map(({ id }) => id)
+    }
+  };
+};
+
+export const runGit = (repositoryRoot, args) => spawnSync('git', args, {
+  cwd: repositoryRoot,
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+
+const gitProbe = (runGitImpl, repositoryRoot, args, expected) => {
+  const result = runGitImpl(repositoryRoot, args);
+  if (!isObject(result) || !Number.isInteger(result.status)
+      || typeof result.stdout !== 'string' || typeof result.stderr !== 'string') {
+    fail('MALFORMED_GIT_RESULT', 'Injected Git runner returned a malformed result.', {
+      expected,
+      observed: { args, resultType: typeof result }
+    });
+  }
+  return result;
+};
+
+export const verifyPromotionResultTree = ({
+  repositoryRoot,
+  baseSha,
+  headSha,
+  runGit: runGitImpl = runGit
+}) => {
+  const expected = {
+    baseSha: normalizeObjectId(baseSha, 'baseSha'),
+    headSha: normalizeObjectId(headSha, 'headSha')
+  };
+  if (typeof repositoryRoot !== 'string' || !repositoryRoot.trim()) {
+    fail('INVALID_REPOSITORY_ROOT', 'repositoryRoot must be a nonempty path.', { expected });
+  }
+  if (typeof runGitImpl !== 'function') {
+    fail('MISSING_GIT_RUNNER', 'A Git runner is required.', { expected });
+  }
+
+  const shallow = gitProbe(
+    runGitImpl,
+    repositoryRoot,
+    ['rev-parse', '--is-shallow-repository'],
+    expected
+  );
+  if (shallow.status !== 0 || shallow.stdout.trim() !== 'false') {
+    fail('INCOMPLETE_GIT_HISTORY', 'Complete Git history is required for promotion tree proof.', {
+      expected,
+      observed: {
+        shallow: shallow.stdout.trim() || 'unknown',
+        error: boundedText(shallow.stderr)
+      }
+    });
+  }
+  for (const [name, sha] of [['baseSha', expected.baseSha], ['headSha', expected.headSha]]) {
+    const object = gitProbe(
+      runGitImpl,
+      repositoryRoot,
+      ['cat-file', '-e', `${sha}^{commit}`],
+      expected
+    );
+    if (object.status !== 0) {
+      fail('MISSING_GIT_OBJECT', `Complete Git object for ${name} is unavailable.`, {
+        expected,
+        observed: { missing: sha, error: boundedText(object.stderr) }
+      });
+    }
+  }
+
+  const headTreeResult = gitProbe(
+    runGitImpl,
+    repositoryRoot,
+    ['rev-parse', '--verify', `${expected.headSha}^{tree}`],
+    expected
+  );
+  const headTreeSha = headTreeResult.stdout.trim().toLowerCase();
+  if (headTreeResult.status !== 0 || !FULL_OBJECT_ID.test(headTreeSha)) {
+    fail('MISSING_GIT_OBJECT', 'Head tree object could not be resolved.', {
+      expected,
+      observed: { error: boundedText(headTreeResult.stderr) }
+    });
+  }
+
+  const mergeResult = gitProbe(
+    runGitImpl,
+    repositoryRoot,
+    ['merge-tree', '--write-tree', '--no-messages', expected.baseSha, expected.headSha],
+    expected
+  );
+  if (mergeResult.status !== 0) {
+    const error = boundedText(mergeResult.stderr || mergeResult.stdout);
+    if (/missing|not a valid object|could not read|unable to read (?:tree|object)|promisor/i.test(error)) {
+      fail('MISSING_GIT_OBJECT', 'Synthetic merge could not read complete Git history.', {
+        expected,
+        observed: { error }
+      });
+    }
+    if (/read-only file system|unable to create temporary file|permission denied/i.test(error)) {
+      fail('GIT_MERGE_TREE_UNAVAILABLE', 'Git could not create the temporary synthetic tree object.', {
+        expected,
+        observed: { error }
+      });
+    }
+    fail('MERGE_CONFLICT', 'Synthetic promotion merge is not conflict-free.', {
+      expected,
+      observed: { error }
+    });
+  }
+  const mergeLines = mergeResult.stdout.trim().split(/\r?\n/).filter(Boolean);
+  const syntheticMergeTreeSha = mergeLines.length === 1
+    ? mergeLines[0].toLowerCase()
+    : '';
+  if (!FULL_OBJECT_ID.test(syntheticMergeTreeSha)) {
+    fail('MALFORMED_MERGE_TREE', 'Synthetic merge did not return one full tree object ID.', {
+      expected,
+      observed: { output: boundedText(mergeResult.stdout) }
+    });
+  }
+  if (syntheticMergeTreeSha !== headTreeSha) {
+    fail('RESULT_TREE_MISMATCH', 'Synthetic promotion merge tree differs from the dev head tree.', {
+      expected: { ...expected, headTreeSha },
+      observed: { syntheticMergeTreeSha }
+    });
+  }
+
+  return {
+    kind: 'promotion-result-tree-evidence',
+    repositoryRoot: resolve(repositoryRoot),
+    baseSha: expected.baseSha,
+    headSha: expected.headSha,
+    syntheticMergeTreeSha,
+    headTreeSha,
+    conflictFree: true,
+    treeMatchesHead: true,
+    method: 'git merge-tree --write-tree --no-messages'
+  };
+};
+
+const parseArguments = (argv) => {
+  const [command, ...rest] = argv;
+  if (!['workflow-evidence', 'merge-tree'].includes(command)) {
+    fail('INVALID_COMMAND', 'Command must be workflow-evidence or merge-tree.', {
+      expected: { commands: ['workflow-evidence', 'merge-tree'] },
+      observed: { command: boundedText(command) }
+    });
+  }
+  const options = new Map();
+  for (let index = 0; index < rest.length; index += 2) {
+    const name = rest[index];
+    const value = rest[index + 1];
+    if (!name?.startsWith('--') || !value || value.startsWith('--') || options.has(name)) {
+      fail('INVALID_ARGUMENTS', 'CLI arguments must be unique --name value pairs.', {
+        observed: { argument: boundedText(name) }
+      });
+    }
+    options.set(name, value);
+  }
+  return { command, options };
+};
+
+const requiredOption = (options, name) => {
+  const value = options.get(name);
+  if (!value) {
+    fail('MISSING_ARGUMENT', `Missing required CLI argument ${name}.`, {
+      expected: { argument: name }
+    });
+  }
+  return value;
+};
+
+export const formatEvidenceSummary = (evidence) => {
+  if (evidence.kind === 'promotion-result-tree-evidence') {
+    return [
+      '## Promotion result tree evidence',
+      '',
+      `- Base SHA: \`${evidence.baseSha}\``,
+      `- Head SHA: \`${evidence.headSha}\``,
+      `- Synthetic/head tree: \`${evidence.headTreeSha}\``,
+      '- Result: conflict-free and tree-identical',
+      ''
+    ].join('\n');
+  }
+  return [
+    '## Promotion workflow evidence',
+    '',
+    `- Repository: \`${evidence.repository}\``,
+    `- Workflow: \`${evidence.workflow.path}\` (ID ${evidence.workflow.id})`,
+    `- Run: [${evidence.run.id}](${evidence.run.url}), attempt ${evidence.run.attempt}`,
+    `- Identity: \`${evidence.run.event}\` / \`${evidence.run.branch}\` / \`${evidence.run.headSha}\``,
+    `- Aggregate: [${evidence.aggregateJob.name}](${evidence.aggregateJob.url})`,
+    '- Result: run and aggregate completed successfully',
+    ''
+  ].join('\n');
+};
+
+export const runPromotionReadinessCli = async ({
+  argv = process.argv.slice(2),
+  env = process.env,
+  cwd = process.cwd(),
+  fetchImpl = globalThis.fetch,
+  runGit: runGitImpl = runGit,
+  stdout = process.stdout,
+  stderr = process.stderr
+} = {}) => {
+  try {
+    const { command, options } = parseArguments(argv);
+    let evidence;
+    if (command === 'workflow-evidence') {
+      const allowed = new Set([
+        '--aggregate-name', '--head-sha', '--repository', '--workflow-path'
+      ]);
+      if ([...options.keys()].some((name) => !allowed.has(name))) {
+        fail('INVALID_ARGUMENTS', 'Unknown workflow-evidence CLI argument.', {
+          observed: { arguments: [...options.keys()] }
+        });
+      }
+      evidence = await verifyWorkflowEvidence({
+        repository: requiredOption(options, '--repository'),
+        workflowPath: requiredOption(options, '--workflow-path'),
+        expectedHeadSha: requiredOption(options, '--head-sha'),
+        expectedAggregateName: requiredOption(options, '--aggregate-name'),
+        token: env.GITHUB_TOKEN,
+        fetchImpl
+      });
+    } else {
+      const allowed = new Set(['--base-sha', '--head-sha', '--repository-root']);
+      if ([...options.keys()].some((name) => !allowed.has(name))) {
+        fail('INVALID_ARGUMENTS', 'Unknown merge-tree CLI argument.', {
+          observed: { arguments: [...options.keys()] }
+        });
+      }
+      evidence = verifyPromotionResultTree({
+        repositoryRoot: options.get('--repository-root') || cwd,
+        baseSha: requiredOption(options, '--base-sha'),
+        headSha: requiredOption(options, '--head-sha'),
+        runGit: runGitImpl
+      });
+    }
+    stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+    if (env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(resolve(env.GITHUB_STEP_SUMMARY), formatEvidenceSummary(evidence), 'utf8');
+    }
+    return 0;
+  } catch (error) {
+    const failure = error instanceof PromotionReadinessError
+      ? error
+      : new PromotionReadinessError('UNEXPECTED_ERROR', 'Unexpected promotion verification failure.', {
+        observed: { error: boundedText(error?.message || String(error)) }
+      });
+    const diagnostic = [
+      `Promotion readiness verification failed [${failure.code}]: ${failure.message}`,
+      `Expected: ${JSON.stringify(failure.expected)}`,
+      `Observed: ${JSON.stringify(failure.observed)}`,
+      ''
+    ].join('\n');
+    const token = typeof env.GITHUB_TOKEN === 'string' ? env.GITHUB_TOKEN : '';
+    stderr.write(token ? diagnostic.replaceAll(token, '[REDACTED]') : diagnostic);
+    return 1;
+  }
+};
+
+const isDirectExecution = process.argv[1]
+  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isDirectExecution) process.exitCode = await runPromotionReadinessCli();

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -235,11 +235,15 @@ const guardPaths = new Set([
   'tools/web-architecture-violations.json',
   'tools/web-change-source.mjs',
   'tools/web-promotion-context.mjs',
+  'tools/check-promotion-readiness.mjs',
   policyPath,
   'docs/internal/WEB_CHANGE_POLICY.md',
   'tests/web/architecture-contracts.test.mjs',
   'tests/web/architecture-ratchet-fixtures.test.mjs',
+  'tests/web/promotion-readiness.test.mjs',
   'tests/web/web-promotion-context.test.mjs',
+  '.github/workflows/gallery-publication.yml',
+  '.github/workflows/deploy_web.yml',
   '.github/workflows/test.yml',
   '.github/workflows/web-base-policy.yml'
 ]);
@@ -249,13 +253,16 @@ const checkerImplementationPaths = new Set([
   'tools/web-architecture-detectors.mjs',
   'tools/web-architecture-evaluation.mjs',
   'tools/web-change-source.mjs',
-  'tools/web-promotion-context.mjs'
+  'tools/web-promotion-context.mjs',
+  'tools/check-promotion-readiness.mjs'
 ]);
 const authorityPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   architectureRulesPath,
   'tools/web-architecture-violations.json',
   policyPath,
+  '.github/workflows/gallery-publication.yml',
+  '.github/workflows/deploy_web.yml',
   '.github/workflows/test.yml',
   '.github/workflows/web-base-policy.yml'
 ]);


### PR DESCRIPTION
## Change class

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Add the checker-only bootstrap for trusted promotion readiness: a bounded module/CLI that verifies GitHub Actions evidence for an exact integrated `dev` SHA and proves that the synthetic `main` + `dev` merge tree is conflict-free and identical to the `dev` tree. This PR intentionally does not wire the helper into any workflow or change an evidence producer.

Start SHA: `c834cb366269707b6ba4d1b91caf8c60005ca52a`  
Exact head SHA: `69e847b59b8499a49e28789de164c684dad4ab04`

## User-visible impact

None. No gbdraw runtime, rendering, scientific output, CLI, Python API, Web UI, deployment, or current promotion workflow behavior changes. The helper remains unwired until a later authority/evidence-producer PR.

## Changes

- Add `tools/check-promotion-readiness.mjs` as the single executable owner for exact-SHA Actions evidence and synthetic merge-result tree proof.
- Resolve each supported workflow by exact path in the expected repository, require an active returned workflow with the exact path and resolved ID, then use only that resolved ID.
- Query all exact `push` / `dev` / head-SHA runs without a success filter; validate repository, workflow path/ID, event, branch, and SHA from returned metadata; select the newest match by `created_at`, then `run_number`, then run ID.
- Re-read the selected run to obtain its current `run_attempt`, require `completed` / `success`, inspect the attempt-specific jobs endpoint, require exactly one exact aggregate display name with `completed` / `success`, and re-read the run after job inspection so an attempt change invalidates the evidence.
- Follow strict GitHub `Link` pagination with immutable query identity, sequential page checks, duplicate/loop detection, stable `total_count`, a 10-page/1,000-result bound, and fail-closed incomplete or malformed handling.
- Emit JSON evidence and a concise `GITHUB_STEP_SUMMARY` record without printing the token or authorization header.
- Validate full hexadecimal object IDs and use argument-array Git plumbing only. `git merge-tree --write-tree --no-messages` creates no checkout or merge commit and must return the exact `dev` head tree.
- Register the helper as checker implementation only. Register its unit test, Gallery/deploy workflows, and the existing workflow/checker contracts in the guard sets. Register Gallery/deploy as authority/evidence producers, not checker implementation.

Source coverage remains owned by `tools/check-web-change-budget.mjs` and same-repository promotion topology remains owned by `tools/web-promotion-context.mjs`; neither algorithm is copied into the new helper.

### Accepted and rejected evidence

| Evidence | Decision |
| --- | --- |
| Active exact-path workflow; exact repository/workflow ID/path; newest exact `push` / `dev` / SHA run completed successfully; current attempt; one exact successful aggregate | Accept |
| Current successful rerun attempt with attempt-specific successful aggregate | Accept |
| Evidence on later complete run/job pages | Accept |
| Wrong repository, workflow path/ID, event, branch, or SHA | Reject |
| Manual dispatch or caller-selected non-`push` / non-`dev` identity | Reject |
| Missing/disabled workflow or no exact matching run | Reject |
| Newer queued/failed run with an older successful run | Reject; never fall back |
| Cancelled, timed-out, skipped, unknown, incomplete, or conclusion-less run | Reject |
| Current attempt differs from an older successful attempt or changes during verification | Reject |
| Missing, duplicate, skipped, cancelled, or failed aggregate job | Reject |
| Malformed, incomplete, looping, reordered, query-changing, or over-bound pagination | Reject |
| Shallow/missing Git history, invalid SHA, merge conflict, or different result tree | Reject |

## Verification

- `npx --yes node@20.20.2 --test tests/web/promotion-readiness.test.mjs` — 18/18 passed.
- `npx --yes node@20.20.2 --test tests/web/architecture-contracts.test.mjs` — 100/100 passed.
- `node --test tests/web/web-promotion-context.test.mjs` — passed.
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs` — passed.
- `node tools/check-web-change-budget.mjs --base origin/dev` — `Result: PASS`, `Size review: CLEAR`.
- Real local tree proof for `main` `bbbe5ed390e6c0cff27e2faf3cd87e7459de5f49` and start `dev` `c834cb366269707b6ba4d1b91caf8c60005ca52a` — conflict-free; synthetic and head tree both `f64fe8ee711cfd4d7b534f860e55988688b8e8c5`.
- `git diff --check` and `git diff --cached --check` — passed.
- Workflow diff — empty.
- Normative docs diff — empty.
- PR template diff — empty.
- `gbdraw/web` runtime diff — empty.
- Hosted checks for exact head `69e847b59b8499a49e28789de164c684dad4ab04` — `Web base policy (trusted base)` passed: https://github.com/satoshikawato/gbdraw/actions/runs/32987963071/job/98238551941; candidate `Web change budget` and hosted architecture/self-authorization contracts passed: https://github.com/satoshikawato/gbdraw/actions/runs/32987962668/job/98238687402; `Web PR smoke`, including the helper unit test in the Node 20 fast Web JavaScript contracts step, passed: https://github.com/satoshikawato/gbdraw/actions/runs/32987962668/job/98238687502; required `PR / gate` passed: https://github.com/satoshikawato/gbdraw/actions/runs/32987962668/job/98240067471. The latest Gallery workflow contains only the existing publication-performance and browser jobs, so no promotion workflow/job was generated: https://github.com/satoshikawato/gbdraw/actions/runs/32987962685. GitHub's Actions major outage delayed and superseded earlier duplicate PR-event runs; the links above are the final/latest evidence set.

Unit tests use only mocked `fetchImpl` and injected `runGit`; they make no live GitHub API requests.

## Risk and review notes

- Gate result and any blocker: local deterministic gates and both hosted required checks pass. The GitHub Actions outage delayed event delivery but no longer blocks this PR's required evidence.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED`; this introduces the planned executable promotion-verifier owner and extends self-authorization classification.
- Architecture impact: **This is architecture-bearing**. The executable promotion-evidence/tree-proof responsibility changes from absent/planned-only to one canonical owner at `tools/check-promotion-readiness.mjs`; it adds one canonical module/CLI path, no parallel owner/path, and no compatibility path. No superseded executable path exists to remove because the helper was previously unwritten and unwired.
- `architecture-change` label, if relevant: applied because this checker/guard registration is architecture-bearing governance tooling; it changes no Web production runtime.
- Ordinary ratchet evidence: owner excess remains zero (one owner for a one-owner capability), path excess remains zero (one bounded module/CLI path), and compatibility burden remains unchanged. Deterministic behavior is covered by the helper and self-authorization fixtures above.
- The helper is deliberately not connected to `pull_request_target` or any other workflow in this PR. Candidate code is not executed by a trusted workflow.

## Rollback

Revert `69e847b59b8499a49e28789de164c684dad4ab04`. This removes the unwired helper, its tests, and its new guard registrations. No workflow, deployment, branch-protection, or persisted-data rollback is required.

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: none. `.github/workflows/test.yml`, `.github/workflows/gallery-publication.yml`, `.github/workflows/web-base-policy.yml`, `.github/workflows/deploy_web.yml`, normative policy, and policy JSON are unchanged.
- Checker implementation files touched: `tools/check-promotion-readiness.mjs` and guard-classification-only edits in `tools/check-web-change-budget.mjs`; focused contracts are in `tests/web/promotion-readiness.test.mjs` and `tests/web/architecture-contracts.test.mjs`.
- Self-authorization separation evidence: helper-only changes pass; helper combined with `test.yml`, `gallery-publication.yml`, `web-base-policy.yml`, or `deploy_web.yml` fails; Gallery/deploy workflow-only fixtures remain reviewable without checker classification; production runtime combined with either newly registered workflow guard fails.
- Branch-protection or ruleset impact, including unchanged settings: no branch-protection/ruleset API mutation was performed. A post-PR authenticated read confirms `strict=true` and the exact required set `Web base policy (trusted base)` plus `PR / gate`, both bound to GitHub Actions app ID `15368`.
- Governance-specific rollback or protection restore point: revert the single commit; branch protection and rulesets require no restore because this PR does not mutate them.
