### PR TITLE
Remove CI transition compatibility after foundation promotion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: ["dev"]
   pull_request:
-    branches: ["dev", "main"]
+    branches: ["dev"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
 
@@ -19,14 +19,10 @@ concurrency:
 jobs:
   web-change-budget:
     name: Web change budget
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -67,13 +63,9 @@ jobs:
 
   core:
     name: Core (Python ${{ matrix.python-version }})
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -137,14 +129,10 @@ jobs:
 
   recipes-standard:
     name: Recipes standard (Python 3.11)
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -169,14 +157,10 @@ jobs:
 
   gallery:
     name: Gallery (Python 3.11)
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -201,13 +185,9 @@ jobs:
 
   browser:
     name: Browser (Python 3.11)
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -362,62 +342,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # PR 7 removes this legacy producer after main protection no longer requires it.
-  playwright-functional-main-transition:
-    name: Playwright functional
-    if: >-
-      github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: npm
-
-      - name: Install Playwright functional dependencies
-        run: |
-          python -m pip install -e ".[dev]"
-          npm ci
-          npx playwright install --with-deps chromium
-
-      - name: Prepare browser wheel
-        run: python tools/prepare_browser_wheel.py
-
-      - name: Run Playwright functional tests
-        run: npm run test:web:functional-full
-
-      - name: Upload Playwright functional traces
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-functional-main-transition-traces-${{ github.run_id }}-${{ github.run_attempt }}
-          path: test-results/
-          if-no-files-found: ignore
-          retention-days: 7
-
   playwright-performance:
     name: Playwright performance
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -460,13 +389,9 @@ jobs:
 
   acceptance-supported-main:
     name: ${{ matrix.surface }} acceptance (Python ${{ matrix.python-version }})
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
@@ -510,13 +435,9 @@ jobs:
 
   slow-main:
     name: Slow (Python ${{ matrix.python-version }})
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -553,14 +474,10 @@ jobs:
 
   lint:
     name: Lint
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -581,13 +498,9 @@ jobs:
 
   losat-cache-browser-acceptance:
     name: LOSAT cache browser acceptance
-    # PR 7 removes the main-PR branch after final promotion protection is active.
     if: >-
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' &&
-      github.head_ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/web-base-policy.yml
+++ b/.github/workflows/web-base-policy.yml
@@ -45,40 +45,6 @@ jobs:
           WEB_ARCHITECTURE_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'architecture-change') }}
         run: node tools/check-web-change-budget.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
 
-  # PR 7 removes this legacy producer after main protection no longer requires it.
-  trusted-base-policy-main-transition:
-    name: Web base policy (trusted base)
-    if: >-
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.ref == 'dev' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout trusted base
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Fetch PR head as Git data
-        env:
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: git fetch --no-tags origin "$HEAD_SHA"
-
-      - name: Check Web policy from trusted base
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          WEB_ARCHITECTURE_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'architecture-change') }}
-        run: node tools/check-web-change-budget.mjs --base "$BASE_SHA" --head "$HEAD_SHA"
-
   promotion-gate:
     name: Promotion / gate
     if: github.event.pull_request.base.ref == 'main'

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -80,12 +80,15 @@ const PR_SMOKE_PLAYWRIGHT_CONFIG = readFileSync(
   join(REPOSITORY_ROOT, 'playwright.pr-smoke.config.js'),
   'utf8'
 );
-const WORKFLOW_SOURCES = readdirSync(
+const WORKFLOW_NAMES = readdirSync(
   join(REPOSITORY_ROOT, '.github/workflows'),
   { withFileTypes: true }
 ).filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
-  .map((entry) => readFileSync(
-    join(REPOSITORY_ROOT, '.github/workflows', entry.name),
+  .map((entry) => entry.name)
+  .sort();
+const WORKFLOW_SOURCES = WORKFLOW_NAMES
+  .map((name) => readFileSync(
+    join(REPOSITORY_ROOT, '.github/workflows', name),
     'utf8'
   ));
 const PULL_REQUEST_TEMPLATE = readFileSync(
@@ -728,7 +731,7 @@ test('workflow triggers separate dev admission, dev staging, promotion, and depl
   };
 
   assert.match(TEST_WORKFLOW, /\n  pull_request:\n/);
-  assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'pull_request'), ['dev', 'main']);
+  assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'pull_request'), ['dev']);
   assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'push'), ['dev']);
   assert.match(TEST_WORKFLOW, activityTypes);
   assert.match(TEST_WORKFLOW, /name: Run core tests/);
