### PR TITLE
Run full validation on exact dev SHAs and wire trusted promotion

### DIFF
--- a/.github/workflows/gallery-publication.yml
+++ b/.github/workflows/gallery-publication.yml
@@ -5,9 +5,7 @@ permissions:
 
 on:
   push:
-    branches: ["main", "refactoring", "dev"]
-  pull_request:
-    branches: ["dev", "main"]
+    branches: ["dev"]
   workflow_dispatch:
     inputs:
       complete_refresh:
@@ -17,7 +15,7 @@ on:
         type: boolean
 
 concurrency:
-  group: gallery-publication-${{ github.ref }}
+  group: gallery-publication-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -55,7 +53,7 @@ jobs:
         run: npm run ${{ matrix.command }}
 
   performance:
-    name: Gallery publication performance
+    name: Gallery publication performance (projection)
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -83,3 +81,18 @@ jobs:
           python tools/measure_gallery_publication_performance.py refresh
           --baseline-revision 574b33b83962949397839e2aaa862a8b96667625
           --revision ${{ github.sha }}
+
+  readiness-gate:
+    name: Gallery readiness / gate
+    needs:
+      - browser
+      - performance
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Require all Gallery readiness evidence
+        run: |
+          set -euo pipefail
+          test "${{ needs.browser.result }}" = "success"
+          test "${{ needs.performance.result }}" = "success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,19 +5,28 @@ permissions:
 
 on:
   push:
-    branches: ["main", "refactoring", "dev"]
+    branches: ["dev"]
   pull_request:
     branches: ["dev", "main"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
 concurrency:
-  group: tests-${{ github.ref }}
+  # Promotion accepts only the current remote dev tip, so older dev staging can be canceled.
+  group: tests-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   web-change-budget:
     name: Web change budget
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -58,6 +67,13 @@ jobs:
 
   core:
     name: Core (Python ${{ matrix.python-version }})
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -121,6 +137,14 @@ jobs:
 
   recipes-standard:
     name: Recipes standard (Python 3.11)
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -145,6 +169,14 @@ jobs:
 
   gallery:
     name: Gallery (Python 3.11)
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -169,6 +201,13 @@ jobs:
 
   browser:
     name: Browser (Python 3.11)
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -275,7 +314,61 @@ jobs:
           retention-days: 7
 
   playwright-functional:
+    name: Playwright functional (shard ${{ matrix.shard }}/4)
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install Playwright functional dependencies
+        run: |
+          python -m pip install -e ".[dev]"
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Prepare browser wheel
+        run: python tools/prepare_browser_wheel.py
+
+      - name: Run Playwright functional tests
+        run: npm run test:web:functional-full -- --shard=${{ matrix.shard }}/4
+
+      - name: Upload Playwright functional traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-functional-shard-${{ matrix.shard }}-traces-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # PR 7 removes this legacy producer after main protection no longer requires it.
+  playwright-functional-main-transition:
     name: Playwright functional
+    if: >-
+      github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -311,13 +404,20 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-functional-traces-${{ github.run_id }}-${{ github.run_attempt }}
+          name: playwright-functional-main-transition-traces-${{ github.run_id }}-${{ github.run_attempt }}
           path: test-results/
           if-no-files-found: ignore
           retention-days: 7
 
   playwright-performance:
     name: Playwright performance
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -360,11 +460,13 @@ jobs:
 
   acceptance-supported-main:
     name: ${{ matrix.surface }} acceptance (Python ${{ matrix.python-version }})
+    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'push' &&
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
@@ -408,11 +510,13 @@ jobs:
 
   slow-main:
     name: Slow (Python ${{ matrix.python-version }})
+    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'push' &&
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -449,6 +553,14 @@ jobs:
 
   lint:
     name: Lint
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -469,6 +581,13 @@ jobs:
 
   losat-cache-browser-acceptance:
     name: LOSAT cache browser acceptance
+    # PR 7 removes the main-PR branch after final promotion protection is active.
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
+      github.head_ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -526,3 +645,39 @@ jobs:
           test "${{ needs.gallery.result }}" = "success"
           test "${{ needs.lint.result }}" = "success"
           test "${{ needs.web-pr-smoke.result }}" = "success"
+
+  dev-staging-gate:
+    name: Dev staging / gate
+    needs:
+      - web-change-budget
+      - core
+      - recipes-standard
+      - gallery
+      - browser
+      - playwright-functional
+      - playwright-performance
+      - acceptance-supported-main
+      - slow-main
+      - lint
+      - losat-cache-browser-acceptance
+    if: >-
+      always() &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Require all exact-SHA staging evidence
+        run: |
+          set -euo pipefail
+          test "${{ needs.web-change-budget.result }}" = "success"
+          test "${{ needs.core.result }}" = "success"
+          test "${{ needs.recipes-standard.result }}" = "success"
+          test "${{ needs.gallery.result }}" = "success"
+          test "${{ needs.browser.result }}" = "success"
+          test "${{ needs.playwright-functional.result }}" = "success"
+          test "${{ needs.playwright-performance.result }}" = "success"
+          test "${{ needs.acceptance-supported-main.result }}" = "success"
+          test "${{ needs.slow-main.result }}" = "success"
+          test "${{ needs.lint.result }}" = "success"
+          test "${{ needs.losat-cache-browser-acceptance.result }}" = "success"

--- a/.github/workflows/web-base-policy.yml
+++ b/.github/workflows/web-base-policy.yml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
+  actions: read
 
 concurrency:
   group: web-base-policy-${{ github.event.pull_request.number }}
@@ -15,6 +17,7 @@ concurrency:
 jobs:
   trusted-base-policy:
     name: Web base policy (trusted base)
+    if: github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -41,3 +44,113 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           WEB_ARCHITECTURE_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'architecture-change') }}
         run: node tools/check-web-change-budget.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
