### PR TITLE
Require plain-language pull request titles and summaries

### DIFF
--- a/.agents/skills/write-clear-pull-request/SKILL.md
+++ b/.agents/skills/write-clear-pull-request/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: write-clear-pull-request
+description: Write, edit, or review gbdraw pull request titles and maintainer-facing descriptions. Use whenever creating or changing a PR title or body, or reviewing either for clarity.
+---
+
+# Write clear pull requests
+
+## Audience
+
+Assume the reader knows gbdraw, Git, and GitHub, but has not read an implementation plan, earlier PRs, or private discussion.
+
+## Required opening
+
+- Write the title as a concrete action plus a concrete object.
+- Begin the body with `## Plain-language summary` and use two to four sentences to say what changes, why, and what differs after merge.
+- Treat internal classifications and process labels as metadata, not as the primary explanation.
+- Preserve exact check names, paths, branch names, options, and code identifiers in backticks. Explain their role in ordinary language when the name is not self-explanatory.
+
+Policy terms may appear in later technical or evidence sections. They fail this standard only when they replace the concrete explanation in the title or opening summary.
+
+## Workflow
+
+1. Name the concrete action and object.
+2. State the reason when it is not obvious.
+3. State the behavior or review condition after merge.
+4. Replace unexplained local abstractions in the title and summary.
+5. Check that the text makes sense without prior plans or PR history.
+6. Save the complete body, then run:
+
+   ```bash
+   node tools/check-pr-language.mjs --title "<concrete title>" --body-file <body.md>
+   ```
+
+Run `gh pr create` or a wording-changing `gh pr edit` separately after the checker passes.
+
+## Regression example
+
+Bad title:
+
+```text
+Promote steady-state CI topology and finalize main admission
+```
+
+Bad summary:
+
+```text
+This promotion removes the transition-only CI topology from main and completes the admission-policy cutover.
+```
+
+Clear title:
+
+```text
+Stop rerunning full CI on dev-to-main pull requests
+```
+
+Clear summary:
+
+```text
+This PR removes CI jobs that were needed only while the new main-merge check was being introduced. After the branch-protection update, dev-to-main pull requests will require only `Promotion / gate` and `CodeQL`.
+```

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,18 @@
+{
+  "description": "Repository pull request wording guardrail.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$(git rev-parse --show-toplevel)/tools/check-pr-language.mjs\" --hook",
+            "timeout": 5,
+            "statusMessage": "Checking pull request title and summary"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,14 @@
+<!--
+Use a concrete action and object in the PR title. Assume the reader has not read the implementation plan or earlier PRs.
+-->
+
+## Plain-language summary
+
+<!--
+In 2-4 sentences, explain what changes, why it changes, and what will be different after merge.
+Keep exact check names, paths, and identifiers in backticks, then explain their role in ordinary language.
+-->
+
 ## Change class
 
 Select exactly one:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,17 @@ For changes affecting Web runtime or normative Web behavior contracts:
 - Keep minimal smoke diagrams in tests. Do not use them as tutorial images, Gallery entries, release examples, or other public showcases.
 - Render and visually inspect the final artifact at a readable scale. Confirm that its documented command, session, or reproduction recipe generates the displayed figure.
 
+## Pull request communication
+
+- Before creating, editing, or reviewing a PR title or maintainer-facing body,
+  read `.agents/skills/write-clear-pull-request/SKILL.md`.
+- Write for a maintainer who has not read the implementation plan or earlier
+  PRs. Internal labels are metadata, not explanations.
+- Keep exact identifiers in backticks and explain their concrete role.
+- Prepare the complete body file first, then run `gh pr create` or a
+  wording-changing `gh pr edit` as a separate command so the hook can inspect it.
+- Do not use `gh pr create --fill`, `--fill-first`, or `--fill-verbose`.
+
 ## Completion Handoff
 
 - After completing an implementation, treat the session as one commit and provide a proposed commit title and summary in English.

--- a/tests/web/pr-language.test.mjs
+++ b/tests/web/pr-language.test.mjs
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test, { after } from 'node:test';
+
+import {
+  evaluateHookCommand,
+  extractPlainLanguageSummary,
+  hookDenialOutput,
+  validateBody,
+  validateProposal,
+  validateTitle
+} from '../../tools/check-pr-language.mjs';
+
+const CHECKER = resolve('tools/check-pr-language.mjs');
+const ORIGINAL_TITLE = 'Promote steady-state CI topology and finalize main admission';
+const CLEAR_TITLE = 'Stop rerunning full CI on dev-to-main pull requests';
+const ORIGINAL_SUMMARY = `## Plain-language summary
+
+This promotion removes the transition-only CI topology from main and completes the admission-policy cutover.`;
+const CLEAR_BODY = `## Plain-language summary
+
+This PR removes CI jobs that existed only while the new main-merge check was introduced. The exact dev commit still has to pass full staging, and main will require \`Promotion / gate\` and \`CodeQL\` before merge.
+
+## Change class
+
+- [x] GOVERNANCE`;
+
+const temporaryDirectory = mkdtempSync(join(tmpdir(), 'gbdraw-pr-language-'));
+const clearBodyFile = join(temporaryDirectory, 'clear-body.md');
+writeFileSync(clearBodyFile, CLEAR_BODY);
+
+after(() => rmSync(temporaryDirectory, { recursive: true, force: true }));
+
+const hookEvent = (command) => JSON.stringify({
+  hook_event_name: 'PreToolUse',
+  tool_name: 'Bash',
+  tool_input: { command }
+});
+
+test('PR 394 original title fails with each matched opaque phrase identified', () => {
+  const errors = validateTitle(ORIGINAL_TITLE);
+  assert.ok(errors.some((error) => error.includes('steady-state')));
+  assert.ok(errors.some((error) => error.includes('CI topology')));
+  assert.ok(errors.some((error) => error.includes('main admission')));
+  errors.forEach((error) => assert.match(error, /Replace it with/));
+});
+
+test('PR 394 original opening sentence fails in the plain-language summary', () => {
+  const errors = validateBody(ORIGINAL_SUMMARY);
+  assert.ok(errors.some((error) => error.includes('transition-only')));
+  assert.ok(errors.some((error) => error.includes('CI topology')));
+  assert.ok(errors.some((error) => error.includes('admission-policy')));
+  assert.ok(errors.some((error) => error.includes('cutover')));
+});
+
+test('a title with a concrete action and object passes', () => {
+  assert.deepEqual(validateTitle(CLEAR_TITLE), []);
+});
+
+test('backticks do not hide opaque language in a PR title', () => {
+  const errors = validateTitle('Remove the `transition-only` CI topology');
+  assert.ok(errors.some((error) => error.includes('transition-only')));
+  assert.ok(errors.some((error) => error.includes('CI topology')));
+});
+
+test('a clear summary with exact backticked check names passes', () => {
+  assert.deepEqual(validateBody(CLEAR_BODY), []);
+});
+
+test('opaque terms in a later technical section are outside the checker scope', () => {
+  const body = `${CLEAR_BODY}
+
+## Technical details
+
+This completes the admission-policy cutover and leaves the steady-state CI topology in place.`;
+  assert.deepEqual(validateBody(body), []);
+  assert.match(extractPlainLanguageSummary(body), /exact dev commit/);
+  assert.doesNotMatch(extractPlainLanguageSummary(body), /cutover/);
+});
+
+test('fenced and inline code in the summary are excluded from opaque-language matching', () => {
+  const body = `## Plain-language summary
+
+This PR documents the exact check names and explains when maintainers use them. The examples remain available after merge.
+
+\`\`\`text
+steady-state CI topology
+\`\`\`
+
+The literal identifier \`admission-policy cutover\` is preserved for lookup.`;
+  assert.deepEqual(validateBody(body), []);
+});
+
+test('a missing or placeholder plain-language summary fails with a specific fix', async (t) => {
+  await t.test('missing section', () => {
+    assert.match(validateBody('## Change class\n\n- [x] STANDARD')[0], /missing/);
+  });
+  await t.test('TODO placeholder', () => {
+    assert.match(validateBody('## Plain-language summary\n\nTODO')[0], /placeholder/);
+  });
+  await t.test('comment-only template', () => {
+    assert.match(validateBody('## Plain-language summary\n\n<!-- Add summary text. -->')[0], /placeholder/);
+  });
+});
+
+test('gh pr create --fill is denied before missing explicit options are reported', () => {
+  const decision = evaluateHookCommand('gh pr create --fill');
+  assert.equal(decision.allowed, false);
+  assert.match(decision.reason, /--fill hides/);
+  assert.match(decision.reason, /--title/);
+  assert.match(decision.reason, /--body-file/);
+});
+
+test('gh pr create with a clear literal title and readable body file is allowed', () => {
+  const decision = evaluateHookCommand(
+    `gh pr create --title '${CLEAR_TITLE}' --body-file '${clearBodyFile}'`
+  );
+  assert.deepEqual(decision, { allowed: true });
+});
+
+test('stdin and unreadable body files are denied with actionable reasons', async (t) => {
+  await t.test('stdin body', () => {
+    const decision = evaluateHookCommand(
+      `gh pr create --title '${CLEAR_TITLE}' --body-file -`
+    );
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /cannot be inspected/);
+    assert.match(decision.reason, /Save the complete PR body/);
+  });
+  await t.test('missing file', () => {
+    const missing = join(temporaryDirectory, 'missing.md');
+    const decision = evaluateHookCommand(
+      `gh pr create --title '${CLEAR_TITLE}' --body-file '${missing}'`
+    );
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /Cannot read PR body file/);
+    assert.match(decision.reason, /run the PR command separately/);
+  });
+});
+
+test('gh pr edit without a wording change is allowed', () => {
+  assert.deepEqual(
+    evaluateHookCommand('gh pr edit 394 --add-label governance'),
+    { allowed: true }
+  );
+});
+
+test('wording-changing gh pr edit commands are validated', async (t) => {
+  await t.test('clear title and body pass', () => {
+    assert.deepEqual(
+      evaluateHookCommand(
+        `gh pr edit 394 --title '${CLEAR_TITLE}' --body-file '${clearBodyFile}'`
+      ),
+      { allowed: true }
+    );
+  });
+  await t.test('opaque title fails', () => {
+    const decision = evaluateHookCommand(`gh pr edit 394 --title '${ORIGINAL_TITLE}'`);
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /steady-state/);
+  });
+  await t.test('literal body is checked', () => {
+    const decision = evaluateHookCommand(
+      `gh pr edit 394 --body '## Plain-language summary
+
+This completes the release admission cutover.'`
+    );
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /release admission/);
+  });
+});
+
+test('unrelated Bash commands and quoted documentation are allowed', () => {
+  assert.deepEqual(evaluateHookCommand('git status --short'), { allowed: true });
+  assert.deepEqual(
+    evaluateHookCommand(`printf '%s\\n' 'gh pr create --fill'`),
+    { allowed: true }
+  );
+});
+
+test('unresolved wording and compound PR commands are denied', async (t) => {
+  await t.test('shell variable title', () => {
+    const decision = evaluateHookCommand(
+      `gh pr create --title "$TITLE" --body-file '${clearBodyFile}'`
+    );
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /unresolved shell expansion/);
+  });
+  await t.test('compound command', () => {
+    const decision = evaluateHookCommand(
+      `git status --short && gh pr create --title '${CLEAR_TITLE}' --body-file '${clearBodyFile}'`
+    );
+    assert.equal(decision.allowed, false);
+    assert.match(decision.reason, /separate command/);
+  });
+});
+
+test('hook denial output uses the current PreToolUse JSON shape', () => {
+  const reason = 'Supply explicit wording.';
+  assert.deepEqual(hookDenialOutput(reason), {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason
+    }
+  });
+
+  const result = spawnSync(process.execPath, [CHECKER, '--hook'], {
+    input: hookEvent('gh pr create --fill'),
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.hookSpecificOutput.hookEventName, 'PreToolUse');
+  assert.equal(output.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(output.hookSpecificOutput.permissionDecisionReason, /--fill/);
+});
+
+test('hook mode exits silently for allowed commands', () => {
+  const result = spawnSync(process.execPath, [CHECKER, '--hook'], {
+    input: hookEvent(`gh pr create --title '${CLEAR_TITLE}' --body-file '${clearBodyFile}'`),
+    encoding: 'utf8'
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr, '');
+});
+
+test('manual mode reports bad wording and accepts a clear proposal', () => {
+  const bad = spawnSync(process.execPath, [
+    CHECKER,
+    '--title', ORIGINAL_TITLE,
+    '--body-file', clearBodyFile
+  ], { encoding: 'utf8' });
+  assert.equal(bad.status, 1);
+  assert.match(bad.stderr, /PR language check failed/);
+  assert.match(bad.stderr, /steady-state/);
+
+  const clear = spawnSync(process.execPath, [
+    CHECKER,
+    '--title', CLEAR_TITLE,
+    '--body-file', clearBodyFile
+  ], { encoding: 'utf8' });
+  assert.equal(clear.status, 0);
+  assert.equal(clear.stdout, 'PR language check passed.\n');
+  assert.equal(clear.stderr, '');
+  assert.deepEqual(validateProposal({ title: CLEAR_TITLE, body: CLEAR_BODY }), []);
+});

--- a/tools/check-pr-language.mjs
+++ b/tools/check-pr-language.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const OPAQUE_LANGUAGE = Object.freeze([
+  { label: 'steady-state', pattern: /\bsteady[ -]state\b/i },
+  { label: 'CI topology', pattern: /\bCI[ -]+topolog(?:y|ies)\b/i },
+  { label: 'main admission', pattern: /\bmain[ -]+admission\b/i },
+  { label: 'release admission', pattern: /\brelease[ -]+admission\b/i },
+  { label: 'admission-policy', pattern: /\badmission[ -]+policy\b/i },
+  { label: 'transition-only', pattern: /\btransition[ -]+only\b/i },
+  { label: 'cutover', pattern: /\bcut[ -]?over\b/i }
+]);
+
+const SUMMARY_HEADING = /^[ \t]{0,3}##[ \t]+Plain-language summary[ \t]*$/i;
+const MARKDOWN_HEADING = /^[ \t]{0,3}#{1,6}[ \t]+\S/;
+
+const fenceAt = (line) => {
+  const match = line.match(/^[ \t]{0,3}(`{3,}|~{3,})/);
+  return match ? { character: match[1][0], length: match[1].length } : null;
+};
+
+const closesFence = (line, fence) => {
+  const trimmed = line.trim();
+  return trimmed.length >= fence.length
+    && [...trimmed].every((character) => character === fence.character);
+};
+
+export const extractPlainLanguageSummary = (body) => {
+  if (typeof body !== 'string') return null;
+
+  const lines = body.split(/\r?\n/);
+  const summary = [];
+  let fence = null;
+  let found = false;
+
+  for (const line of lines) {
+    if (fence) {
+      if (found) summary.push(line);
+      if (closesFence(line, fence)) fence = null;
+      continue;
+    }
+
+    const openingFence = fenceAt(line);
+    if (openingFence) {
+      fence = openingFence;
+      if (found) summary.push(line);
+      continue;
+    }
+
+    if (!found) {
+      if (SUMMARY_HEADING.test(line)) found = true;
+      continue;
+    }
+
+    if (MARKDOWN_HEADING.test(line)) break;
+    summary.push(line);
+  }
+
+  return found ? summary.join('\n').trim() : null;
+};
+
+const stripFencedCode = (text) => {
+  const kept = [];
+  let fence = null;
+
+  for (const line of text.split(/\r?\n/)) {
+    if (fence) {
+      if (closesFence(line, fence)) fence = null;
+      kept.push('');
+      continue;
+    }
+    const openingFence = fenceAt(line);
+    if (openingFence) {
+      fence = openingFence;
+      kept.push('');
+      continue;
+    }
+    kept.push(line);
+  }
+
+  return kept.join('\n');
+};
+
+const stripInlineCode = (text) => {
+  let result = '';
+  let index = 0;
+
+  while (index < text.length) {
+    if (text[index] !== '`') {
+      result += text[index];
+      index += 1;
+      continue;
+    }
+
+    let length = 1;
+    while (text[index + length] === '`') length += 1;
+    const delimiter = '`'.repeat(length);
+    const end = text.indexOf(delimiter, index + length);
+    if (end === -1) {
+      result += delimiter;
+      index += length;
+      continue;
+    }
+    result += ' ';
+    index = end + length;
+  }
+
+  return result;
+};
+
+const explanatoryText = (text) => stripInlineCode(stripFencedCode(text))
+  .replace(/<!--[\s\S]*?-->/g, ' ');
+
+export const findOpaqueLanguage = (text, { ignoreCode = true } = {}) => {
+  const source = ignoreCode ? explanatoryText(text) : text;
+  return OPAQUE_LANGUAGE.flatMap(({ label, pattern }) => {
+    const match = source.match(pattern);
+    return match ? [{ label, phrase: match[0] }] : [];
+  });
+};
+
+const isPlaceholder = (text) => {
+  const visible = explanatoryText(text)
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[\s*_>#\[\]{}()!.-]+/g, ' ')
+    .trim();
+  if (!visible) return true;
+  return /^(?:todo|tbd|n\/?a|none|placeholder|coming soon)$/i.test(visible)
+    || /^(?:add|describe|write|fill(?: in)?|insert|replace)\b.*\b(?:summary|change|details|text)\b/i.test(visible);
+};
+
+const opaqueErrors = (scope, text, options) => findOpaqueLanguage(text, options).map(({ phrase }) => (
+  `${scope} uses the opaque phrase "${phrase}". Replace it with the concrete action, object, or post-merge effect.`
+));
+
+export const validateTitle = (title) => {
+  if (typeof title !== 'string' || !title.trim()) {
+    return ['PR title is missing. Provide a concrete action and object with --title.'];
+  }
+  if (isPlaceholder(title)) {
+    return ['PR title is placeholder text. Replace it with a concrete action and object.'];
+  }
+  return opaqueErrors('PR title', title, { ignoreCode: false });
+};
+
+export const validateBody = (body) => {
+  const summary = extractPlainLanguageSummary(body);
+  if (summary === null) {
+    return ['PR body is missing "## Plain-language summary". Add it first and explain what changes, why, and what differs after merge.'];
+  }
+  if (isPlaceholder(summary)) {
+    return ['Plain-language summary is empty or placeholder text. Write 2-4 concrete sentences covering what changes, why, and the post-merge result.'];
+  }
+  return opaqueErrors('Plain-language summary', summary);
+};
+
+export const validateProposal = ({ title, body }) => [
+  ...validateTitle(title),
+  ...validateBody(body)
+];
+
+export const splitShellCommand = (command) => {
+  const segments = [];
+  let current = [];
+  let value = '';
+  let started = false;
+  let dynamic = false;
+  let quote = null;
+  let parseError = '';
+
+  const finishToken = () => {
+    if (!started) return;
+    current.push({ value, dynamic });
+    value = '';
+    started = false;
+    dynamic = false;
+  };
+  const finishSegment = () => {
+    finishToken();
+    if (current.length) segments.push(current);
+    current = [];
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index];
+    const next = command[index + 1];
+
+    if (quote === "'") {
+      if (character === "'") quote = null;
+      else value += character;
+      started = true;
+      continue;
+    }
+
+    if (quote === '"') {
+      if (character === '"') {
+        quote = null;
+      } else if (character === '\\' && next !== undefined) {
+        if (next !== '\n') value += next;
+        index += 1;
+      } else {
+        if (character === '$' || character === '`') dynamic = true;
+        value += character;
+      }
+      started = true;
+      continue;
+    }
+
+    if (character === '\\' && next !== undefined) {
+      if (next !== '\n') {
+        value += next;
+        started = true;
+      }
+      index += 1;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      started = true;
+      continue;
+    }
+    if (character === '#' && !started) {
+      while (index + 1 < command.length && command[index + 1] !== '\n') index += 1;
+      continue;
+    }
+    if (character === '\n') {
+      finishSegment();
+      continue;
+    }
+    if (/\s/.test(character)) {
+      finishToken();
+      continue;
+    }
+    if (';|&()'.includes(character)) {
+      finishSegment();
+      if ((character === '&' || character === '|') && next === character) index += 1;
+      continue;
+    }
+    if (character === '$' || character === '`'
+        || ((character === '<' || character === '>') && next === '(')) {
+      dynamic = true;
+    }
+    value += character;
+    started = true;
+  }
+
+  finishSegment();
+  if (quote) parseError = `unclosed ${quote} quote`;
+  return { segments, parseError };
+};
+
+const isAssignment = ({ value }) => /^[A-Za-z_][A-Za-z0-9_]*=/.test(value);
+
+const findPrCommands = (segments) => segments.flatMap((tokens, segmentIndex) => {
+  let commandIndex = 0;
+  while (tokens[commandIndex] && isAssignment(tokens[commandIndex])) commandIndex += 1;
+  if (tokens[commandIndex]?.value !== 'gh'
+      || tokens[commandIndex + 1]?.value !== 'pr'
+      || !['create', 'edit'].includes(tokens[commandIndex + 2]?.value)) {
+    return [];
+  }
+  return [{
+    action: tokens[commandIndex + 2].value,
+    args: tokens.slice(commandIndex + 3),
+    segmentIndex
+  }];
+});
+
+const optionOccurrences = (args, name) => {
+  const occurrences = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token.value === name) {
+      const supplied = args[index + 1];
+      occurrences.push(supplied && !supplied.value.startsWith('--')
+        ? supplied
+        : { value: '', dynamic: false, missing: true });
+      index += supplied && !supplied.value.startsWith('--') ? 1 : 0;
+    } else if (token.value.startsWith(`${name}=`)) {
+      occurrences.push({
+        value: token.value.slice(name.length + 1),
+        dynamic: token.dynamic,
+        missing: token.value.length === name.length + 1
+      });
+    }
+  }
+  return occurrences;
+};
+
+const oneInspectableOption = (args, name, label, { path = false } = {}) => {
+  const occurrences = optionOccurrences(args, name);
+  if (occurrences.length !== 1 || occurrences[0].missing || !occurrences[0].value) {
+    return { error: `Provide exactly one explicit ${name} value so the hook can inspect the ${label}.` };
+  }
+  const token = occurrences[0];
+  if (token.dynamic || (path && /[*?{}\[]/.test(token.value))) {
+    return { error: `${name} uses an unresolved shell expansion. Provide a literal, inspectable ${label}.` };
+  }
+  return { value: token.value };
+};
+
+const bodyFromFile = (args, readFile) => {
+  const bodyFile = oneInspectableOption(args, '--body-file', 'body file path', { path: true });
+  if (bodyFile.error) return bodyFile;
+  if (bodyFile.value === '-') {
+    return { error: '--body-file - cannot be inspected. Save the complete PR body to a readable file first.' };
+  }
+  try {
+    return { value: readFile(bodyFile.value, 'utf8') };
+  } catch (_error) {
+    return { error: `Cannot read PR body file "${bodyFile.value}". Create a readable file first, then run the PR command separately.` };
+  }
+};
+
+const denied = (reason) => ({ allowed: false, reason });
+const allowed = () => ({ allowed: true });
+
+const validationDecision = (errors) => errors.length ? denied(errors.join(' ')) : allowed();
+
+const evaluateCreate = (args, readFile) => {
+  const fillFlag = args.find(({ value }) => (
+    ['--fill', '--fill-first', '--fill-verbose'].includes(value.split('=')[0])
+  ));
+  if (fillFlag) {
+    return denied(`${fillFlag.value.split('=')[0]} hides the proposed wording. Supply an explicit --title and a readable --body-file instead.`);
+  }
+
+  const title = oneInspectableOption(args, '--title', 'PR title');
+  if (title.error) return denied(title.error);
+  const body = bodyFromFile(args, readFile);
+  if (body.error) return denied(body.error);
+  return validationDecision(validateProposal({ title: title.value, body: body.value }));
+};
+
+const evaluateEdit = (args, readFile) => {
+  const titleOptions = optionOccurrences(args, '--title');
+  const bodyOptions = optionOccurrences(args, '--body');
+  const bodyFileOptions = optionOccurrences(args, '--body-file');
+  if (!titleOptions.length && !bodyOptions.length && !bodyFileOptions.length) return allowed();
+
+  const errors = [];
+  if (titleOptions.length) {
+    const title = oneInspectableOption(args, '--title', 'PR title');
+    if (title.error) errors.push(title.error);
+    else errors.push(...validateTitle(title.value));
+  }
+
+  if (bodyOptions.length && bodyFileOptions.length) {
+    errors.push('Use either --body or --body-file for a wording change, not both.');
+  } else if (bodyOptions.length) {
+    const body = oneInspectableOption(args, '--body', 'PR body');
+    if (body.error) errors.push(body.error);
+    else errors.push(...validateBody(body.value));
+  } else if (bodyFileOptions.length) {
+    const body = bodyFromFile(args, readFile);
+    if (body.error) errors.push(body.error);
+    else errors.push(...validateBody(body.value));
+  }
+
+  return validationDecision(errors);
+};
+
+export const evaluateHookCommand = (command, { readFile = readFileSync } = {}) => {
+  if (typeof command !== 'string') return allowed();
+  const parsed = splitShellCommand(command);
+  const prCommands = findPrCommands(parsed.segments);
+  if (!prCommands.length) return allowed();
+  if (parsed.parseError) {
+    return denied(`Cannot inspect this PR command because it has an ${parsed.parseError}. Use ordinary explicit gh pr arguments.`);
+  }
+
+  for (const prCommand of prCommands) {
+    const changesWording = prCommand.action === 'create'
+      || ['--title', '--body', '--body-file'].some((name) => (
+        optionOccurrences(prCommand.args, name).length > 0
+      ));
+    if (changesWording && parsed.segments.length !== 1) {
+      return denied(`Run gh pr ${prCommand.action} as a separate command after the complete body file exists so the hook can inspect the final wording.`);
+    }
+    const decision = prCommand.action === 'create'
+      ? evaluateCreate(prCommand.args, readFile)
+      : evaluateEdit(prCommand.args, readFile);
+    if (!decision.allowed) return decision;
+  }
+  return allowed();
+};
+
+export const hookDenialOutput = (reason) => ({
+  hookSpecificOutput: {
+    hookEventName: 'PreToolUse',
+    permissionDecision: 'deny',
+    permissionDecisionReason: reason
+  }
+});
+
+export const evaluateHookEvent = (event, options) => evaluateHookCommand(
+  event?.tool_input?.command,
+  options
+);
+
+const readManualArguments = (args) => {
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 1) {
+    const name = args[index];
+    if (!['--title', '--body-file'].includes(name) || index + 1 >= args.length) {
+      return { error: 'Usage: node tools/check-pr-language.mjs --title "..." --body-file path/to/body.md' };
+    }
+    if (values.has(name)) return { error: `${name} may be supplied only once.` };
+    values.set(name, args[index + 1]);
+    index += 1;
+  }
+  if (!values.has('--title') || !values.has('--body-file')) {
+    return { error: 'Manual mode requires both --title and --body-file.' };
+  }
+  return { title: values.get('--title'), bodyFile: values.get('--body-file') };
+};
+
+const runManual = (args) => {
+  const parsed = readManualArguments(args);
+  if (parsed.error) {
+    process.stderr.write(`${parsed.error}\n`);
+    return 1;
+  }
+
+  let body;
+  try {
+    body = readFileSync(parsed.bodyFile, 'utf8');
+  } catch (_error) {
+    process.stderr.write(`Cannot read PR body file "${parsed.bodyFile}".\n`);
+    return 1;
+  }
+
+  const errors = validateProposal({ title: parsed.title, body });
+  if (errors.length) {
+    process.stderr.write(`PR language check failed:\n- ${errors.join('\n- ')}\n`);
+    return 1;
+  }
+  process.stdout.write('PR language check passed.\n');
+  return 0;
+};
+
+const runHook = () => {
+  let event;
+  try {
+    event = JSON.parse(readFileSync(0, 'utf8'));
+  } catch (_error) {
+    process.stdout.write(`${JSON.stringify(hookDenialOutput(
+      'Cannot inspect the Codex hook event. Retry the PR command with ordinary explicit arguments.'
+    ))}\n`);
+    return 0;
+  }
+  const decision = evaluateHookEvent(event);
+  if (!decision.allowed) process.stdout.write(`${JSON.stringify(hookDenialOutput(decision.reason))}\n`);
+  return 0;
+};
+
+const run = (args) => args.length === 1 && args[0] === '--hook'
+  ? runHook()
+  : runManual(args);
+
+if (process.argv[1]
+    && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exitCode = run(process.argv.slice(2));
+}