@@ -753,7 +756,7 @@ test('workflow triggers separate dev admission, dev staging, promotion, and depl
   assert.match(GALLERY_PUBLICATION_WORKFLOW, /\n  workflow_dispatch:\n/);
 
   assert.deepEqual(triggerBranches(DEPLOY_WORKFLOW, 'push'), ['main']);
-  assert.doesNotMatch(TEST_WORKFLOW, /branches: \[[^\]]*"main"[^\]]*\]\n  pull_request:/);
+  assert.doesNotMatch(TEST_WORKFLOW, /"main"|"refactoring"/);
   assert.doesNotMatch(GALLERY_PUBLICATION_WORKFLOW, /"main"|"refactoring"/);
 });
 
@@ -1007,54 +1010,25 @@ test('trusted promotion uses base code for topology, exact-SHA evidence, and tre
   assert.doesNotMatch(promotion, /uses: \.\//);
 });
 
-test('foundation promotion keeps substantive producers for legacy main contexts', () => {
-  [
-    'Web change budget',
-    'Core (Python ${{ matrix.python-version }})',
-    'Recipes standard (Python 3.11)',
-    'Gallery (Python 3.11)',
-    'Browser (Python 3.11)',
-    'Playwright performance',
-    'Lint',
-    'LOSAT cache browser acceptance'
-  ].forEach((displayName) => {
-    assert.ok(TEST_WORKFLOW.includes(`name: ${displayName}`), `Missing legacy job: ${displayName}`);
-  });
-  assert.match(TEST_WORKFLOW, /python-version: \["3\.10", "3\.11", "3\.12"\]/);
-  const mainFunctional = workflowJob('playwright-functional-main-transition');
-  assert.match(mainFunctional, /\n    name: Playwright functional\n/);
-  assert.match(mainFunctional, /npm run test:web:functional-full/);
-  assert.doesNotMatch(mainFunctional, /--shard=/);
-
-  for (const jobId of [
-    'web-change-budget',
-    'core',
-    'recipes-standard',
-    'gallery',
-    'browser',
-    'playwright-functional-main-transition',
-    'playwright-performance',
-    'acceptance-supported-main',
-    'slow-main',
-    'lint',
-    'losat-cache-browser-acceptance'
-  ]) {
-    const job = workflowJob(jobId);
-    assert.match(job, /github\.base_ref == 'main'|pull_request\.base\.ref == 'main'/);
-    assert.match(job, /github\.head_ref == 'dev'|pull_request\.head\.ref == 'dev'/);
-    assert.match(job, /head\.repo\.full_name == github\.repository/);
-  }
-
-  const mainPolicy = workflowJob(
-    'trusted-base-policy-main-transition',
-    BASE_POLICY_WORKFLOW
+test('steady-state topology removes legacy main producers without changing final owners', () => {
+  assert.doesNotMatch(TEST_WORKFLOW, /\n  playwright-functional-main-transition:\n/);
+  assert.doesNotMatch(TEST_WORKFLOW, /main-transition|PR 7 removes/);
+  assert.doesNotMatch(
+    TEST_WORKFLOW,
+    /github\.base_ref == 'main'|github\.head_ref == 'dev'|head\.repo\.full_name == github\.repository/
   );
-  assert.match(mainPolicy, /\n    name: Web base policy \(trusted base\)\n/);
-  assert.match(mainPolicy, /node tools\/check-web-change-budget\.mjs/);
-  assert.match(
-    BASE_POLICY_WORKFLOW,
-    /PR 7 removes this legacy producer[\s\S]*trusted-base-policy-main-transition:/
+  assert.doesNotMatch(BASE_POLICY_WORKFLOW, /trusted-base-policy-main-transition|PR 7 removes/);
+  assert.equal(
+    [...BASE_POLICY_WORKFLOW.matchAll(/name: Web base policy \(trusted base\)/g)].length,
+    1
   );
+  assert.equal([...BASE_POLICY_WORKFLOW.matchAll(/name: Promotion \/ gate/g)].length, 1);
+  assert.deepEqual(WORKFLOW_NAMES, [
+    'deploy_web.yml',
+    'gallery-publication.yml',
+    'test.yml',
+    'web-base-policy.yml'
+  ]);
   assert.doesNotMatch(TEST_WORKFLOW, /needs: web-change-budget/);
   assert.equal(
     existsSync(join(REPOSITORY_ROOT, '.github/workflows/dev-staging.yml')),
@@ -1167,14 +1141,11 @@ test('dev staging Web checks scope only the newly integrated change', () => {
   );
 });
 
-test('supported-version and slow matrices cover dev staging and transition promotions', () => {
+test('supported-version and slow matrices cover exact dev staging', () => {
   const stagingCondition = [
     "    if: >-",
     "      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||",
-    "      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') ||",
-    "      (github.event_name == 'pull_request' && github.base_ref == 'main' &&",
-    "      github.head_ref == 'dev' &&",
-    "      github.event.pull_request.head.repo.full_name == github.repository)"
+    "      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')"
   ].join('\n');
 
   for (const jobName of ['acceptance-supported-main', 'slow-main']) {
@@ -1182,7 +1153,7 @@ test('supported-version and slow matrices cover dev staging and transition promo
       new RegExp(`\\n  ${jobName}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
     )?.[0];
     assert.ok(job, `${jobName} job must exist`);
-    assert.ok(job.includes(stagingCondition), `${jobName} must use the staging transition condition`);
+    assert.ok(job.includes(stagingCondition), `${jobName} must use the exact dev staging condition`);
   }
 });
 


### PR DESCRIPTION
## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Remove the workflow paths kept only for the PR #392 foundation promotion. The repository then has one execution path for each steady-state event: fast admission on pull requests to `dev`, full Tests and Gallery evidence on pushes to `dev`, trusted promotion on `dev -> main`, and deploy on pushes to `main`.

Start `dev` SHA: `5f97ec79c020c9bbdd0f314c29cd47f8745e0336`

Head SHA: `b690ac13a1b881c7b53aafc4c52fde2e3b954390`

PR #393 merge SHA: `98b7e459c961f4b1399e4637751a7f16d7de4dcd`

PR #392 merge SHA: `0826ec0d4eb1bcdb402f6385ff9a9f31d60a1f6e`

## User-visible impact

No application, rendering, scientific-output, session, or deploy behavior changes. Pull requests to `main` stop rerunning implementation suites after the final protection cutover. CI ownership is narrower and duplicate work is removed.

## Preconditions

- PR #392 merged `dev` to `main` with merge commit `0826ec0d4eb1bcdb402f6385ff9a9f31d60a1f6e`.
- The `main` tree and promoted `dev` tree both resolve to `dbda9b102ce755d860309c4551be4c6fc92defcd`.
- The exact-main [deploy run 33034075753](https://github.com/satoshikawato/gbdraw/actions/runs/33034075753) completed successfully.
- Current `main` contains `Promotion / gate`, exact Tests/Gallery evidence selection, source-coverage validation, and synthetic result-tree proof.
- Classic `main` protection still has the 21 repository-owned legacy contexts listed below plus external `CodeQL`. Classic `dev` protection requires only `Web base policy (trusted base)` and `PR / gate`.
- No repository ruleset is active. This pull request does not change branch protection.

## Transition inventory

| File | Item | Why it remained through PR #392 | PR #392 evidence | Final owner | Disposition |
| --- | --- | --- | --- | --- | --- |
| `.github/workflows/test.yml` | `pull_request` base `main` trigger | Started legacy Tests contexts on the foundation promotion | [Tests run 33033230640](https://github.com/satoshikawato/gbdraw/actions/runs/33033230640) | No Tests execution on promotion PRs | Remove |
| `.github/workflows/test.yml` | main-PR branches in `web-change-budget`, `core`, `recipes-standard`, `gallery`, `browser`, `playwright-performance`, `acceptance-supported-main`, `slow-main`, `lint`, and `losat-cache-browser-acceptance` | Produced 19 legacy leaf contexts from existing jobs | [Tests run 33033230640](https://github.com/satoshikawato/gbdraw/actions/runs/33033230640) | `PR / gate` and `Dev staging / gate` on their final events | Remove main branches only |
| `.github/workflows/test.yml` | `playwright-functional-main-transition` | Produced the unsharded legacy `Playwright functional` context | [Tests run 33033230640](https://github.com/satoshikawato/gbdraw/actions/runs/33033230640) | Four `playwright-functional` shards under `Dev staging / gate` | Remove job |
| `.github/workflows/web-base-policy.yml` | `trusted-base-policy-main-transition` | Produced the legacy trusted-base context from `main` code | [trusted-base run 33033230683](https://github.com/satoshikawato/gbdraw/actions/runs/33033230683) | `promotion-gate` | Remove job |
| `tests/web/architecture-contracts.test.mjs` | foundation-transition assertions and fixture expectations | Proved the temporary producers were substantive for PR #392 | Same two hosted runs | Steady-state event/job contract | Replace assertions |
| `.github/workflows/gallery-publication.yml` | PR/main/refactoring triggers | PR #390 had already removed them | [PR #390](https://github.com/satoshikawato/gbdraw/pull/390) | Push-to-`dev` Gallery readiness | Already absent; keep unchanged |
| `.github/workflows/test.yml` | push-to-main/refactoring triggers | PR #390 had already removed them | [PR #390](https://github.com/satoshikawato/gbdraw/pull/390) | Push-to-`dev` Tests staging | Already absent; keep unchanged |
| `package.json` | `test:web:functional-smoke` | PR #386 retained it as a local compatibility alias when `functional-full` became canonical; a historical execution record still names it | [PR #386](https://github.com/satoshikawato/gbdraw/pull/386) | Local command alias, not a status producer | Keep |
| Playwright configs | full, smoke, and shard selection | Current configs are final test owners, not transition aliases | Local list and smoke runs below | Existing configs | Keep unchanged |

### Removed legacy contexts

All Tests rows below use [PR #392 Tests run 33033230640](https://github.com/satoshikawato/gbdraw/actions/runs/33033230640) as producer evidence. The trusted-base row uses [run 33033230683](https://github.com/satoshikawato/gbdraw/actions/runs/33033230683). PR #392 placed the trusted promotion implementation on `main`, satisfying each removal condition.

| Old context | Old job | Substantive command | Final owner or gate |
| --- | --- | --- | --- |
| `Web change budget` | `web-change-budget` | Web checker plus architecture contracts | `PR / gate`; `Dev staging / gate` |
| `Core (Python 3.10)` | `core` matrix | Core pytest selection on Python 3.10 | `Dev staging / gate` |
| `Core (Python 3.11)` | `core` matrix | Core pytest selection on Python 3.11 | `Dev staging / gate` |
| `Core (Python 3.12)` | `core` matrix | Core pytest selection on Python 3.12 | `Dev staging / gate` |
| `Recipes standard (Python 3.11)` | `recipes-standard` | `pytest -m "recipe and not slow"` | `PR / gate`; `Dev staging / gate` |
| `Gallery (Python 3.11)` | `gallery` | `pytest -m "gallery and not slow"` | `PR / gate`; `Dev staging / gate` |
| `Browser (Python 3.11)` | `browser` | Web JavaScript, Python browser, and offline packaging contracts | `Dev staging / gate` |
| `Playwright functional` | `playwright-functional-main-transition` | `npm run test:web:functional-full` | Four shards under `Dev staging / gate` |
| `Playwright performance` | `playwright-performance` | `npm run test:web:perf-smoke` | `Dev staging / gate` |
| `Lint` | `lint` | `ruff check gbdraw/` | `PR / gate`; `Dev staging / gate` |
| `LOSAT cache browser acceptance` | `losat-cache-browser-acceptance` | `python tests/run_losat_cache_browser_acceptance.py` | `Dev staging / gate` |
| `recipe acceptance (Python 3.10)` | `acceptance-supported-main` matrix | Recipe pytest selection on Python 3.10 | `Dev staging / gate` |
| `gallery acceptance (Python 3.10)` | `acceptance-supported-main` matrix | Gallery pytest selection on Python 3.10 | `Dev staging / gate` |
| `browser acceptance (Python 3.10)` | `acceptance-supported-main` matrix | Browser pytest selection on Python 3.10 | `Dev staging / gate` |
| `recipe acceptance (Python 3.12)` | `acceptance-supported-main` matrix | Recipe pytest selection on Python 3.12 | `Dev staging / gate` |
| `gallery acceptance (Python 3.12)` | `acceptance-supported-main` matrix | Gallery pytest selection on Python 3.12 | `Dev staging / gate` |
| `browser acceptance (Python 3.12)` | `acceptance-supported-main` matrix | Browser pytest selection on Python 3.12 | `Dev staging / gate` |
| `Slow (Python 3.10)` | `slow-main` matrix | `pytest -m "slow and not browser"` on Python 3.10 | `Dev staging / gate` |
| `Slow (Python 3.11)` | `slow-main` matrix | `pytest -m "slow and not browser"` on Python 3.11 | `Dev staging / gate` |
| `Slow (Python 3.12)` | `slow-main` matrix | `pytest -m "slow and not browser"` on Python 3.12 | `Dev staging / gate` |
| `Web base policy (trusted base)` | `trusted-base-policy-main-transition` | Trusted-main `node tools/check-web-change-budget.mjs --base ... --head ...` | `Promotion / gate` |

External `CodeQL` is not removed or changed.

## Before and after event matrix

“Before” describes the definitions at start SHA `5f97ec79...`; “after” describes this head.

| Event | Before | After |
| --- | --- | --- |
| `pull_request` base `dev` | Six fast Tests jobs, `PR / gate`; trusted-base policy; full jobs skipped | Unchanged |
| fork `pull_request` base `dev` | Same fast candidate graph; trusted-base policy executes base code | Unchanged |
| `pull_request` base `main`, same-repository `dev` head | 20 Tests legacy contexts; trusted-base transition context; `Promotion / gate`; PR/dev-staging aggregates skipped | Tests workflow does not trigger; `Promotion / gate` only after the steady-state definition reaches `main` |
| arbitrary same-repository branch to `main` | Tests workflow triggered but its jobs skipped; promotion failed topology | Tests workflow does not trigger; promotion still fails topology |
| fork pull request to `main` | Tests workflow triggered but its jobs skipped; promotion failed repository topology | Tests workflow does not trigger; promotion still fails repository topology |
| `pull_request_target` base `dev` | `Web base policy (trusted base)` only | Unchanged |
| `pull_request_target` base `main` | trusted-base transition context plus `Promotion / gate` | `Promotion / gate` only |
| push to `dev` | 23 mandatory Tests leaf checks plus `Dev staging / gate`; three Gallery readiness owners plus aggregate | Unchanged |
| push to `main` | Deploy workflow only | Unchanged |
| push to `refactoring` | No Tests or Gallery workflow | Unchanged |
| `workflow_dispatch` on `dev` | Diagnostic full Tests graph and Gallery readiness; manual deploy remains separately dispatchable | Unchanged; manual runs are not promotion evidence |
| `workflow_dispatch` on `main` or another ref | Tests jobs skip because the ref is not `dev`; Gallery and deploy keep their existing diagnostic/manual behavior when explicitly dispatched | Unchanged |

## Responsibility owners

| Responsibility | Before | After |
| --- | --- | --- |
| Ordinary PR fast CI | `.github/workflows/test.yml` | Same |
| Exact `dev` full CI | `.github/workflows/test.yml` | Same |
| Gallery readiness | `.github/workflows/gallery-publication.yml` | Same |
| Trusted `dev` admission | `.github/workflows/web-base-policy.yml` | Same |
| Trusted `main` promotion | `.github/workflows/web-base-policy.yml` | Same, without the duplicate trusted-base context |
| Exact `main` release/deploy | `.github/workflows/deploy_web.yml` | Same |

The owner set does not expand. This change removes the main-PR implementation path and its duplicate trusted-policy context.

## Full coverage inventory

| Aggregate | Mandatory inventory before | Mandatory inventory after |
| --- | --- | --- |
| `PR / gate` | Web change budget, Core PR 3.11, Recipes 3.11, Gallery 3.11, Lint, Web PR smoke | Identical six-job set |
| `Dev staging / gate` | Web policy; Core 3.10/3.11/3.12; Recipes; Gallery; Browser; four Playwright shards; performance; six supported-version acceptance jobs; Slow 3.10/3.11/3.12; Lint; LOSAT | Identical 23 leaf checks plus aggregate |
| `Gallery readiness / gate` | common 9, Vibrio, projection performance | Identical three-owner set plus aggregate |
| `Promotion / gate` | Repository topology, current `dev` tip, source coverage, exact push/dev/SHA Tests evidence, exact Gallery evidence, synthetic tree identity | Identical trusted job |

The full Playwright command still lists 101 tests in 16 files. The staging matrix remains exactly four shards. Base CI retries remain 2, workers remain 1, and trace capture remains `on-first-retry`. The retained 15 Tests jobs are identical to their base definitions after removing only their event conditions; both retained trusted jobs are byte-equivalent YAML objects before and after.

## Aggregate contracts

- `PR / gate` still has six explicit `needs` entries and requires every result to equal `success` under `always()`.
- `Dev staging / gate` still has 11 explicit job dependencies, including the four-shard matrix, and requires every result to equal `success`.
- `Gallery readiness / gate` still requires both matrix-backed browser owners and projection performance to succeed.
- `Promotion / gate` remains the only repository-owned promotion aggregate. It has no candidate implementation dependency.

## Package and config audit

`package.json` and every Playwright config have empty diffs. `test:web:functional-smoke` remains because PR #386 intentionally kept it as a compatibility alias for local users, and a historical execution record refers to it. No active workflow uses it. The alias is not a temporary required-status producer.

## Candidate-execution prohibition

The `promotion-gate` YAML object is unchanged from `origin/dev`. It checks out the trusted base SHA once, fetches `dev` only as Git data, uses the GitHub API for exact-SHA evidence, and runs no candidate dependency installation or candidate script. Contract tests reject candidate checkout/switch, local candidate actions, manual evidence, wrong repository/branch/SHA, older-success fallback, and missing or duplicate aggregates.

## Verification

- `npm ci`: pass; 0 vulnerabilities.
- `npm run test:web:pr-smoke`: 7 passed in 59.0 seconds, one worker, zero retries.
- `npm run test:web:functional-full -- --list`: 101 tests in 16 files.
- Node 20 `architecture-contracts.test.mjs`: 112 passed.
- Node 20 ratchet, promotion-context, and promotion-readiness tests: 39 passed.
- `node tools/check-web-change-budget.mjs --base origin/dev`: `Gate: PASS`, `Review: REQUIRED`; no blocking violation.
- PyYAML and Ruby parsed all four workflow files.
- Stable Tests job-body comparison: 15/15 unchanged except event conditions; only `playwright-functional-main-transition` removed.
- Stable trusted-job comparison: 2/2 unchanged; only `trusted-base-policy-main-transition` removed.
- `git diff --check`: pass.
- Diffs are empty for checker/helper/source-parser code, normative docs, PR template, Web runtime, Gallery workflow, deploy workflow, package/config files, and scientific/reference outputs.

Hosted PR evidence is complete for exact head `b690ac13a1b881c7b53aafc4c52fde2e3b954390`:

- [Tests run 33036927647, attempt 1](https://github.com/satoshikawato/gbdraw/actions/runs/33036927647) used the `pull_request` event and completed successfully in 4m50s. [PR / gate](https://github.com/satoshikawato/gbdraw/actions/runs/33036927647/job/98402258887) passed after Web change budget, Core PR, Recipes standard, Gallery, Lint, and Web PR smoke succeeded.
- The same Tests run skipped Core full, Browser, Playwright functional, Playwright performance, supported-version acceptance, Slow, LOSAT cache browser acceptance, and `Dev staging / gate`. This is the expected fast-only PR topology.
- [Web base policy run 33036927671, attempt 1](https://github.com/satoshikawato/gbdraw/actions/runs/33036927671) used the `pull_request_target` event for the same head and completed successfully in 1m37s. [Web base policy (trusted base)](https://github.com/satoshikawato/gbdraw/actions/runs/33036927671/job/98401520681) passed; `Promotion / gate` and the base-branch copy of the transition compatibility job were skipped.
- The separate Gallery publication workflow did not run for this PR head. Branch protection remains unchanged: `dev` requires `Web base policy (trusted base)` and `PR / gate`; `main` retains its 22 existing contexts; no repository ruleset is active.

PR #393 merged to `dev` as `98b7e459c961f4b1399e4637751a7f16d7de4dcd` at 2026-08-27 03:44:51 UTC. Post-merge evidence for that exact SHA is complete:

- [Tests run 33037286706, attempt 1](https://github.com/satoshikawato/gbdraw/actions/runs/33037286706) used `push`, branch `dev`, and the exact merge SHA. It completed successfully in 7m08s. All 23 mandatory leaf checks passed, including [shard 1/4](https://github.com/satoshikawato/gbdraw/actions/runs/33037286706/job/98402672277), [shard 2/4](https://github.com/satoshikawato/gbdraw/actions/runs/33037286706/job/98402672338), [shard 3/4](https://github.com/satoshikawato/gbdraw/actions/runs/33037286706/job/98402672275), and [shard 4/4](https://github.com/satoshikawato/gbdraw/actions/runs/33037286706/job/98402672144). [Dev staging / gate](https://github.com/satoshikawato/gbdraw/actions/runs/33037286706/job/98403798938) passed. PR-only jobs and `PR / gate` were skipped.
- [Gallery publication run 33037286705, attempt 1](https://github.com/satoshikawato/gbdraw/actions/runs/33037286705) used `push`, branch `dev`, and the exact merge SHA. It completed successfully in 21m06s. [Projection performance](https://github.com/satoshikawato/gbdraw/actions/runs/33037286705/job/98402671452), [common 9](https://github.com/satoshikawato/gbdraw/actions/runs/33037286705/job/98402671588), [Vibrio](https://github.com/satoshikawato/gbdraw/actions/runs/33037286705/job/98402671575), and [Gallery readiness / gate](https://github.com/satoshikawato/gbdraw/actions/runs/33037286705/job/98406094422) all passed.
- `origin/dev` resolves to the merge SHA, and its tree `51842b755b4719f9a9eb1303229cfef9070e875f` matches the PR head tree. The only changes from the start SHA are the two workflow files and the architecture contract test listed in this pull request.
- Final workflow inventory is exactly `deploy_web.yml`, `gallery-publication.yml`, `test.yml`, and `web-base-policy.yml`. Tests pull requests and pushes target `dev` only; Gallery publication pushes target `dev` only; trusted policy has only `trusted-base-policy` and `promotion-gate`; deploy still pushes on `main`. No transition job or condition remains, and the full Playwright matrix is `[1, 2, 3, 4]`.
- Checker/helper code, normative docs, PR template, Web runtime, deploy, package/config files, scientific/reference outputs, branch protection, and repository rulesets remain unchanged.

The exact PR #8 evidence SHA is `98b7e459c961f4b1399e4637751a7f16d7de4dcd`.

## Risk and review notes

- Gate result and any blocker: local Gate and hosted gates pass; no blocker remains.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because two workflow evidence producers change.
- Architecture impact: **This is architecture-bearing** for CI event responsibility. Canonical owners stay in the same four workflow files. The superseded main-PR Tests path and duplicate trusted-policy context are removed; no owner, path, or persisted-compatibility excess is added.
- `architecture-change` label: not applied because Web production source is unchanged.

## Rollback

The pre-merge restore point was commit `b690ac13a1b881c7b53aafc4c52fde2e3b954390`. Exact `dev` staging and Gallery readiness passed after merge, so no rollback was needed. If a later correction is required before PR #8, prepare a workflow-only correction or revert targeting `dev`, obtain successful evidence for the new exact `dev` SHA, and hand that SHA to PR #8. Do not patch `main`, rewrite history, restore every legacy context, or substitute a manual or older run.

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/test.yml`, `.github/workflows/web-base-policy.yml`.
- Checker implementation files touched: none.
- Self-authorization separation evidence: checker/helper/parser/evaluator/policy/normative-doc diffs are empty; only bounded workflow contracts change with the workflows.
- Branch-protection or ruleset impact, including unchanged settings: no mutation. Classic `dev` and `main` protection remain as recorded above; no ruleset is active.
- Governance-specific rollback or protection restore point: protection has no change to restore. The code restore point is commit `b690ac13a1b881c7b53aafc4c52fde2e3b954390`.