+
+  # PR 7 removes this legacy producer after main protection no longer requires it.
+  trusted-base-policy-main-transition:
+    name: Web base policy (trusted base)
+    if: >-
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.ref == 'dev' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Fetch PR head as Git data
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch --no-tags origin "$HEAD_SHA"
+
+      - name: Check Web policy from trusted base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          WEB_ARCHITECTURE_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'architecture-change') }}
+        run: node tools/check-web-change-budget.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
+
+  promotion-gate:
+    name: Promotion / gate
+    if: github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout trusted main base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Verify promotion topology and current dev tip
+        env:
+          EXPECTED_REPOSITORY: satoshikawato/gbdraw
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$BASE_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$HEAD_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          test "$BASE_REF" = "main"
+          test "$HEAD_REF" = "dev"
+          git fetch --no-tags origin "refs/heads/dev:refs/remotes/origin/dev"
+          REMOTE_DEV_SHA="$(git rev-parse refs/remotes/origin/dev)"
+          test "$HEAD_SHA" = "$REMOTE_DEV_SHA"
+          git cat-file -e "$HEAD_SHA^{commit}"
+
+      - name: Check source coverage from trusted main
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node tools/check-web-change-budget.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
+
+      - name: Verify exact dev Tests staging evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          node tools/check-promotion-readiness.mjs workflow-evidence
+          --repository "$GITHUB_REPOSITORY"
+          --workflow-path .github/workflows/test.yml
+          --aggregate-name "Dev staging / gate"
+          --head-sha "$HEAD_SHA"
+
+      - name: Verify exact dev Gallery readiness evidence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          node tools/check-promotion-readiness.mjs workflow-evidence
+          --repository "$GITHUB_REPOSITORY"
+          --workflow-path .github/workflows/gallery-publication.yml
+          --aggregate-name "Gallery readiness / gate"
+          --head-sha "$HEAD_SHA"
+
+      - name: Prove promotion result tree identity
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          node tools/check-promotion-readiness.mjs merge-tree
+          --repository-root .
+          --base-sha "$BASE_SHA"
+          --head-sha "$HEAD_SHA"

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -56,10 +56,22 @@ const BASE_POLICY_WORKFLOW = readFileSync(
   join(REPOSITORY_ROOT, '.github/workflows/web-base-policy.yml'),
   'utf8'
 );
+const GALLERY_PUBLICATION_WORKFLOW = readFileSync(
+  join(REPOSITORY_ROOT, '.github/workflows/gallery-publication.yml'),
+  'utf8'
+);
+const DEPLOY_WORKFLOW = readFileSync(
+  join(REPOSITORY_ROOT, '.github/workflows/deploy_web.yml'),
+  'utf8'
+);
 const PACKAGE_SCRIPTS = JSON.parse(readFileSync(
   join(REPOSITORY_ROOT, 'package.json'),
   'utf8'
 )).scripts;
