### PR TITLE
Add Product Impact Ratchet mechanics

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -33,6 +33,10 @@ import {
   validateArchitectureRuleRegistry
 } from '../../tools/web-architecture-evaluation.mjs';
 import {
+  validateProductDecisionAuthority,
+  validateProductImpactMap
+} from '../../tools/web-product-impact-evaluation.mjs';
+import {
   literalImportSpecifiers,
   maskJavaScript
 } from '../../tools/web-change-source.mjs';
@@ -111,6 +115,22 @@ const WEB_ARCHITECTURE_RULES = JSON.parse(WEB_ARCHITECTURE_RULES_SOURCE);
 const WEB_CHANGE_BUDGET_SOURCE = readFileSync(
   join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs'),
   'utf8'
+);
+const PRODUCT_IMPACT_EVALUATION_SOURCE = readFileSync(
+  join(REPOSITORY_ROOT, 'tools/web-product-impact-evaluation.mjs'),
+  'utf8'
+);
+const PRODUCT_IMPACT_DECISION_SOURCE = readFileSync(
+  join(REPOSITORY_ROOT, 'tools/web-product-impact-decision-source.mjs'),
+  'utf8'
+);
+const PRODUCT_IMPACT_MAP_PATH = join(
+  REPOSITORY_ROOT,
+  'tools/web-product-impact-map.json'
+);
+const PRODUCT_DECISIONS_PATH = join(
+  REPOSITORY_ROOT,
+  'tools/web-product-decisions.json'
 );
 
 const normalizePath = (path) => path.split(sep).join('/');
@@ -660,6 +680,43 @@ test('pure architecture evaluation owns no I/O, source detection, or authority d
   assert.doesNotMatch(WEB_ARCHITECTURE_EVALUATION_SOURCE, /^#!|process\.argv/);
 });
 