### PR DESCRIPTION
## Plain-language summary

This PR adds repository instructions, a summary-first PR template, and a Codex hook that checks pull request titles and opening summaries before `gh pr create` or a wording-changing `gh pr edit` runs. PR #394 showed that internal process terms can hide a simple change from maintainers who have not read earlier plans. After merge, Codex will block missing summaries, the small set of opaque phrases from that regression, and command forms whose title or body cannot be inspected; exact identifiers in backticks and later technical sections remain allowed.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Make the PR title and first explanatory section understandable without local plans or earlier PR history.

## User-visible impact

Maintainers will see the concrete change, reason, and post-merge result before repository classifications and evidence. Codex users must review and trust the project-local hook through `/hooks` before it runs.

## Changes

- Added a short PR communication rule to `AGENTS.md`.
- Added the focused `write-clear-pull-request` Skill.
- Put `## Plain-language summary` first in the PR template.
- Replaced the empty `.codex` placeholder with a synchronous `PreToolUse` hook.
- Added the dependency-free `tools/check-pr-language.mjs` checker and Node tests.

## Verification

- `npx --yes node@20 --test tests/web/pr-language.test.mjs`: 28 tests passed.
- PR fast JavaScript command from `.github/workflows/test.yml`: 268 tests passed.
- `npx --yes node@20 --test tests/web/architecture-contracts.test.mjs`: 112 tests passed.
- `python -m pytest tests/test_documentation_contracts.py -q`: 7 tests passed.
- `npx --yes node@20 tools/check-web-change-budget.mjs`: Gate PASS, Review REQUIRED for the PR template change.
- Manual checker cases: PR #394 wording failed with phrase-specific fixes; the clear title and body passed.
- Direct hook cases: `gh pr create --fill` returned the current structured deny JSON; an unrelated Bash command exited silently.
- `ruff check gbdraw/`, Skill validation, hook JSON validation, and `git diff --cached --check` passed.

