### PR TITLE
Add the render-request Product Impact map

### DIFF
--- a/tools/web-product-decisions.json
+++ b/tools/web-product-decisions.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "maintainerLogins": [
+    "satoshikawato"
+  ],
+  "decisions": []
+}

--- a/tools/web-product-impact-map.json
+++ b/tools/web-product-impact-map.json
@@ -1,0 +1,134 @@
+{
+  "schemaVersion": 1,
+  "ruleCoverage": [
+    {
+      "ruleKey": "canonical-path.render-request",
+      "coverage": "complete",
+      "enforcement": "report-only"
+    },
+    {
+      "ruleKey": "semantic-owner.render-request",
+      "coverage": "complete",
+      "enforcement": "report-only"
+    }
+  ],
+  "concerns": [
+    {
+      "key": "product.canonical-render-request-boundary",
+      "scenarioRevision": 1,
+      "title": "Canonical render request continuity",
+      "layer": "STATE",
+      "journeys": [
+        {
+          "id": "JRN-RENDER-001",
+          "actor": "Web user",
+          "context": "A diagram is configured and ready for generation or later reproduction.",
+          "goal": "Generate a Result and reproduce it from the same canonical state after a Session round trip.",
+          "steps": [
+            "Configure the diagram inputs and layout",
+            "Select Generate",
+            "Inspect the Result",
+            "Save and reload the Session when needed",
+            "Generate again from the restored canonical state"
+          ],
+          "checkpoints": [
+            {
+              "id": "generate-submit",
+              "label": "Generate request submission"
+            },
+            {
+              "id": "fresh-result",
+              "label": "Fresh Result admission"
+            },
+            {
+              "id": "roundtrip-regeneration",
+              "label": "Regeneration after Session round trip"
+            }
+          ]
+        }
+      ],
+      "effects": [
+        {
+          "id": "EFF-RENDER-REQUEST-CURRENT-STATE",
+          "checkpointRef": "JRN-RENDER-001:generate-submit",
+          "statement": "At Generate submission, the render request reflects the current canonical UI and Session model."
+        },
+        {
+          "id": "EFF-RENDER-REQUEST-ROUNDTRIP",
+          "checkpointRef": "JRN-RENDER-001:roundtrip-regeneration",
+          "statement": "Reloaded and freshly generated output use the same request semantics."
+        }
+      ],
+      "options": [
+        {
+          "id": "canonical-typed-request-boundary",
+          "summary": "Fresh generation and replay converge on one typed canonical render-request boundary.",
+          "effectRefs": [
+            "EFF-RENDER-REQUEST-CURRENT-STATE",
+            "EFF-RENDER-REQUEST-ROUNDTRIP"
+          ],
+          "requirements": [
+            {
+              "id": "REQ-RENDER-REQUEST-ENTRY",
+              "category": "SEMANTIC",
+              "checkpointRefs": [
+                "JRN-RENDER-001:generate-submit"
+              ],
+              "anyOf": [
+                {
+                  "ruleKey": "canonical-path.render-request",
+                  "subjectCategory": "canonical-entry-edge",
+                  "subject": "app/run-analysis.js -> services/session-request.js"
+                }
+              ]
+            },
+            {
+              "id": "REQ-RENDER-REQUEST-OWNER",
+              "category": "SEMANTIC",
+              "checkpointRefs": [
+                "JRN-RENDER-001:generate-submit",
+                "JRN-RENDER-001:roundtrip-regeneration"
+              ],
+              "anyOf": [
+                {
+                  "ruleKey": "semantic-owner.render-request",
+                  "subjectCategory": "definition-path",
+                  "subject": "services/session-request.js"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "resolution": {
+        "kind": "authority-covered",
+        "selectedOptionId": "canonical-typed-request-boundary",
+        "authorityRefs": [
+          "gbdraw/web/CLAUDE.md#request-and-session-boundary",
+          "gbdraw/web/CLAUDE.md#runtime-data-flow"
+        ]
+      },
+      "contracts": [
+        {
+          "ref": "tests/web/architecture-contracts.test.mjs::production rendering crosses the canonical request and Worker boundary",
+          "checkpointRefs": [
+            "JRN-RENDER-001:generate-submit"
+          ],
+          "sensitivity": "DIRECT_ASSERTION",
+          "execution": "PR_GATE",
+          "residualRisk": "This contract fixes the Generate-to-request and Worker wiring but does not compare every projected UI field or a Session round trip."
+        },
+        {
+          "ref": "tests/web/contracts/session-regenerate-intent.playwright.spec.js::no-draft session preserves preview, active config, canonical request, and catalog",
+          "checkpointRefs": [
+            "JRN-RENDER-001:fresh-result",
+            "JRN-RENDER-001:roundtrip-regeneration"
+          ],
+          "sensitivity": "DIRECT_ASSERTION",
+          "execution": "DEV_STAGING",
+          "residualRisk": "The browser contract exercises one representative current no-draft Session during dev staging; alternate modes, migrations, and every request field are not exhaustively covered here."
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Plain-language summary

This PR records how the Web app's current render-request owner and Generate entry path jointly preserve generation and Session replay behavior. It adds an inert Product Impact map and an empty human-maintainer decision registry so a later checker integration can report these relationships without guessing them. After merge, runtime and Gate behavior remain unchanged; both mapped rules are complete but stay `report-only`.

## Change class

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Establish trusted-base Product Impact authority for the existing canonical render-request boundary before report integration is enabled in a later pull request.

## User-visible impact

None. The two files are inert JSON authority, and this PR changes no Web runtime, checker orchestration, workflow, or product behavior.

## Changes

- Add complete `report-only` coverage for `canonical-path.render-request`, whose current subject is `app/run-analysis.js -> services/session-request.js`.
- Add complete `report-only` coverage for `semantic-owner.render-request`, whose current subject is `services/session-request.js`.
- Map both rules to `product.canonical-render-request-boundary` and journey `JRN-RENDER-001`, including `generate-submit`, `fresh-result`, and `roundtrip-regeneration` checkpoints.
- Record `EFF-RENDER-REQUEST-CURRENT-STATE` and `EFF-RENDER-REQUEST-ROUNDTRIP` under the single `canonical-typed-request-boundary` option.
- Keep request entry and request ownership as separate jointly required requirements: `REQ-RENDER-REQUEST-ENTRY` and `REQ-RENDER-REQUEST-OWNER`.
- Select the current option from the static promises in `gbdraw/web/CLAUDE.md#runtime-data-flow` and `gbdraw/web/CLAUDE.md#request-and-session-boundary`.
- Reference the exact Generate-boundary PR contract and the dev-staging Session-regeneration contract, with their limited coverage stated as residual risk.
- Add `satoshikawato` as the only Product Decision Owner login and leave `decisions` empty. This PR introduces no product choice or durable `BD-###` decision.

## Verification

- Direct `validateProductImpactMap` and `validateProductDecisionAuthority`: both `{ valid: true, errors: [] }`.
- `node --test tests/web/product-impact-ratchet-fixtures.test.mjs`: passed.
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs`: passed.
- `node --test tests/web/architecture-contracts.test.mjs`: 118 passed, 0 failed.
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD`: `Gate: PASS`; `Review: REQUIRED` for the two governance authority files; both active architecture rules remain conforming.
- `git diff --check origin/dev...HEAD`: passed.
- `git diff --name-only origin/dev...HEAD`: exactly `tools/web-product-decisions.json` and `tools/web-product-impact-map.json`.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocking violations.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because this is an authority-only governance change.
- Architecture impact: **This is not architecture-bearing**. The current semantic owner and canonical production path are recorded but not moved, duplicated, removed, or redefined.
- `architecture-change` label, if relevant: not applicable.
- Contract scope: the PR-gated architecture assertion fixes the Generate-to-request/Worker wiring but does not compare every UI projection field. The full no-draft Session request/result comparison runs at `DEV_STAGING` and represents one current Session; alternate modes, migrations, and all request fields are not exhaustively covered by that single contract.
- Same-PR authority: candidate authority is validation-only and cannot authorize same-PR runtime. There is no runtime in this diff.

## Rollback

Revert this authority PR or remove `tools/web-product-impact-map.json` and `tools/web-product-decisions.json` together. No checker reporting, Gate behavior, workflow, or runtime has been enabled.

## Conditional Product Impact

- Product-impact role: DECISION_ONLY
- Affected concern(s), if known: `product.canonical-render-request-boundary`
- Authority and decision references: `gbdraw/web/CLAUDE.md#runtime-data-flow`; `gbdraw/web/CLAUDE.md#request-and-session-boundary`; decision registry empty
- Behavior contracts and residual risk: `tests/web/architecture-contracts.test.mjs::production rendering crosses the canonical request and Worker boundary` at `PR_GATE`; `tests/web/contracts/session-regenerate-intent.playwright.spec.js::no-draft session preserves preview, active config, canonical request, and catalog` at `DEV_STAGING`; limitations are stated above and in the map

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `tools/web-product-impact-map.json`; `tools/web-product-decisions.json`
- Checker implementation files touched: none
- Self-authorization separation evidence: the diff contains only the two inert authority files; merged base validators check them; candidate authority is not used for same-PR runtime admission
- Branch-protection or ruleset impact, including unchanged settings: none; required status contexts and workflow triggers are unchanged
- Governance-specific rollback or protection restore point: revert commit `d14723d179a618a51e5a7485a49d49b4f785a04b`; no protection setting needs restoration