+test('pure Product Impact mechanics own no I/O, Git, environment, reporting, or CLI', () => {
+  for (const source of [PRODUCT_IMPACT_EVALUATION_SOURCE, PRODUCT_IMPACT_DECISION_SOURCE]) {
+    assert.doesNotMatch(source, /^\s*import\s/m);
+    assert.doesNotMatch(
+      source,
+      /node:(?:fs|path|child_process|process)|process\.|console\.|(?:read|write|append)File|execFile|spawn|fetch\s*\(/
+    );
+    assert.doesNotMatch(source, /^#!|process\.argv/);
+  }
+  assert.doesNotMatch(
+    PRODUCT_IMPACT_EVALUATION_SOURCE,
+    /web-product-impact-(?:map|decisions)\.json|web-architecture-rules\.json/
+  );
+});
+
+test('Product Impact authority bootstrap accepts zero or two inert JSON files', () => {
+  const mapExists = existsSync(PRODUCT_IMPACT_MAP_PATH);
+  const decisionsExist = existsSync(PRODUCT_DECISIONS_PATH);
+  assert.equal(
+    mapExists,
+    decisionsExist,
+    'Product Impact map and durable decision authority must be introduced together'
+  );
+  if (!mapExists) return;
+
+  const map = JSON.parse(readFileSync(PRODUCT_IMPACT_MAP_PATH, 'utf8'));
+  const decisions = JSON.parse(readFileSync(PRODUCT_DECISIONS_PATH, 'utf8'));
+  assert.deepEqual(
+    validateProductImpactMap(map, WEB_ARCHITECTURE_RULES, WEB_ARCHITECTURE_DETECTORS),
+    { valid: true, errors: [] }
+  );
+  assert.deepEqual(validateProductDecisionAuthority(decisions, map), {
+    valid: true,
+    errors: []
+  });
+});
+
 test('registered architecture authority and executable matching have separate owners', () => {
   assert.deepEqual(Object.keys(WEB_ARCHITECTURE_RULES), ['schemaVersion', 'rules']);
   assert.doesNotMatch(
@@ -694,6 +751,11 @@ test('the Web checker remains the sole evaluator orchestrator and CLI entry poin
   assert.match(WEB_CHANGE_BUDGET_SOURCE, /^#!\/usr\/bin\/env node/);
   assert.match(WEB_CHANGE_BUDGET_SOURCE, /WEB_ARCHITECTURE_DETECTORS\[rule\.detector\]/);
   assert.doesNotMatch(WEB_CHANGE_BUDGET_SOURCE, /import\s*\(.*web-architecture-detectors/);
+  assert.doesNotMatch(
+    WEB_CHANGE_BUDGET_SOURCE,
+    /from '\.\/web-product-impact-(?:evaluation|decision-source)\.mjs'/
+  );
+  assert.doesNotMatch(WEB_CHANGE_BUDGET_SOURCE, /## Product impact/);
 });
 
 test('report-only source facts preserve the characterized masking behavior', () => {
@@ -1060,6 +1122,25 @@ test('the PR template retains architecture evidence anchors', () => {
   });
 });
 
+test('the PR template contains one optional bounded Product Impact decision block', () => {
+  const startMarkers = PULL_REQUEST_TEMPLATE.match(
+    /<!-- gbdraw-product-impact-decision:start -->/g
+  ) || [];
+  const endMarkers = PULL_REQUEST_TEMPLATE.match(
+    /<!-- gbdraw-product-impact-decision:end -->/g
+  ) || [];
+  assert.equal(startMarkers.length, 1);
+  assert.equal(endMarkers.length, 1);
+  assert.ok(
+    PULL_REQUEST_TEMPLATE.indexOf(startMarkers[0])
+      < PULL_REQUEST_TEMPLATE.indexOf(endMarkers[0])
+  );
+  assert.match(
+    PULL_REQUEST_TEMPLATE,
+    /\{"schemaVersion":1,"headSha":"","decisions":\[\]\}/
+  );
+});
+
 test('the PR template requires exact changed-scope architecture debt arithmetic', () => {
   [
     'Owner-excess rows (repeat for every changed capability)',
@@ -1166,9 +1247,21 @@ const WEB_ARCHITECTURE_EVALUATION_MODULE = join(
   REPOSITORY_ROOT,
   'tools/web-architecture-evaluation.mjs'
 );
+const PRODUCT_IMPACT_EVALUATION_MODULE = join(
+  REPOSITORY_ROOT,
+  'tools/web-product-impact-evaluation.mjs'
+);
+const PRODUCT_IMPACT_DECISION_MODULE = join(
+  REPOSITORY_ROOT,
+  'tools/web-product-impact-decision-source.mjs'
+);
 const WEB_ARCHITECTURE_RATCHET_FIXTURES = join(
   REPOSITORY_ROOT,
   'tests/web/architecture-ratchet-fixtures.test.mjs'
+);
+const PRODUCT_IMPACT_RATCHET_FIXTURES = join(
+  REPOSITORY_ROOT,
+  'tests/web/product-impact-ratchet-fixtures.test.mjs'
 );
 const WEB_PROMOTION_CONTEXT_MODULE = join(
   REPOSITORY_ROOT,
@@ -1250,6 +1343,14 @@ const BUDGET_FIXTURE = Object.freeze({
     WEB_ARCHITECTURE_EVALUATION_MODULE,
     'utf8'
   ),
+  'tools/web-product-impact-evaluation.mjs': readFileSync(
+    PRODUCT_IMPACT_EVALUATION_MODULE,
+    'utf8'
+  ),
+  'tools/web-product-impact-decision-source.mjs': readFileSync(
+    PRODUCT_IMPACT_DECISION_MODULE,
+    'utf8'
+  ),
   'tools/web-architecture-rules.json': WEB_ARCHITECTURE_RULES_SOURCE,
   'tools/web-change-source.mjs': readFileSync(
     join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
@@ -1262,6 +1363,10 @@ const BUDGET_FIXTURE = Object.freeze({
   'tools/web-change-policy.json': `${JSON.stringify(BUDGET_POLICY, null, 2)}\n`,
   'tests/web/architecture-ratchet-fixtures.test.mjs': readFileSync(
     WEB_ARCHITECTURE_RATCHET_FIXTURES,
+    'utf8'
+  ),
+  'tests/web/product-impact-ratchet-fixtures.test.mjs': readFileSync(
+    PRODUCT_IMPACT_RATCHET_FIXTURES,
     'utf8'
   ),
   'gbdraw/web/index.html': '<main>baseline</main>\n',
@@ -1304,6 +1409,28 @@ const FUTURE_AUTHORITY_PATHS = Object.freeze([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   'tools/web-architecture-rules.json',
   'tools/web-architecture-violations.json'
+]);
+const PRODUCT_IMPACT_GUARD_PATHS = Object.freeze([
+  'docs/internal/PRODUCT_IMPACT_RATCHET.md',
+  'tools/web-product-impact-map.json',
+  'tools/web-product-decisions.json',
+  'tools/web-product-impact-evaluation.mjs',
+  'tools/web-product-impact-decision-source.mjs',
+  'tests/web/product-impact-ratchet-fixtures.test.mjs'
+]);
+const PRODUCT_IMPACT_CHECKER_IMPLEMENTATION_PATHS = Object.freeze([
+  'tools/web-product-impact-evaluation.mjs',
+  'tools/web-product-impact-decision-source.mjs'
+]);
+const PRODUCT_IMPACT_AUTHORITY_PATHS = Object.freeze([
+  'docs/internal/PRODUCT_IMPACT_RATCHET.md',
+  'tools/web-product-impact-map.json',
+  'tools/web-product-decisions.json'
+]);
+const NARROW_PRODUCT_IMPACT_AUTHORITY_BUNDLE = Object.freeze([
+  'tools/web-architecture-rules.json',
+  'tools/web-product-impact-map.json',
+  'tools/web-product-decisions.json'
 ]);
 const reservedPathContent = (path) => {
   if (path === 'tools/web-architecture-rules.json') {
@@ -2554,6 +2681,70 @@ test('reserved future guard paths need not exist before their rollout', () => {
   assert.doesNotMatch(result.output, /- Result:|- Size review:/);
 });
 
+test('every Product Impact policy, checker, authority, parser, and fixture path is guarded', () => {
+  PRODUCT_IMPACT_GUARD_PATHS.forEach((guardPath) => {
+    assertNonWaivableWorkingTreeFailure((write) => {
+      write(
+        'gbdraw/web/js/services/session-file.js',
+        'export const readSession = () => ({ version: 2 });\n'
+      );
+      write(
+        guardPath,
+        BUDGET_FIXTURE[guardPath]
+          ? `${BUDGET_FIXTURE[guardPath]}\n// changed\n`
+          : reservedPathContent(guardPath)
+      );
+    }, [/production runtime files and Web guard\/CI files changed together/], guardPath);
+  });
+});
+
+test('Product Impact checker implementation is separate from Product Impact authority', () => {
+  PRODUCT_IMPACT_CHECKER_IMPLEMENTATION_PATHS.forEach((implementationPath) => {
+    PRODUCT_IMPACT_AUTHORITY_PATHS.forEach((authorityPath) => {
+      assertNonWaivableWorkingTreeFailure((write) => {
+        write(
+          implementationPath,
+          `${BUDGET_FIXTURE[implementationPath]}\n// changed\n`
+        );
+        write(authorityPath, reservedPathContent(authorityPath));
+      }, [/Web checker\/source parser and authority policy\/workflow files changed together/]);
+    });
+  });
+});
+
+test('the narrow inert authority bundle contains only architecture rules, map, and decisions', () => {
+  assert.deepEqual(NARROW_PRODUCT_IMPACT_AUTHORITY_BUNDLE, [
+    'tools/web-architecture-rules.json',
+    'tools/web-product-impact-map.json',
+    'tools/web-product-decisions.json'
+  ]);
+
+  const productAuthorityOnly = runChangeBudgetCase((write) => {
+    write('tools/web-product-impact-map.json', '{"schemaVersion":1}\n');
+    write('tools/web-product-decisions.json', '{"schemaVersion":1}\n');
+  });
+  assert.equal(productAuthorityOnly.status, 0, productAuthorityOnly.output);
+  assert.match(productAuthorityOnly.output, /Gate: \*\*PASS\*\*/);
+  assert.match(productAuthorityOnly.output, /Review: \*\*REQUIRED\*\*/);
+
+  const completeBundle = runChangeBudgetCase((write) => {
+    write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource);
+    write('tools/web-product-impact-map.json', '{"schemaVersion":1}\n');
+    write('tools/web-product-decisions.json', '{"schemaVersion":1}\n');
+  });
+  assert.equal(completeBundle.status, 0, completeBundle.output);
+  assert.match(completeBundle.output, /Classification: EXPANSION/);
+
+  const expandedBundle = runChangeBudgetCase((write) => {
+    write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource);
+    write('tools/web-product-impact-map.json', '{"schemaVersion":1}\n');
+    write('tools/web-product-decisions.json', '{"schemaVersion":1}\n');
+    write('docs/internal/PRODUCT_IMPACT_RATCHET.md', '# changed policy\n');
+  });
+  assert.equal(expandedBundle.status, 1, expandedBundle.output);
+  assert.match(expandedBundle.output, /architecture rule authority changes must be isolated/);
+});
+
 test('runtime cannot co-change with any protected architecture guard path', () => {
   PROTECTED_ARCHITECTURE_GUARD_PATHS.forEach((guardPath) => {
     assertNonWaivableWorkingTreeFailure((write) => {
@@ -2572,15 +2763,20 @@ test('checker implementation and authority files cannot change together', () => 
     'tools/web-change-source.mjs',
     'tools/web-architecture-detectors.mjs',
     'tools/web-architecture-evaluation.mjs',
+    'tools/web-product-impact-evaluation.mjs',
+    'tools/web-product-impact-decision-source.mjs',
     'tools/web-promotion-context.mjs',
     'tools/check-promotion-readiness.mjs'
   ];
   const authorityPaths = [
     'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+    'docs/internal/PRODUCT_IMPACT_RATCHET.md',
     'docs/internal/WEB_CHANGE_POLICY.md',
     'tools/web-change-policy.json',
     'tools/web-architecture-rules.json',
     'tools/web-architecture-violations.json',
+    'tools/web-product-impact-map.json',
+    'tools/web-product-decisions.json',
     '.github/workflows/gallery-publication.yml',
     '.github/workflows/deploy_web.yml',
     '.github/workflows/test.yml',
@@ -2608,6 +2804,8 @@ test('all checker implementations are separated from reserved future authority',
     'tools/web-change-source.mjs',
     'tools/web-architecture-detectors.mjs',
     'tools/web-architecture-evaluation.mjs',
+    'tools/web-product-impact-evaluation.mjs',
+    'tools/web-product-impact-decision-source.mjs',
     'tools/web-promotion-context.mjs',
     'tools/check-promotion-readiness.mjs'
   ];

--- a/tests/web/product-impact-ratchet-fixtures.test.mjs
+++ b/tests/web/product-impact-ratchet-fixtures.test.mjs
@@ -1,0 +1,981 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { WEB_ARCHITECTURE_DETECTORS } from '../../tools/web-architecture-detectors.mjs';
+import { createArchitectureSubjectDelta } from '../../tools/web-architecture-evaluation.mjs';
+import { parseCurrentProductImpactDecisions } from '../../tools/web-product-impact-decision-source.mjs';
+import {
+  evaluateProductImpact,
+  validateProductDecisionAuthority,
+  validateProductImpactMap
+} from '../../tools/web-product-impact-evaluation.mjs';
+
+const HEAD_SHA = 'a'.repeat(40);
+const START_MARKER = '<!-- gbdraw-product-impact-decision:start -->';
+const END_MARKER = '<!-- gbdraw-product-impact-decision:end -->';
+const OWNER_CURRENT = 'services/session-request.js';
+const OWNER_FUTURE = 'services/future-session-request.js';
+const ENTRY_CURRENT = 'app/run-analysis.js -> services/session-request.js';
+const ENTRY_FUTURE = 'app/alternate.js -> services/session-request.js';
+
+const architectureRegistry = () => ({
+  schemaVersion: 1,
+  rules: [
+    {
+      key: 'canonical-path.render-request',
+      kind: 'single-canonical-entry-edge',
+      detector: 'canonical-path.render-request.v1',
+      allowedEdges: [
+        { from: 'app/alternate.js', to: 'services/session-request.js' },
+        { from: 'app/run-analysis.js', to: 'services/session-request.js' }
+      ],
+      exactActiveEdgeCount: 1,
+      enforcement: 'hard',
+      baselineEligible: false
+    },
+    {
+      key: 'semantic-owner.render-request',
+      kind: 'single-semantic-owner',
+      detector: 'semantic-owner.render-request.v1',
+      allowedDefinitionPaths: [OWNER_FUTURE, OWNER_CURRENT],
+      exactDefinitionCount: 1,
+      enforcement: 'hard',
+      baselineEligible: false
+    }
+  ]
+});
+
+const candidate = (ruleKey, subjectCategory, subject) => ({
+  ruleKey,
+  subjectCategory,
+  subject
+});
+const entryCandidates = () => [
+  candidate('canonical-path.render-request', 'canonical-entry-edge', ENTRY_FUTURE),
+  candidate('canonical-path.render-request', 'canonical-entry-edge', ENTRY_CURRENT)
+];
+const ownerCandidates = () => [
+  candidate('semantic-owner.render-request', 'definition-path', OWNER_FUTURE),
+  candidate('semantic-owner.render-request', 'definition-path', OWNER_CURRENT)
+];
+const entryRequirement = (overrides = {}) => ({
+  id: 'REQ-RENDER-ENTRY',
+  category: 'SEMANTIC',
+  checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+  anyOf: entryCandidates(),
+  ...overrides
+});
+const ownerRequirement = (overrides = {}) => ({
+  id: 'REQ-RENDER-OWNER',
+  category: 'SEMANTIC',
+  checkpointRefs: [
+    'JRN-RENDER-001:generate-submit',
+    'JRN-RENDER-001:roundtrip-regeneration'
+  ],
+  anyOf: ownerCandidates(),
+  ...overrides
+});
+const contracts = () => [
+  {
+    ref: 'tests/web/request.test.mjs::canonical request projection',
+    checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+    sensitivity: 'DIRECT_ASSERTION',
+    execution: 'PR_GATE',
+    residualRisk: 'Browser timing is reviewed separately.'
+  },
+  {
+    ref: 'tests/web/session.test.mjs::request round trip',
+    checkpointRefs: ['JRN-RENDER-001:roundtrip-regeneration'],
+    sensitivity: 'MUTATION_FAIL',
+    execution: 'PR_GATE',
+    residualRisk: 'Future schema migrations require separate coverage.'
+  }
+];
+const baseConcern = (overrides = {}) => ({
+  key: 'product.render-request',
+  scenarioRevision: 1,
+  title: 'Canonical render request continuity',
+  layer: 'STATE',
+  journeys: [{
+    id: 'JRN-RENDER-001',
+    actor: 'Web user',
+    context: 'A configured diagram is ready to generate.',
+    goal: 'Generate and reproduce a diagram from canonical state.',
+    steps: ['Configure a diagram', 'Select Generate', 'Reload and regenerate'],
+    checkpoints: [
+      { id: 'generate-submit', label: 'Generate request construction' },
+      { id: 'roundtrip-regeneration', label: 'Regeneration after Session round trip' }
+    ]
+  }],
+  effects: [
+    {
+      id: 'EFF-RENDER-CURRENT',
+      checkpointRef: 'JRN-RENDER-001:generate-submit',
+      statement: 'Generation uses the current canonical configuration.'
+    },
+    {
+      id: 'EFF-RENDER-ROUNDTRIP',
+      checkpointRef: 'JRN-RENDER-001:roundtrip-regeneration',
+      statement: 'Reloaded state regenerates with the same request semantics.'
+    }
+  ],
+  options: [{
+    id: 'canonical-boundary',
+    summary: 'Generation and replay share one canonical request boundary.',
+    effectRefs: ['EFF-RENDER-CURRENT', 'EFF-RENDER-ROUNDTRIP'],
+    requirements: [entryRequirement(), ownerRequirement()]
+  }],
+  resolution: {
+    kind: 'authority-covered',
+    selectedOptionId: 'canonical-boundary',
+    authorityRefs: [
+      'gbdraw/web/CLAUDE.md#request-and-session-boundary',
+      'gbdraw/web/CLAUDE.md#runtime-data-flow'
+    ]
+  },
+  contracts: contracts(),
+  ...overrides
+});
+const productMap = (overrides = {}) => ({
+  schemaVersion: 1,
+  ruleCoverage: [
+    {
+      ruleKey: 'canonical-path.render-request',
+      coverage: 'complete',
+      enforcement: 'report-only'
+    },
+    {
+      ruleKey: 'semantic-owner.render-request',
+      coverage: 'complete',
+      enforcement: 'report-only'
+    }
+  ],
+  concerns: [baseConcern()],
+  ...overrides
+});
+const decisionAuthority = (overrides = {}) => ({
+  schemaVersion: 1,
+  maintainerLogins: ['maintainer'],
+  decisions: [],
+  ...overrides
+});
+const validationCodes = (map, registry = architectureRegistry()) => (
+  validateProductImpactMap(map, registry, WEB_ARCHITECTURE_DETECTORS)
+    .errors.map(({ code }) => code)
+);
+const ownerDelta = (beforeSubjects, afterSubjects) => createArchitectureSubjectDelta({
+  ruleKey: 'semantic-owner.render-request',
+  kind: 'single-semantic-owner',
+  detector: 'semantic-owner.render-request.v1',
+  subjectCategory: 'definition-path',
+  beforeSubjects,
+  afterSubjects
+});
+const entryDelta = (beforeSubjects, afterSubjects) => createArchitectureSubjectDelta({
+  ruleKey: 'canonical-path.render-request',
+  kind: 'single-canonical-entry-edge',
+  detector: 'canonical-path.render-request.v1',
+  subjectCategory: 'canonical-entry-edge',
+  beforeSubjects,
+  afterSubjects
+});
+const ruleFacts = ({
+  ownerBefore = [OWNER_CURRENT],
+  ownerAfter = [OWNER_FUTURE],
+  entryBefore = [ENTRY_CURRENT],
+  entryAfter = [ENTRY_CURRENT]
+} = {}) => [
+  {
+    ruleKey: 'canonical-path.render-request',
+    subjectCategory: 'canonical-entry-edge',
+    beforeSubjects: entryBefore,
+    afterSubjects: entryAfter
+  },
+  {
+    ruleKey: 'semantic-owner.render-request',
+    subjectCategory: 'definition-path',
+    beforeSubjects: ownerBefore,
+    afterSubjects: ownerAfter
+  }
+];
+const emptyCurrentDecisions = () => parseCurrentProductImpactDecisions({
+  body: '',
+  eventHeadSha: HEAD_SHA,
+  eventAuthorLogin: 'maintainer',
+  maxBodyBytes: 65536,
+  maxDecisionCount: 8
+});
+const decisionBlock = (decisions, { headSha = HEAD_SHA } = {}) => (
+  `${START_MARKER}\n${JSON.stringify({ schemaVersion: 1, headSha, decisions })}\n${END_MARKER}`
+);
+const currentDecision = (overrides = {}) => ({
+  concernKey: 'product.render-request',
+  scenarioRevision: 2,
+  selectedOptionId: 'after-option',
+  acceptedImpactClass: 'AFFORDANCE_PRESERVED',
+  rationale: 'The internal request owner changes while the supported workflow remains intact.',
+  acknowledgedChangedRequirementRefs: ['REQ-AFTER-OWNER', 'REQ-BEFORE-OWNER'],
+  evidenceRefs: ['tests/web/request.test.mjs::owner transition'],
+  residualRisk: 'No additional residual risk is accepted.',
+  ...overrides
+});
+const parseDecisions = (decisions, overrides = {}) => parseCurrentProductImpactDecisions({
+  body: decisionBlock(decisions, overrides),
+  eventHeadSha: overrides.eventHeadSha || HEAD_SHA,
+  eventAuthorLogin: overrides.eventAuthorLogin || 'maintainer',
+  maxBodyBytes: overrides.maxBodyBytes || 65536,
+  maxDecisionCount: overrides.maxDecisionCount || 8
+});
+
+const transitionConcern = ({ afterEffects = ['EFF-SHARED'], resolution = null } = {}) => ({
+  key: 'product.render-request',
+  scenarioRevision: 2,
+  title: 'Equivalent render request realization',
+  layer: 'STATE',
+  journeys: [{
+    id: 'JRN-RENDER-001',
+    actor: 'Web user',
+    context: 'Generation is requested.',
+    goal: 'Keep the supported generation outcome.',
+    steps: ['Select Generate', 'Inspect the Result'],
+    checkpoints: [{ id: 'generate-submit', label: 'Generate submission' }]
+  }],
+  effects: [
+    {
+      id: 'EFF-CHANGED',
+      checkpointRef: 'JRN-RENDER-001:generate-submit',
+      statement: 'Generation exposes a materially different continuation.'
+    },
+    {
+      id: 'EFF-SHARED',
+      checkpointRef: 'JRN-RENDER-001:generate-submit',
+      statement: 'Generation preserves the supported Result continuation.'
+    }
+  ],
+  options: [
+    {
+      id: 'after-option',
+      summary: 'The preauthorized future owner provides the request boundary.',
+      effectRefs: afterEffects,
+      requirements: [
+        entryRequirement({ id: 'REQ-AFTER-ENTRY' }),
+        ownerRequirement({
+          id: 'REQ-AFTER-OWNER',
+          checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+          anyOf: [candidate(
+            'semantic-owner.render-request',
+            'definition-path',
+            OWNER_FUTURE
+          )]
+        })
+      ]
+    },
+    {
+      id: 'before-option',
+      summary: 'The current owner provides the request boundary.',
+      effectRefs: ['EFF-SHARED'],
+      requirements: [
+        entryRequirement({ id: 'REQ-BEFORE-ENTRY' }),
+        ownerRequirement({
+          id: 'REQ-BEFORE-OWNER',
+          checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+          anyOf: [candidate(
+            'semantic-owner.render-request',
+            'definition-path',
+            OWNER_CURRENT
+          )]
+        })
+      ]
+    }
+  ],
+  resolution: resolution || { kind: 'decision-required' },
+  contracts: [{
+    ref: 'tests/web/request.test.mjs::owner transition',
+    checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+    sensitivity: 'DIRECT_ASSERTION',
+    execution: 'PR_GATE',
+    residualRisk: 'Timing remains outside this direct contract.'
+  }]
+});
+const transitionMap = (options = {}) => productMap({
+  concerns: [transitionConcern(options)]
+});
+const evaluate = ({
+  map = productMap(),
+  authority = decisionAuthority(),
+  deltas = [ownerDelta([OWNER_CURRENT], [OWNER_FUTURE])],
+  facts = ruleFacts(),
+  current = emptyCurrentDecisions(),
+  changedPaths = []
+} = {}) => evaluateProductImpact({
+  subjectDeltas: deltas,
+  ruleFacts: facts,
+  map,
+  decisionAuthority: authority,
+  currentDecisions: current,
+  changedPaths
+});
+
+test('structured subject deltas normalize unchanged, addition, removal, and replacement', () => {
+  assert.deepEqual(ownerDelta([OWNER_CURRENT, OWNER_CURRENT], [OWNER_CURRENT]), {
+    ruleKey: 'semantic-owner.render-request',
+    kind: 'single-semantic-owner',
+    detector: 'semantic-owner.render-request.v1',
+    subjectCategory: 'definition-path',
+    beforeSubjects: [OWNER_CURRENT],
+    addedSubjects: [],
+    removedSubjects: [],
+    afterSubjects: [OWNER_CURRENT],
+    changed: false
+  });
+  assert.deepEqual(ownerDelta([], [OWNER_CURRENT]).addedSubjects, [OWNER_CURRENT]);
+  assert.deepEqual(ownerDelta([OWNER_CURRENT], []).removedSubjects, [OWNER_CURRENT]);
+  assert.deepEqual(
+    ownerDelta([OWNER_CURRENT], [OWNER_FUTURE]),
+    {
+      ruleKey: 'semantic-owner.render-request',
+      kind: 'single-semantic-owner',
+      detector: 'semantic-owner.render-request.v1',
+      subjectCategory: 'definition-path',
+      beforeSubjects: [OWNER_CURRENT],
+      addedSubjects: [OWNER_FUTURE],
+      removedSubjects: [OWNER_CURRENT],
+      afterSubjects: [OWNER_FUTURE],
+      changed: true
+    }
+  );
+});
+
+test('structured subject deltas reject unknown fields and invalid canonical identifiers', () => {
+  assert.throws(() => createArchitectureSubjectDelta({
+    ruleKey: 'semantic-owner.render-request',
+    kind: 'single-semantic-owner',
+    detector: 'semantic-owner.render-request.v1',
+    subjectCategory: 'definition-path',
+    beforeSubjects: [],
+    afterSubjects: [],
+    extra: true
+  }), /requires exactly/);
+  assert.throws(() => ownerDelta([' padded '], []), /canonical nonempty subject strings/);
+  assert.throws(() => createArchitectureSubjectDelta({
+    ruleKey: 'INVALID',
+    kind: 'single-semantic-owner',
+    detector: 'semantic-owner.render-request.v1',
+    subjectCategory: 'definition-path',
+    beforeSubjects: [],
+    afterSubjects: []
+  }), /canonical rule key/);
+});
+
+test('structured subject delta inputs remain unchanged and outputs are deeply frozen', () => {
+  const input = {
+    ruleKey: 'semantic-owner.render-request',
+    kind: 'single-semantic-owner',
+    detector: 'semantic-owner.render-request.v1',
+    subjectCategory: 'definition-path',
+    beforeSubjects: [OWNER_CURRENT, OWNER_FUTURE],
+    afterSubjects: [OWNER_CURRENT]
+  };
+  const before = structuredClone(input);
+  const delta = createArchitectureSubjectDelta(input);
+  assert.deepEqual(input, before);
+  assert.equal(Object.isFrozen(delta), true);
+  assert.equal(Object.isFrozen(delta.beforeSubjects), true);
+  assert.throws(() => delta.beforeSubjects.push('x'));
+});
+
+test('the canonical Product Impact fixture validates', () => {
+  assert.deepEqual(
+    validateProductImpactMap(productMap(), architectureRegistry(), WEB_ARCHITECTURE_DETECTORS),
+    { valid: true, errors: [] }
+  );
+  assert.deepEqual(validateProductDecisionAuthority(decisionAuthority(), productMap()), {
+    valid: true,
+    errors: []
+  });
+});
+
+test('strict map validation rejects unknown fields at every schema level', () => {
+  const mutations = [
+    (map) => { map.extra = true; },
+    (map) => { map.ruleCoverage[0].extra = true; },
+    (map) => { map.concerns[0].extra = true; },
+    (map) => { map.concerns[0].journeys[0].extra = true; },
+    (map) => { map.concerns[0].journeys[0].checkpoints[0].extra = true; },
+    (map) => { map.concerns[0].effects[0].extra = true; },
+    (map) => { map.concerns[0].options[0].extra = true; },
+    (map) => { map.concerns[0].options[0].requirements[0].extra = true; },
+    (map) => { map.concerns[0].options[0].requirements[0].anyOf[0].extra = true; },
+    (map) => { map.concerns[0].resolution.extra = true; },
+    (map) => { map.concerns[0].contracts[0].extra = true; }
+  ];
+  mutations.forEach((mutate) => {
+    const map = productMap();
+    mutate(map);
+    assert.ok(validationCodes(map).includes('unknown-field'));
+  });
+});
+
+test('canonical IDs and references must be sorted and unique', () => {
+  const duplicateEffects = productMap();
+  duplicateEffects.concerns[0].options[0].effectRefs = [
+    'EFF-RENDER-ROUNDTRIP',
+    'EFF-RENDER-ROUNDTRIP'
+  ];
+  assert.ok(validationCodes(duplicateEffects).includes('duplicate-value'));
+
+  const unsortedCoverage = productMap();
+  unsortedCoverage.ruleCoverage.reverse();
+  assert.ok(validationCodes(unsortedCoverage).includes('unsorted-array'));
+
+  const unsortedRequirements = productMap();
+  unsortedRequirements.concerns[0].options[0].requirements.reverse();
+  assert.ok(validationCodes(unsortedRequirements).includes('unsorted-array'));
+});
+
+test('invalid architecture rule, subject category, and subject references fail closed', () => {
+  const cases = [
+    ['unknown-architecture-rule', (candidate_) => { candidate_.ruleKey = 'unknown.rule'; }],
+    ['subject-category-mismatch', (candidate_) => { candidate_.subjectCategory = 'definition-path'; }],
+    ['unapproved-architecture-subject', (candidate_) => { candidate_.subject = 'app/unknown.js'; }]
+  ];
+  cases.forEach(([code, mutate]) => {
+    const map = productMap();
+    mutate(map.concerns[0].options[0].requirements[0].anyOf[0]);
+    assert.ok(validationCodes(map).includes(code), code);
+  });
+});
+
+test('hard enforcement rejects partial coverage and manual-only checkpoint evidence', () => {
+  const hardPartial = productMap();
+  hardPartial.ruleCoverage[0] = {
+    ...hardPartial.ruleCoverage[0],
+    coverage: 'partial',
+    enforcement: 'hard'
+  };
+  assert.ok(validationCodes(hardPartial).includes('hard-requires-complete-coverage'));
+
+  const manualOnly = productMap();
+  manualOnly.ruleCoverage.forEach((coverage) => { coverage.enforcement = 'hard'; });
+  manualOnly.concerns[0].contracts.forEach((contract) => {
+    contract.sensitivity = 'MANUAL_ACCEPTANCE';
+    contract.execution = 'MANUAL';
+  });
+  const codes = validationCodes(manualOnly);
+  assert.ok(codes.includes('missing-hard-contract-coverage'));
+  assert.ok(codes.includes('manual-only-hard-concern'));
+});
+
+test('complete coverage rejects an unmapped allowed subject', () => {
+  const map = productMap();
+  map.concerns[0].options[0].requirements[0].anyOf = [
+    candidate('canonical-path.render-request', 'canonical-entry-edge', ENTRY_CURRENT)
+  ];
+  assert.ok(validationCodes(map).includes('unmapped-allowed-subject'));
+});
+
+test('journey, checkpoint, effect, option, and contract references are cross-validated', () => {
+  const cases = [
+    ['unknown-checkpoint-ref', (map) => {
+      map.concerns[0].effects[0].checkpointRef = 'JRN-RENDER-001:unknown';
+    }],
+    ['unknown-effect-ref', (map) => {
+      map.concerns[0].options[0].effectRefs[0] = 'EFF-UNKNOWN';
+    }],
+    ['unknown-selected-option', (map) => {
+      map.concerns[0].resolution.selectedOptionId = 'unknown-option';
+    }],
+    ['unknown-checkpoint-ref', (map) => {
+      map.concerns[0].contracts[0].checkpointRefs = ['JRN-RENDER-001:unknown'];
+    }]
+  ];
+  cases.forEach(([code, mutate]) => {
+    const map = productMap();
+    mutate(map);
+    assert.ok(validationCodes(map).includes(code), code);
+  });
+});
+
+test('AND-of-OR alternatives preserve one option when its active provider changes', () => {
+  const results = evaluate();
+  assert.equal(results.length, 1);
+  assert.equal(results[0].impactClass, 'NO_USER_VISIBLE_DIFFERENCE');
+  assert.equal(results[0].observation, 'CONFORMING');
+  assert.deepEqual(results[0].beforeOptions, ['canonical-boundary']);
+  assert.deepEqual(results[0].afterOptions, ['canonical-boundary']);
+  assert.deepEqual(
+    results[0].requirementResults.find(({ requirementRef }) => (
+      requirementRef === 'REQ-RENDER-OWNER'
+    )),
+    {
+      requirementRef: 'REQ-RENDER-OWNER',
+      category: 'SEMANTIC',
+      beforeSatisfied: true,
+      afterSatisfied: true,
+      beforeActiveSubjects: [OWNER_CURRENT],
+      afterActiveSubjects: [OWNER_FUTURE],
+      changed: true
+    }
+  );
+});
+
+test('separate jointly required contributions cannot be hidden by a shared option ID', () => {
+  const results = evaluate({
+    deltas: [entryDelta([ENTRY_CURRENT], [])],
+    facts: ruleFacts({
+      ownerBefore: [OWNER_CURRENT],
+      ownerAfter: [OWNER_CURRENT],
+      entryBefore: [ENTRY_CURRENT],
+      entryAfter: []
+    })
+  });
+  assert.equal(results[0].impactClass, 'RETIREMENT');
+  assert.equal(results[0].observation, 'ORDINARY_REGRESSION');
+  assert.deepEqual(results[0].beforeOptions, ['canonical-boundary']);
+  assert.deepEqual(results[0].afterOptions, []);
+  assert.equal(
+    results[0].requirementResults.find(({ requirementRef }) => (
+      requirementRef === 'REQ-RENDER-OWNER'
+    )).afterSatisfied,
+    true
+  );
+});
+
+test('effect-equivalent option transitions require authority and retain stable effects', () => {
+  const map = transitionMap();
+  assert.equal(validationCodes(map).length, 0);
+  const result = evaluate({ map })[0];
+  assert.equal(result.impactClass, 'AFFORDANCE_PRESERVED');
+  assert.equal(result.observation, 'UNRESOLVED_DECISION');
+  assert.deepEqual(result.beforeEffects, ['EFF-SHARED']);
+  assert.deepEqual(result.afterEffects, ['EFF-SHARED']);
+});
+
+test('a stable effect change or retirement is not eligible for a current decision', () => {
+  const map = transitionMap({ afterEffects: ['EFF-CHANGED'] });
+  const current = parseDecisions([currentDecision()]);
+  assert.equal(current.valid, true);
+  const result = evaluate({ map, current })[0];
+  assert.equal(result.impactClass, 'RETIREMENT');
+  assert.equal(result.observation, 'UNRESOLVED_DECISION');
+  assert.match(result.currentDecisionIssues.join(' '), /not affordance-preserving/);
+});
+
+test('static and domain authority are represented separately', () => {
+  const staticResult = evaluate()[0];
+  assert.equal(staticResult.authorityResolution, 'STATIC_AUTHORITY');
+
+  const domainMap = productMap();
+  domainMap.concerns[0].resolution = {
+    kind: 'domain-derived',
+    selectedOptionId: 'canonical-boundary',
+    authorityRefs: ['docs/domain.md#canonical-request-invariant']
+  };
+  assert.equal(validationCodes(domainMap).length, 0);
+  assert.equal(evaluate({ map: domainMap })[0].authorityResolution, 'DOMAIN_AUTHORITY');
+});
+
+test('durable decisions validate active uniqueness, concern revision, and contracts', () => {
+  const map = transitionMap();
+  const durable = {
+    id: 'BD-001',
+    concernKey: 'product.render-request',
+    scenarioRevision: 2,
+    selectedOptionId: 'after-option',
+    acceptedImpactClass: 'AFFORDANCE_PRESERVED',
+    acknowledgedRetiredRequirementRefs: [],
+    acceptanceCheckpointRefs: ['JRN-RENDER-001:generate-submit'],
+    rationale: 'The future owner preserves the supported generation outcome.'
+  };
+  const authority = decisionAuthority({ decisions: [durable] });
+  assert.deepEqual(validateProductDecisionAuthority(authority, map), {
+    valid: true,
+    errors: []
+  });
+  assert.equal(evaluate({ map, authority })[0].authorityResolution, 'DURABLE_DECISION');
+
+  const stale = decisionAuthority({
+    decisions: [{ ...durable, scenarioRevision: 1 }]
+  });
+  assert.ok(
+    validateProductDecisionAuthority(stale, map).errors
+      .some(({ code }) => code === 'stale-scenario-revision')
+  );
+
+  const duplicate = decisionAuthority({
+    decisions: [durable, { ...durable, id: 'BD-002' }]
+  });
+  assert.ok(
+    validateProductDecisionAuthority(duplicate, map).errors
+      .some(({ code }) => code === 'duplicate-active-decision')
+  );
+});
+
+test('durable decision authority rejects unknown fields and invalid retirement scope', () => {
+  const map = transitionMap();
+  const durable = {
+    id: 'BD-001',
+    concernKey: 'product.render-request',
+    scenarioRevision: 2,
+    selectedOptionId: 'after-option',
+    acceptedImpactClass: 'AFFORDANCE_PRESERVED',
+    acknowledgedRetiredRequirementRefs: [],
+    acceptanceCheckpointRefs: ['JRN-RENDER-001:generate-submit'],
+    rationale: 'The selected outcome preserves the supported generation continuation.'
+  };
+  const unknownTop = decisionAuthority({ extra: true });
+  assert.ok(
+    validateProductDecisionAuthority(unknownTop, map).errors
+      .some(({ code }) => code === 'unknown-field')
+  );
+  const unknownDecision = decisionAuthority({ decisions: [{ ...durable, extra: true }] });
+  assert.ok(
+    validateProductDecisionAuthority(unknownDecision, map).errors
+      .some(({ code }) => code === 'unknown-field')
+  );
+  const invalidRetirement = decisionAuthority({
+    decisions: [{
+      ...durable,
+      acknowledgedRetiredRequirementRefs: ['REQ-BEFORE-OWNER']
+    }]
+  });
+  assert.ok(
+    validateProductDecisionAuthority(invalidRetirement, map).errors
+      .some(({ code }) => code === 'retirement-impact-mismatch')
+  );
+  assert.ok(
+    validateProductDecisionAuthority(
+      decisionAuthority({ maintainerLogins: [] }),
+      map
+    ).errors.some(({ code }) => code === 'empty-maintainer-logins')
+  );
+});
+
+test('durable decisions are forbidden for static authority and automatic no-difference', () => {
+  const decision = {
+    id: 'BD-001',
+    concernKey: 'product.render-request',
+    scenarioRevision: 1,
+    selectedOptionId: 'canonical-boundary',
+    acceptedImpactClass: 'PRODUCT_CHANGE',
+    acknowledgedRetiredRequirementRefs: [],
+    acceptanceCheckpointRefs: ['JRN-RENDER-001:generate-submit'],
+    rationale: 'A durable choice is deliberately attempted against static authority.'
+  };
+  const validation = validateProductDecisionAuthority(
+    decisionAuthority({ decisions: [decision] }),
+    productMap()
+  );
+  assert.ok(validation.errors.some(({ code }) => code === 'decision-conflicts-with-resolution'));
+  assert.ok(
+    validateProductDecisionAuthority(
+      decisionAuthority({ decisions: [{ ...decision, acceptedImpactClass: 'NO_USER_VISIBLE_DIFFERENCE' }] }),
+      productMap()
+    ).errors.some(({ code }) => code === 'invalid-accepted-impact-class')
+  );
+});
+
+test('bounded parser accepts empty declarations without a head SHA', () => {
+  const parsed = parseCurrentProductImpactDecisions({
+    body: decisionBlock([], { headSha: '' }),
+    eventHeadSha: '',
+    eventAuthorLogin: 'Maintainer',
+    maxBodyBytes: 4096,
+    maxDecisionCount: 2
+  });
+  assert.deepEqual(parsed, {
+    valid: true,
+    present: true,
+    metadata: { eventAuthorLogin: 'maintainer', eventHeadSha: '' },
+    declaration: { schemaVersion: 1, headSha: '', decisions: [] },
+    errors: []
+  });
+});
+
+test('bounded parser normalizes exact-head decisions and product-level rationale', () => {
+  const parsed = parseCurrentProductImpactDecisions({
+    body: decisionBlock([currentDecision({ rationale: '  Preserve   the supported outcome.  ' })], {
+      headSha: HEAD_SHA.toUpperCase()
+    }),
+    eventHeadSha: HEAD_SHA,
+    eventAuthorLogin: 'Maintainer',
+    maxBodyBytes: 65536,
+    maxDecisionCount: 8
+  });
+  assert.equal(parsed.valid, true);
+  assert.equal(parsed.declaration.headSha, HEAD_SHA);
+  assert.equal(parsed.declaration.decisions[0].rationale, 'Preserve the supported outcome.');
+  assert.equal(parsed.metadata.eventAuthorLogin, 'maintainer');
+});
+
+test('bounded parser rejects stale heads, wrong impact class, and incomplete rationale', () => {
+  const stale = parseDecisions([currentDecision()], { eventHeadSha: 'b'.repeat(40) });
+  assert.ok(stale.errors.some(({ code }) => code === 'stale-head-sha'));
+
+  const wrongImpact = parseDecisions([currentDecision({ acceptedImpactClass: 'PRODUCT_CHANGE' })]);
+  assert.ok(wrongImpact.errors.some(({ code }) => code === 'invalid-current-impact-class'));
+
+  const emptyRationale = parseDecisions([currentDecision({ rationale: '   ' })]);
+  assert.ok(emptyRationale.errors.some(({ code }) => code === 'invalid-string'));
+});
+
+test('bounded parser rejects unknown fields and bounded collection overflows', () => {
+  const unknownTopBody = `${START_MARKER}\n${JSON.stringify({
+    schemaVersion: 1,
+    headSha: '',
+    decisions: [],
+    extra: true
+  })}\n${END_MARKER}`;
+  const unknownTop = parseCurrentProductImpactDecisions({
+    body: unknownTopBody,
+    eventHeadSha: HEAD_SHA,
+    eventAuthorLogin: 'maintainer',
+    maxBodyBytes: 65536,
+    maxDecisionCount: 8
+  });
+  assert.ok(unknownTop.errors.some(({ code }) => code === 'unknown-field'));
+
+  const unknownDecision = parseDecisions([currentDecision({ extra: true })]);
+  assert.ok(unknownDecision.errors.some(({ code }) => code === 'unknown-field'));
+
+  const tooManyDecisions = parseDecisions(
+    [currentDecision(), currentDecision({ concernKey: 'product.second' })],
+    { maxDecisionCount: 1 }
+  );
+  assert.ok(tooManyDecisions.errors.some(({ code }) => code === 'too-many-decisions'));
+
+  const oversizedRefs = parseDecisions([currentDecision({
+    evidenceRefs: Array.from({ length: 33 }, (_, index) => `evidence-${String(index).padStart(2, '0')}`)
+  })]);
+  assert.ok(oversizedRefs.errors.some(({ code }) => code === 'oversized-array'));
+});
+
+test('bounded parser rejects unmatched, reversed, duplicate, malformed, and oversized blocks', () => {
+  const inputs = [
+    START_MARKER,
+    `${END_MARKER}\n{}\n${START_MARKER}`,
+    `${decisionBlock([])}\n${decisionBlock([])}`,
+    `${START_MARKER}\nnot-json\n${END_MARKER}`
+  ];
+  inputs.forEach((body) => {
+    const parsed = parseCurrentProductImpactDecisions({
+      body,
+      eventHeadSha: HEAD_SHA,
+      eventAuthorLogin: 'maintainer',
+      maxBodyBytes: 65536,
+      maxDecisionCount: 8
+    });
+    assert.equal(parsed.valid, false, body.slice(0, 40));
+  });
+  const oversized = parseCurrentProductImpactDecisions({
+    body: 'x'.repeat(101),
+    eventHeadSha: HEAD_SHA,
+    eventAuthorLogin: 'maintainer',
+    maxBodyBytes: 100,
+    maxDecisionCount: 8
+  });
+  assert.ok(oversized.errors.some(({ code }) => code === 'oversized-body'));
+});
+
+test('parser errors are sanitized and never expose the untrusted body', () => {
+  const secret = 'PRIVATE-SEQUENCE-DO-NOT-ECHO';
+  const parsed = parseCurrentProductImpactDecisions({
+    body: `${START_MARKER}\n${secret}\n${END_MARKER}`,
+    eventHeadSha: HEAD_SHA,
+    eventAuthorLogin: 'maintainer',
+    maxBodyBytes: 65536,
+    maxDecisionCount: 8
+  });
+  assert.equal(parsed.valid, false);
+  assert.doesNotMatch(JSON.stringify(parsed.errors), new RegExp(secret));
+});
+
+test('free-form PRODUCT_DECISION text is never parsed as checker authority', () => {
+  const human = [
+    'PRODUCT_DECISION',
+    'Concern: product.render-request',
+    'Choice: after-option',
+    'Rationale: preserve behavior'
+  ].join('\n');
+  const outsideMarkers = parseCurrentProductImpactDecisions({
+    body: human,
+    eventHeadSha: HEAD_SHA,
+    eventAuthorLogin: 'maintainer',
+    maxBodyBytes: 65536,
+    maxDecisionCount: 8
+  });
+  assert.equal(outsideMarkers.valid, true);
+  assert.equal(outsideMarkers.present, false);
+  assert.deepEqual(outsideMarkers.declaration.decisions, []);
+
+  const insideMarkers = parseCurrentProductImpactDecisions({
+    body: `${START_MARKER}\n${human}\n${END_MARKER}`,
+    eventHeadSha: HEAD_SHA,
+    eventAuthorLogin: 'maintainer',
+    maxBodyBytes: 65536,
+    maxDecisionCount: 8
+  });
+  assert.equal(insideMarkers.valid, false);
+  assert.ok(insideMarkers.errors.some(({ code }) => code === 'invalid-json'));
+});
+
+test('an exact-head current maintainer decision resolves an effect-equivalent transition', () => {
+  const map = transitionMap();
+  const current = parseDecisions([currentDecision()]);
+  assert.equal(current.valid, true);
+  const result = evaluate({ map, current })[0];
+  assert.equal(result.observation, 'CONFORMING');
+  assert.equal(result.authorityResolution, 'CURRENT_MAINTAINER_DECISION');
+  assert.equal(result.selectedOptionId, 'after-option');
+  assert.equal(result.decisionRationale, currentDecision().rationale);
+});
+
+test('non-maintainers and incomplete changed-requirement acknowledgements are ineligible', () => {
+  const map = transitionMap();
+  const nonMaintainer = parseDecisions([currentDecision()], {
+    eventAuthorLogin: 'contributor'
+  });
+  const first = evaluate({ map, current: nonMaintainer })[0];
+  assert.equal(first.observation, 'UNRESOLVED_DECISION');
+  assert.match(first.currentDecisionIssues.join(' '), /not an eligible Product Decision Owner/);
+
+  const incomplete = parseDecisions([currentDecision({
+    acknowledgedChangedRequirementRefs: ['REQ-AFTER-OWNER']
+  })]);
+  const second = evaluate({ map, current: incomplete })[0];
+  assert.equal(second.observation, 'UNRESOLVED_DECISION');
+  assert.match(second.currentDecisionIssues.join(' '), /acknowledgement is incomplete/);
+});
+
+test('incompatible durable and current selections produce authority conflict', () => {
+  const map = transitionMap();
+  const durable = decisionAuthority({
+    decisions: [{
+      id: 'BD-001',
+      concernKey: 'product.render-request',
+      scenarioRevision: 2,
+      selectedOptionId: 'after-option',
+      acceptedImpactClass: 'AFFORDANCE_PRESERVED',
+      acknowledgedRetiredRequirementRefs: [],
+      acceptanceCheckpointRefs: ['JRN-RENDER-001:generate-submit'],
+      rationale: 'The future owner is the durable selected outcome.'
+    }]
+  });
+  const current = parseDecisions([currentDecision({ selectedOptionId: 'before-option' })]);
+  const result = evaluate({ map, authority: durable, current })[0];
+  assert.equal(result.observation, 'AUTHORITY_CONFLICT');
+  assert.equal(result.authorityResolution, 'CONFLICT');
+  assert.equal(result.selectedOptionId, null);
+});
+
+test('a current decision incompatible with static authority also produces conflict', () => {
+  const map = transitionMap({
+    resolution: {
+      kind: 'authority-covered',
+      selectedOptionId: 'before-option',
+      authorityRefs: ['gbdraw/web/CLAUDE.md#runtime-data-flow']
+    }
+  });
+  const current = parseDecisions([currentDecision()]);
+  const result = evaluate({ map, current })[0];
+  assert.equal(result.observation, 'AUTHORITY_CONFLICT');
+  assert.equal(result.authorityResolution, 'CONFLICT');
+});
+
+test('a selected static option missing after the change is an ordinary regression', () => {
+  const result = evaluate({
+    deltas: [entryDelta([ENTRY_CURRENT], [])],
+    facts: ruleFacts({
+      ownerBefore: [OWNER_CURRENT],
+      ownerAfter: [OWNER_CURRENT],
+      entryBefore: [ENTRY_CURRENT],
+      entryAfter: []
+    })
+  })[0];
+  assert.equal(result.observation, 'ORDINARY_REGRESSION');
+  assert.equal(result.selectedOptionId, 'canonical-boundary');
+});
+
+test('missing complete inventories and partial mappings yield insufficient evidence', () => {
+  const partial = productMap();
+  partial.ruleCoverage[1].coverage = 'partial';
+  const partialResult = evaluate({ map: partial })[0];
+  assert.equal(partialResult.observation, 'INSUFFICIENT_EVIDENCE');
+
+  const missingFactResult = evaluate({ facts: ruleFacts().slice(0, 1) })[0];
+  assert.equal(missingFactResult.observation, 'INSUFFICIENT_EVIDENCE');
+  assert.match(missingFactResult.evidenceGaps.join(' '), /Missing complete/);
+});
+
+test('candidate-modified mapped contracts cannot be sole hard evidence', () => {
+  const map = productMap();
+  map.ruleCoverage.forEach((coverage) => { coverage.enforcement = 'hard'; });
+  assert.equal(validationCodes(map).length, 0);
+  const result = evaluate({
+    map,
+    changedPaths: ['tests/web/request.test.mjs']
+  })[0];
+  assert.equal(result.observation, 'INSUFFICIENT_EVIDENCE');
+  assert.equal(
+    result.contractResults.find(({ ref }) => ref.startsWith('tests/web/request.test.mjs'))
+      .candidateModified,
+    true
+  );
+});
+
+test('one concern triggered by multiple rules is evaluated exactly once', () => {
+  const results = evaluate({
+    deltas: [
+      entryDelta([ENTRY_CURRENT], [ENTRY_FUTURE]),
+      ownerDelta([OWNER_CURRENT], [OWNER_FUTURE])
+    ],
+    facts: ruleFacts({ entryAfter: [ENTRY_FUTURE] })
+  });
+  assert.equal(results.length, 1);
+  assert.deepEqual(results[0].triggeringRuleKeys, [
+    'canonical-path.render-request',
+    'semantic-owner.render-request'
+  ]);
+  assert.equal(results[0].impactClass, 'NO_USER_VISIBLE_DIFFERENCE');
+});
+
+test('unchanged registered subjects with no current decision are not applicable', () => {
+  const results = evaluate({
+    deltas: [ownerDelta([OWNER_CURRENT], [OWNER_CURRENT])],
+    facts: ruleFacts({
+      ownerBefore: [OWNER_CURRENT],
+      ownerAfter: [OWNER_CURRENT]
+    })
+  });
+  assert.deepEqual(results, []);
+});
+
+test('evaluation ordering is deterministic, inputs remain unchanged, and outputs are deeply frozen', () => {
+  const input = {
+    subjectDeltas: [ownerDelta([OWNER_CURRENT], [OWNER_FUTURE])],
+    ruleFacts: ruleFacts(),
+    map: productMap(),
+    decisionAuthority: decisionAuthority(),
+    currentDecisions: emptyCurrentDecisions(),
+    changedPaths: []
+  };
+  const before = structuredClone(input);
+  const first = evaluateProductImpact(input);
+  const second = evaluateProductImpact(input);
+  assert.deepEqual(first, second);
+  assert.deepEqual(input, before);
+  assert.equal(Object.isFrozen(first), true);
+  assert.equal(Object.isFrozen(first[0]), true);
+  assert.equal(Object.isFrozen(first[0].requirementResults), true);
+  assert.throws(() => first[0].requirementResults.push({}));
+});
+
+test('validation results are deterministic deeply frozen plain data', () => {
+  const map = productMap();
+  const first = validateProductImpactMap(map, architectureRegistry(), WEB_ARCHITECTURE_DETECTORS);
+  const second = validateProductImpactMap(map, architectureRegistry(), WEB_ARCHITECTURE_DETECTORS);
+  assert.deepEqual(first, second);
+  assert.equal(Object.getPrototypeOf(first), Object.prototype);
+  assert.equal(Object.isFrozen(first), true);
+  assert.equal(Object.isFrozen(first.errors), true);
+});

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -316,15 +316,26 @@ const changedVendorPaths = productionPaths.filter((path) => path.startsWith('gbd
 const policyPath = 'tools/web-change-policy.json';
 const architectureRulesPath = 'tools/web-architecture-rules.json';
 const acceptedViolationsPath = 'tools/web-architecture-violations.json';
+const productImpactPolicyPath = 'docs/internal/PRODUCT_IMPACT_RATCHET.md';
+const productImpactMapPath = 'tools/web-product-impact-map.json';
+const productDecisionAuthorityPath = 'tools/web-product-decisions.json';
+const productImpactEvaluationPath = 'tools/web-product-impact-evaluation.mjs';
+const productImpactDecisionSourcePath = 'tools/web-product-impact-decision-source.mjs';
+const productImpactFixturePath = 'tests/web/product-impact-ratchet-fixtures.test.mjs';
 const trustedWorkflowPath = '.github/workflows/web-base-policy.yml';
 const guardPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+  productImpactPolicyPath,
   '.github/pull_request_template.md',
   'tools/check-web-change-budget.mjs',
   'tools/web-architecture-detectors.mjs',
   'tools/web-architecture-evaluation.mjs',
+  productImpactEvaluationPath,
+  productImpactDecisionSourcePath,
   architectureRulesPath,
   acceptedViolationsPath,
+  productImpactMapPath,
+  productDecisionAuthorityPath,
   'tools/web-change-source.mjs',
   'tools/web-promotion-context.mjs',
   'tools/check-promotion-readiness.mjs',
@@ -332,6 +343,7 @@ const guardPaths = new Set([
   'docs/internal/WEB_CHANGE_POLICY.md',
   'tests/web/architecture-contracts.test.mjs',
   'tests/web/architecture-ratchet-fixtures.test.mjs',
+  productImpactFixturePath,
   'tests/web/promotion-readiness.test.mjs',
   'tests/web/web-promotion-context.test.mjs',
   '.github/workflows/gallery-publication.yml',
@@ -344,15 +356,20 @@ const checkerImplementationPaths = new Set([
   'tools/check-web-change-budget.mjs',
   'tools/web-architecture-detectors.mjs',
   'tools/web-architecture-evaluation.mjs',
+  productImpactEvaluationPath,
+  productImpactDecisionSourcePath,
   'tools/web-change-source.mjs',
   'tools/web-promotion-context.mjs',
   'tools/check-promotion-readiness.mjs'
 ]);
 const authorityPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+  productImpactPolicyPath,
   'docs/internal/WEB_CHANGE_POLICY.md',
   architectureRulesPath,
   acceptedViolationsPath,
+  productImpactMapPath,
+  productDecisionAuthorityPath,
   policyPath,
   '.github/workflows/gallery-publication.yml',
   '.github/workflows/deploy_web.yml',
@@ -372,6 +389,11 @@ const governancePaths = new Set([
 const changedGovernancePaths = [...changed.keys()]
   .filter((path) => governancePaths.has(path))
   .sort();
+const narrowAuthorityBundlePaths = new Set([
+  architectureRulesPath,
+  productImpactMapPath,
+  productDecisionAuthorityPath
+]);
 const baseAcceptedViolationsSource = readRevisionFile(base, acceptedViolationsPath);
 const candidateAcceptedViolationsSource = readHeadFile(acceptedViolationsPath);
 const acceptedViolationAuthorityErrors = [];
@@ -821,7 +843,7 @@ if (baseArchitectureRulesSource !== null || proposedArchitectureRulesSource !== 
     );
     if (architectureAuthorityDelta.changes.length) {
       const companionPaths = [...changed.keys()]
-        .filter((path) => path !== architectureRulesPath)
+        .filter((path) => !narrowAuthorityBundlePaths.has(path))
         .sort();
       if (companionPaths.length) {
         candidateArchitectureErrors.push(

--- a/tools/web-architecture-evaluation.mjs
+++ b/tools/web-architecture-evaluation.mjs
@@ -85,6 +85,76 @@ const stableTextSet = (values, label) => {
   return Object.freeze(stableUnique(values));
 };
 
+const SUBJECT_DELTA_FIELDS = Object.freeze([
+  'afterSubjects',
+  'beforeSubjects',
+  'detector',
+  'kind',
+  'ruleKey',
+  'subjectCategory'
+]);
+const CANONICAL_IDENTIFIER_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+
+const canonicalSubjectSet = (values, label) => {
+  const subjects = stableTextSet(values, label);
+  subjects.forEach((subject) => {
+    if (!subject || subject !== subject.trim() || /[\u0000-\u001f\u007f]/.test(subject)) {
+      throw new Error(`${label} must contain canonical nonempty subject strings`);
+    }
+  });
+  return subjects;
+};
+
+export const createArchitectureSubjectDelta = (input) => {
+  if (!isRecord(input)) {
+    throw new Error('Architecture subject delta requires one input object');
+  }
+  const fields = Object.keys(input).sort(compareText);
+  if (
+    fields.length !== SUBJECT_DELTA_FIELDS.length
+    || fields.some((field, index) => field !== SUBJECT_DELTA_FIELDS[index])
+  ) {
+    throw new Error(
+      `Architecture subject delta requires exactly: ${SUBJECT_DELTA_FIELDS.join(', ')}`
+    );
+  }
+  if (typeof input.ruleKey !== 'string' || !RULE_KEY_PATTERN.test(input.ruleKey)) {
+    throw new Error('Architecture subject delta ruleKey must be a canonical rule key');
+  }
+  if (typeof input.detector !== 'string' || !DETECTOR_ID_PATTERN.test(input.detector)) {
+    throw new Error('Architecture subject delta detector must be a versioned detector ID');
+  }
+  for (const field of ['kind', 'subjectCategory']) {
+    if (
+      typeof input[field] !== 'string'
+      || !CANONICAL_IDENTIFIER_PATTERN.test(input[field])
+    ) {
+      throw new Error(`Architecture subject delta ${field} must be a canonical identifier`);
+    }
+  }
+  const beforeSubjects = canonicalSubjectSet(
+    input.beforeSubjects,
+    'Architecture subject delta beforeSubjects'
+  );
+  const afterSubjects = canonicalSubjectSet(
+    input.afterSubjects,
+    'Architecture subject delta afterSubjects'
+  );
+  const addedSubjects = Object.freeze(stableDifference(afterSubjects, beforeSubjects));
+  const removedSubjects = Object.freeze(stableDifference(beforeSubjects, afterSubjects));
+  return Object.freeze({
+    ruleKey: input.ruleKey,
+    kind: input.kind,
+    detector: input.detector,
+    subjectCategory: input.subjectCategory,
+    beforeSubjects,
+    addedSubjects,
+    removedSubjects,
+    afterSubjects,
+    changed: addedSubjects.length > 0 || removedSubjects.length > 0
+  });
+};
+
 export const summarizeArchitectureInventory = (beforeValues, afterValues) => {
   const before = stableTextSet(beforeValues, 'Architecture inventory before');
   const after = stableTextSet(afterValues, 'Architecture inventory after');

--- a/tools/web-product-impact-decision-source.mjs
+++ b/tools/web-product-impact-decision-source.mjs
@@ -1,0 +1,390 @@
+const SCHEMA_VERSION = 1;
+const START_MARKER = '<!-- gbdraw-product-impact-decision:start -->';
+const END_MARKER = '<!-- gbdraw-product-impact-decision:end -->';
+const DEFAULT_MAX_BODY_BYTES = 64 * 1024;
+const DEFAULT_MAX_DECISION_COUNT = 8;
+const MAXIMUM_BODY_BOUND = 1024 * 1024;
+const MAXIMUM_DECISION_BOUND = 100;
+const MAXIMUM_ARRAY_LENGTH = 32;
+const MAXIMUM_ID_LENGTH = 160;
+const MAXIMUM_REF_LENGTH = 1000;
+const MAXIMUM_TEXT_LENGTH = 2000;
+const INPUT_FIELDS = Object.freeze([
+  'body',
+  'eventAuthorLogin',
+  'eventHeadSha',
+  'maxBodyBytes',
+  'maxDecisionCount'
+]);
+const DECLARATION_FIELDS = Object.freeze(['decisions', 'headSha', 'schemaVersion']);
+const DECISION_FIELDS = Object.freeze([
+  'acceptedImpactClass',
+  'acknowledgedChangedRequirementRefs',
+  'concernKey',
+  'evidenceRefs',
+  'rationale',
+  'residualRisk',
+  'scenarioRevision',
+  'selectedOptionId'
+]);
+const CONCERN_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+const OPTION_ID_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const REQUIREMENT_ID_PATTERN = /^REQ-[A-Z0-9]+(?:-[A-Z0-9]+)*$/;
+const HEAD_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const LOGIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+
+const compareText = (left, right) => left < right ? -1 : left > right ? 1 : 0;
+const isRecord = (value) => value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value)
+  && [Object.prototype, null].includes(Object.getPrototypeOf(value));
+const deepFreeze = (value) => {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+};
+const addError = (errors, code, path, message) => {
+  errors.push({ code, path, message });
+};
+const exactFields = (value, expectedFields, path, errors) => {
+  const expected = new Set(expectedFields);
+  Object.keys(value).sort(compareText).forEach((field) => {
+    if (!expected.has(field)) {
+      addError(errors, 'unknown-field', `${path}.${field}`, `Unknown field ${field}`);
+    }
+  });
+  expectedFields.forEach((field) => {
+    if (!Object.hasOwn(value, field)) {
+      addError(errors, 'missing-field', `${path}.${field}`, `Missing required field ${field}`);
+    }
+  });
+};
+const normalizeText = (value) => typeof value === 'string'
+  ? value.trim().replace(/\s+/g, ' ')
+  : '';
+const markerCount = (source, marker) => {
+  let count = 0;
+  let offset = 0;
+  while (offset <= source.length) {
+    const index = source.indexOf(marker, offset);
+    if (index < 0) break;
+    count += 1;
+    offset = index + marker.length;
+  }
+  return count;
+};
+const byteLength = (source) => new TextEncoder().encode(source).byteLength;
+const emptyDeclaration = () => ({ schemaVersion: SCHEMA_VERSION, headSha: '', decisions: [] });
+const result = ({ errors, present, metadata, declaration }) => deepFreeze({
+  valid: errors.length === 0,
+  present,
+  metadata,
+  declaration,
+  errors
+});
+const validateBound = (value, fallback, maximum, field, errors) => {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1 || value > maximum) {
+    addError(errors, 'invalid-bound', `$.${field}`, `Invalid ${field} parser bound`);
+    return fallback;
+  }
+  return value;
+};
+const canonicalString = (
+  value,
+  path,
+  errors,
+  { pattern = null, maximumLength = MAXIMUM_ID_LENGTH, normalize = false } = {}
+) => {
+  const normalized = normalize ? normalizeText(value) : value;
+  if (
+    typeof normalized !== 'string'
+    || !normalized
+    || normalized !== normalized.trim()
+    || normalized.length > maximumLength
+    || /[\u0000-\u001f\u007f]/.test(normalized)
+    || (pattern && !pattern.test(normalized))
+  ) {
+    addError(errors, 'invalid-string', path, 'Expected a bounded canonical nonempty string');
+    return '';
+  }
+  return normalized;
+};
+const sortedUniqueStrings = (values, path, errors, options = {}) => {
+  if (!Array.isArray(values)) {
+    addError(errors, 'invalid-array', path, 'Expected an array');
+    return [];
+  }
+  if (values.length > MAXIMUM_ARRAY_LENGTH) {
+    addError(errors, 'oversized-array', path, 'Array exceeds the parser bound');
+  }
+  const normalized = [];
+  const seen = new Set();
+  let previous = null;
+  values.slice(0, MAXIMUM_ARRAY_LENGTH).forEach((value, index) => {
+    const item = canonicalString(value, `${path}[${index}]`, errors, options);
+    if (!item) return;
+    if (seen.has(item)) {
+      addError(errors, 'duplicate-value', `${path}[${index}]`, 'Array values must be unique');
+    }
+    if (previous !== null && compareText(previous, item) > 0) {
+      addError(errors, 'unsorted-array', path, 'Array values must use canonical order');
+    }
+    seen.add(item);
+    previous = item;
+    normalized.push(item);
+  });
+  return normalized;
+};
+const compareDecision = (left, right) => compareText(left.concernKey, right.concernKey)
+  || left.scenarioRevision - right.scenarioRevision
+  || compareText(left.selectedOptionId, right.selectedOptionId);
+
+export const parseCurrentProductImpactDecisions = (input) => {
+  const errors = [];
+  const fallbackMetadata = { eventAuthorLogin: '', eventHeadSha: '' };
+  if (!isRecord(input)) {
+    addError(errors, 'invalid-input', '$', 'Expected one parser input object');
+    return result({
+      errors,
+      present: false,
+      metadata: fallbackMetadata,
+      declaration: emptyDeclaration()
+    });
+  }
+  Object.keys(input).sort(compareText).forEach((field) => {
+    if (!INPUT_FIELDS.includes(field)) {
+      addError(errors, 'unknown-field', `$.${field}`, `Unknown parser input field ${field}`);
+    }
+  });
+  for (const field of ['body', 'eventHeadSha', 'eventAuthorLogin']) {
+    if (typeof input[field] !== 'string') {
+      addError(errors, 'invalid-input-string', `$.${field}`, `Expected string ${field}`);
+    }
+  }
+  const maximumBodyBytes = validateBound(
+    input.maxBodyBytes,
+    DEFAULT_MAX_BODY_BYTES,
+    MAXIMUM_BODY_BOUND,
+    'maxBodyBytes',
+    errors
+  );
+  const maximumDecisionCount = validateBound(
+    input.maxDecisionCount,
+    DEFAULT_MAX_DECISION_COUNT,
+    MAXIMUM_DECISION_BOUND,
+    'maxDecisionCount',
+    errors
+  );
+  const normalizedEventHeadSha = typeof input.eventHeadSha === 'string'
+    ? input.eventHeadSha.trim().toLowerCase()
+    : '';
+  const normalizedAuthorLogin = typeof input.eventAuthorLogin === 'string'
+    ? input.eventAuthorLogin.trim().toLowerCase()
+    : '';
+  if (normalizedAuthorLogin && !LOGIN_PATTERN.test(normalizedAuthorLogin)) {
+    addError(errors, 'invalid-event-author', '$.eventAuthorLogin', 'Event author login is malformed');
+  }
+  const metadata = {
+    eventAuthorLogin: normalizedAuthorLogin,
+    eventHeadSha: normalizedEventHeadSha
+  };
+  if (typeof input.body !== 'string') {
+    return result({ errors, present: false, metadata, declaration: emptyDeclaration() });
+  }
+  if (
+    input.body.length > maximumBodyBytes
+    || byteLength(input.body) > maximumBodyBytes
+  ) {
+    addError(errors, 'oversized-body', '$.body', 'Pull request body exceeds the parser byte bound');
+    return result({ errors, present: false, metadata, declaration: emptyDeclaration() });
+  }
+
+  const startCount = markerCount(input.body, START_MARKER);
+  const endCount = markerCount(input.body, END_MARKER);
+  const present = startCount > 0 || endCount > 0;
+  if (startCount === 0 && endCount === 0) {
+    return result({ errors, present: false, metadata, declaration: emptyDeclaration() });
+  }
+  if (startCount !== 1 || endCount !== 1) {
+    addError(
+      errors,
+      'invalid-marker-count',
+      '$.body',
+      'Expected zero or one exact Product Impact decision marker pair'
+    );
+    return result({ errors, present, metadata, declaration: emptyDeclaration() });
+  }
+  const start = input.body.indexOf(START_MARKER);
+  const end = input.body.indexOf(END_MARKER);
+  if (start > end) {
+    addError(errors, 'reversed-markers', '$.body', 'Product Impact decision markers are reversed');
+    return result({ errors, present, metadata, declaration: emptyDeclaration() });
+  }
+  const block = input.body.slice(start + START_MARKER.length, end).trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(block);
+  } catch (_error) {
+    addError(errors, 'invalid-json', '$.decisionBlock', 'Product Impact decision block is not JSON');
+    return result({ errors, present, metadata, declaration: emptyDeclaration() });
+  }
+  if (!isRecord(parsed)) {
+    addError(errors, 'invalid-declaration', '$.decisionBlock', 'Expected a decision declaration object');
+    return result({ errors, present, metadata, declaration: emptyDeclaration() });
+  }
+  exactFields(parsed, DECLARATION_FIELDS, '$.decisionBlock', errors);
+  if (parsed.schemaVersion !== SCHEMA_VERSION) {
+    addError(
+      errors,
+      'unsupported-schema-version',
+      '$.decisionBlock.schemaVersion',
+      `Expected schemaVersion ${SCHEMA_VERSION}`
+    );
+  }
+  if (!Array.isArray(parsed.decisions)) {
+    addError(errors, 'invalid-array', '$.decisionBlock.decisions', 'Expected a decisions array');
+    return result({ errors, present, metadata, declaration: emptyDeclaration() });
+  }
+  if (parsed.decisions.length > maximumDecisionCount) {
+    addError(
+      errors,
+      'too-many-decisions',
+      '$.decisionBlock.decisions',
+      'Decision count exceeds the parser bound'
+    );
+  }
+  const normalizedHeadSha = typeof parsed.headSha === 'string'
+    ? parsed.headSha.trim().toLowerCase()
+    : '';
+  if (parsed.decisions.length) {
+    if (!HEAD_SHA_PATTERN.test(normalizedEventHeadSha)) {
+      addError(errors, 'invalid-event-head-sha', '$.eventHeadSha', 'Event head SHA is malformed');
+    }
+    if (!HEAD_SHA_PATTERN.test(normalizedHeadSha)) {
+      addError(
+        errors,
+        'invalid-declaration-head-sha',
+        '$.decisionBlock.headSha',
+        'Nonempty decisions require a 40-hex head SHA'
+      );
+    } else if (normalizedHeadSha !== normalizedEventHeadSha) {
+      addError(
+        errors,
+        'stale-head-sha',
+        '$.decisionBlock.headSha',
+        'Decision head SHA does not match the event head SHA'
+      );
+    }
+  } else if (normalizedHeadSha && !HEAD_SHA_PATTERN.test(normalizedHeadSha)) {
+    addError(
+      errors,
+      'invalid-declaration-head-sha',
+      '$.decisionBlock.headSha',
+      'Head SHA must be empty or 40 hexadecimal characters'
+    );
+  }
+
+  const normalizedDecisions = [];
+  const seenDecisionScopes = new Set();
+  let previousDecision = null;
+  parsed.decisions.slice(0, maximumDecisionCount).forEach((decision, index) => {
+    const path = `$.decisionBlock.decisions[${index}]`;
+    if (!isRecord(decision)) {
+      addError(errors, 'invalid-decision', path, 'Expected a current decision object');
+      return;
+    }
+    exactFields(decision, DECISION_FIELDS, path, errors);
+    const concernKey = canonicalString(
+      decision.concernKey,
+      `${path}.concernKey`,
+      errors,
+      { pattern: CONCERN_KEY_PATTERN }
+    );
+    const selectedOptionId = canonicalString(
+      decision.selectedOptionId,
+      `${path}.selectedOptionId`,
+      errors,
+      { pattern: OPTION_ID_PATTERN }
+    );
+    if (!Number.isInteger(decision.scenarioRevision) || decision.scenarioRevision < 1) {
+      addError(
+        errors,
+        'invalid-scenario-revision',
+        `${path}.scenarioRevision`,
+        'Expected a positive integer scenario revision'
+      );
+    }
+    if (decision.acceptedImpactClass !== 'AFFORDANCE_PRESERVED') {
+      addError(
+        errors,
+        'invalid-current-impact-class',
+        `${path}.acceptedImpactClass`,
+        'Current decisions accept only AFFORDANCE_PRESERVED'
+      );
+    }
+    const rationale = canonicalString(
+      decision.rationale,
+      `${path}.rationale`,
+      errors,
+      { maximumLength: MAXIMUM_TEXT_LENGTH, normalize: true }
+    );
+    const residualRisk = canonicalString(
+      decision.residualRisk,
+      `${path}.residualRisk`,
+      errors,
+      { maximumLength: MAXIMUM_TEXT_LENGTH, normalize: true }
+    );
+    const acknowledgedChangedRequirementRefs = sortedUniqueStrings(
+      decision.acknowledgedChangedRequirementRefs,
+      `${path}.acknowledgedChangedRequirementRefs`,
+      errors,
+      { pattern: REQUIREMENT_ID_PATTERN, maximumLength: MAXIMUM_ID_LENGTH }
+    );
+    const evidenceRefs = sortedUniqueStrings(
+      decision.evidenceRefs,
+      `${path}.evidenceRefs`,
+      errors,
+      { maximumLength: MAXIMUM_REF_LENGTH }
+    );
+    if (!evidenceRefs.length) {
+      addError(errors, 'empty-evidence-refs', `${path}.evidenceRefs`, 'Expected evidence references');
+    }
+    const normalized = {
+      concernKey,
+      scenarioRevision: decision.scenarioRevision,
+      selectedOptionId,
+      acceptedImpactClass: decision.acceptedImpactClass,
+      rationale,
+      acknowledgedChangedRequirementRefs,
+      evidenceRefs,
+      residualRisk
+    };
+    if (concernKey && Number.isInteger(decision.scenarioRevision)) {
+      const scope = `${concernKey}\u0000${decision.scenarioRevision}`;
+      if (seenDecisionScopes.has(scope)) {
+        addError(errors, 'duplicate-decision-scope', path, 'Decision scopes must be unique');
+      }
+      seenDecisionScopes.add(scope);
+    }
+    if (previousDecision && compareDecision(previousDecision, normalized) > 0) {
+      addError(
+        errors,
+        'unsorted-decisions',
+        '$.decisionBlock.decisions',
+        'Decisions must use canonical concern/revision/option order'
+      );
+    }
+    previousDecision = normalized;
+    normalizedDecisions.push(normalized);
+  });
+
+  const declaration = {
+    schemaVersion: SCHEMA_VERSION,
+    headSha: normalizedHeadSha,
+    decisions: normalizedDecisions
+  };
+  return result({ errors, present, metadata, declaration });
+};

--- a/tools/web-product-impact-evaluation.mjs
+++ b/tools/web-product-impact-evaluation.mjs
@@ -1,0 +1,1600 @@
+const SCHEMA_VERSION = 1;
+const MAP_FIELDS = Object.freeze(['concerns', 'ruleCoverage', 'schemaVersion']);
+const RULE_COVERAGE_FIELDS = Object.freeze(['coverage', 'enforcement', 'ruleKey']);
+const CONCERN_FIELDS = Object.freeze([
+  'contracts',
+  'effects',
+  'journeys',
+  'key',
+  'layer',
+  'options',
+  'resolution',
+  'scenarioRevision',
+  'title'
+]);
+const JOURNEY_FIELDS = Object.freeze([
+  'actor',
+  'checkpoints',
+  'context',
+  'goal',
+  'id',
+  'steps'
+]);
+const CHECKPOINT_FIELDS = Object.freeze(['id', 'label']);
+const EFFECT_FIELDS = Object.freeze(['checkpointRef', 'id', 'statement']);
+const OPTION_FIELDS = Object.freeze(['effectRefs', 'id', 'requirements', 'summary']);
+const REQUIREMENT_FIELDS = Object.freeze([
+  'anyOf',
+  'category',
+  'checkpointRefs',
+  'id'
+]);
+const CANDIDATE_FIELDS = Object.freeze(['ruleKey', 'subject', 'subjectCategory']);
+const CONTRACT_FIELDS = Object.freeze([
+  'checkpointRefs',
+  'execution',
+  'ref',
+  'residualRisk',
+  'sensitivity'
+]);
+const DECISION_AUTHORITY_FIELDS = Object.freeze([
+  'decisions',
+  'maintainerLogins',
+  'schemaVersion'
+]);
+const DURABLE_DECISION_FIELDS = Object.freeze([
+  'acceptanceCheckpointRefs',
+  'acceptedImpactClass',
+  'acknowledgedRetiredRequirementRefs',
+  'concernKey',
+  'id',
+  'rationale',
+  'scenarioRevision',
+  'selectedOptionId'
+]);
+const SUBJECT_DELTA_FIELDS = Object.freeze([
+  'addedSubjects',
+  'afterSubjects',
+  'beforeSubjects',
+  'changed',
+  'detector',
+  'kind',
+  'removedSubjects',
+  'ruleKey',
+  'subjectCategory'
+]);
+const RULE_FACT_FIELDS = Object.freeze([
+  'afterSubjects',
+  'beforeSubjects',
+  'ruleKey',
+  'subjectCategory'
+]);
+const EVALUATION_INPUT_FIELDS = Object.freeze([
+  'changedPaths',
+  'currentDecisions',
+  'decisionAuthority',
+  'map',
+  'ruleFacts',
+  'subjectDeltas'
+]);
+
+const COVERAGE_LEVELS = Object.freeze(['complete', 'partial']);
+const PRODUCT_ENFORCEMENTS = Object.freeze(['hard', 'report-only']);
+const CONCERN_LAYERS = Object.freeze([
+  'DOMAIN',
+  'INTERACTION',
+  'OUTPUT',
+  'PERSISTENCE',
+  'STATE'
+]);
+const REQUIREMENT_CATEGORIES = Object.freeze(['AFFORDANCE', 'COMPATIBILITY', 'SEMANTIC']);
+const RESOLUTION_KINDS = Object.freeze([
+  'authority-covered',
+  'decision-required',
+  'domain-derived'
+]);
+const CONTRACT_SENSITIVITIES = Object.freeze([
+  'BASE_FAIL',
+  'DIRECT_ASSERTION',
+  'MANUAL_ACCEPTANCE',
+  'MUTATION_FAIL'
+]);
+const CONTRACT_EXECUTIONS = Object.freeze(['DEV_STAGING', 'MANUAL', 'PR_GATE']);
+const ACCEPTED_IMPACT_CLASSES = Object.freeze([
+  'AFFORDANCE_PRESERVED',
+  'PRODUCT_CHANGE',
+  'RETIREMENT'
+]);
+const RULE_KEY_PATTERN = /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/;
+const LOWER_ID_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const DECISION_ID_PATTERN = /^BD-[0-9]{3,}$/;
+const LOGIN_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/;
+const REPOSITORY_PATH_PATTERN = /^[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*$/;
+
+const compareText = (left, right) => left < right ? -1 : left > right ? 1 : 0;
+const isRecord = (value) => value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value)
+  && [Object.prototype, null].includes(Object.getPrototypeOf(value));
+const stableUnique = (values) => [...new Set(values)].sort(compareText);
+const arraysEqual = (left, right) => left.length === right.length
+  && left.every((value, index) => value === right[index]);
+const stableDifference = (left, right) => {
+  const rightSet = new Set(right);
+  return left.filter((value) => !rightSet.has(value));
+};
+const deepFreeze = (value) => {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+};
+const validationResult = (errors) => deepFreeze({
+  valid: errors.length === 0,
+  errors
+});
+const addError = (errors, code, path, message) => {
+  errors.push({ code, path, message });
+};
+const validateExactFields = (value, fields, path, errors) => {
+  const expected = new Set(fields);
+  Object.keys(value).sort(compareText).forEach((field) => {
+    if (!expected.has(field)) {
+      addError(errors, 'unknown-field', `${path}.${field}`, `Unknown field ${field}`);
+    }
+  });
+  fields.forEach((field) => {
+    if (!Object.hasOwn(value, field)) {
+      addError(errors, 'missing-field', `${path}.${field}`, `Missing required field ${field}`);
+    }
+  });
+};
+const validateCanonicalString = (
+  value,
+  path,
+  errors,
+  { pattern = null, maximumLength = 1000, code = 'invalid-string' } = {}
+) => {
+  if (
+    typeof value !== 'string'
+    || !value
+    || value !== value.trim()
+    || value.length > maximumLength
+    || /[\u0000-\u001f\u007f]/.test(value)
+    || (pattern && !pattern.test(value))
+  ) {
+    addError(errors, code, path, 'Expected a canonical nonempty string');
+    return false;
+  }
+  return true;
+};
+const validateSortedUniqueStrings = (
+  values,
+  path,
+  errors,
+  options = {}
+) => {
+  if (!Array.isArray(values)) {
+    addError(errors, 'invalid-array', path, 'Expected an array');
+    return [];
+  }
+  const seen = new Set();
+  let previous = null;
+  values.forEach((value, index) => {
+    const valuePath = `${path}[${index}]`;
+    if (!validateCanonicalString(value, valuePath, errors, options)) return;
+    if (seen.has(value)) {
+      addError(errors, 'duplicate-value', valuePath, 'Values must be unique');
+    }
+    if (previous !== null && compareText(previous, value) > 0) {
+      addError(errors, 'unsorted-array', path, 'Values must use ascending canonical order');
+    }
+    seen.add(value);
+    previous = value;
+  });
+  return values.filter((value) => typeof value === 'string');
+};
+const validateNonemptyTextArray = (values, path, errors) => {
+  if (!Array.isArray(values) || !values.length) {
+    addError(errors, 'invalid-array', path, 'Expected a nonempty array');
+    return;
+  }
+  values.forEach((value, index) => {
+    validateCanonicalString(value, `${path}[${index}]`, errors, { maximumLength: 1000 });
+  });
+};
+const validateRecordOrder = (key, previous, path, errors) => {
+  if (previous !== null && compareText(previous, key) > 0) {
+    addError(errors, 'unsorted-array', path, 'Records must use ascending canonical key order');
+  }
+};
+const checkpointReference = (journeyId, checkpointId) => `${journeyId}:${checkpointId}`;
+const contractRepositoryPath = (reference) => (
+  typeof reference === 'string' ? reference.slice(0, reference.indexOf('::')) : ''
+);
+const isAutomatedPrGateContract = (contract) => contract.execution === 'PR_GATE'
+  && contract.sensitivity !== 'MANUAL_ACCEPTANCE';
+
+const architectureRuleIndex = (architectureRegistry, detectorCatalog, errors) => {
+  if (!isRecord(architectureRegistry) || !Array.isArray(architectureRegistry.rules)) {
+    addError(errors, 'invalid-architecture-registry', '$architecture', 'Expected architecture rules');
+    return new Map();
+  }
+  const index = new Map();
+  architectureRegistry.rules.forEach((rule, ruleIndex) => {
+    if (!isRecord(rule) || typeof rule.key !== 'string') return;
+    const detector = detectorCatalog?.[rule.detector];
+    const allowedInputs = rule.kind === 'single-semantic-owner'
+      ? (Array.isArray(rule.allowedDefinitionPaths)
+        ? rule.allowedDefinitionPaths.map((path) => ({ path })) : [])
+      : rule.kind === 'single-canonical-entry-edge'
+        ? (Array.isArray(rule.allowedEdges) ? rule.allowedEdges : [])
+        : [];
+    const allowedSubjects = [];
+    if (!detector || typeof detector.encodeSubject !== 'function') {
+      addError(
+        errors,
+        'invalid-architecture-detector',
+        `$architecture.rules[${ruleIndex}].detector`,
+        `Architecture rule ${rule.key} has no trusted stable subject encoder`
+      );
+    } else {
+      allowedInputs.forEach((candidate) => {
+        try {
+          const subject = detector.encodeSubject(Object.freeze({ ...candidate }));
+          if (typeof subject === 'string' && subject) allowedSubjects.push(subject);
+        } catch (_error) {
+          addError(
+            errors,
+            'invalid-architecture-subject',
+            `$architecture.rules[${ruleIndex}]`,
+            `Architecture rule ${rule.key} cannot encode an allowed subject`
+          );
+        }
+      });
+    }
+    index.set(rule.key, {
+      rule,
+      detector,
+      subjectCategory: detector?.subjectCategory || '',
+      allowedSubjects: stableUnique(allowedSubjects)
+    });
+  });
+  return index;
+};
+
+export const validateProductImpactMap = (
+  map,
+  architectureRegistry,
+  detectorCatalog
+) => {
+  const errors = [];
+  if (!isRecord(map)) {
+    addError(errors, 'invalid-map', '$', 'Expected a Product Impact map object');
+    return validationResult(errors);
+  }
+  validateExactFields(map, MAP_FIELDS, '$', errors);
+  if (map.schemaVersion !== SCHEMA_VERSION) {
+    addError(
+      errors,
+      'unsupported-schema-version',
+      '$.schemaVersion',
+      `Expected schemaVersion ${SCHEMA_VERSION}`
+    );
+  }
+  const architectureRules = architectureRuleIndex(
+    architectureRegistry,
+    detectorCatalog,
+    errors
+  );
+  const coverageByRule = new Map();
+  if (!Array.isArray(map.ruleCoverage)) {
+    addError(errors, 'invalid-array', '$.ruleCoverage', 'Expected an array');
+  } else {
+    let previousRuleKey = null;
+    map.ruleCoverage.forEach((coverage, index) => {
+      const path = `$.ruleCoverage[${index}]`;
+      if (!isRecord(coverage)) {
+        addError(errors, 'invalid-rule-coverage', path, 'Expected a rule coverage object');
+        return;
+      }
+      validateExactFields(coverage, RULE_COVERAGE_FIELDS, path, errors);
+      const validRuleKey = validateCanonicalString(
+        coverage.ruleKey,
+        `${path}.ruleKey`,
+        errors,
+        { pattern: RULE_KEY_PATTERN, code: 'invalid-rule-key' }
+      );
+      if (validRuleKey) {
+        validateRecordOrder(coverage.ruleKey, previousRuleKey, '$.ruleCoverage', errors);
+        if (coverageByRule.has(coverage.ruleKey)) {
+          addError(errors, 'duplicate-rule-coverage', `${path}.ruleKey`, 'Duplicate rule coverage');
+        }
+        if (!architectureRules.has(coverage.ruleKey)) {
+          addError(errors, 'unknown-architecture-rule', `${path}.ruleKey`, 'Unknown architecture rule');
+        }
+        coverageByRule.set(coverage.ruleKey, coverage);
+        previousRuleKey = coverage.ruleKey;
+      }
+      if (!COVERAGE_LEVELS.includes(coverage.coverage)) {
+        addError(errors, 'invalid-coverage', `${path}.coverage`, 'Unsupported coverage level');
+      }
+      if (!PRODUCT_ENFORCEMENTS.includes(coverage.enforcement)) {
+        addError(errors, 'invalid-enforcement', `${path}.enforcement`, 'Unsupported enforcement');
+      }
+      if (coverage.enforcement === 'hard' && coverage.coverage !== 'complete') {
+        addError(
+          errors,
+          'hard-requires-complete-coverage',
+          path,
+          'Hard Product Impact enforcement requires complete coverage'
+        );
+      }
+    });
+  }
+
+  const mappedSubjectsByRule = new Map();
+  const concernsByKey = new Map();
+  if (!Array.isArray(map.concerns)) {
+    addError(errors, 'invalid-array', '$.concerns', 'Expected an array');
+  } else {
+    let previousConcernKey = null;
+    map.concerns.forEach((concern, concernIndex) => {
+      const concernPath = `$.concerns[${concernIndex}]`;
+      if (!isRecord(concern)) {
+        addError(errors, 'invalid-concern', concernPath, 'Expected a concern object');
+        return;
+      }
+      validateExactFields(concern, CONCERN_FIELDS, concernPath, errors);
+      const validConcernKey = validateCanonicalString(
+        concern.key,
+        `${concernPath}.key`,
+        errors,
+        { pattern: RULE_KEY_PATTERN, code: 'invalid-concern-key' }
+      );
+      if (validConcernKey) {
+        validateRecordOrder(concern.key, previousConcernKey, '$.concerns', errors);
+        if (concernsByKey.has(concern.key)) {
+          addError(errors, 'duplicate-concern-key', `${concernPath}.key`, 'Duplicate concern key');
+        }
+        concernsByKey.set(concern.key, concern);
+        previousConcernKey = concern.key;
+      }
+      if (!Number.isInteger(concern.scenarioRevision) || concern.scenarioRevision < 1) {
+        addError(
+          errors,
+          'invalid-scenario-revision',
+          `${concernPath}.scenarioRevision`,
+          'Expected a positive integer scenario revision'
+        );
+      }
+      validateCanonicalString(concern.title, `${concernPath}.title`, errors);
+      if (!CONCERN_LAYERS.includes(concern.layer)) {
+        addError(errors, 'invalid-layer', `${concernPath}.layer`, 'Unsupported concern layer');
+      }
+
+      const checkpointRefs = new Set();
+      const journeyIds = new Set();
+      if (!Array.isArray(concern.journeys) || !concern.journeys.length) {
+        addError(errors, 'invalid-journeys', `${concernPath}.journeys`, 'Expected journeys');
+      } else {
+        let previousJourneyId = null;
+        concern.journeys.forEach((journey, journeyIndex) => {
+          const journeyPath = `${concernPath}.journeys[${journeyIndex}]`;
+          if (!isRecord(journey)) {
+            addError(errors, 'invalid-journey', journeyPath, 'Expected a journey object');
+            return;
+          }
+          validateExactFields(journey, JOURNEY_FIELDS, journeyPath, errors);
+          const validJourneyId = validateCanonicalString(
+            journey.id,
+            `${journeyPath}.id`,
+            errors,
+            { pattern: /^JRN-[A-Z0-9]+(?:-[A-Z0-9]+)*$/, code: 'invalid-journey-id' }
+          );
+          if (validJourneyId) {
+            validateRecordOrder(journey.id, previousJourneyId, `${concernPath}.journeys`, errors);
+            if (journeyIds.has(journey.id)) {
+              addError(errors, 'duplicate-journey-id', `${journeyPath}.id`, 'Duplicate journey ID');
+            }
+            journeyIds.add(journey.id);
+            previousJourneyId = journey.id;
+          }
+          for (const field of ['actor', 'context', 'goal']) {
+            validateCanonicalString(journey[field], `${journeyPath}.${field}`, errors);
+          }
+          validateNonemptyTextArray(journey.steps, `${journeyPath}.steps`, errors);
+          if (!Array.isArray(journey.checkpoints) || !journey.checkpoints.length) {
+            addError(errors, 'invalid-checkpoints', `${journeyPath}.checkpoints`, 'Expected checkpoints');
+          } else {
+            const localCheckpointIds = new Set();
+            journey.checkpoints.forEach((checkpoint, checkpointIndex) => {
+              const checkpointPath = `${journeyPath}.checkpoints[${checkpointIndex}]`;
+              if (!isRecord(checkpoint)) {
+                addError(errors, 'invalid-checkpoint', checkpointPath, 'Expected a checkpoint object');
+                return;
+              }
+              validateExactFields(checkpoint, CHECKPOINT_FIELDS, checkpointPath, errors);
+              const validCheckpoint = validateCanonicalString(
+                checkpoint.id,
+                `${checkpointPath}.id`,
+                errors,
+                { pattern: LOWER_ID_PATTERN, code: 'invalid-checkpoint-id' }
+              );
+              validateCanonicalString(checkpoint.label, `${checkpointPath}.label`, errors);
+              if (validCheckpoint && validJourneyId) {
+                if (localCheckpointIds.has(checkpoint.id)) {
+                  addError(
+                    errors,
+                    'duplicate-checkpoint-id',
+                    `${checkpointPath}.id`,
+                    'Duplicate checkpoint ID in journey'
+                  );
+                }
+                localCheckpointIds.add(checkpoint.id);
+                checkpointRefs.add(checkpointReference(journey.id, checkpoint.id));
+              }
+            });
+          }
+        });
+      }
+
+      const effectsById = new Map();
+      if (!Array.isArray(concern.effects) || !concern.effects.length) {
+        addError(errors, 'invalid-effects', `${concernPath}.effects`, 'Expected stable effects');
+      } else {
+        let previousEffectId = null;
+        concern.effects.forEach((effect, effectIndex) => {
+          const effectPath = `${concernPath}.effects[${effectIndex}]`;
+          if (!isRecord(effect)) {
+            addError(errors, 'invalid-effect', effectPath, 'Expected an effect object');
+            return;
+          }
+          validateExactFields(effect, EFFECT_FIELDS, effectPath, errors);
+          const validEffectId = validateCanonicalString(
+            effect.id,
+            `${effectPath}.id`,
+            errors,
+            { pattern: /^EFF-[A-Z0-9]+(?:-[A-Z0-9]+)*$/, code: 'invalid-effect-id' }
+          );
+          if (validEffectId) {
+            validateRecordOrder(effect.id, previousEffectId, `${concernPath}.effects`, errors);
+            if (effectsById.has(effect.id)) {
+              addError(errors, 'duplicate-effect-id', `${effectPath}.id`, 'Duplicate effect ID');
+            }
+            effectsById.set(effect.id, effect);
+            previousEffectId = effect.id;
+          }
+          if (!checkpointRefs.has(effect.checkpointRef)) {
+            addError(
+              errors,
+              'unknown-checkpoint-ref',
+              `${effectPath}.checkpointRef`,
+              'Effect references an unknown checkpoint'
+            );
+          }
+          validateCanonicalString(effect.statement, `${effectPath}.statement`, errors);
+        });
+      }
+
+      const optionIds = new Set();
+      const requirementIds = new Set();
+      const referencedRuleKeys = new Set();
+      const hardRequirementCheckpointRefs = new Set();
+      if (!Array.isArray(concern.options) || !concern.options.length) {
+        addError(errors, 'invalid-options', `${concernPath}.options`, 'Expected behavior options');
+      } else {
+        let previousOptionId = null;
+        concern.options.forEach((option, optionIndex) => {
+          const optionPath = `${concernPath}.options[${optionIndex}]`;
+          if (!isRecord(option)) {
+            addError(errors, 'invalid-option', optionPath, 'Expected an option object');
+            return;
+          }
+          validateExactFields(option, OPTION_FIELDS, optionPath, errors);
+          const validOptionId = validateCanonicalString(
+            option.id,
+            `${optionPath}.id`,
+            errors,
+            { pattern: LOWER_ID_PATTERN, code: 'invalid-option-id' }
+          );
+          if (validOptionId) {
+            validateRecordOrder(option.id, previousOptionId, `${concernPath}.options`, errors);
+            if (optionIds.has(option.id)) {
+              addError(errors, 'duplicate-option-id', `${optionPath}.id`, 'Duplicate option ID');
+            }
+            optionIds.add(option.id);
+            previousOptionId = option.id;
+          }
+          validateCanonicalString(option.summary, `${optionPath}.summary`, errors);
+          const effectRefs = validateSortedUniqueStrings(
+            option.effectRefs,
+            `${optionPath}.effectRefs`,
+            errors,
+            { pattern: /^EFF-[A-Z0-9]+(?:-[A-Z0-9]+)*$/, code: 'invalid-effect-ref' }
+          );
+          if (!effectRefs.length) {
+            addError(errors, 'empty-effect-refs', `${optionPath}.effectRefs`, 'Expected effect refs');
+          }
+          effectRefs.forEach((effectRef, refIndex) => {
+            if (!effectsById.has(effectRef)) {
+              addError(
+                errors,
+                'unknown-effect-ref',
+                `${optionPath}.effectRefs[${refIndex}]`,
+                'Option references an unknown effect'
+              );
+            }
+          });
+          if (!Array.isArray(option.requirements) || !option.requirements.length) {
+            addError(
+              errors,
+              'invalid-requirements',
+              `${optionPath}.requirements`,
+              'Expected at least one requirement'
+            );
+            return;
+          }
+          let previousRequirementId = null;
+          option.requirements.forEach((requirement, requirementIndex) => {
+            const requirementPath = `${optionPath}.requirements[${requirementIndex}]`;
+            if (!isRecord(requirement)) {
+              addError(errors, 'invalid-requirement', requirementPath, 'Expected a requirement');
+              return;
+            }
+            validateExactFields(requirement, REQUIREMENT_FIELDS, requirementPath, errors);
+            const validRequirementId = validateCanonicalString(
+              requirement.id,
+              `${requirementPath}.id`,
+              errors,
+              { pattern: /^REQ-[A-Z0-9]+(?:-[A-Z0-9]+)*$/, code: 'invalid-requirement-id' }
+            );
+            if (validRequirementId) {
+              validateRecordOrder(
+                requirement.id,
+                previousRequirementId,
+                `${optionPath}.requirements`,
+                errors
+              );
+              if (requirementIds.has(requirement.id)) {
+                addError(
+                  errors,
+                  'duplicate-requirement-id',
+                  `${requirementPath}.id`,
+                  'Requirement IDs must be unique within a concern'
+                );
+              }
+              requirementIds.add(requirement.id);
+              previousRequirementId = requirement.id;
+            }
+            if (!REQUIREMENT_CATEGORIES.includes(requirement.category)) {
+              addError(
+                errors,
+                'invalid-requirement-category',
+                `${requirementPath}.category`,
+                'Unsupported requirement category'
+              );
+            }
+            const requirementCheckpointRefs = validateSortedUniqueStrings(
+              requirement.checkpointRefs,
+              `${requirementPath}.checkpointRefs`,
+              errors
+            );
+            if (!requirementCheckpointRefs.length) {
+              addError(
+                errors,
+                'empty-checkpoint-refs',
+                `${requirementPath}.checkpointRefs`,
+                'Expected checkpoint refs'
+              );
+            }
+            requirementCheckpointRefs.forEach((reference, referenceIndex) => {
+              if (!checkpointRefs.has(reference)) {
+                addError(
+                  errors,
+                  'unknown-checkpoint-ref',
+                  `${requirementPath}.checkpointRefs[${referenceIndex}]`,
+                  'Requirement references an unknown checkpoint'
+                );
+              }
+            });
+            if (!Array.isArray(requirement.anyOf) || !requirement.anyOf.length) {
+              addError(
+                errors,
+                'invalid-candidates',
+                `${requirementPath}.anyOf`,
+                'Expected at least one subject candidate'
+              );
+              return;
+            }
+            const candidateKeys = new Set();
+            let previousCandidateKey = null;
+            let requirementUsesHardRule = false;
+            requirement.anyOf.forEach((candidate, candidateIndex) => {
+              const candidatePath = `${requirementPath}.anyOf[${candidateIndex}]`;
+              if (!isRecord(candidate)) {
+                addError(errors, 'invalid-candidate', candidatePath, 'Expected a subject candidate');
+                return;
+              }
+              validateExactFields(candidate, CANDIDATE_FIELDS, candidatePath, errors);
+              const validRuleKey = validateCanonicalString(
+                candidate.ruleKey,
+                `${candidatePath}.ruleKey`,
+                errors,
+                { pattern: RULE_KEY_PATTERN, code: 'invalid-rule-key' }
+              );
+              validateCanonicalString(
+                candidate.subjectCategory,
+                `${candidatePath}.subjectCategory`,
+                errors,
+                { pattern: LOWER_ID_PATTERN, code: 'invalid-subject-category' }
+              );
+              validateCanonicalString(candidate.subject, `${candidatePath}.subject`, errors);
+              if (!validRuleKey || typeof candidate.subject !== 'string') return;
+              const candidateKey = [
+                candidate.ruleKey,
+                candidate.subjectCategory,
+                candidate.subject
+              ].join('\u0000');
+              validateRecordOrder(
+                candidateKey,
+                previousCandidateKey,
+                `${requirementPath}.anyOf`,
+                errors
+              );
+              if (candidateKeys.has(candidateKey)) {
+                addError(
+                  errors,
+                  'duplicate-candidate',
+                  candidatePath,
+                  'Requirement candidates must be unique'
+                );
+              }
+              candidateKeys.add(candidateKey);
+              previousCandidateKey = candidateKey;
+              referencedRuleKeys.add(candidate.ruleKey);
+              if (!mappedSubjectsByRule.has(candidate.ruleKey)) {
+                mappedSubjectsByRule.set(candidate.ruleKey, new Set());
+              }
+              mappedSubjectsByRule.get(candidate.ruleKey).add(candidate.subject);
+              const architecture = architectureRules.get(candidate.ruleKey);
+              const coverage = coverageByRule.get(candidate.ruleKey);
+              if (!architecture) {
+                addError(
+                  errors,
+                  'unknown-architecture-rule',
+                  `${candidatePath}.ruleKey`,
+                  'Candidate references an unknown architecture rule'
+                );
+              } else {
+                if (candidate.subjectCategory !== architecture.subjectCategory) {
+                  addError(
+                    errors,
+                    'subject-category-mismatch',
+                    `${candidatePath}.subjectCategory`,
+                    'Candidate subject category does not match its detector'
+                  );
+                }
+                if (!architecture.allowedSubjects.includes(candidate.subject)) {
+                  addError(
+                    errors,
+                    'unapproved-architecture-subject',
+                    `${candidatePath}.subject`,
+                    'Candidate subject is not allowed by the architecture rule'
+                  );
+                }
+              }
+              if (!coverage) {
+                addError(
+                  errors,
+                  'missing-rule-coverage',
+                  `${candidatePath}.ruleKey`,
+                  'Referenced architecture rule has no Product Impact coverage entry'
+                );
+              } else if (coverage.enforcement === 'hard') {
+                requirementUsesHardRule = true;
+              }
+            });
+            if (requirementUsesHardRule) {
+              requirementCheckpointRefs.forEach((reference) => {
+                hardRequirementCheckpointRefs.add(reference);
+              });
+            }
+          });
+        });
+      }
+
+      if (!isRecord(concern.resolution)) {
+        addError(errors, 'invalid-resolution', `${concernPath}.resolution`, 'Expected a resolution');
+      } else {
+        const kind = concern.resolution.kind;
+        const fields = kind === 'decision-required'
+          ? ['kind']
+          : ['authorityRefs', 'kind', 'selectedOptionId'];
+        validateExactFields(concern.resolution, fields, `${concernPath}.resolution`, errors);
+        if (!RESOLUTION_KINDS.includes(kind)) {
+          addError(
+            errors,
+            'invalid-resolution-kind',
+            `${concernPath}.resolution.kind`,
+            'Unsupported concern resolution kind'
+          );
+        }
+        if (kind !== 'decision-required') {
+          if (!optionIds.has(concern.resolution.selectedOptionId)) {
+            addError(
+              errors,
+              'unknown-selected-option',
+              `${concernPath}.resolution.selectedOptionId`,
+              'Resolution references an unknown option'
+            );
+          }
+          const authorityRefs = validateSortedUniqueStrings(
+            concern.resolution.authorityRefs,
+            `${concernPath}.resolution.authorityRefs`,
+            errors
+          );
+          if (!authorityRefs.length) {
+            addError(
+              errors,
+              'empty-authority-refs',
+              `${concernPath}.resolution.authorityRefs`,
+              'Static and domain resolutions require authority references'
+            );
+          }
+        }
+      }
+
+      const contracts = [];
+      if (!Array.isArray(concern.contracts)) {
+        addError(errors, 'invalid-array', `${concernPath}.contracts`, 'Expected contracts');
+      } else {
+        const contractRefs = new Set();
+        let previousContractRef = null;
+        concern.contracts.forEach((contract, contractIndex) => {
+          const contractPath = `${concernPath}.contracts[${contractIndex}]`;
+          if (!isRecord(contract)) {
+            addError(errors, 'invalid-contract', contractPath, 'Expected a contract object');
+            return;
+          }
+          validateExactFields(contract, CONTRACT_FIELDS, contractPath, errors);
+          const validContractRef = validateCanonicalString(
+            contract.ref,
+            `${contractPath}.ref`,
+            errors,
+            { maximumLength: 1000, code: 'invalid-contract-ref' }
+          );
+          if (validContractRef) {
+            const separator = contract.ref.indexOf('::');
+            const repositoryPath = contractRepositoryPath(contract.ref);
+            if (
+              separator < 1
+              || separator === contract.ref.length - 2
+              || !REPOSITORY_PATH_PATTERN.test(repositoryPath)
+              || repositoryPath.split('/').some((segment) => segment === '.' || segment === '..')
+            ) {
+              addError(
+                errors,
+                'invalid-contract-ref',
+                `${contractPath}.ref`,
+                'Expected a normalized repository path and named check separated by ::'
+              );
+            }
+            validateRecordOrder(
+              contract.ref,
+              previousContractRef,
+              `${concernPath}.contracts`,
+              errors
+            );
+            if (contractRefs.has(contract.ref)) {
+              addError(errors, 'duplicate-contract-ref', `${contractPath}.ref`, 'Duplicate contract ref');
+            }
+            contractRefs.add(contract.ref);
+            previousContractRef = contract.ref;
+          }
+          const contractCheckpointRefs = validateSortedUniqueStrings(
+            contract.checkpointRefs,
+            `${contractPath}.checkpointRefs`,
+            errors
+          );
+          if (!contractCheckpointRefs.length) {
+            addError(
+              errors,
+              'empty-checkpoint-refs',
+              `${contractPath}.checkpointRefs`,
+              'Expected checkpoint refs'
+            );
+          }
+          contractCheckpointRefs.forEach((reference, referenceIndex) => {
+            if (!checkpointRefs.has(reference)) {
+              addError(
+                errors,
+                'unknown-checkpoint-ref',
+                `${contractPath}.checkpointRefs[${referenceIndex}]`,
+                'Contract references an unknown checkpoint'
+              );
+            }
+          });
+          if (!CONTRACT_SENSITIVITIES.includes(contract.sensitivity)) {
+            addError(
+              errors,
+              'invalid-contract-sensitivity',
+              `${contractPath}.sensitivity`,
+              'Unsupported contract sensitivity'
+            );
+          }
+          if (!CONTRACT_EXECUTIONS.includes(contract.execution)) {
+            addError(
+              errors,
+              'invalid-contract-execution',
+              `${contractPath}.execution`,
+              'Unsupported contract execution boundary'
+            );
+          }
+          validateCanonicalString(
+            contract.residualRisk,
+            `${contractPath}.residualRisk`,
+            errors,
+            { maximumLength: 2000 }
+          );
+          contracts.push(contract);
+        });
+      }
+
+      hardRequirementCheckpointRefs.forEach((reference) => {
+        const covered = contracts.some((contract) => (
+          Array.isArray(contract.checkpointRefs)
+          && contract.checkpointRefs.includes(reference)
+          && isAutomatedPrGateContract(contract)
+        ));
+        if (!covered) {
+          addError(
+            errors,
+            'missing-hard-contract-coverage',
+            `${concernPath}.contracts`,
+            `Hard checkpoint ${reference} requires automated PR_GATE coverage`
+          );
+        }
+      });
+      if (hardRequirementCheckpointRefs.size && contracts.length && contracts.every((contract) => (
+        contract.sensitivity === 'MANUAL_ACCEPTANCE' || contract.execution === 'MANUAL'
+      ))) {
+        addError(
+          errors,
+          'manual-only-hard-concern',
+          `${concernPath}.contracts`,
+          'Manual-only evidence cannot establish hard completeness'
+        );
+      }
+      referencedRuleKeys.forEach((ruleKey) => {
+        if (!coverageByRule.has(ruleKey)) {
+          addError(
+            errors,
+            'missing-rule-coverage',
+            `${concernPath}.options`,
+            `Concern references rule ${ruleKey} without coverage`
+          );
+        }
+      });
+    });
+  }
+
+  coverageByRule.forEach((coverage, ruleKey) => {
+    if (coverage.coverage !== 'complete') return;
+    const architecture = architectureRules.get(ruleKey);
+    if (!architecture) return;
+    const mapped = mappedSubjectsByRule.get(ruleKey) || new Set();
+    architecture.allowedSubjects.forEach((subject) => {
+      if (!mapped.has(subject)) {
+        addError(
+          errors,
+          'unmapped-allowed-subject',
+          '$.concerns',
+          `Complete coverage for ${ruleKey} does not map an allowed subject`
+        );
+      }
+    });
+  });
+
+  return validationResult(errors);
+};
+
+const concernIndex = (map) => new Map(
+  (Array.isArray(map?.concerns) ? map.concerns : []).map((concern) => [concern.key, concern])
+);
+const checkpointSet = (concern) => new Set(concern.journeys.flatMap((journey) => (
+  journey.checkpoints.map((checkpoint) => checkpointReference(journey.id, checkpoint.id))
+)));
+const requirementsForConcern = (concern) => concern.options.flatMap((option) => option.requirements);
+
+export const validateProductDecisionAuthority = (authority, map) => {
+  const errors = [];
+  if (!isRecord(authority)) {
+    addError(errors, 'invalid-decision-authority', '$', 'Expected a decision authority object');
+    return validationResult(errors);
+  }
+  validateExactFields(authority, DECISION_AUTHORITY_FIELDS, '$', errors);
+  if (authority.schemaVersion !== SCHEMA_VERSION) {
+    addError(
+      errors,
+      'unsupported-schema-version',
+      '$.schemaVersion',
+      `Expected schemaVersion ${SCHEMA_VERSION}`
+    );
+  }
+  const maintainerLogins = validateSortedUniqueStrings(
+    authority.maintainerLogins,
+    '$.maintainerLogins',
+    errors,
+    { pattern: LOGIN_PATTERN, maximumLength: 39, code: 'invalid-maintainer-login' }
+  );
+  if (!maintainerLogins.length) {
+    addError(
+      errors,
+      'empty-maintainer-logins',
+      '$.maintainerLogins',
+      'Decision authority requires at least one canonical maintainer login'
+    );
+  }
+  const concerns = concernIndex(map);
+  const seenIds = new Set();
+  const seenConcernRevisions = new Set();
+  if (!Array.isArray(authority.decisions)) {
+    addError(errors, 'invalid-array', '$.decisions', 'Expected a decisions array');
+    return validationResult(errors);
+  }
+  let previousDecisionId = null;
+  authority.decisions.forEach((decision, index) => {
+    const path = `$.decisions[${index}]`;
+    if (!isRecord(decision)) {
+      addError(errors, 'invalid-decision', path, 'Expected a durable decision object');
+      return;
+    }
+    validateExactFields(decision, DURABLE_DECISION_FIELDS, path, errors);
+    const validId = validateCanonicalString(
+      decision.id,
+      `${path}.id`,
+      errors,
+      { pattern: DECISION_ID_PATTERN, code: 'invalid-decision-id' }
+    );
+    if (validId) {
+      validateRecordOrder(decision.id, previousDecisionId, '$.decisions', errors);
+      if (seenIds.has(decision.id)) {
+        addError(errors, 'duplicate-decision-id', `${path}.id`, 'Duplicate decision ID');
+      }
+      seenIds.add(decision.id);
+      previousDecisionId = decision.id;
+    }
+    validateCanonicalString(
+      decision.concernKey,
+      `${path}.concernKey`,
+      errors,
+      { pattern: RULE_KEY_PATTERN, code: 'invalid-concern-key' }
+    );
+    if (!Number.isInteger(decision.scenarioRevision) || decision.scenarioRevision < 1) {
+      addError(
+        errors,
+        'invalid-scenario-revision',
+        `${path}.scenarioRevision`,
+        'Expected a positive integer scenario revision'
+      );
+    }
+    const concernRevisionKey = `${decision.concernKey}\u0000${decision.scenarioRevision}`;
+    if (seenConcernRevisions.has(concernRevisionKey)) {
+      addError(
+        errors,
+        'duplicate-active-decision',
+        path,
+        'Only one active decision is allowed per concern and scenario revision'
+      );
+    }
+    seenConcernRevisions.add(concernRevisionKey);
+    if (!ACCEPTED_IMPACT_CLASSES.includes(decision.acceptedImpactClass)) {
+      addError(
+        errors,
+        'invalid-accepted-impact-class',
+        `${path}.acceptedImpactClass`,
+        'Unsupported accepted impact class'
+      );
+    }
+    const retiredRefs = validateSortedUniqueStrings(
+      decision.acknowledgedRetiredRequirementRefs,
+      `${path}.acknowledgedRetiredRequirementRefs`,
+      errors,
+      { pattern: /^REQ-[A-Z0-9]+(?:-[A-Z0-9]+)*$/, code: 'invalid-requirement-ref' }
+    );
+    if (retiredRefs.length && decision.acceptedImpactClass !== 'RETIREMENT') {
+      addError(
+        errors,
+        'retirement-impact-mismatch',
+        `${path}.acknowledgedRetiredRequirementRefs`,
+        'Retired requirements require RETIREMENT impact'
+      );
+    }
+    if (decision.acceptedImpactClass === 'RETIREMENT' && !retiredRefs.length) {
+      addError(
+        errors,
+        'missing-retirement-refs',
+        `${path}.acknowledgedRetiredRequirementRefs`,
+        'RETIREMENT requires exact retired requirement references'
+      );
+    }
+    const acceptanceRefs = validateSortedUniqueStrings(
+      decision.acceptanceCheckpointRefs,
+      `${path}.acceptanceCheckpointRefs`,
+      errors
+    );
+    if (!acceptanceRefs.length) {
+      addError(
+        errors,
+        'empty-acceptance-checkpoints',
+        `${path}.acceptanceCheckpointRefs`,
+        'Durable decisions require acceptance checkpoints'
+      );
+    }
+    validateCanonicalString(
+      decision.rationale,
+      `${path}.rationale`,
+      errors,
+      { maximumLength: 2000 }
+    );
+
+    const concern = concerns.get(decision.concernKey);
+    if (!concern) {
+      addError(errors, 'unknown-concern', `${path}.concernKey`, 'Decision references an unknown concern');
+      return;
+    }
+    if (concern.scenarioRevision !== decision.scenarioRevision) {
+      addError(
+        errors,
+        'stale-scenario-revision',
+        `${path}.scenarioRevision`,
+        'Decision scenario revision does not match the active concern'
+      );
+    }
+    if (concern.resolution.kind !== 'decision-required') {
+      addError(
+        errors,
+        'decision-conflicts-with-resolution',
+        `${path}.concernKey`,
+        'Static and domain concerns cannot carry durable decisions'
+      );
+    }
+    if (!concern.options.some((option) => option.id === decision.selectedOptionId)) {
+      addError(
+        errors,
+        'unknown-selected-option',
+        `${path}.selectedOptionId`,
+        'Decision references an unknown option'
+      );
+    }
+    const requirementIds = new Set(requirementsForConcern(concern).map(({ id }) => id));
+    retiredRefs.forEach((reference, referenceIndex) => {
+      if (!requirementIds.has(reference)) {
+        addError(
+          errors,
+          'unknown-retired-requirement',
+          `${path}.acknowledgedRetiredRequirementRefs[${referenceIndex}]`,
+          'Decision references an unknown retired requirement'
+        );
+      }
+    });
+    const checkpoints = checkpointSet(concern);
+    acceptanceRefs.forEach((reference, referenceIndex) => {
+      if (!checkpoints.has(reference)) {
+        addError(
+          errors,
+          'unknown-checkpoint-ref',
+          `${path}.acceptanceCheckpointRefs[${referenceIndex}]`,
+          'Decision references an unknown checkpoint'
+        );
+        return;
+      }
+      const covered = concern.contracts.some((contract) => contract.checkpointRefs.includes(reference));
+      if (!covered) {
+        addError(
+          errors,
+          'uncovered-acceptance-checkpoint',
+          `${path}.acceptanceCheckpointRefs[${referenceIndex}]`,
+          'Acceptance checkpoint has no mapped behavior contract'
+        );
+      }
+    });
+  });
+  return validationResult(errors);
+};
+
+const canonicalSubjectArray = (values, label) => {
+  if (!Array.isArray(values) || values.some((value) => (
+    typeof value !== 'string'
+    || !value
+    || value !== value.trim()
+    || /[\u0000-\u001f\u007f]/.test(value)
+  ))) {
+    throw new Error(`${label} must contain canonical subject strings`);
+  }
+  return stableUnique(values);
+};
+const normalizeSubjectDelta = (delta) => {
+  if (!isRecord(delta)) throw new Error('Product Impact subject delta must be an object');
+  const fields = Object.keys(delta).sort(compareText);
+  if (!arraysEqual(fields, SUBJECT_DELTA_FIELDS)) {
+    throw new Error(`Product Impact subject delta requires exactly: ${SUBJECT_DELTA_FIELDS.join(', ')}`);
+  }
+  for (const field of ['ruleKey', 'kind', 'detector', 'subjectCategory']) {
+    if (typeof delta[field] !== 'string' || !delta[field] || delta[field] !== delta[field].trim()) {
+      throw new Error(`Product Impact subject delta ${field} must be canonical`);
+    }
+  }
+  const beforeSubjects = canonicalSubjectArray(delta.beforeSubjects, 'Subject delta beforeSubjects');
+  const afterSubjects = canonicalSubjectArray(delta.afterSubjects, 'Subject delta afterSubjects');
+  const addedSubjects = stableDifference(afterSubjects, beforeSubjects);
+  const removedSubjects = stableDifference(beforeSubjects, afterSubjects);
+  if (
+    !arraysEqual(canonicalSubjectArray(delta.addedSubjects, 'Subject delta addedSubjects'), addedSubjects)
+    || !arraysEqual(canonicalSubjectArray(delta.removedSubjects, 'Subject delta removedSubjects'), removedSubjects)
+    || delta.changed !== Boolean(addedSubjects.length || removedSubjects.length)
+  ) {
+    throw new Error(`Product Impact subject delta ${delta.ruleKey} is internally inconsistent`);
+  }
+  return deepFreeze({
+    ruleKey: delta.ruleKey,
+    kind: delta.kind,
+    detector: delta.detector,
+    subjectCategory: delta.subjectCategory,
+    beforeSubjects,
+    addedSubjects,
+    removedSubjects,
+    afterSubjects,
+    changed: delta.changed
+  });
+};
+const normalizeRuleFact = (fact) => {
+  if (!isRecord(fact)) throw new Error('Product Impact rule fact must be an object');
+  const fields = Object.keys(fact).sort(compareText);
+  if (!arraysEqual(fields, RULE_FACT_FIELDS)) {
+    throw new Error(`Product Impact rule fact requires exactly: ${RULE_FACT_FIELDS.join(', ')}`);
+  }
+  if (
+    typeof fact.ruleKey !== 'string'
+    || !RULE_KEY_PATTERN.test(fact.ruleKey)
+    || typeof fact.subjectCategory !== 'string'
+    || !LOWER_ID_PATTERN.test(fact.subjectCategory)
+  ) {
+    throw new Error('Product Impact rule fact identifiers must be canonical');
+  }
+  return deepFreeze({
+    ruleKey: fact.ruleKey,
+    subjectCategory: fact.subjectCategory,
+    beforeSubjects: canonicalSubjectArray(fact.beforeSubjects, 'Rule fact beforeSubjects'),
+    afterSubjects: canonicalSubjectArray(fact.afterSubjects, 'Rule fact afterSubjects')
+  });
+};
+const normalizeChangedPaths = (paths) => {
+  if (!Array.isArray(paths) || paths.some((path) => (
+    typeof path !== 'string'
+    || !REPOSITORY_PATH_PATTERN.test(path)
+    || path.split('/').some((segment) => segment === '.' || segment === '..')
+  ))) {
+    throw new Error('Product Impact changedPaths must contain normalized repository paths');
+  }
+  return stableUnique(paths);
+};
+const normalizeCurrentDecisionSource = (source) => {
+  if (source === null || source === undefined) {
+    return deepFreeze({
+      valid: true,
+      present: false,
+      metadata: { eventAuthorLogin: '', eventHeadSha: '' },
+      declaration: { schemaVersion: SCHEMA_VERSION, headSha: '', decisions: [] },
+      errors: []
+    });
+  }
+  if (!isRecord(source)) throw new Error('Current decisions must be a parser result');
+  const fields = Object.keys(source).sort(compareText);
+  if (!arraysEqual(fields, ['declaration', 'errors', 'metadata', 'present', 'valid'])) {
+    throw new Error('Current decisions must use the bounded parser result shape');
+  }
+  if (source.valid !== true || !Array.isArray(source.errors) || source.errors.length) {
+    throw new Error('Current decisions must be a valid bounded parser result');
+  }
+  if (!isRecord(source.metadata) || !isRecord(source.declaration)) {
+    throw new Error('Current decisions parser metadata or declaration is malformed');
+  }
+  if (!Array.isArray(source.declaration.decisions)) {
+    throw new Error('Current decisions parser declaration is malformed');
+  }
+  return source;
+};
+const resultSeverity = Object.freeze({
+  AUTHORITY_CONFLICT: 5,
+  INSUFFICIENT_EVIDENCE: 4,
+  ORDINARY_REGRESSION: 3,
+  UNRESOLVED_DECISION: 2,
+  CONFORMING: 1,
+  NOT_APPLICABLE: 0
+});
+const choiceObservation = (candidates) => [...candidates]
+  .sort((left, right) => resultSeverity[right] - resultSeverity[left])[0];
+
+export const evaluateProductImpact = (input) => {
+  if (!isRecord(input)) throw new Error('Product Impact evaluation requires one input object');
+  const fields = Object.keys(input).sort(compareText);
+  if (!arraysEqual(fields, EVALUATION_INPUT_FIELDS)) {
+    throw new Error(`Product Impact evaluation requires exactly: ${EVALUATION_INPUT_FIELDS.join(', ')}`);
+  }
+  if (!isRecord(input.map)) throw new Error('Product Impact evaluation requires a validated map');
+  const decisionValidation = validateProductDecisionAuthority(input.decisionAuthority, input.map);
+  if (!decisionValidation.valid) {
+    throw new Error('Product Impact evaluation requires valid durable decision authority');
+  }
+  const subjectDeltas = input.subjectDeltas.map(normalizeSubjectDelta)
+    .sort((left, right) => compareText(left.ruleKey, right.ruleKey));
+  const duplicateDelta = subjectDeltas.find((delta, index) => (
+    index > 0 && delta.ruleKey === subjectDeltas[index - 1].ruleKey
+  ));
+  if (duplicateDelta) throw new Error(`Duplicate Product Impact subject delta ${duplicateDelta.ruleKey}`);
+  const ruleFacts = input.ruleFacts.map(normalizeRuleFact)
+    .sort((left, right) => compareText(left.ruleKey, right.ruleKey));
+  const factsByRule = new Map();
+  ruleFacts.forEach((fact) => {
+    if (factsByRule.has(fact.ruleKey)) throw new Error(`Duplicate Product Impact rule fact ${fact.ruleKey}`);
+    factsByRule.set(fact.ruleKey, fact);
+  });
+  const changedPathSet = new Set(normalizeChangedPaths(input.changedPaths));
+  const currentSource = normalizeCurrentDecisionSource(input.currentDecisions);
+  const currentDecisionList = currentSource.declaration.decisions;
+  const changedDeltas = subjectDeltas.filter(({ changed }) => changed);
+  const changedRuleKeys = new Set(changedDeltas.map(({ ruleKey }) => ruleKey));
+  const currentConcernKeys = new Set(currentDecisionList.map(({ concernKey }) => concernKey));
+  const coverageByRule = new Map(input.map.ruleCoverage.map((coverage) => [
+    coverage.ruleKey,
+    coverage
+  ]));
+  const mappedSubjectsByRule = new Map();
+  input.map.concerns.forEach((concern) => {
+    concern.options.forEach((option) => option.requirements.forEach((requirement) => {
+      requirement.anyOf.forEach((candidate) => {
+        if (!mappedSubjectsByRule.has(candidate.ruleKey)) {
+          mappedSubjectsByRule.set(candidate.ruleKey, new Set());
+        }
+        mappedSubjectsByRule.get(candidate.ruleKey).add(candidate.subject);
+      });
+    }));
+  });
+  const authorityDecisions = input.decisionAuthority.decisions;
+  const maintainerLogins = new Set(input.decisionAuthority.maintainerLogins);
+  const results = [];
+
+  [...input.map.concerns]
+    .sort((left, right) => compareText(left.key, right.key))
+    .forEach((concern) => {
+      const referencedRules = stableUnique(concern.options.flatMap((option) => (
+        option.requirements.flatMap((requirement) => requirement.anyOf.map(({ ruleKey }) => ruleKey))
+      )));
+      const triggeringRuleKeys = referencedRules.filter((ruleKey) => changedRuleKeys.has(ruleKey));
+      if (!triggeringRuleKeys.length && !currentConcernKeys.has(concern.key)) return;
+      const triggeringDeltas = subjectDeltas.filter((delta) => (
+        triggeringRuleKeys.includes(delta.ruleKey)
+      ));
+      const evidenceGaps = [];
+      const activeFactsByRule = new Map();
+      referencedRules.forEach((ruleKey) => {
+        const fact = factsByRule.get(ruleKey);
+        if (!fact) {
+          evidenceGaps.push(`Missing complete before/after subject inventory for ${ruleKey}.`);
+          activeFactsByRule.set(ruleKey, {
+            beforeSubjects: [],
+            afterSubjects: [],
+            subjectCategory: ''
+          });
+          return;
+        }
+        activeFactsByRule.set(ruleKey, fact);
+      });
+      triggeringDeltas.forEach((delta) => {
+        const fact = factsByRule.get(delta.ruleKey);
+        if (fact && (
+          fact.subjectCategory !== delta.subjectCategory
+          || !arraysEqual(fact.beforeSubjects, delta.beforeSubjects)
+          || !arraysEqual(fact.afterSubjects, delta.afterSubjects)
+        )) {
+          evidenceGaps.push(`Subject delta and complete rule facts disagree for ${delta.ruleKey}.`);
+        }
+        const coverage = coverageByRule.get(delta.ruleKey);
+        if (!coverage) {
+          evidenceGaps.push(`Changed rule ${delta.ruleKey} has no Product Impact coverage.`);
+        } else if (coverage.coverage !== 'complete') {
+          evidenceGaps.push(`Changed rule ${delta.ruleKey} has only partial Product Impact coverage.`);
+        }
+        const mapped = mappedSubjectsByRule.get(delta.ruleKey) || new Set();
+        [...delta.addedSubjects, ...delta.removedSubjects].forEach((subject) => {
+          if (!mapped.has(subject)) {
+            evidenceGaps.push(`Changed subject for ${delta.ruleKey} is not mapped.`);
+          }
+        });
+      });
+
+      const requirementResults = [];
+      const optionResults = concern.options.map((option) => {
+        const optionRequirementResults = option.requirements.map((requirement) => {
+          const beforeActiveSubjects = stableUnique(requirement.anyOf
+            .filter((candidate) => (
+              activeFactsByRule.get(candidate.ruleKey)?.beforeSubjects.includes(candidate.subject)
+            ))
+            .map((candidate) => candidate.subject));
+          const afterActiveSubjects = stableUnique(requirement.anyOf
+            .filter((candidate) => (
+              activeFactsByRule.get(candidate.ruleKey)?.afterSubjects.includes(candidate.subject)
+            ))
+            .map((candidate) => candidate.subject));
+          const result = {
+            requirementRef: requirement.id,
+            category: requirement.category,
+            beforeSatisfied: beforeActiveSubjects.length > 0,
+            afterSatisfied: afterActiveSubjects.length > 0,
+            beforeActiveSubjects,
+            afterActiveSubjects,
+            changed: !arraysEqual(beforeActiveSubjects, afterActiveSubjects)
+          };
+          requirementResults.push(result);
+          return result;
+        });
+        return {
+          optionId: option.id,
+          effectRefs: [...option.effectRefs],
+          requirementRefs: option.requirements.map(({ id }) => id),
+          beforeRealized: optionRequirementResults.every(({ beforeSatisfied }) => beforeSatisfied),
+          afterRealized: optionRequirementResults.every(({ afterSatisfied }) => afterSatisfied)
+        };
+      });
+      requirementResults.sort((left, right) => compareText(left.requirementRef, right.requirementRef));
+      optionResults.sort((left, right) => compareText(left.optionId, right.optionId));
+      const beforeOptions = optionResults.filter(({ beforeRealized }) => beforeRealized)
+        .map(({ optionId }) => optionId);
+      const afterOptions = optionResults.filter(({ afterRealized }) => afterRealized)
+        .map(({ optionId }) => optionId);
+      const beforeEffects = stableUnique(optionResults.filter(({ beforeRealized }) => beforeRealized)
+        .flatMap(({ effectRefs }) => effectRefs));
+      const afterEffects = stableUnique(optionResults.filter(({ afterRealized }) => afterRealized)
+        .flatMap(({ effectRefs }) => effectRefs));
+      const changedRequirementRefs = requirementResults.filter(({ changed }) => changed)
+        .map(({ requirementRef }) => requirementRef);
+      const lostProtectedRequirements = requirementResults.filter((requirement) => (
+        ['AFFORDANCE', 'COMPATIBILITY'].includes(requirement.category)
+        && requirement.beforeSatisfied
+        && !requirement.afterSatisfied
+      )).map(({ requirementRef }) => requirementRef);
+      const lostEffects = stableDifference(beforeEffects, afterEffects);
+      const addedEffects = stableDifference(afterEffects, beforeEffects);
+      const affectedCheckpointRefs = stableUnique(concern.options.flatMap((option) => (
+        option.requirements.filter((requirement) => changedRequirementRefs.includes(requirement.id))
+          .flatMap(({ checkpointRefs }) => checkpointRefs)
+      )));
+      if (!affectedCheckpointRefs.length) {
+        concern.effects.forEach(({ checkpointRef }) => affectedCheckpointRefs.push(checkpointRef));
+        affectedCheckpointRefs.sort(compareText);
+      }
+      const hardAffected = triggeringRuleKeys.some((ruleKey) => (
+        coverageByRule.get(ruleKey)?.enforcement === 'hard'
+      ));
+      const contractResults = concern.contracts.map((contract) => ({
+        ref: contract.ref,
+        checkpointRefs: [...contract.checkpointRefs],
+        sensitivity: contract.sensitivity,
+        execution: contract.execution,
+        candidateModified: changedPathSet.has(contractRepositoryPath(contract.ref)),
+        automatedPrGate: isAutomatedPrGateContract(contract)
+      })).sort((left, right) => compareText(left.ref, right.ref));
+      affectedCheckpointRefs.forEach((checkpointRef) => {
+        const covering = concern.contracts.filter((contract) => (
+          contract.checkpointRefs.includes(checkpointRef)
+        ));
+        if (!covering.length) {
+          evidenceGaps.push(`Affected checkpoint ${checkpointRef} has no mapped contract.`);
+        }
+        if (hardAffected) {
+          const unmodifiedAutomated = covering.some((contract) => (
+            isAutomatedPrGateContract(contract)
+            && !changedPathSet.has(contractRepositoryPath(contract.ref))
+          ));
+          if (!unmodifiedAutomated) {
+            evidenceGaps.push(
+              `Hard checkpoint ${checkpointRef} lacks unmodified automated PR_GATE evidence.`
+            );
+          }
+        }
+      });
+
+      const stableEvidenceGaps = stableUnique(evidenceGaps);
+      const strictNoDifference = beforeOptions.length > 0
+        && arraysEqual(beforeOptions, afterOptions)
+        && requirementResults.every((requirement) => (
+          requirement.beforeSatisfied === requirement.afterSatisfied
+        ))
+        && !lostProtectedRequirements.length
+        && arraysEqual(beforeEffects, afterEffects)
+        && !stableEvidenceGaps.length;
+      let impactClass;
+      if (strictNoDifference) impactClass = 'NO_USER_VISIBLE_DIFFERENCE';
+      else if (lostEffects.length || lostProtectedRequirements.length) impactClass = 'RETIREMENT';
+      else if (
+        arraysEqual(beforeEffects, afterEffects)
+        && beforeEffects.length
+      ) impactClass = 'AFFORDANCE_PRESERVED';
+      else impactClass = 'PRODUCT_CHANGE';
+
+      const durable = authorityDecisions.find((decision) => (
+        decision.concernKey === concern.key
+        && decision.scenarioRevision === concern.scenarioRevision
+      ));
+      const current = currentDecisionList.find((decision) => (
+        decision.concernKey === concern.key
+        && decision.scenarioRevision === concern.scenarioRevision
+      ));
+      const staticAuthority = concern.resolution.kind === 'authority-covered'
+        ? {
+          type: 'STATIC_AUTHORITY',
+          selectedOptionId: concern.resolution.selectedOptionId,
+          rationale: ''
+        }
+        : concern.resolution.kind === 'domain-derived'
+          ? {
+            type: 'DOMAIN_AUTHORITY',
+            selectedOptionId: concern.resolution.selectedOptionId,
+            rationale: ''
+          }
+          : null;
+      const durableAuthority = durable ? {
+        type: 'DURABLE_DECISION',
+        selectedOptionId: durable.selectedOptionId,
+        rationale: durable.rationale
+      } : null;
+      const currentIssues = [];
+      let currentEligible = false;
+      if (current) {
+        if (!maintainerLogins.has(currentSource.metadata.eventAuthorLogin)) {
+          currentIssues.push('The pull request author is not an eligible Product Decision Owner.');
+        }
+        if (concern.resolution.kind !== 'decision-required') {
+          currentIssues.push('Current decisions apply only to decision-required concerns.');
+        }
+        if (current.acceptedImpactClass !== 'AFFORDANCE_PRESERVED') {
+          currentIssues.push('Current decisions accept only AFFORDANCE_PRESERVED.');
+        }
+        if (impactClass !== 'AFFORDANCE_PRESERVED') {
+          currentIssues.push('The evaluated transition is not affordance-preserving.');
+        }
+        const selectedOption = optionResults.find(({ optionId }) => (
+          optionId === current.selectedOptionId
+        ));
+        if (!selectedOption?.afterRealized) {
+          currentIssues.push('The current decision selected option is not realized after the change.');
+        }
+        if (selectedOption && !arraysEqual(beforeEffects, selectedOption.effectRefs)) {
+          currentIssues.push('The current decision selected option does not preserve stable effects.');
+        }
+        if (lostProtectedRequirements.length) {
+          currentIssues.push('A current decision cannot retire affordance or compatibility requirements.');
+        }
+        if (!arraysEqual(
+          current.acknowledgedChangedRequirementRefs,
+          changedRequirementRefs
+        )) {
+          currentIssues.push('Changed requirement acknowledgement is incomplete or stale.');
+        }
+        if (stableEvidenceGaps.length) {
+          currentIssues.push('Mapped Product Impact evidence is incomplete.');
+        }
+        currentEligible = currentIssues.length === 0;
+      }
+
+      const conflictCandidates = [staticAuthority, durableAuthority].filter(Boolean);
+      if (current && conflictCandidates.some((authority) => (
+        authority.selectedOptionId !== current.selectedOptionId
+      ))) {
+        conflictCandidates.push({
+          type: 'CURRENT_MAINTAINER_DECISION',
+          selectedOptionId: current.selectedOptionId,
+          rationale: current.rationale
+        });
+      }
+      const conflict = new Set(conflictCandidates.map(({ selectedOptionId }) => selectedOptionId)).size > 1;
+      let recognizedAuthority = staticAuthority || durableAuthority;
+      if (!recognizedAuthority && currentEligible) {
+        recognizedAuthority = {
+          type: 'CURRENT_MAINTAINER_DECISION',
+          selectedOptionId: current.selectedOptionId,
+          rationale: current.rationale
+        };
+      }
+      if (
+        durableAuthority
+        && impactClass !== 'NO_USER_VISIBLE_DIFFERENCE'
+        && (
+          durable.acceptedImpactClass !== impactClass
+          || !arraysEqual(
+            durable.acknowledgedRetiredRequirementRefs,
+            lostProtectedRequirements
+          )
+        )
+      ) {
+        recognizedAuthority = staticAuthority;
+        currentIssues.push(
+          'The durable decision impact class or retired requirement scope does not match the evaluated transition.'
+        );
+      }
+      const selectedOptionResult = recognizedAuthority
+        ? optionResults.find(({ optionId }) => optionId === recognizedAuthority.selectedOptionId)
+        : null;
+      const observationCandidates = [];
+      if (stableEvidenceGaps.length) observationCandidates.push('INSUFFICIENT_EVIDENCE');
+      if (conflict) observationCandidates.push('AUTHORITY_CONFLICT');
+      if (recognizedAuthority && !selectedOptionResult?.afterRealized) {
+        observationCandidates.push('ORDINARY_REGRESSION');
+      }
+      const changeNeedsDecision = concern.resolution.kind === 'decision-required'
+        && impactClass !== 'NO_USER_VISIBLE_DIFFERENCE';
+      if (changeNeedsDecision && !recognizedAuthority) {
+        observationCandidates.push('UNRESOLVED_DECISION');
+      }
+      const observation = observationCandidates.length
+        ? choiceObservation(observationCandidates)
+        : 'CONFORMING';
+      const authorityResolution = conflict
+        ? 'CONFLICT'
+        : recognizedAuthority?.type || 'UNRESOLVED';
+      const nextAction = observation === 'CONFORMING'
+        ? 'No Product Impact action is required.'
+        : observation === 'ORDINARY_REGRESSION'
+          ? 'Restore the selected option realization before integration.'
+          : observation === 'UNRESOLVED_DECISION'
+            ? 'Obtain an eligible Product Decision Owner disposition through the documented route.'
+            : observation === 'AUTHORITY_CONFLICT'
+              ? 'Resolve the incompatible product authorities in an authority-only change.'
+              : 'Complete the mapped rule facts and contract evidence before relying on this result.';
+      const residualRisks = stableUnique([
+        ...concern.contracts.map(({ residualRisk }) => residualRisk),
+        ...(current?.residualRisk ? [current.residualRisk] : [])
+      ]);
+      results.push({
+        concernKey: concern.key,
+        scenarioRevision: concern.scenarioRevision,
+        triggeringRuleKeys,
+        subjectDeltas: triggeringDeltas,
+        journeys: concern.journeys.map((journey) => ({
+          id: journey.id,
+          actor: journey.actor,
+          context: journey.context,
+          goal: journey.goal,
+          steps: [...journey.steps],
+          checkpoints: journey.checkpoints.map((checkpoint) => ({ ...checkpoint }))
+        })),
+        checkpoints: stableUnique([...checkpointSet(concern)]),
+        requirementResults,
+        optionResults,
+        beforeOptions,
+        afterOptions,
+        beforeEffects,
+        afterEffects,
+        impactClass,
+        authorityResolution,
+        selectedOptionId: conflict ? null : recognizedAuthority?.selectedOptionId || null,
+        decisionRationale: recognizedAuthority?.rationale || current?.rationale || '',
+        observation,
+        contractResults,
+        residualRisks,
+        decisionRequired: observation === 'UNRESOLVED_DECISION',
+        nextAction,
+        changedRequirementRefs,
+        lostRequirementRefs: lostProtectedRequirements,
+        addedEffectRefs: addedEffects,
+        lostEffectRefs: lostEffects,
+        evidenceGaps: stableEvidenceGaps,
+        currentDecisionIssues: stableUnique(currentIssues)
+      });
+    });
+
+  return deepFreeze(results);
+};


### PR DESCRIPTION
## Plain-language summary

This PR adds deterministic, side-effect-free mechanics for relating registered Web architecture subject changes to product behavior concerns. It also adds a bounded parser for machine-readable current-PR decisions and classifies the planned Product Impact files in the existing Web guard. Product Impact is not wired into the checker CLI or Gate in this PR, so merging it changes no Web runtime behavior or required status.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Prepare the inert mechanics required before Product Impact authority data is introduced. The implementation keeps subject-delta construction, map and authority validation, option realization, authority resolution, and PR-body parsing independently testable without Git, filesystem, environment, report, or CLI ownership.

## User-visible impact

None. The Web application, renderer, workflows, dependencies, required statuses, and existing checker report/exit behavior are unchanged.

## Changes

- Add `createArchitectureSubjectDelta` for canonical, immutable before/after subject sets and deterministic added/removed/changed results.
- Add `validateProductImpactMap`, `validateProductDecisionAuthority`, and `evaluateProductImpact` as pure APIs. Evaluation uses AND-of-OR requirement realization and strict no-difference semantics: matching option IDs alone cannot hide lost requirements or changed effects.
- Add `parseCurrentProductImpactDecisions`, which accepts only a single exact marker pair containing bounded machine JSON, binds nonempty decisions to the exact head SHA, accepts only `AFFORDANCE_PRESERVED`, and retains the normalized product rationale in the evaluator result.
- Extend existing guard/checker/authority classifications for the planned Product Impact policy, mechanics, parser, fixture, map, and durable decision files. The narrow inert authority bundle is limited to architecture rules plus the Product Impact map and durable decisions.
- Add 36 focused Product Impact fixtures and extend the Web architecture contract suite to cover bootstrap, purity, guard separation, and PR 3 admission.

Product Impact remains intentionally disconnected from `tools/check-web-change-budget.mjs` orchestration: the checker does not import the new modules, parse PR decisions, render a Product Impact section, or change Gate/Review exit semantics.

## Verification

- `npx --yes node@20.20.2 tests/web/product-impact-ratchet-fixtures.test.mjs` — 36/36 passed.
- `npx --yes node@20.20.2 tests/web/architecture-ratchet-fixtures.test.mjs` — 14/14 passed.
- `npx --yes node@20.20.2 --test tests/web/architecture-contracts.test.mjs` — 118/118 passed.
- `node --test tests/web/product-impact-ratchet-fixtures.test.mjs` — passed on the committed head.
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs` — passed on the committed head.
- `node --test tests/web/architecture-contracts.test.mjs` — 118/118 passed on the committed head.
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD` — Gate `PASS`, Review `REQUIRED`; zero production changes and no Product Impact report section.
- `git diff --check origin/dev...HEAD` — passed.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocking violations.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because the existing checker implementation and its pure evaluators changed.
- Architecture impact: **This is not architecture-bearing**. No Web production owner, canonical runtime path, compatibility path, or responsibility changes; the architecture inventory is unchanged.
- `architecture-change` label, if relevant: not applicable.

The principal risk is a mismatch between the pure schema/evaluation contract and the inert authority files planned for the next PR. Strict schema tests, real detector-catalog validation, the zero-or-two authority bootstrap contract, and the narrow bundle test bound that interface before authority is introduced.

## Rollback

Revert `Add Product Impact Ratchet mechanics`. This removes the pure mechanics and guard bootstrap; the existing Architecture Ratchet, its reports, and its Gate behavior remain in place.

## Conditional Product Impact

- Product-impact role: N/A
- Affected concern(s), if known: none; this governance PR does not change a registered production subject.
- Authority and decision references: none; no Product Impact map or durable decision authority is added.
- Behavior contracts and residual risk: no product behavior contract changes.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: no authority files; `tools/web-architecture-evaluation.mjs` gains the pure structured subject-delta producer.
- Checker implementation files touched: `tools/check-web-change-budget.mjs`, `tools/web-architecture-evaluation.mjs`, `tools/web-product-impact-evaluation.mjs`, and `tools/web-product-impact-decision-source.mjs`.
- Self-authorization separation evidence: no Product Impact authority JSON is present or changed; candidate Product Impact modules are not imported or executed by the trusted checker; contract tests reject checker implementation co-changes with authority and runtime paths.
- Branch-protection or ruleset impact, including unchanged settings: none. No workflow, check name, required status, or ruleset changes.
- Governance-specific rollback or protection restore point: revert this single commit; existing Architecture Ratchet protection remains unchanged.