## Risk and review notes

- Gate result and any blocker: PASS; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: REQUIRED because `.github/pull_request_template.md` is a registered governance file and this adds one repository-local parser and hook path.
- Architecture impact: **This is architecture-bearing**. PR-language validation has one semantic owner at `tools/check-pr-language.mjs` and one canonical path from `.codex/hooks.json`; the replaced empty `.codex` file owned no behavior. Owner excess, path excess, and compatibility burden remain non-increasing, with no superseded runtime path retained.
- `architecture-change` label, if relevant: not applied because no Web application implementation changes and the ordinary Web profile passes.
- Parser limitation: the hook recognizes ordinary explicit `gh pr create` and `gh pr edit` shell forms at a command-segment boundary. Aliases, wrapper scripts, and browser-created PRs remain outside this local hook.
- Project-local Codex hooks do not run until the exact hook definition is reviewed and trusted through `/hooks`.

## Rollback

Revert commit `c62d61a1`. This restores the empty `.codex` placeholder and removes the checker, Skill, template section, repository instruction, and tests together.

## Conditional evidence

Complete only the section for the selected change class.

### GOVERNANCE

Complete only when `GOVERNANCE` is selected.

- Authority or evidence-producer files touched: `.github/pull_request_template.md` is the only existing registered guard file changed. No workflow or normative policy file changed.
- Checker implementation files touched: `tools/check-pr-language.mjs`, with `tests/web/pr-language.test.mjs`; `.codex/hooks.json` is its only adapter.
- Self-authorization separation evidence: the existing Web checker, Web authority, evidence workflows, and production runtime are unchanged. The new local adapter calls only the new checker, cannot change GitHub repository settings, and requires separate user trust in Codex.
- Branch-protection or ruleset impact, including unchanged settings: none; no branch-protection, ruleset, required-check, or repository-setting operation was performed.
- Governance-specific rollback or protection restore point: revert `c62d61a1`; branch protection and rulesets need no restore operation because they were not changed.