+const BASE_PLAYWRIGHT_CONFIG = readFileSync(
+  join(REPOSITORY_ROOT, 'playwright.config.js'),
+  'utf8'
+);
 const FUNCTIONAL_PLAYWRIGHT_CONFIG = readFileSync(
   join(REPOSITORY_ROOT, 'playwright.functional.config.js'),
   'utf8'
@@ -113,8 +125,8 @@ const PLAYWRIGHT_SPEC_SOURCES = walkJavaScriptFiles(
 ).filter((path) => path.endsWith('.playwright.spec.js'))
   .map((path) => readFileSync(path, 'utf8'));
 
-const workflowJob = (jobId) => {
-  const job = TEST_WORKFLOW.match(
+const workflowJob = (jobId, workflow = TEST_WORKFLOW) => {
+  const job = workflow.match(
     new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
   )?.[0];
   assert.ok(job, `${jobId} job must exist`);
@@ -705,11 +717,11 @@ test('report-only source facts preserve the characterized masking behavior', () 
   });
 });
 
-test('PR workflows separate normal tests from trusted base-policy execution', () => {
+test('workflow triggers separate dev admission, dev staging, promotion, and deployment', () => {
   const activityTypes = /types: \[opened, synchronize, reopened, labeled, unlabeled\]/;
   const triggerBranches = (workflow, trigger) => {
     const match = workflow.match(new RegExp(
-      `\\n  ${trigger}:\\n    branches: (\\[[^\\n]+\\])`
+      `\\r?\\n  ${trigger}:\\r?\\n    branches: (\\[[^\\r\\n]+\\])`
     ));
     assert.ok(match, `${trigger} branch filter must exist`);
     return JSON.parse(match[1]);
@@ -717,8 +729,13 @@ test('PR workflows separate normal tests from trusted base-policy execution', ()
 
   assert.match(TEST_WORKFLOW, /\n  pull_request:\n/);
   assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'pull_request'), ['dev', 'main']);
+  assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'push'), ['dev']);
   assert.match(TEST_WORKFLOW, activityTypes);
   assert.match(TEST_WORKFLOW, /name: Run core tests/);
+  assert.match(
+    TEST_WORKFLOW,
+    /group: tests-\$\{\{ github\.event_name \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/
+  );
 
   assert.match(BASE_POLICY_WORKFLOW, /\n  pull_request_target:\n/);
   assert.deepEqual(
@@ -726,22 +743,18 @@ test('PR workflows separate normal tests from trusted base-policy execution', ()
     ['dev', 'main']
   );
   assert.match(BASE_POLICY_WORKFLOW, activityTypes);
-  assert.match(BASE_POLICY_WORKFLOW, /permissions:\n  contents: read/);
-  assert.match(BASE_POLICY_WORKFLOW, /name: Web base policy \(trusted base\)/);
-  assert.match(BASE_POLICY_WORKFLOW, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
-  assert.match(BASE_POLICY_WORKFLOW, /fetch-depth: 0/);
-  assert.match(BASE_POLICY_WORKFLOW, /persist-credentials: false/);
-  assert.equal([...BASE_POLICY_WORKFLOW.matchAll(/uses: actions\/checkout@/g)].length, 1);
-  assert.match(BASE_POLICY_WORKFLOW, /git fetch --no-tags origin "\$HEAD_SHA"/);
   assert.match(
     BASE_POLICY_WORKFLOW,
-    /node tools\/check-web-change-budget\.mjs --base "\$BASE_SHA" --head "\$HEAD_SHA"/
+    /permissions:\n  contents: read\n  pull-requests: read\n  actions: read/
   );
-  assert.doesNotMatch(
-    BASE_POLICY_WORKFLOW,
-    /(?:checkout|run):[^\n]*pull_request\.head|ref:.*pull_request\.head|git (?:checkout|switch) /
-  );
-  assert.doesNotMatch(BASE_POLICY_WORKFLOW, /Core PR \(Python 3\.11\)|Web PR smoke|PR \/ gate/);
+
+  assert.deepEqual(triggerBranches(GALLERY_PUBLICATION_WORKFLOW, 'push'), ['dev']);
+  assert.doesNotMatch(GALLERY_PUBLICATION_WORKFLOW, /\n  pull_request:\n/);
+  assert.match(GALLERY_PUBLICATION_WORKFLOW, /\n  workflow_dispatch:\n/);
+
+  assert.deepEqual(triggerBranches(DEPLOY_WORKFLOW, 'push'), ['main']);
+  assert.doesNotMatch(TEST_WORKFLOW, /branches: \[[^\]]*"main"[^\]]*\]\n  pull_request:/);
+  assert.doesNotMatch(GALLERY_PUBLICATION_WORKFLOW, /"main"|"refactoring"/);
 });
 
 test('PR-to-dev fast candidates and aggregate fail closed over the mandatory evidence', () => {
@@ -800,6 +813,30 @@ test('PR-to-dev fast candidates and aggregate fail closed over the mandatory evi
     );
   });
   assert.doesNotMatch(gate, /gh api|curl|check-web-change-budget|pull_request_target/);
+
+  for (const jobId of ['web-change-budget', 'recipes-standard', 'gallery', 'lint']) {
+    assert.match(
+      workflowJob(jobId),
+      /github\.event_name == 'pull_request' && github\.base_ref == 'dev'/,
+      `${jobId} must remain in the fast dev-PR graph`
+    );
+  }
+  for (const jobId of [
+    'core',
+    'browser',
+    'playwright-functional',
+    'playwright-performance',
+    'acceptance-supported-main',
+    'slow-main',
+    'losat-cache-browser-acceptance'
+  ]) {
+    const job = workflowJob(jobId);
+    assert.doesNotMatch(
+      job,
+      /github\.event_name == 'pull_request' && github\.base_ref == 'dev'/,
+      `${jobId} must not run on a dev pull request`
+    );
+  }
 });
 
 test('PR smoke selection is explicit while the full functional inventory stays wide', () => {
@@ -839,14 +876,144 @@ test('PR smoke selection is explicit while the full functional inventory stays w
   assert.ok(selectedCount >= 6 && selectedCount <= 10, `selected ${selectedCount} smoke tests`);
 });
 
-test('PR 1 preserves legacy check identities and does not add policy owners or mutators', () => {
+test('exact dev staging runs the full inventory with four mandatory Playwright shards', () => {
+  const stagingOnly = [
+    'core',
+    'browser',
+    'playwright-functional',
+    'playwright-performance',
+    'acceptance-supported-main',
+    'slow-main',
+    'losat-cache-browser-acceptance'
+  ];
+  for (const jobId of stagingOnly) {
+    const job = workflowJob(jobId);
+    assert.match(job, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/);
+    assert.match(
+      job,
+      /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
+    );
+  }
+
+  const fullPlaywright = workflowJob('playwright-functional');
+  assert.match(fullPlaywright, /\n    name: Playwright functional \(shard \$\{\{ matrix\.shard \}\}\/4\)\n/);
+  assert.match(fullPlaywright, /shard: \[1, 2, 3, 4\]/);
+  assert.match(
+    fullPlaywright,
+    /npm run test:web:functional-full -- --shard=\$\{\{ matrix\.shard \}\}\/4/
+  );
+  assert.match(fullPlaywright, /playwright-functional-shard-\$\{\{ matrix\.shard \}\}-traces-/);
+  assert.match(BASE_PLAYWRIGHT_CONFIG, /retries: process\.env\.CI \? 2 : 0/);
+  assert.match(BASE_PLAYWRIGHT_CONFIG, /workers: process\.env\.CI \? 1 : undefined/);
+
+  const gate = workflowJob('dev-staging-gate');
+  const dependencies = gate.match(
+    /\n    needs:\n((?:      - [a-z0-9-]+\n)+)/
+  )?.[1].trim().split('\n').map((line) => line.replace('- ', '').trim());
+  assert.deepEqual(dependencies, [
+    'web-change-budget',
+    'core',
+    'recipes-standard',
+    'gallery',
+    'browser',
+    'playwright-functional',
+    'playwright-performance',
+    'acceptance-supported-main',
+    'slow-main',
+    'lint',
+    'losat-cache-browser-acceptance'
+  ]);
+  assert.match(gate, /\n    name: Dev staging \/ gate\n/);
+  assert.match(gate, /always\(\)/);
+  assert.match(gate, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/);
+  assert.match(
+    gate,
+    /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
+  );
+  dependencies.forEach((jobId) => {
+    assert.ok(
+      gate.includes(`test "\${{ needs.${jobId}.result }}" = "success"`),
+      `${jobId} must fail the staging aggregate unless it succeeds`
+    );
+  });
+  assert.doesNotMatch(gate, /gh api|curl|check-promotion-readiness/);
+});
+
+test('Gallery readiness aggregates common, Vibrio, and projection evidence on dev', () => {
+  const browser = workflowJob('browser', GALLERY_PUBLICATION_WORKFLOW);
+  assert.match(browser, /example: common 9\n            command: test:web:gallery-publication/);
+  assert.match(browser, /example: Vibrio\n            command: test:web:vibrio-generate/);
+  assert.match(browser, /ref: \$\{\{ github\.sha \}\}/);
+
+  const performance = workflowJob('performance', GALLERY_PUBLICATION_WORKFLOW);
+  assert.match(performance, /\n    name: Gallery publication performance \(projection\)\n/);
+  assert.match(performance, /measure_gallery_publication_performance\.py projection/);
+  assert.match(performance, /github\.event_name == 'workflow_dispatch' && inputs\.complete_refresh/);
+  assert.match(performance, /measure_gallery_publication_performance\.py refresh/);
+
+  const gate = workflowJob('readiness-gate', GALLERY_PUBLICATION_WORKFLOW);
+  assert.match(gate, /\n    name: Gallery readiness \/ gate\n/);
+  assert.match(gate, /\n    needs:\n      - browser\n      - performance\n/);
+  assert.match(gate, /\n    if: always\(\)\n/);
+  for (const jobId of ['browser', 'performance']) {
+    assert.ok(
+      gate.includes(`test "\${{ needs.${jobId}.result }}" = "success"`),
+      `${jobId} must fail the Gallery aggregate unless all matrix jobs succeed`
+    );
+  }
+  assert.doesNotMatch(gate, /gh api|curl|check-promotion-readiness/);
+});
+
+test('trusted promotion uses base code for topology, exact-SHA evidence, and tree proof', () => {
+  const devPolicy = workflowJob('trusted-base-policy', BASE_POLICY_WORKFLOW);
+  assert.match(devPolicy, /\n    name: Web base policy \(trusted base\)\n/);
+  assert.match(devPolicy, /if: github\.event\.pull_request\.base\.ref == 'dev'/);
+
+  const promotion = workflowJob('promotion-gate', BASE_POLICY_WORKFLOW);
+  assert.match(promotion, /\n    name: Promotion \/ gate\n/);
+  assert.match(promotion, /if: github\.event\.pull_request\.base\.ref == 'main'/);
+  assert.equal([...promotion.matchAll(/uses: actions\/checkout@/g)].length, 1);
+  assert.match(promotion, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.match(promotion, /fetch-depth: 0/);
+  assert.match(promotion, /persist-credentials: false/);
+  assert.match(promotion, /EXPECTED_REPOSITORY: satoshikawato\/gbdraw/);
+  assert.match(promotion, /test "\$BASE_REF" = "main"/);
+  assert.match(promotion, /test "\$HEAD_REF" = "dev"/);
+  assert.match(promotion, /test "\$HEAD_REPOSITORY" = "\$EXPECTED_REPOSITORY"/);
+  assert.match(
+    promotion,
+    /git fetch --no-tags origin "refs\/heads\/dev:refs\/remotes\/origin\/dev"/
+  );
+  assert.match(promotion, /test "\$HEAD_SHA" = "\$REMOTE_DEV_SHA"/);
+  assert.match(
+    promotion,
+    /node tools\/check-web-change-budget\.mjs --base "\$BASE_SHA" --head "\$HEAD_SHA"/
+  );
+  assert.equal([...promotion.matchAll(/workflow-evidence/g)].length, 2);
+  assert.match(
+    promotion,
+    /--workflow-path \.github\/workflows\/test\.yml[\s\S]*--aggregate-name "Dev staging \/ gate"/
+  );
+  assert.match(
+    promotion,
+    /--workflow-path \.github\/workflows\/gallery-publication\.yml[\s\S]*--aggregate-name "Gallery readiness \/ gate"/
+  );
+  assert.match(promotion, /check-promotion-readiness\.mjs merge-tree/);
+  assert.match(promotion, /--base-sha "\$BASE_SHA"[\s\S]*--head-sha "\$HEAD_SHA"/);
+  assert.doesNotMatch(
+    promotion,
+    /ref:.*pull_request\.head|git (?:checkout|switch) |npm ci|pip install|functional-full|perf-smoke|pytest/
+  );
+  assert.doesNotMatch(promotion, /uses: \.\//);
+});
+
+test('foundation promotion keeps substantive producers for legacy main contexts', () => {
   [
     'Web change budget',
     'Core (Python ${{ matrix.python-version }})',
     'Recipes standard (Python 3.11)',
     'Gallery (Python 3.11)',
     'Browser (Python 3.11)',
-    'Playwright functional',
     'Playwright performance',
     'Lint',
     'LOSAT cache browser acceptance'
@@ -854,7 +1021,40 @@ test('PR 1 preserves legacy check identities and does not add policy owners or m
     assert.ok(TEST_WORKFLOW.includes(`name: ${displayName}`), `Missing legacy job: ${displayName}`);
   });
   assert.match(TEST_WORKFLOW, /python-version: \["3\.10", "3\.11", "3\.12"\]/);
-  assert.match(BASE_POLICY_WORKFLOW, /name: Web base policy \(trusted base\)/);
+  const mainFunctional = workflowJob('playwright-functional-main-transition');
+  assert.match(mainFunctional, /\n    name: Playwright functional\n/);
+  assert.match(mainFunctional, /npm run test:web:functional-full/);
+  assert.doesNotMatch(mainFunctional, /--shard=/);
+
+  for (const jobId of [
+    'web-change-budget',
+    'core',
+    'recipes-standard',
+    'gallery',
+    'browser',
+    'playwright-functional-main-transition',
+    'playwright-performance',
+    'acceptance-supported-main',
+    'slow-main',
+    'lint',
+    'losat-cache-browser-acceptance'
+  ]) {
+    const job = workflowJob(jobId);
+    assert.match(job, /github\.base_ref == 'main'|pull_request\.base\.ref == 'main'/);
+    assert.match(job, /github\.head_ref == 'dev'|pull_request\.head\.ref == 'dev'/);
+    assert.match(job, /head\.repo\.full_name == github\.repository/);
+  }
+
+  const mainPolicy = workflowJob(
+    'trusted-base-policy-main-transition',
+    BASE_POLICY_WORKFLOW
+  );
+  assert.match(mainPolicy, /\n    name: Web base policy \(trusted base\)\n/);
+  assert.match(mainPolicy, /node tools\/check-web-change-budget\.mjs/);
+  assert.match(
+    BASE_POLICY_WORKFLOW,
+    /PR 7 removes this legacy producer[\s\S]*trusted-base-policy-main-transition:/
+  );
   assert.doesNotMatch(TEST_WORKFLOW, /needs: web-change-budget/);
   assert.equal(
     existsSync(join(REPOSITORY_ROOT, '.github/workflows/dev-staging.yml')),
@@ -918,12 +1118,11 @@ test('the PR template requires exact changed-scope architecture debt arithmetic'
   });
 });
 
-test('normal CI uses dev as the staging push branch', () => {
+test('normal CI uses only dev as the staging push branch', () => {
   assert.match(
     TEST_WORKFLOW,
-    /push:\n    branches: \["main", "refactoring", "dev"\]/
+    /push:\n    branches: \["dev"\]/
   );
-  assert.doesNotMatch(TEST_WORKFLOW, /branches: \[[^\]]*"develop"/);
   assert.match(TEST_WORKFLOW, /\n  workflow_dispatch:\n/);
 });
 
@@ -968,13 +1167,14 @@ test('dev staging Web checks scope only the newly integrated change', () => {
   );
 });
 
-test('supported-version and slow matrices cover main PRs and dev staging runs', () => {
+test('supported-version and slow matrices cover dev staging and transition promotions', () => {
   const stagingCondition = [
     "    if: >-",
-    "      (github.event_name == 'pull_request' && github.base_ref == 'main') ||",
-    "      (github.event_name == 'push' &&",
-    "      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) ||",
-    "      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')"
+    "      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||",
+    "      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||",
+    "      (github.event_name == 'pull_request' && github.base_ref == 'main' &&",
+    "      github.head_ref == 'dev' &&",
+    "      github.event.pull_request.head.repo.full_name == github.repository)"
   ].join('\n');
 
   for (const jobName of ['acceptance-supported-main', 'slow-main']) {
@@ -982,7 +1182,7 @@ test('supported-version and slow matrices cover main PRs and dev staging runs', 
       new RegExp(`\\n  ${jobName}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
     )?.[0];
     assert.ok(job, `${jobName} job must exist`);
-    assert.ok(job.includes(stagingCondition), `${jobName} must use the main protection condition`);
+    assert.ok(job.includes(stagingCondition), `${jobName} must use the staging transition condition`);
   }
 });
 


### PR DESCRIPTION
## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Move full validation from ordinary pull requests to the exact integrated `dev` SHA, add stable staging and Gallery aggregates, and wire the trusted `dev -> main` promotion gate without adding workflow owners.

Start SHA: `ad826fbbd9494bec98638ba7f73617b26920b9f6`

Head SHA: `4d058468772bb94caa1543744f72197f012d855c`

Merged `dev` SHA: `2acbdae759d181b2ea6cbbcb824b430f675ba53f`

## User-visible impact

No application or scientific-output behavior changes. Pull requests to `dev` keep the fast graph. Full tests and Gallery readiness run after integration on `dev`.

## Changes

Event ownership before and after:

| Event | Before | After |
| --- | --- | --- |
| PR to `dev` | Fast jobs plus unconditioned full jobs; Gallery also ran | Fast jobs and `PR / gate` only |
| Push to `dev` | Full Tests and Gallery jobs without stable full aggregates | Full Tests with `Dev staging / gate`; Gallery with `Gallery readiness / gate` |
| PR `dev -> main` | Legacy full jobs and trusted Web policy | Transition-only legacy producers plus the candidate trusted `Promotion / gate` definition |
| Push to `main` | General Tests, Gallery, and deploy | Deploy workflow only |
| Push to `refactoring` | General Tests and Gallery | No Tests or Gallery workflow |

Fast PR evidence remains:

- `Web change budget`
- `Core PR (Python 3.11)`
- `Recipes standard (Python 3.11)`
- `Gallery (Python 3.11)`
- `Lint`
- `Web PR smoke`
- `PR / gate`

Exact `dev` staging retains:

| Surface | Inventory |
| --- | --- |
| Web policy | Integrated push range plus architecture contracts |
| Core | Python 3.10, 3.11, 3.12 |
| Recipes and Gallery | Standard recipes and Gallery Python on 3.11 |
| Browser | JavaScript, Python browser, and slow offline packaging contracts |
| Playwright functional | Full 101-test, 16-file inventory split across shards 1/4 through 4/4 |
| Playwright performance | Existing performance configuration and command |
| Supported-version acceptance | recipe, gallery, browser on Python 3.10 and 3.12 |
| Slow | Python 3.10, 3.11, 3.12 |
| LOSAT | Existing cache browser acceptance |
| Lint | Ruff 0.15.12 |

Gallery readiness runs the existing common 9, Vibrio, and projection checks in parallel. Manual complete-refresh input remains available.

The main promotion job has `contents: read`, `pull-requests: read`, and `actions: read`. It checks out the exact base SHA, fetches `dev` as Git data, verifies repository/base/head topology and the current remote `dev` tip, runs source coverage with trusted base code, selects exact push evidence for the two stable aggregates, and proves synthetic result-tree identity. It does not install or execute candidate dependencies, scripts, or actions.

## Verification

- `npm ci`: pass
- `npm run test:web:pr-smoke`: 7 passed in 57.1s, retries 0
- `npm run test:web:functional-full -- --list`: 101 tests in 16 files
- Four-shard list proof: shard counts 26, 25, 26, 24; union 101; missing 0; extra 0; cross-shard duplicates 0
- `node tests/web/architecture-contracts.test.mjs`: 103 passed
- `node tests/web/architecture-ratchet-fixtures.test.mjs`: 14 passed
- `node tests/web/web-promotion-context.test.mjs`: 7 passed
- `node tests/web/promotion-readiness.test.mjs`: 18 passed
- `node tools/check-web-change-budget.mjs --base origin/dev`: Result PASS, Size review CLEAR
- Python and Ruby YAML parsing for all four workflows: pass
- `git diff --check`: pass
- Diffs for both checker implementations, `docs/internal`, `gbdraw/web`, Playwright/package configs, and `.github/workflows/deploy_web.yml`: empty

Baseline hosted duration evidence from successful exact SHA `97aa03758329f1da92e1f9ff32d6c244c8918c93`:

| Job or step | Observed duration |
| --- | ---: |
| Tests workflow | 14m38s |
| Playwright functional job | 14m33s |
| Playwright functional test step | 11m21s |
| Gallery common 9 job | 5m44s |
| Gallery Vibrio job | 19m31s |
| Gallery projection job | 2m10s |

Hosted PR verification for head SHA `4d058468772bb94caa1543744f72197f012d855c`:

- Tests run: https://github.com/satoshikawato/gbdraw/actions/runs/33019343442
- Trusted-base run: https://github.com/satoshikawato/gbdraw/actions/runs/33019340813
- `PR / gate`: pass
- `Core PR (Python 3.11)`: pass in 4m01s
- `Gallery (Python 3.11)`: pass in 3m23s
- `Web PR smoke`: pass in 3m24s
- `Web change budget`: pass in 2m13s
- `Recipes standard (Python 3.11)`: pass in 2m01s
- `Lint`: pass in 32s
- `Web base policy (trusted base)`: pass in 1m36s
- Full, slow, LOSAT, supported-version acceptance, Browser Python, performance, and Playwright shard jobs: skipped by their explicit event conditions

Hosted exact-dev staging/readiness for merge SHA `2acbdae759d181b2ea6cbbcb824b430f675ba53f`:

| Evidence | Attempt | Result | Observed duration | Run |
| --- | ---: | --- | ---: | --- |
| Tests / `Dev staging / gate` | 1 | pass | Tests run 7m00s; gate 2s | https://github.com/satoshikawato/gbdraw/actions/runs/33027335477 |
| Gallery publication / `Gallery readiness / gate` | 1 | pass | Gallery run 16m11s; gate 5s | https://github.com/satoshikawato/gbdraw/actions/runs/33027335516 |

All four Playwright shards passed: shard 1/4 in 6m49s, 2/4 in 3m32s, 3/4 in 2m27s, and 4/4 in 4m04s. The Tests run recorded 24 successful full-graph jobs, four expected PR-only skips, and no failure. Gallery projection passed in 2m02s, common 9 in 4m20s, and Vibrio in 15m57s. These are automatic push runs for the exact merged `dev` SHA; no manual run or rerun was substituted.

## Risk and review notes

- Gate result and any blocker: local Gate PASS, hosted `PR / gate` PASS, exact-dev `Dev staging / gate` PASS, and exact-dev `Gallery readiness / gate` PASS. No blocker remains.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because evidence-producer workflows and CI responsibility boundaries change.
- Architecture impact: **This is architecture-bearing** for CI event responsibility. The canonical owners remain `test.yml`, `gallery-publication.yml`, `web-base-policy.yml`, and `deploy_web.yml`; superseded main/refactoring and Gallery PR execution paths are removed. No semantic-owner, canonical-path, or persisted-compatibility excess is added.
- `architecture-change` label, if relevant: not applied; Web production source is unchanged.

## Rollback

Revert `4d058468772bb94caa1543744f72197f012d855c` before promotion. This restores the previous triggers and unsharded full job. Do not promote a failed exact `dev` SHA, substitute a manual run, or weaken the test inventory.

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/test.yml`, `.github/workflows/gallery-publication.yml`, `.github/workflows/web-base-policy.yml`.
- Checker implementation files touched: none.
- Self-authorization separation evidence: `tools/check-promotion-readiness.mjs`, `tools/check-web-change-budget.mjs`, source parsers, evaluators, policies, and normative docs have empty diffs. Workflow contracts changed only in `tests/web/architecture-contracts.test.mjs`.
- Branch-protection or ruleset impact, including unchanged settings: no mutation in this PR. `main` uses classic protection with `strict: false`; non-status protection settings remain untouched. No repository ruleset is active.
- Governance-specific rollback or protection restore point: branch protection is unchanged, so the code rollback is the commit revert above.

Current `main` required-context inventory and transition mapping:

| Required context | App ID / slug | Producer during foundation transition | PR 7 removal |
| --- | --- | --- | --- |
| `Web change budget` | 15368 / `github-actions` | `test.yml` integrated checker | Remove main-PR condition |
| `Web base policy (trusted base)` | 15368 / `github-actions` | `web-base-policy.yml` trusted base checker | Remove transition job |
| `Core (Python 3.10)` | 15368 / `github-actions` | `test.yml` core matrix | Remove main-PR condition |
| `Core (Python 3.11)` | 15368 / `github-actions` | `test.yml` core matrix | Remove main-PR condition |
| `Core (Python 3.12)` | 15368 / `github-actions` | `test.yml` core matrix | Remove main-PR condition |
| `Recipes standard (Python 3.11)` | 15368 / `github-actions` | `test.yml` recipe test | Remove main-PR condition |
| `Gallery (Python 3.11)` | 15368 / `github-actions` | `test.yml` Gallery test | Remove main-PR condition |
| `Browser (Python 3.11)` | 15368 / `github-actions` | `test.yml` Browser test | Remove main-PR condition |
| `Playwright functional` | 15368 / `github-actions` | `test.yml` unsharded transition job | Remove transition job |
| `Playwright performance` | 15368 / `github-actions` | `test.yml` performance job | Remove main-PR condition |
| `Lint` | 15368 / `github-actions` | `test.yml` lint job | Remove main-PR condition |
| `LOSAT cache browser acceptance` | 15368 / `github-actions` | `test.yml` LOSAT acceptance | Remove main-PR condition |
| `recipe acceptance (Python 3.10)` | 15368 / `github-actions` | `test.yml` acceptance matrix | Remove main-PR condition |
| `gallery acceptance (Python 3.10)` | 15368 / `github-actions` | `test.yml` acceptance matrix | Remove main-PR condition |
| `browser acceptance (Python 3.10)` | 15368 / `github-actions` | `test.yml` acceptance matrix | Remove main-PR condition |
| `recipe acceptance (Python 3.12)` | 15368 / `github-actions` | `test.yml` acceptance matrix | Remove main-PR condition |
| `gallery acceptance (Python 3.12)` | 15368 / `github-actions` | `test.yml` acceptance matrix | Remove main-PR condition |
| `browser acceptance (Python 3.12)` | 15368 / `github-actions` | `test.yml` acceptance matrix | Remove main-PR condition |
| `Slow (Python 3.10)` | 15368 / `github-actions` | `test.yml` slow matrix | Remove main-PR condition |
| `Slow (Python 3.11)` | 15368 / `github-actions` | `test.yml` slow matrix | Remove main-PR condition |
| `Slow (Python 3.12)` | 15368 / `github-actions` | `test.yml` slow matrix | Remove main-PR condition |
| `CodeQL` | 57789 / CodeQL app | Existing external CodeQL producer; not duplicated | Keep external producer |

All transition jobs run their current substantive commands and are limited to same-repository `dev -> main`. PR 7 removes them after the foundation has reached `main` and the final promotion protection is ready.
