### PR TITLE
Integrate trusted Product Impact reporting

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -132,6 +132,8 @@ const PRODUCT_DECISIONS_PATH = join(
   REPOSITORY_ROOT,
   'tools/web-product-decisions.json'
 );
+const PRODUCT_IMPACT_MAP_SOURCE = readFileSync(PRODUCT_IMPACT_MAP_PATH, 'utf8');
+const PRODUCT_DECISIONS_SOURCE = readFileSync(PRODUCT_DECISIONS_PATH, 'utf8');
 
 const normalizePath = (path) => path.split(sep).join('/');
 const relativeModulePath = (path) => normalizePath(relative(JAVASCRIPT_ROOT, path));
@@ -715,6 +717,14 @@ test('Product Impact authority bootstrap accepts zero or two inert JSON files', 
     valid: true,
     errors: []
   });
+  assert.deepEqual(
+    map.ruleCoverage.map(({ enforcement }) => enforcement),
+    ['report-only', 'report-only']
+  );
+  assert.deepEqual(decisions.decisions, []);
+  map.concerns.flatMap(({ contracts }) => contracts).forEach(({ ref }) => {
+    assert.equal(existsSync(join(REPOSITORY_ROOT, ref.split('::', 1)[0])), true, ref);
+  });
 });
 
 test('registered architecture authority and executable matching have separate owners', () => {
@@ -751,11 +761,22 @@ test('the Web checker remains the sole evaluator orchestrator and CLI entry poin
   assert.match(WEB_CHANGE_BUDGET_SOURCE, /^#!\/usr\/bin\/env node/);
   assert.match(WEB_CHANGE_BUDGET_SOURCE, /WEB_ARCHITECTURE_DETECTORS\[rule\.detector\]/);
   assert.doesNotMatch(WEB_CHANGE_BUDGET_SOURCE, /import\s*\(.*web-architecture-detectors/);
-  assert.doesNotMatch(
+  assert.match(
     WEB_CHANGE_BUDGET_SOURCE,
     /from '\.\/web-product-impact-(?:evaluation|decision-source)\.mjs'/
   );
-  assert.doesNotMatch(WEB_CHANGE_BUDGET_SOURCE, /## Product impact/);
+  [
+    'createArchitectureSubjectDelta',
+    'evaluateProductImpact',
+    'parseCurrentProductImpactDecisions',
+    'validateProductDecisionAuthority',
+    'validateProductImpactMap'
+  ].forEach((name) => {
+    assert.match(WEB_CHANGE_BUDGET_SOURCE, new RegExp(`\\b${name}\\s*\\(`));
+  });
+  assert.match(WEB_CHANGE_BUDGET_SOURCE, /## Product impact/);
+  assert.match(WEB_CHANGE_BUDGET_SOURCE, /NOT_AUTHORITATIVE_CANDIDATE/);
+  assert.match(WEB_CHANGE_BUDGET_SOURCE, /candidate data does not alter this head runtime admission/);
 });
 
 test('report-only source facts preserve the characterized masking behavior', () => {
@@ -1326,6 +1347,9 @@ const BUDGET_FIXTURE = Object.freeze({
   'docs/internal/WEB_CHANGE_POLICY.md': '# Baseline Web change policy\n',
   'package.json': '{"private":true}\n',
   'tests/web/architecture-contracts.test.mjs': '// baseline contract\n',
+  'tests/web/contracts/session-regenerate-intent.playwright.spec.js': (
+    "test('no-draft session preserves preview, active config, canonical request, and catalog', () => {});\n"
+  ),
   'tests/web/promotion-readiness.test.mjs': readFileSync(
     PROMOTION_READINESS_TEST,
     'utf8'
@@ -1351,6 +1375,8 @@ const BUDGET_FIXTURE = Object.freeze({
     PRODUCT_IMPACT_DECISION_MODULE,
     'utf8'
   ),
+  'tools/web-product-impact-map.json': PRODUCT_IMPACT_MAP_SOURCE,
+  'tools/web-product-decisions.json': PRODUCT_DECISIONS_SOURCE,
   'tools/web-architecture-rules.json': WEB_ARCHITECTURE_RULES_SOURCE,
   'tools/web-change-source.mjs': readFileSync(
     join(REPOSITORY_ROOT, 'tools/web-change-source.mjs'),
@@ -1645,6 +1671,12 @@ const assertRevisionChangeBudgetFailure = (mutate, expectedPatterns) => {
 
 const TRUSTED_ARCHITECTURE_FIXTURE_FILES = Object.freeze({
   'package.json': '{"private":true}\n',
+  'tests/web/architecture-contracts.test.mjs': (
+    "test('production rendering crosses the canonical request and Worker boundary', () => {});\n"
+  ),
+  'tests/web/contracts/session-regenerate-intent.playwright.spec.js': (
+    "test('no-draft session preserves preview, active config, canonical request, and catalog', () => {});\n"
+  ),
   'tools/check-web-change-budget.mjs': readFileSync(CHANGE_BUDGET_CHECKER, 'utf8'),
   'tools/web-architecture-detectors.mjs': readFileSync(
     WEB_ARCHITECTURE_DETECTOR_MODULE,
@@ -1655,6 +1687,16 @@ const TRUSTED_ARCHITECTURE_FIXTURE_FILES = Object.freeze({
     'utf8'
   ),
   'tools/web-architecture-rules.json': WEB_ARCHITECTURE_RULES_SOURCE,
+  'tools/web-product-impact-evaluation.mjs': readFileSync(
+    PRODUCT_IMPACT_EVALUATION_MODULE,
+    'utf8'
+  ),
+  'tools/web-product-impact-decision-source.mjs': readFileSync(
+    PRODUCT_IMPACT_DECISION_MODULE,
+    'utf8'
+  ),
+  'tools/web-product-impact-map.json': PRODUCT_IMPACT_MAP_SOURCE,
+  'tools/web-product-decisions.json': PRODUCT_DECISIONS_SOURCE,
   'tools/web-change-policy.json': readFileSync(
     join(REPOSITORY_ROOT, 'tools/web-change-policy.json'),
     'utf8'
@@ -1708,11 +1750,198 @@ const preauthorizedCanonicalRulesSource = rulesSource((rules) => {
 const reportOnlyCanonicalRulesSource = rulesSource((rules) => {
   canonicalRule(rules).enforcement = 'report-only';
 });
+const productImpactMapSourceForRules = (architectureSource) => {
+  const map = JSON.parse(PRODUCT_IMPACT_MAP_SOURCE);
+  const architecture = JSON.parse(architectureSource);
+  const rules = new Map(architecture.rules.map((rule) => [rule.key, rule]));
+  const concern = map.concerns[0];
+  const requirements = new Map(
+    concern.options[0].requirements.map((requirement) => [requirement.id, requirement])
+  );
+  requirements.get('REQ-RENDER-REQUEST-ENTRY').anyOf = rules
+    .get('canonical-path.render-request').allowedEdges.map(({ from, to }) => ({
+      ruleKey: 'canonical-path.render-request',
+      subjectCategory: 'canonical-entry-edge',
+      subject: `${from} -> ${to}`
+    }));
+  requirements.get('REQ-RENDER-REQUEST-OWNER').anyOf = rules
+    .get('semantic-owner.render-request').allowedDefinitionPaths.map((subject) => ({
+      ruleKey: 'semantic-owner.render-request',
+      subjectCategory: 'definition-path',
+      subject
+    }));
+  return `${JSON.stringify(map, null, 2)}\n`;
+};
+const canonicalTransitionProductImpactMapSource = ({
+  enforcement = 'report-only',
+  resolution = { kind: 'decision-required' }
+} = {}) => {
+  const map = JSON.parse(PRODUCT_IMPACT_MAP_SOURCE);
+  const concern = map.concerns[0];
+  concern.scenarioRevision = 2;
+  concern.options = [
+    {
+      id: 'after-entry-option',
+      summary: 'Generation uses the preauthorized alternate entry and preserves the supported Result and Session continuation.',
+      effectRefs: [
+        'EFF-RENDER-REQUEST-CURRENT-STATE',
+        'EFF-RENDER-REQUEST-ROUNDTRIP'
+      ],
+      requirements: [
+        {
+          id: 'REQ-AFTER-ENTRY',
+          category: 'SEMANTIC',
+          checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+          anyOf: [{
+            ruleKey: 'canonical-path.render-request',
+            subjectCategory: 'canonical-entry-edge',
+            subject: 'app/alternate.js -> services/session-request.js'
+          }]
+        },
+        {
+          id: 'REQ-AFTER-OWNER',
+          category: 'SEMANTIC',
+          checkpointRefs: [
+            'JRN-RENDER-001:generate-submit',
+            'JRN-RENDER-001:roundtrip-regeneration'
+          ],
+          anyOf: [{
+            ruleKey: 'semantic-owner.render-request',
+            subjectCategory: 'definition-path',
+            subject: 'services/session-request.js'
+          }]
+        }
+      ]
+    },
+    {
+      id: 'before-entry-option',
+      summary: 'Generation uses the current entry and preserves the supported Result and Session continuation.',
+      effectRefs: [
+        'EFF-RENDER-REQUEST-CURRENT-STATE',
+        'EFF-RENDER-REQUEST-ROUNDTRIP'
+      ],
+      requirements: [
+        {
+          id: 'REQ-BEFORE-ENTRY',
+          category: 'SEMANTIC',
+          checkpointRefs: ['JRN-RENDER-001:generate-submit'],
+          anyOf: [{
+            ruleKey: 'canonical-path.render-request',
+            subjectCategory: 'canonical-entry-edge',
+            subject: 'app/run-analysis.js -> services/session-request.js'
+          }]
+        },
+        {
+          id: 'REQ-BEFORE-OWNER',
+          category: 'SEMANTIC',
+          checkpointRefs: [
+            'JRN-RENDER-001:generate-submit',
+            'JRN-RENDER-001:roundtrip-regeneration'
+          ],
+          anyOf: [{
+            ruleKey: 'semantic-owner.render-request',
+            subjectCategory: 'definition-path',
+            subject: 'services/session-request.js'
+          }]
+        }
+      ]
+    }
+  ];
+  concern.resolution = resolution;
+  map.ruleCoverage.forEach((coverage) => { coverage.enforcement = enforcement; });
+  if (enforcement === 'hard') {
+    concern.contracts.forEach((contract) => {
+      contract.execution = 'PR_GATE';
+    });
+  }
+  return `${JSON.stringify(map, null, 2)}\n`;
+};
+const preauthorizedProductPolicy = JSON.parse(JSON.stringify(WEB_CHANGE_POLICY));
+for (const target of ['services/diagram-generation.js', 'services/session-request.js']) {
+  preauthorizedProductPolicy.allowedPrivilegedImporters[target].push('app/alternate.js');
+  preauthorizedProductPolicy.allowedPrivilegedImporters[target].sort();
+}
+for (const capability of ['Diagram Worker', 'Render request']) {
+  preauthorizedProductPolicy.allowedPrivilegedOwners[capability].push('app/alternate.js');
+  preauthorizedProductPolicy.allowedPrivilegedOwners[capability].sort();
+}
+const preauthorizedProductBaseFiles = (mapSource) => ({
+  'tools/web-architecture-rules.json': preauthorizedCanonicalRulesSource,
+  'tools/web-change-policy.json': `${JSON.stringify(preauthorizedProductPolicy, null, 2)}\n`,
+  'tools/web-product-impact-map.json': mapSource
+});
+const moveCanonicalEntry = (write) => {
+  write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n');
+  write('gbdraw/web/js/app/alternate.js', canonicalCallerSource);
+};
+const currentDecisionBody = (head, overrides = {}) => {
+  const decision = {
+    concernKey: 'product.canonical-render-request-boundary',
+    scenarioRevision: 2,
+    selectedOptionId: 'after-entry-option',
+    acceptedImpactClass: 'AFFORDANCE_PRESERVED',
+    rationale: 'The entry changes while the supported Result and Session continuation remains intact.',
+    acknowledgedChangedRequirementRefs: ['REQ-AFTER-ENTRY', 'REQ-BEFORE-ENTRY'],
+    evidenceRefs: [
+      'tests/web/architecture-contracts.test.mjs::production rendering crosses the canonical request and Worker boundary'
+    ],
+    residualRisk: 'Alternate modes remain covered by the mapped staging contract.',
+    ...overrides
+  };
+  return [
+    '<!-- gbdraw-product-impact-decision:start -->',
+    JSON.stringify({ schemaVersion: 1, headSha: head, decisions: [decision] }),
+    '<!-- gbdraw-product-impact-decision:end -->'
+  ].join('\n');
+};
+const productImpactPullRequestEnvironment = ({
+  author = 'satoshikawato',
+  baseRef = 'dev',
+  body = '',
+  eventName = 'pull_request_target',
+  summary = false
+} = {}) => ({ base, head, root }) => {
+  const eventPath = join(root, '.git', 'product-impact-event.json');
+  const resolvedBody = typeof body === 'function' ? body({ base, head }) : body;
+  writeFileSync(eventPath, JSON.stringify({
+    pull_request: {
+      base: {
+        ref: baseRef,
+        sha: base,
+        repo: { full_name: 'satoshikawato/gbdraw' }
+      },
+      head: {
+        ref: 'feature/product-impact-fixture',
+        sha: head,
+        repo: { full_name: 'satoshikawato/gbdraw' }
+      },
+      user: { login: author },
+      body: resolvedBody
+    }
+  }), 'utf8');
+  return {
+    GITHUB_EVENT_NAME: eventName,
+    GITHUB_EVENT_PATH: eventPath,
+    GITHUB_REPOSITORY: 'satoshikawato/gbdraw',
+    ...(summary ? { GITHUB_STEP_SUMMARY: join(root, 'product-impact-summary.md') } : {})
+  };
+};
 
-const withTrustedArchitectureRepository = (mutateHead, runCase, baseFiles = {}) => {
+const withTrustedArchitectureRepository = (
+  mutateHead,
+  runCase,
+  baseFiles = {},
+  executionEnvironment = {}
+) => {
   const root = mkdtempSync(join(tmpdir(), 'gbdraw-architecture-ratchet-'));
   try {
-    Object.entries({ ...TRUSTED_ARCHITECTURE_FIXTURE_FILES, ...baseFiles })
+    const fixtureFiles = { ...TRUSTED_ARCHITECTURE_FIXTURE_FILES, ...baseFiles };
+    if (!Object.hasOwn(baseFiles, 'tools/web-product-impact-map.json')) {
+      fixtureFiles['tools/web-product-impact-map.json'] = productImpactMapSourceForRules(
+        fixtureFiles['tools/web-architecture-rules.json']
+      );
+    }
+    Object.entries(fixtureFiles)
       .forEach(([path, content]) => writeFixtureFile(root, path, content));
     const git = (args) => spawnSync('git', args, {
       cwd: root,
@@ -1730,6 +1959,9 @@ const withTrustedArchitectureRepository = (mutateHead, runCase, baseFiles = {}) 
     assert.equal(git(['commit', '--quiet', '-m', 'candidate head']).status, 0);
     const head = git(['rev-parse', 'HEAD']).stdout.trim();
     assert.equal(git(['checkout', '--quiet', '--detach', base]).status, 0);
+    const extraEnvironment = typeof executionEnvironment === 'function'
+      ? executionEnvironment({ base, head, root })
+      : executionEnvironment;
     const result = spawnSync(process.execPath, [
       'tools/check-web-change-budget.mjs',
       '--base', base,
@@ -1739,15 +1971,19 @@ const withTrustedArchitectureRepository = (mutateHead, runCase, baseFiles = {}) 
       encoding: 'utf8',
       env: {
         ...process.env,
+        GITHUB_ACTIONS: '',
         GITHUB_EVENT_NAME: '',
         GITHUB_EVENT_PATH: '',
-        GITHUB_REPOSITORY: ''
+        GITHUB_REPOSITORY: '',
+        GITHUB_STEP_SUMMARY: '',
+        ...extraEnvironment
       },
       stdio: ['ignore', 'pipe', 'pipe']
     });
     runCase({
       base,
       head,
+      root,
       status: result.status,
       output: `${result.stdout || ''}${result.stderr || ''}`
     });
@@ -2057,6 +2293,429 @@ test('a preauthorized one-for-one canonical path move passes and requires review
   );
 });
 
+test('trusted Product Impact stays absent for unchanged source and non-authoritative pull requests', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('fixture-note.txt', 'no registered Product Impact delta\n'),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.doesNotMatch(output, /## Product impact/);
+    },
+    {},
+    productImpactPullRequestEnvironment()
+  );
+
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.doesNotMatch(output, /## Product impact/);
+      assert.doesNotMatch(output, /PRIVATE-CANDIDATE-BODY/);
+    },
+    preauthorizedProductBaseFiles(
+      productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+    ),
+    productImpactPullRequestEnvironment({
+      eventName: 'pull_request',
+      body: '<!-- gbdraw-product-impact-decision:start -->PRIVATE-CANDIDATE-BODY'
+    })
+  );
+
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.doesNotMatch(output, /## Product impact/);
+      assert.doesNotMatch(output, /PRIVATE-NON-DEV-BODY/);
+    },
+    preauthorizedProductBaseFiles(
+      productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+    ),
+    productImpactPullRequestEnvironment({
+      baseRef: 'feature-base',
+      body: '<!-- gbdraw-product-impact-decision:start -->PRIVATE-NON-DEV-BODY'
+    })
+  );
+});
+
+test('trusted Product Impact reports a mapped provider substitution as one conforming concern', () => {
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /## Product impact/);
+      assert.match(output, /Runtime context: TRUSTED_BASE_PULL_REQUEST/);
+      assert.match(output, /Impact: NO_USER_VISIBLE_DIFFERENCE/);
+      assert.match(output, /Observation: CONFORMING/);
+      assert.match(output, /Gate contribution: None \(report-only/);
+      assert.equal(
+        [...output.matchAll(/### product\.canonical-render-request-boundary/g)].length,
+        1
+      );
+    },
+    preauthorizedProductBaseFiles(
+      productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+    ),
+    productImpactPullRequestEnvironment()
+  );
+});
+
+test('two changed architecture rules still produce one trusted Product Impact concern packet', () => {
+  const rules = JSON.parse(preauthorizedCanonicalRulesSource);
+  canonicalRule(rules).allowedEdges = [
+    { from: 'app/alternate.js', to: 'services/future-session-request.js' },
+    { from: 'app/run-analysis.js', to: 'services/session-request.js' }
+  ];
+  rules.rules.find(({ key }) => key === 'semantic-owner.render-request')
+    .allowedDefinitionPaths = [
+      'services/future-session-request.js',
+      'services/session-request.js'
+    ];
+  const twoRuleSource = `${JSON.stringify(rules, null, 2)}\n`;
+  withTrustedArchitectureRepository(
+    (write) => {
+      write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n');
+      write(
+        'gbdraw/web/js/app/alternate.js',
+        canonicalCallerSource.replaceAll('session-request.js', 'future-session-request.js')
+      );
+      write(
+        'gbdraw/web/js/services/session-request.js',
+        'export const retiredRequestHelper = () => ({});\n'
+      );
+      write(
+        'gbdraw/web/js/services/future-session-request.js',
+        'export const buildCanonicalRenderRequest = () => ({});\n'
+      );
+    },
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Rule: `canonical-path\.render-request`/);
+      assert.match(output, /Rule: `semantic-owner\.render-request`/);
+      assert.equal(
+        [...output.matchAll(/### product\.canonical-render-request-boundary/g)].length,
+        1
+      );
+      assert.match(output, /Observation: CONFORMING/);
+    },
+    {
+      ...preauthorizedProductBaseFiles(productImpactMapSourceForRules(twoRuleSource)),
+      'tools/web-architecture-rules.json': twoRuleSource
+    },
+    productImpactPullRequestEnvironment()
+  );
+});
+
+test('report-only Product Impact regression requires review without changing a passing Gate', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n'),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Gate: \*\*PASS\*\*/);
+      assert.match(output, /Review: \*\*REQUIRED\*\*/);
+      assert.match(output, /Impact: RETIREMENT/);
+      assert.match(output, /Observation: ORDINARY_REGRESSION/);
+      assert.match(output, /Gate contribution: None \(report-only/);
+    },
+    { 'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource },
+    productImpactPullRequestEnvironment()
+  );
+});
+
+test('Decision Pack routing is outcome-oriented and accepts only an eligible exact-head decision', () => {
+  const transitionMap = canonicalTransitionProductImpactMapSource();
+  const baseFiles = preauthorizedProductBaseFiles(transitionMap);
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Observation: UNRESOLVED_DECISION/);
+      assert.match(output, /#### Decision Pack/);
+      for (const code of ['A', 'B', 'C', 'D', 'E', 'F']) {
+        assert.match(output, new RegExp(`  - ${code}\\.`));
+      }
+      assert.match(output, /B\..*after-entry-option.*PR_LOCAL_ALLOWED/);
+      assert.match(output, /Action: Configure the diagram inputs and layout -> Select Generate/);
+      assert.match(output, /Effects: `EFF-RENDER-REQUEST-CURRENT-STATE`:/);
+      assert.match(output, /Concern: product\.canonical-render-request-boundary/);
+      assert.match(output, /Scenario revision: 2/);
+      assert.match(output, /The human does not edit JSON, SHA, requirement refs, or evidence refs/);
+    },
+    baseFiles,
+    productImpactPullRequestEnvironment()
+  );
+
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Resolution: CURRENT_MAINTAINER_DECISION/);
+      assert.match(output, /Observation: CONFORMING/);
+      assert.match(
+        output,
+        /entry changes while the supported Result and Session continuation remains intact/
+      );
+      assert.match(output, /\\<script\\>not markup\\<\/script\\>/);
+      assert.equal(output.includes('<script>'), false);
+      assert.doesNotMatch(output, /#### Decision Pack/);
+    },
+    baseFiles,
+    productImpactPullRequestEnvironment({
+      body: ({ head }) => currentDecisionBody(head, {
+        rationale: (
+          'The entry changes while the supported Result and Session continuation remains intact; '
+          + '<script>not markup</script>.'
+        )
+      })
+    })
+  );
+});
+
+test('stale and non-maintainer Product Impact decisions remain unresolved and routed', () => {
+  const baseFiles = preauthorizedProductBaseFiles(
+    canonicalTransitionProductImpactMapSource()
+  );
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Current decision declaration/);
+      assert.match(output, /Observation: INSUFFICIENT_EVIDENCE/);
+      assert.match(output, /Observation: UNRESOLVED_DECISION/);
+      assert.match(output, /review the exact current head/);
+    },
+    baseFiles,
+    productImpactPullRequestEnvironment({
+      body: () => currentDecisionBody('a'.repeat(40))
+    })
+  );
+
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /not an eligible Product Decision Owner/);
+      assert.match(output, /B\..*after-entry-option.*DURABLE_AUTHORITY_REQUIRED/);
+    },
+    baseFiles,
+    productImpactPullRequestEnvironment({
+      author: 'contributor',
+      body: ({ head }) => currentDecisionBody(head)
+    })
+  );
+});
+
+test('invalid current Product Impact authority fails closed without exposing body content', () => {
+  const secret = 'PRIVATE-SEQUENCE-DO-NOT-ECHO';
+  const baseFiles = preauthorizedProductBaseFiles(
+    canonicalTransitionProductImpactMapSource()
+  );
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /invalid-current-impact-class/);
+      assert.doesNotMatch(output, new RegExp(secret));
+    },
+    baseFiles,
+    productImpactPullRequestEnvironment({
+      body: ({ head }) => currentDecisionBody(head, {
+        acceptedImpactClass: 'PRODUCT_CHANGE',
+        rationale: secret
+      })
+    })
+  );
+});
+
+test('conflicting static and current Product Impact authority is report-only but explicit', () => {
+  const map = canonicalTransitionProductImpactMapSource({
+    resolution: {
+      kind: 'authority-covered',
+      selectedOptionId: 'before-entry-option',
+      authorityRefs: ['gbdraw/web/CLAUDE.md#runtime-data-flow']
+    }
+  });
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /Resolution: CONFLICT/);
+      assert.match(output, /Observation: AUTHORITY_CONFLICT/);
+      assert.match(output, /`STATIC_AUTHORITY` -> `before-entry-option`/);
+      assert.match(output, /`CURRENT_MAINTAINER_DECISION` -> `after-entry-option`/);
+      assert.match(output, /authority-only change/);
+    },
+    preauthorizedProductBaseFiles(map),
+    productImpactPullRequestEnvironment({
+      body: ({ head }) => currentDecisionBody(head)
+    })
+  );
+});
+
+test('candidate Product Impact authority is validation-only and cannot authorize candidate runtime', () => {
+  withTrustedArchitectureRepository(
+    (write) => {
+      moveCanonicalEntry(write);
+      write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource);
+      write(
+        'tools/web-product-impact-map.json',
+        productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+      );
+    },
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Candidate authority validation: VALID \(inert data only\)/);
+      assert.match(output, /candidate data does not alter this head runtime admission/);
+      assert.match(output, /Observation: INSUFFICIENT_EVIDENCE/);
+      assert.doesNotMatch(output, /Observation: CONFORMING/);
+    },
+    {},
+    productImpactPullRequestEnvironment()
+  );
+});
+
+test('malformed candidate Product Impact authority fails closed', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('tools/web-product-decisions.json', '{'),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /candidate Product Impact authority: Cannot parse/);
+      assert.match(output, /Gate: \*\*FAIL\*\*/);
+    },
+    {},
+    productImpactPullRequestEnvironment()
+  );
+});
+
+test('mapped contract changes are surfaced while unrelated tests add no Product Impact burden', () => {
+  const rules = JSON.parse(WEB_ARCHITECTURE_RULES_SOURCE);
+  rules.rules.forEach((rule) => { rule.enforcement = 'report-only'; });
+  const reportOnlyRules = `${JSON.stringify(rules, null, 2)}\n`;
+  withTrustedArchitectureRepository(
+    (write) => {
+      write(
+        'gbdraw/web/js/services/session-request.js',
+        'export const retiredRequestHelper = () => ({});\n'
+      );
+      write(
+        'tests/web/contracts/session-regenerate-intent.playwright.spec.js',
+        "test('no-draft session preserves preview, active config, canonical request, and catalog', () => { /* changed */ });\n"
+      );
+    },
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.match(output, /integrity=CANDIDATE_MODIFIED/);
+      assert.match(output, /mapped contract changed in the candidate/);
+      assert.match(output, /Gate contribution: None \(report-only/);
+    },
+    { 'tools/web-architecture-rules.json': reportOnlyRules },
+    productImpactPullRequestEnvironment()
+  );
+
+  withTrustedArchitectureRepository(
+    (write) => write('tests/web/unrelated.test.mjs', 'test("unrelated", () => {});\n'),
+    ({ status, output }) => {
+      assert.equal(status, 0, output);
+      assert.doesNotMatch(output, /## Product impact/);
+    },
+    {},
+    productImpactPullRequestEnvironment()
+  );
+});
+
+test('Product Impact stdout and GitHub summary use the same deterministic report', () => {
+  withTrustedArchitectureRepository(
+    (write) => write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n'),
+    ({ root, status, output }) => {
+      assert.equal(status, 0, output);
+      const summary = readFileSync(join(root, 'product-impact-summary.md'), 'utf8');
+      assert.equal(output, summary);
+      assert.match(summary, /Observation: ORDINARY_REGRESSION/);
+    },
+    { 'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource },
+    productImpactPullRequestEnvironment({ summary: true })
+  );
+});
+
+test('hard Product Impact fixtures block every blocking observation', () => {
+  const reportOnlyRules = rulesSource((rules) => {
+    rules.rules.forEach((rule) => { rule.enforcement = 'report-only'; });
+  });
+  const hardCurrentMap = (() => {
+    const map = JSON.parse(PRODUCT_IMPACT_MAP_SOURCE);
+    map.ruleCoverage.forEach((coverage) => { coverage.enforcement = 'hard'; });
+    map.concerns[0].contracts.forEach((contract) => { contract.execution = 'PR_GATE'; });
+    return `${JSON.stringify(map, null, 2)}\n`;
+  })();
+  withTrustedArchitectureRepository(
+    (write) => write('gbdraw/web/js/app/run-analysis.js', 'export const run = () => 1;\n'),
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Product Impact hard enforcement:.*ORDINARY_REGRESSION/);
+    },
+    {
+      'tools/web-architecture-rules.json': reportOnlyRules,
+      'tools/web-product-impact-map.json': hardCurrentMap
+    },
+    productImpactPullRequestEnvironment()
+  );
+
+  const hardTransition = canonicalTransitionProductImpactMapSource({ enforcement: 'hard' });
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Product Impact hard enforcement:.*UNRESOLVED_DECISION/);
+    },
+    preauthorizedProductBaseFiles(hardTransition),
+    productImpactPullRequestEnvironment()
+  );
+
+  const hardConflict = canonicalTransitionProductImpactMapSource({
+    enforcement: 'hard',
+    resolution: {
+      kind: 'authority-covered',
+      selectedOptionId: 'before-entry-option',
+      authorityRefs: ['gbdraw/web/CLAUDE.md#runtime-data-flow']
+    }
+  });
+  withTrustedArchitectureRepository(
+    moveCanonicalEntry,
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Product Impact hard enforcement:.*AUTHORITY_CONFLICT/);
+    },
+    preauthorizedProductBaseFiles(hardConflict),
+    productImpactPullRequestEnvironment({ body: ({ head }) => currentDecisionBody(head) })
+  );
+
+  const hardEvidenceMap = JSON.parse(hardTransition);
+  hardEvidenceMap.concerns[0].contracts[0].ref = (
+    'tests/web/contracts/product-impact-entry.test.mjs::canonical alternate entry'
+  );
+  const hardEvidenceSource = `${JSON.stringify(hardEvidenceMap, null, 2)}\n`;
+  withTrustedArchitectureRepository(
+    (write) => {
+      moveCanonicalEntry(write);
+      write(
+        'tests/web/contracts/product-impact-entry.test.mjs',
+        "test('canonical alternate entry', () => { /* candidate modified */ });\n"
+      );
+    },
+    ({ status, output }) => {
+      assert.equal(status, 1, output);
+      assert.match(output, /Product Impact hard enforcement:.*INSUFFICIENT_EVIDENCE/);
+      assert.match(output, /integrity=CANDIDATE_MODIFIED/);
+    },
+    {
+      ...preauthorizedProductBaseFiles(hardEvidenceSource),
+      'tests/web/contracts/product-impact-entry.test.mjs': (
+        "test('canonical alternate entry', () => {});\n"
+      )
+    },
+    productImpactPullRequestEnvironment()
+  );
+});
+
 test('report-only rules report absence without consulting an accepted store or failing', () => {
   withTrustedArchitectureRepository(
     (write) => write(
@@ -2161,9 +2820,15 @@ test('proposed detector ID and implementation cannot alter trusted source observ
   );
 });
 
-test('isolated architecture-rule preauthorization passes and requires review', () => {
+test('cross-validated inert architecture and Product Impact preauthorization passes and requires review', () => {
   withTrustedArchitectureRepository(
-    (write) => write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource),
+    (write) => {
+      write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource);
+      write(
+        'tools/web-product-impact-map.json',
+        productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+      );
+    },
     ({ status, output }) => {
       assert.equal(status, 0, output);
       assert.match(output, /Gate: \*\*PASS\*\*/);
@@ -2720,8 +3385,8 @@ test('the narrow inert authority bundle contains only architecture rules, map, a
   ]);
 
   const productAuthorityOnly = runChangeBudgetCase((write) => {
-    write('tools/web-product-impact-map.json', '{"schemaVersion":1}\n');
-    write('tools/web-product-decisions.json', '{"schemaVersion":1}\n');
+    write('tools/web-product-impact-map.json', `${PRODUCT_IMPACT_MAP_SOURCE}\n`);
+    write('tools/web-product-decisions.json', `${PRODUCT_DECISIONS_SOURCE}\n`);
   });
   assert.equal(productAuthorityOnly.status, 0, productAuthorityOnly.output);
   assert.match(productAuthorityOnly.output, /Gate: \*\*PASS\*\*/);
@@ -2729,16 +3394,22 @@ test('the narrow inert authority bundle contains only architecture rules, map, a
 
   const completeBundle = runChangeBudgetCase((write) => {
     write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource);
-    write('tools/web-product-impact-map.json', '{"schemaVersion":1}\n');
-    write('tools/web-product-decisions.json', '{"schemaVersion":1}\n');
+    write(
+      'tools/web-product-impact-map.json',
+      productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+    );
+    write('tools/web-product-decisions.json', `${PRODUCT_DECISIONS_SOURCE}\n`);
   });
   assert.equal(completeBundle.status, 0, completeBundle.output);
   assert.match(completeBundle.output, /Classification: EXPANSION/);
 
   const expandedBundle = runChangeBudgetCase((write) => {
     write('tools/web-architecture-rules.json', preauthorizedCanonicalRulesSource);
-    write('tools/web-product-impact-map.json', '{"schemaVersion":1}\n');
-    write('tools/web-product-decisions.json', '{"schemaVersion":1}\n');
+    write(
+      'tools/web-product-impact-map.json',
+      productImpactMapSourceForRules(preauthorizedCanonicalRulesSource)
+    );
+    write('tools/web-product-decisions.json', `${PRODUCT_DECISIONS_SOURCE}\n`);
     write('docs/internal/PRODUCT_IMPACT_RATCHET.md', '# changed policy\n');
   });
   assert.equal(expandedBundle.status, 1, expandedBundle.output);

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -14,11 +14,18 @@ import {
 import {
   classifyArchitectureAuthorityDelta,
   classifyArchitectureRuleObservation,
+  createArchitectureSubjectDelta,
   evaluateArchitectureRuleResult,
   findDirectedGraphCycles,
   summarizeArchitectureInventory,
   validateArchitectureRuleRegistry
 } from './web-architecture-evaluation.mjs';
+import { parseCurrentProductImpactDecisions } from './web-product-impact-decision-source.mjs';
+import {
+  evaluateProductImpact,
+  validateProductDecisionAuthority,
+  validateProductImpactMap
+} from './web-product-impact-evaluation.mjs';
 import { literalImportSpecifiers, maskJavaScript } from './web-change-source.mjs';
 import {
   classifyWebChangeContext,
@@ -33,6 +40,10 @@ const runGit = (root, args, options = {}) => execFileSync(
 
 const stableReasons = (values) => [...new Set(values.filter(Boolean))]
   .sort((left, right) => left.localeCompare(right));
+const safeReportText = (value) => String(value || '')
+  .replace(/([\\`*{}\[\]<>#|])/g, '\\$1');
+const reportSentenceFragment = (value) => safeReportText(value).replace(/[.!?]+$/, '');
+const inlineCode = (value) => `\`${String(value || '').replaceAll('`', '\\`')}\``;
 const createPolicyResult = ({
   blockingViolations = [],
   reviewReasons = [],
@@ -112,6 +123,37 @@ const changeContext = classifyWebChangeContext({
   baseSha: base,
   headSha: head
 });
+const emptyPullRequestProductImpactMetadata = Object.freeze({
+  authorLogin: '',
+  body: '',
+  headSha: '',
+  trustedToDev: false
+});
+const pullRequestProductImpactMetadata = (() => {
+  if (
+    githubEventName !== 'pull_request_target'
+    || changeContext.isPromotion
+    || changeContext.errors.length
+    || !githubEventPayloadSource
+  ) {
+    return emptyPullRequestProductImpactMetadata;
+  }
+  try {
+    const payload = JSON.parse(githubEventPayloadSource);
+    const pullRequest = payload?.pull_request;
+    if (pullRequest?.base?.ref !== 'dev') return emptyPullRequestProductImpactMetadata;
+    return Object.freeze({
+      authorLogin: typeof pullRequest?.user?.login === 'string'
+        ? pullRequest.user.login
+        : '',
+      body: typeof pullRequest?.body === 'string' ? pullRequest.body : '',
+      headSha: typeof pullRequest?.head?.sha === 'string' ? pullRequest.head.sha : '',
+      trustedToDev: true
+    });
+  } catch (_error) {
+    return emptyPullRequestProductImpactMetadata;
+  }
+})();
 
 const promotionSourceCoverage = (() => {
   if (!changeContext.isPromotion) {
@@ -226,6 +268,7 @@ if (!head) {
   ]).split('\0').filter(Boolean);
   untracked.forEach((path) => changed.set(path, 'A'));
 }
+const changedPaths = [...changed.keys()].sort();
 
 const numstat = new Map(
   parseDiffLines(runGit(repositoryRoot, [
@@ -233,12 +276,22 @@ const numstat = new Map(
   ])).map(([additions, deletions, path]) => [path, { additions, deletions }])
 );
 
+const revisionFileCache = new Map();
 const readRevisionFile = (revision, path) => {
+  const key = `${revision}\u0000${path}`;
+  if (revisionFileCache.has(key)) return revisionFileCache.get(key);
+  let source;
   try {
-    return runGit(repositoryRoot, ['show', `${revision}:${path}`], { stdio: ['ignore', 'pipe', 'ignore'] });
+    source = runGit(
+      repositoryRoot,
+      ['show', `${revision}:${path}`],
+      { stdio: ['ignore', 'pipe', 'ignore'] }
+    );
   } catch (_error) {
-    return null;
+    source = null;
   }
+  revisionFileCache.set(key, source);
+  return source;
 };
 
 const readRevisionFiles = (revision, paths) => {
@@ -693,6 +746,10 @@ let architectureAuthorityDelta = Object.freeze({
   directions: Object.freeze([]),
   changes: Object.freeze([])
 });
+let baseArchitectureRegistry = null;
+let candidateArchitectureRegistry = null;
+let baseArchitectureRuleFacts = [];
+let headArchitectureRuleFacts = [];
 
 const parseArchitectureRuleRegistry = (source, revision) => {
   if (source === null) return { registry: emptyRuleRegistry(), error: null };
@@ -731,6 +788,7 @@ const evaluateArchitectureSource = (registry, sources) => {
   const rows = [];
   const authorityLocations = [];
   const canonicalContracts = [];
+  const ruleFacts = [];
   [...registry.rules]
     .sort((left, right) => left.key.localeCompare(right.key))
     .forEach((rule) => {
@@ -738,6 +796,11 @@ const evaluateArchitectureSource = (registry, sources) => {
       try {
         const detectorOutput = detector.detect(sources);
         const observation = classifyArchitectureRuleObservation(rule, detectorOutput);
+        ruleFacts.push(Object.freeze({
+          ruleKey: rule.key,
+          subjectCategory: detector.subjectCategory,
+          subjects: Object.freeze([...observation.subjects].sort())
+        }));
         const result = evaluateArchitectureRuleResult({
           observation: observation.observation,
           mode: rule.enforcement.replace('-', '_').toUpperCase(),
@@ -773,7 +836,14 @@ const evaluateArchitectureSource = (registry, sources) => {
         errors.push(`${rule.key}: ${error.message}`);
       }
     });
-  return { errors, failures, rows, authorityLocations, canonicalContracts };
+  return {
+    errors,
+    failures,
+    rows,
+    authorityLocations,
+    canonicalContracts,
+    ruleFacts
+  };
 };
 
 const baseArchitectureRulesSource = readRevisionFile(base, architectureRulesPath);
@@ -811,6 +881,8 @@ if (baseArchitectureRulesSource !== null || proposedArchitectureRulesSource !== 
       ...formatRuleValidationErrors('candidate registry', candidateValidation)
     );
   }
+  if (baseValidation?.valid) baseArchitectureRegistry = parsedBase.registry;
+  if (candidateValidation?.valid) candidateArchitectureRegistry = parsedCandidate.registry;
 
   if (baseValidation?.valid) {
     const beforeArchitecture = evaluateArchitectureSource(
@@ -826,6 +898,8 @@ if (baseArchitectureRulesSource !== null || proposedArchitectureRulesSource !== 
     activeArchitectureErrors.push(...afterArchitecture.errors);
     activeArchitectureFailures.push(...afterArchitecture.failures);
     activeArchitectureRows.push(...afterArchitecture.rows);
+    baseArchitectureRuleFacts = beforeArchitecture.ruleFacts;
+    headArchitectureRuleFacts = afterArchitecture.ruleFacts;
     registeredAuthorityLocationDelta = summarizeArchitectureInventory(
       beforeArchitecture.authorityLocations,
       afterArchitecture.authorityLocations
@@ -915,6 +989,239 @@ if (baseArchitectureRulesSource !== null || proposedArchitectureRulesSource !== 
         }
       });
     }
+  }
+}
+
+const productImpactBaseErrors = [];
+const productImpactCandidateErrors = [];
+const productImpactDecisionDeclarationIssues = [];
+const changedProductImpactAuthorityPaths = [
+  productImpactMapPath,
+  productDecisionAuthorityPath
+].filter((path) => changed.has(path));
+const candidateAuthorityCompanionPaths = changedProductImpactAuthorityPaths.length
+  ? changedPaths.filter((path) => !narrowAuthorityBundlePaths.has(path))
+  : [];
+if (candidateAuthorityCompanionPaths.length) {
+  productImpactCandidateErrors.push(
+    'Product Impact authority changes must use only the narrow inert authority bundle: '
+    + candidateAuthorityCompanionPaths.join(', ')
+  );
+}
+
+const parseProductImpactJson = (source, path, revision, errors) => {
+  if (source === null) {
+    errors.push(`Missing required ${path} at ${revision}`);
+    return null;
+  }
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    errors.push(`Cannot parse ${path} at ${revision}: ${error.message}`);
+    return null;
+  }
+};
+const formatProductValidationErrors = (label, validation) => validation.errors.map((error) => (
+  `${label} ${error.path} [${error.code}]: ${error.message}`
+));
+const mappedContractPaths = (map) => stableReasons((map?.concerns || []).flatMap((concern) => (
+  (concern.contracts || []).map(({ ref }) => String(ref || '').split('::', 1)[0])
+)));
+const requireBaseContractFiles = (map, label, errors) => {
+  mappedContractPaths(map).forEach((path) => {
+    if (readRevisionFile(base, path) === null) {
+      errors.push(`${label} references a mapped contract file absent from trusted base: ${path}`);
+    }
+  });
+};
+
+const baseProductImpactMapSource = readRevisionFile(base, productImpactMapPath);
+const candidateProductImpactMapSource = readHeadFile(productImpactMapPath);
+const baseProductDecisionAuthoritySource = readRevisionFile(base, productDecisionAuthorityPath);
+const candidateProductDecisionAuthoritySource = readHeadFile(productDecisionAuthorityPath);
+const baseProductImpactMap = parseProductImpactJson(
+  baseProductImpactMapSource,
+  productImpactMapPath,
+  base,
+  productImpactBaseErrors
+);
+const candidateProductImpactMap = parseProductImpactJson(
+  candidateProductImpactMapSource,
+  productImpactMapPath,
+  head || 'working tree',
+  productImpactCandidateErrors
+);
+const baseProductDecisionAuthority = parseProductImpactJson(
+  baseProductDecisionAuthoritySource,
+  productDecisionAuthorityPath,
+  base,
+  productImpactBaseErrors
+);
+const candidateProductDecisionAuthority = parseProductImpactJson(
+  candidateProductDecisionAuthoritySource,
+  productDecisionAuthorityPath,
+  head || 'working tree',
+  productImpactCandidateErrors
+);
+
+let baseProductImpactMapValid = false;
+let candidateProductImpactMapValid = false;
+let baseProductDecisionAuthorityValid = false;
+let candidateProductDecisionAuthorityValid = false;
+if (baseProductImpactMap && baseArchitectureRegistry) {
+  const validation = validateProductImpactMap(
+    baseProductImpactMap,
+    baseArchitectureRegistry,
+    WEB_ARCHITECTURE_DETECTORS
+  );
+  baseProductImpactMapValid = validation.valid;
+  productImpactBaseErrors.push(...formatProductValidationErrors('base Product Impact map', validation));
+  if (validation.valid) requireBaseContractFiles(
+    baseProductImpactMap,
+    'Base Product Impact map',
+    productImpactBaseErrors
+  );
+}
+if (candidateProductImpactMap && candidateArchitectureRegistry) {
+  const validation = validateProductImpactMap(
+    candidateProductImpactMap,
+    candidateArchitectureRegistry,
+    WEB_ARCHITECTURE_DETECTORS
+  );
+  candidateProductImpactMapValid = validation.valid;
+  productImpactCandidateErrors.push(
+    ...formatProductValidationErrors('candidate Product Impact map', validation)
+  );
+  if (validation.valid) requireBaseContractFiles(
+    candidateProductImpactMap,
+    'Candidate Product Impact map',
+    productImpactCandidateErrors
+  );
+}
+if (baseProductDecisionAuthority && baseProductImpactMapValid) {
+  const validation = validateProductDecisionAuthority(
+    baseProductDecisionAuthority,
+    baseProductImpactMap
+  );
+  baseProductDecisionAuthorityValid = validation.valid;
+  productImpactBaseErrors.push(
+    ...formatProductValidationErrors('base Product Impact decisions', validation)
+  );
+}
+if (candidateProductDecisionAuthority && candidateProductImpactMapValid) {
+  const validation = validateProductDecisionAuthority(
+    candidateProductDecisionAuthority,
+    candidateProductImpactMap
+  );
+  candidateProductDecisionAuthorityValid = validation.valid;
+  productImpactCandidateErrors.push(
+    ...formatProductValidationErrors('candidate Product Impact decisions', validation)
+  );
+}
+
+const trustedBasePullRequest = githubEventName === 'pull_request_target'
+  && pullRequestProductImpactMetadata.trustedToDev;
+const productImpactRuntimeStatus = trustedBasePullRequest
+  ? 'TRUSTED_BASE_PULL_REQUEST'
+  : isPullRequestEvent(githubEventName)
+    ? 'NOT_AUTHORITATIVE_CANDIDATE'
+    : ['push', 'workflow_dispatch'].includes(githubEventName)
+      ? 'TRUSTED_INTEGRATED_DIFF'
+      : 'TRUSTED_LOCAL_DIFF';
+const parseCurrentDecisionSource = ({ body = '', authorLogin = '', headSha = '' } = {}) => (
+  parseCurrentProductImpactDecisions({
+    body,
+    eventAuthorLogin: authorLogin,
+    eventHeadSha: headSha
+  })
+);
+let currentProductImpactDecisions = parseCurrentDecisionSource();
+if (productImpactRuntimeStatus === 'TRUSTED_BASE_PULL_REQUEST') {
+  currentProductImpactDecisions = parseCurrentDecisionSource({
+    body: pullRequestProductImpactMetadata.body,
+    authorLogin: pullRequestProductImpactMetadata.authorLogin,
+    headSha: pullRequestProductImpactMetadata.headSha
+  });
+}
+if (!currentProductImpactDecisions.valid) {
+  const staleOnly = currentProductImpactDecisions.errors.length > 0
+    && currentProductImpactDecisions.errors.every(({ code }) => code === 'stale-head-sha');
+  if (staleOnly) {
+    productImpactDecisionDeclarationIssues.push(
+      'Observation: INSUFFICIENT_EVIDENCE. The current decision is stale for the event head SHA.'
+    );
+    currentProductImpactDecisions = parseCurrentDecisionSource({
+      authorLogin: pullRequestProductImpactMetadata.authorLogin,
+      headSha: pullRequestProductImpactMetadata.headSha
+    });
+  } else {
+    productImpactBaseErrors.push(...currentProductImpactDecisions.errors.map((error) => (
+      `current Product Impact decision ${error.path} [${error.code}]: ${error.message}`
+    )));
+  }
+}
+
+const baseRuleFactsByKey = new Map(
+  baseArchitectureRuleFacts.map((fact) => [fact.ruleKey, fact])
+);
+const headRuleFactsByKey = new Map(
+  headArchitectureRuleFacts.map((fact) => [fact.ruleKey, fact])
+);
+const productImpactRuleFacts = [];
+const productImpactSubjectDeltas = [];
+if (baseArchitectureRegistry) {
+  [...baseArchitectureRegistry.rules]
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .forEach((rule) => {
+      const before = baseRuleFactsByKey.get(rule.key);
+      const after = headRuleFactsByKey.get(rule.key);
+      if (!before || !after) {
+        productImpactBaseErrors.push(
+          `Product Impact source facts are missing for architecture rule ${rule.key}`
+        );
+        return;
+      }
+      productImpactRuleFacts.push(Object.freeze({
+        ruleKey: rule.key,
+        subjectCategory: before.subjectCategory,
+        beforeSubjects: before.subjects,
+        afterSubjects: after.subjects
+      }));
+      try {
+        productImpactSubjectDeltas.push(createArchitectureSubjectDelta({
+          ruleKey: rule.key,
+          kind: rule.kind,
+          detector: rule.detector,
+          subjectCategory: before.subjectCategory,
+          beforeSubjects: before.subjects,
+          afterSubjects: after.subjects
+        }));
+      } catch (error) {
+        productImpactBaseErrors.push(
+          `Product Impact subject delta failed for ${rule.key}: ${error.message}`
+        );
+      }
+    });
+}
+
+let productImpactResults = [];
+if (
+  productImpactRuntimeStatus !== 'NOT_AUTHORITATIVE_CANDIDATE'
+  && baseProductImpactMapValid
+  && baseProductDecisionAuthorityValid
+  && !productImpactBaseErrors.length
+) {
+  try {
+    productImpactResults = evaluateProductImpact({
+      subjectDeltas: productImpactSubjectDeltas,
+      ruleFacts: productImpactRuleFacts,
+      map: baseProductImpactMap,
+      decisionAuthority: baseProductDecisionAuthority,
+      currentDecisions: currentProductImpactDecisions,
+      changedPaths
+    });
+  } catch (error) {
+    productImpactBaseErrors.push(`Product Impact runtime evaluation failed: ${error.message}`);
   }
 }
 
@@ -1070,7 +1377,6 @@ const architectureSignalDeltas = [
 const changedArchitectureSignals = architectureSignalDeltas
   .filter(([, delta]) => deltaChanged(delta))
   .map(([name]) => name);
-const changedPaths = [...changed.keys()].sort();
 const performanceEvidencePaths = new Set([
   'tests/test_gallery_publication_performance.py',
   'tests/test_performance_short_circuits.py',
@@ -1132,11 +1438,45 @@ if (changedSessionContractPaths.length) {
     `Material behavior/output risk: registered session or compatibility paths changed (${changedSessionContractPaths.join(', ')})`
   );
 }
+if (changedProductImpactAuthorityPaths.length) {
+  reviewReasons.push(
+    'Governance and authority: Product Impact authority changed for future revisions '
+    + `(${changedProductImpactAuthorityPaths.join(', ')})`
+  );
+}
+if (productImpactDecisionDeclarationIssues.length) {
+  reviewReasons.push(
+    `Product impact: current decision declaration requires attention (${productImpactDecisionDeclarationIssues.length} issue(s))`
+  );
+}
+productImpactResults.forEach((result) => {
+  const candidateModifiedContracts = result.contractResults
+    .filter(({ candidateModified }) => candidateModified)
+    .map(({ ref }) => ref);
+  if (
+    result.observation !== 'CONFORMING'
+    || result.impactClass !== 'NO_USER_VISIBLE_DIFFERENCE'
+    || result.currentDecisionIssues.length
+    || candidateModifiedContracts.length
+  ) {
+    reviewReasons.push(
+      `Product impact: ${result.concernKey} is ${result.observation} `
+      + `with ${result.impactClass}`
+    );
+  }
+  if (candidateModifiedContracts.length) {
+    reviewReasons.push(
+      `Product impact: mapped contract changed in the candidate (${candidateModifiedContracts.join(', ')})`
+    );
+  }
+});
 
 const blockingViolations = [
   ...changeContext.errors,
   ...acceptedViolationAuthorityErrors,
-  ...unsafeTrustedWorkflowChanges
+  ...unsafeTrustedWorkflowChanges,
+  ...productImpactBaseErrors.map((error) => `trusted Product Impact authority: ${error}`),
+  ...productImpactCandidateErrors.map((error) => `candidate Product Impact authority: ${error}`)
 ];
 if (newProductionDependencies.length) {
   blockingViolations.push('new production dependencies are not allowed');
@@ -1195,6 +1535,38 @@ blockingViolations.push(...activeArchitectureErrors.map((error) => (
 blockingViolations.push(...activeArchitectureFailures.map((error) => (
   `active architecture rules: ${error}`
 )));
+const productImpactCoverageByRule = new Map(
+  (baseProductImpactMap?.ruleCoverage || []).map((coverage) => [coverage.ruleKey, coverage])
+);
+const productImpactResultRuleKeys = (result) => {
+  if (result.triggeringRuleKeys.length) return result.triggeringRuleKeys;
+  const concern = (baseProductImpactMap?.concerns || []).find(({ key }) => (
+    key === result.concernKey
+  ));
+  return stableReasons((concern?.options || []).flatMap((option) => (
+    option.requirements.flatMap((requirement) => (
+      requirement.anyOf.map(({ ruleKey }) => ruleKey)
+    ))
+  )));
+};
+productImpactResults.forEach((result) => {
+  const hard = productImpactResultRuleKeys(result).some((ruleKey) => (
+    productImpactCoverageByRule.get(ruleKey)?.enforcement === 'hard'
+  ));
+  if (
+    hard
+    && [
+      'AUTHORITY_CONFLICT',
+      'INSUFFICIENT_EVIDENCE',
+      'ORDINARY_REGRESSION',
+      'UNRESOLVED_DECISION'
+    ].includes(result.observation)
+  ) {
+    blockingViolations.push(
+      `Product Impact hard enforcement: ${result.concernKey} is ${result.observation}`
+    );
+  }
+});
 const policyResult = createPolicyResult({
   blockingViolations,
   reviewReasons,
@@ -1202,6 +1574,8 @@ const policyResult = createPolicyResult({
   observations: {
     architectureAuthorityDelta,
     changedArchitectureSignals,
+    productImpactResults,
+    productImpactRuntimeStatus,
     productionGrossChurn,
     productionNetAdditions,
     productionPaths,
@@ -1316,6 +1690,277 @@ const fanOutRows = fanOutPaths.map((path) => {
   return `| ${path} | ${beforeCount} | ${afterCount} | ${signed(afterCount - beforeCount)} |`;
 });
 const statusRows = productionPaths.map((path) => `${changed.get(path)} ${path}`);
+const productConcernByKey = new Map(
+  (baseProductImpactMap?.concerns || []).map((concern) => [concern.key, concern])
+);
+const productDecisionOwnerLogin = currentProductImpactDecisions.metadata.eventAuthorLogin;
+const productDecisionOwnerEligible = Boolean(
+  productDecisionOwnerLogin
+  && baseProductDecisionAuthority?.maintainerLogins?.includes(productDecisionOwnerLogin)
+);
+const stableIntersection = (left, right) => {
+  const rightSet = new Set(right);
+  return left.filter((value) => rightSet.has(value));
+};
+const productImpactGateContribution = (result) => {
+  const hard = productImpactResultRuleKeys(result).some((ruleKey) => (
+    productImpactCoverageByRule.get(ruleKey)?.enforcement === 'hard'
+  ));
+  const blocking = [
+    'AUTHORITY_CONFLICT',
+    'INSUFFICIENT_EVIDENCE',
+    'ORDINARY_REGRESSION',
+    'UNRESOLVED_DECISION'
+  ].includes(result.observation);
+  return hard && blocking ? 'FAIL' : 'None (report-only for the triggering rule set)';
+};
+const renderDecisionPack = (result, concern) => {
+  const optionsById = new Map(concern.options.map((option) => [option.id, option]));
+  const optionResultsById = new Map(
+    result.optionResults.map((option) => [option.optionId, option])
+  );
+  const beforeOptionId = result.beforeOptions[0] || '';
+  const afterOptionId = result.afterOptions[0] || '';
+  const beforeEffects = result.beforeEffects;
+  const routeForMappedOption = (optionId) => {
+    const optionResult = optionResultsById.get(optionId);
+    if (!optionResult?.afterRealized) return 'NOT_ALLOWED';
+    const effectEquivalent = JSON.stringify([...optionResult.effectRefs].sort())
+      === JSON.stringify([...beforeEffects].sort());
+    if (!effectEquivalent) return 'DURABLE_AUTHORITY_REQUIRED';
+    return productDecisionOwnerEligible
+      ? 'PR_LOCAL_ALLOWED'
+      : 'DURABLE_AUTHORITY_REQUIRED';
+  };
+  const choices = [
+    {
+      code: 'A',
+      optionId: beforeOptionId,
+      outcome: beforeOptionId
+        ? `Keep the before behavior: ${optionsById.get(beforeOptionId)?.summary || beforeOptionId}`
+        : 'Keep the before behavior.',
+      route: beforeOptionId ? routeForMappedOption(beforeOptionId) : 'NOT_ALLOWED'
+    },
+    {
+      code: 'B',
+      optionId: afterOptionId,
+      outcome: afterOptionId
+        ? `Select the after behavior: ${optionsById.get(afterOptionId)?.summary || afterOptionId}`
+        : 'Select the after behavior.',
+      route: afterOptionId ? routeForMappedOption(afterOptionId) : 'NOT_ALLOWED'
+    },
+    {
+      code: 'C',
+      optionId: '',
+      outcome: 'Define a new mapped option that combines useful properties.',
+      route: 'DURABLE_AUTHORITY_REQUIRED'
+    },
+    {
+      code: 'D',
+      optionId: '',
+      outcome: 'Preserve both outcomes as distinct supported workflows.',
+      route: 'DURABLE_AUTHORITY_REQUIRED'
+    },
+    {
+      code: 'E',
+      optionId: '',
+      outcome: 'Intentionally retire a supported behavior or affordance.',
+      route: 'DURABLE_AUTHORITY_REQUIRED'
+    },
+    {
+      code: 'F',
+      optionId: '',
+      outcome: 'Defer the convergence and gather the missing evidence.',
+      route: 'EVIDENCE_REQUIRED'
+    }
+  ];
+  const renderOptionEffects = (optionId) => {
+    const effectRefs = optionsById.get(optionId)?.effectRefs || [];
+    return effectRefs.length
+      ? effectRefs.map((effectRef) => (
+        `${inlineCode(effectRef)}: ${reportSentenceFragment(
+          concern.effects.find(({ id }) => id === effectRef)?.statement
+        )}`
+      )).join('; ')
+      : 'not mapped';
+  };
+  return [
+    '',
+    '#### Decision Pack',
+    '',
+    '- Why a decision is required: the mapped options differ and no eligible authority selects the proposed outcome.',
+    `- Actor: ${safeReportText(result.journeys[0]?.actor)}`,
+    `- Context: ${safeReportText(result.journeys[0]?.context)}`,
+    `- Goal: ${safeReportText(result.journeys[0]?.goal)}`,
+    `- Action: ${(result.journeys[0]?.steps || []).map(safeReportText).join(' -> ')}`,
+    `- Before option(s): ${result.beforeOptions.length ? result.beforeOptions.map(inlineCode).join(', ') : 'None'}`,
+    `- After option(s): ${result.afterOptions.length ? result.afterOptions.map(inlineCode).join(', ') : 'None'}`,
+    `- Authority searched: ${result.authorityResolution}; no eligible selecting authority was found.`,
+    `- Product Decision Owner: base allowlisted maintainer; event author ${productDecisionOwnerLogin ? inlineCode(productDecisionOwnerLogin) : 'is unavailable'} (${productDecisionOwnerEligible ? 'eligible' : 'not eligible for PR-local routing'}).`,
+    '- Choices:',
+    ...choices.map(({ code, optionId, outcome, route }) => (
+      `  - ${code}. ${safeReportText(outcome)} Option ID: ${optionId ? inlineCode(optionId) : 'not mapped'}. Effects: ${renderOptionEffects(optionId)}. Route: ${inlineCode(route)}.`
+    )),
+    '- Removal consequences:',
+    `  - Lost effects: ${result.lostEffectRefs.length ? result.lostEffectRefs.map(inlineCode).join(', ') : 'None'}`,
+    `  - Lost affordance/compatibility requirements: ${result.lostRequirementRefs.length ? result.lostRequirementRefs.map(inlineCode).join(', ') : 'None'}`,
+    '- Route meanings:',
+    '  - `PR_LOCAL_ALLOWED`: Product Decision Owner response -> Codex serializes an exact-head PR-body decision.',
+    '  - `DURABLE_AUTHORITY_REQUIRED`: Product Decision Owner response -> Codex prepares a narrow authority-only PR -> merge -> rebase implementation.',
+    '  - `EVIDENCE_REQUIRED`: stop the runtime convergence and collect evidence or merge an evidence-only PR.',
+    '  - `NOT_ALLOWED`: revise the implementation; product authority cannot waive the failing boundary.',
+    '- The Product Decision Owner returns this short response to Codex. The human does not edit JSON, SHA, requirement refs, or evidence refs; Codex serializes only the explicit choice and the trusted checker validates it.',
+    '',
+    '```text',
+    'PRODUCT_DECISION',
+    `Concern: ${result.concernKey}`,
+    `Scenario revision: ${result.scenarioRevision}`,
+    'Choice:',
+    'Rationale:',
+    'Must preserve:',
+    'May retire:',
+    'Accepted residual risk:',
+    '```'
+  ];
+};
+const renderProductImpactPacket = (result) => {
+  const concern = productConcernByKey.get(result.concernKey);
+  if (!concern) return [];
+  const effectsById = new Map(concern.effects.map((effect) => [effect.id, effect]));
+  const preservedEffects = stableIntersection(result.beforeEffects, result.afterEffects);
+  const authorityRefs = concern.resolution.authorityRefs || [];
+  const durableDecision = (baseProductDecisionAuthority?.decisions || []).find((decision) => (
+    decision.concernKey === result.concernKey
+    && decision.scenarioRevision === result.scenarioRevision
+  ));
+  const currentDecision = (currentProductImpactDecisions.declaration.decisions || [])
+    .find((decision) => (
+      decision.concernKey === result.concernKey
+      && decision.scenarioRevision === result.scenarioRevision
+    ));
+  const authoritySelections = [
+    ...(['authority-covered', 'domain-derived'].includes(concern.resolution.kind) ? [{
+      type: concern.resolution.kind === 'domain-derived' ? 'DOMAIN_AUTHORITY' : 'STATIC_AUTHORITY',
+      selectedOptionId: concern.resolution.selectedOptionId
+    }] : []),
+    ...(durableDecision ? [{
+      type: 'DURABLE_DECISION',
+      selectedOptionId: durableDecision.selectedOptionId
+    }] : []),
+    ...(currentDecision ? [{
+      type: 'CURRENT_MAINTAINER_DECISION',
+      selectedOptionId: currentDecision.selectedOptionId
+    }] : [])
+  ];
+  const lines = [
+    `### ${result.concernKey}`,
+    '',
+    `- Scenario revision: ${result.scenarioRevision}`,
+    `- Layer: ${concern.layer}`,
+    `- Product Decision Owner eligibility: ${productDecisionOwnerEligible ? 'eligible base maintainer' : 'no eligible PR-local author in this context'}`,
+    '',
+    '#### Architecture delta',
+    '',
+    ...result.subjectDeltas.flatMap((delta) => [
+      `- Rule: ${inlineCode(delta.ruleKey)}`,
+      `  - Added: ${delta.addedSubjects.length ? delta.addedSubjects.map(inlineCode).join(', ') : 'None'}`,
+      `  - Removed: ${delta.removedSubjects.length ? delta.removedSubjects.map(inlineCode).join(', ') : 'None'}`
+    ]),
+    '',
+    '#### Journeys and checkpoints',
+    '',
+    ...result.journeys.flatMap((journey) => [
+      `- ${inlineCode(journey.id)}: ${safeReportText(journey.actor)}; ${safeReportText(journey.context)}`,
+      `  - Goal: ${safeReportText(journey.goal)}`,
+      `  - Checkpoints: ${journey.checkpoints.map(({ id }) => inlineCode(`${journey.id}:${id}`)).join(', ')}`
+    ]),
+    '',
+    '#### Requirement realization',
+    '',
+    '| Requirement | Category | Before | After | Before providers | After providers |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...result.requirementResults.map((requirement) => (
+      `| ${inlineCode(requirement.requirementRef)} | ${requirement.category} | ${requirement.beforeSatisfied} | ${requirement.afterSatisfied} | `
+      + `${requirement.beforeActiveSubjects.length ? requirement.beforeActiveSubjects.map(inlineCode).join(', ') : 'None'} | `
+      + `${requirement.afterActiveSubjects.length ? requirement.afterActiveSubjects.map(inlineCode).join(', ') : 'None'} |`
+    )),
+    '',
+    '#### Behavior options and effects',
+    '',
+    `- Before realized options: ${result.beforeOptions.length ? result.beforeOptions.map(inlineCode).join(', ') : 'None'}`,
+    `- After realized options: ${result.afterOptions.length ? result.afterOptions.map(inlineCode).join(', ') : 'None'}`,
+    `- Preserved effects: ${preservedEffects.length ? preservedEffects.map((id) => `${inlineCode(id)}: ${reportSentenceFragment(effectsById.get(id)?.statement)}`).join('; ') : 'None'}`,
+    `- Added effects: ${result.addedEffectRefs.length ? result.addedEffectRefs.map(inlineCode).join(', ') : 'None'}`,
+    `- Lost effects: ${result.lostEffectRefs.length ? result.lostEffectRefs.map(inlineCode).join(', ') : 'None'}`,
+    '',
+    '#### Authority and contracts',
+    '',
+    `- Resolution: ${result.authorityResolution}`,
+    `- Selected option: ${result.selectedOptionId ? inlineCode(result.selectedOptionId) : 'None'}`,
+    `- Authority selections: ${authoritySelections.length ? authoritySelections
+      .map(({ type, selectedOptionId }) => (
+        `${inlineCode(type)} -> ${inlineCode(selectedOptionId)}`
+      )).join('; ') : 'None'}`,
+    `- Authority references: ${authorityRefs.length ? authorityRefs.map(inlineCode).join(', ') : 'None'}`,
+    `- Current-decision rationale: ${result.decisionRationale ? safeReportText(result.decisionRationale) : 'None'}`,
+    ...result.contractResults.map((contract) => (
+      `- Contract ${inlineCode(contract.ref)}: sensitivity=${contract.sensitivity}; execution=${contract.execution}; integrity=${contract.candidateModified ? 'CANDIDATE_MODIFIED' : 'UNCHANGED'}`
+    )),
+    ...result.residualRisks.map((risk) => `- Residual risk: ${safeReportText(risk)}`),
+    ...result.evidenceGaps.map((gap) => `- Evidence gap: ${safeReportText(gap)}`),
+    ...result.currentDecisionIssues.map((issue) => `- Current decision issue: ${safeReportText(issue)}`),
+    '',
+    '#### Result',
+    '',
+    `- Impact: ${result.impactClass}`,
+    `- Observation: ${result.observation}`,
+    `- Product decision required: ${result.decisionRequired ? 'yes' : 'no'}`,
+    `- Gate contribution: ${productImpactGateContribution(result)}`,
+    `- Next action: ${safeReportText(result.nextAction)}`
+  ];
+  if (result.decisionRequired) lines.push(...renderDecisionPack(result, concern));
+  return lines;
+};
+const productImpactAuthorityProposal = Boolean(
+  changedProductImpactAuthorityPaths.length || architectureAuthorityDelta.changes.length
+);
+const productImpactReportUseful = Boolean(
+  productImpactResults.length
+  || productImpactDecisionDeclarationIssues.length
+  || productImpactAuthorityProposal
+);
+const productImpactReportLines = productImpactReportUseful ? [
+  '## Product impact',
+  '',
+  `- Runtime context: ${productImpactRuntimeStatus}`,
+  '- Runtime authority: trusted base map, decisions, architecture rules, detectors, and checker only.',
+  `- Base authority validation: ${productImpactBaseErrors.length ? 'INVALID' : 'VALID'}`,
+  `- Candidate authority validation: ${candidateProductImpactMapValid && candidateProductDecisionAuthorityValid ? 'VALID (inert data only)' : 'INVALID'}`,
+  `- Candidate authority separation: ${candidateAuthorityCompanionPaths.length ? 'INVALID' : 'VALID'}`,
+  `- Runtime result count: ${productImpactResults.length}`,
+  ...(productImpactRuntimeStatus === 'NOT_AUTHORITATIVE_CANDIDATE' ? [
+    '- This pull request context is non-authoritative and emits no runtime admission packet.'
+  ] : []),
+  ...(productImpactAuthorityProposal ? [
+    '',
+    '### Candidate authority proposal',
+    '',
+    `- Changed Product Impact authority paths: ${changedProductImpactAuthorityPaths.length ? changedProductImpactAuthorityPaths.map(inlineCode).join(', ') : 'None'}`,
+    `- Candidate map: ${candidateProductImpactMapValid ? 'VALID' : 'INVALID'}`,
+    `- Candidate decision registry: ${candidateProductDecisionAuthorityValid ? 'VALID' : 'INVALID'}`,
+    '- Runtime effect: validation-only future preauthorization; candidate data does not alter this head runtime admission.'
+  ] : []),
+  ...productImpactDecisionDeclarationIssues.flatMap((issue) => [
+    '',
+    '### Current decision declaration',
+    '',
+    `- ${safeReportText(issue)}`,
+    '- Gate contribution: None (report-only).',
+    '- Next action: the Product Decision Owner must review the exact current head and Codex must serialize a renewed declaration.'
+  ]),
+  ...productImpactResults.flatMap((result) => ['', ...renderProductImpactPacket(result)]),
+  ''
+] : [];
 const report = [
   '# Web change policy',
   '',
@@ -1342,6 +1987,7 @@ const report = [
   '',
   ...list(policyResult.reviewReasons),
   '',
+  ...productImpactReportLines,
   '## Key architecture differential summary',
   '',
   '| Inventory | Before | Added | Removed | After | Delta | Classification |',
@@ -1490,7 +2136,9 @@ if (changeContext.isPromotion || changeContext.errors.length) {
       ],
       reviewReasons: /tools\/web-(?:change-policy|architecture-(?:rules|violations))\.json/.test(
         errorMessage
-      ) ? ['Governance and authority: required authority input is malformed'] : [],
+      ) || /tools\/web-product-(?:impact-map|decisions)\.json/.test(errorMessage)
+        ? ['Governance and authority: required authority input is malformed']
+        : [],
       context: changeContext.context,
       observations: { errorType: error?.name || typeof error }
     });


### PR DESCRIPTION
## Plain-language summary

This PR connects the existing Product Impact map, evaluator, and PR-body parser to `tools/check-web-change-budget.mjs`. When a trusted pull request to `dev` changes either pilot architecture rule, the checker now emits one deterministic Product Impact report and, when needed, a routed Decision Pack; the pilot remains review-only. Candidate-code pull requests cannot use candidate authority or PR-body decisions for runtime admission, and promotion behavior and existing gates stay unchanged.

## Change class

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

The Product Impact schema, pure evaluator, bounded current-decision parser, and inert pilot authority were already present but were not called by the Web policy checker. This change joins their structured results to the checker so maintainers can review user-journey effects before the pilot moves beyond `report-only`.

## User-visible impact

The Web application, rendering output, Python API, and CLI do not change. Maintainers gain a Product Impact section in the existing Web policy report when a mapped concern changes. An unresolved effect-equivalent choice includes a Decision Pack with outcome choices, routes, and a ready-to-copy `PRODUCT_DECISION` response.

## Changes

- `tools/check-web-change-budget.mjs` now validates base and candidate Product Impact authority, reuses the Architecture Ratchet detector facts, builds structured subject deltas, and calls the pure evaluator once per affected concern.
- Trusted current decisions come only from a bounded `pull_request_target` event body and must match the exact head SHA, a base-allowlisted maintainer, and an effect-equivalent `AFFORDANCE_PRESERVED` transition.
- Candidate authority is cross-validated as inert future preauthorization. It never controls the current runtime result, and authority plus runtime changes still fail separation.
- Mapped contract paths are checked against the trusted base. A changed mapped contract is reported as `CANDIDATE_MODIFIED`, requires review, and cannot prove hard safety by itself.
- The canonical report is written unchanged to stdout and `GITHUB_STEP_SUMMARY`. The existing warning annotation remains the only review annotation.
- `tests/web/architecture-contracts.test.mjs` now covers trusted and candidate contexts, report-only outcomes, Decision Pack routing, current-decision bounds, authority conflicts, contract integrity, hard-mode fixtures, deterministic output, and candidate self-authorization attempts.

### Trusted input and context behavior

| Context | Checker and runtime authority | Head input | PR body |
| --- | --- | --- | --- |
| `pull_request_target` to `dev` | trusted base checker, detectors, rules, map, and decisions | fetched head source data | bounded exact-head current decision allowed |
| candidate `pull_request` | candidate authority is validation-only | candidate diff inventory | not read for Product Impact admission |
| `push` / `workflow_dispatch` integrated diff | checked-in trusted authority | explicit base/head source data | not used |
| promotion to `main` | existing bounded promotion checker | exact staging and source-coverage evidence | Product Impact evaluation is skipped |

The checker scans each source revision through the existing Architecture Ratchet detector pass. It retains normalized rule facts, computes subject deltas from those facts, and sends them to the pure Product Impact evaluator. The evaluator deduplicates both pilot rules into `product.canonical-render-request-boundary` before report rendering.

### Report examples

Safe provider substitution:

```text
Impact: NO_USER_VISIBLE_DIFFERENCE
Observation: CONFORMING
Gate contribution: None (report-only for the triggering rule set)
```

Mapped behavior removal:

```text
Impact: RETIREMENT
Observation: ORDINARY_REGRESSION
Gate contribution: None (report-only for the triggering rule set)
Next action: Restore the selected option realization before integration.
```

An unresolved effect-equivalent transition reports `UNRESOLVED_DECISION` and choices A through F. Every choice has one of `PR_LOCAL_ALLOWED`, `DURABLE_AUTHORITY_REQUIRED`, `EVIDENCE_REQUIRED`, or `NOT_ALLOWED`, plus an option ID when the choice maps to an existing option. The response template contains the actual concern key and scenario revision; the Product Decision Owner supplies the choice and rationale while Codex derives the SHA and evidence references.

### Report-only truth table

| Observation | Product Impact gate contribution | Product Impact review contribution |
| --- | --- | --- |
| `CONFORMING` | none | none by itself |
| `ORDINARY_REGRESSION` | none | `REQUIRED` |
| `UNRESOLVED_DECISION` | none | `REQUIRED` |
| `AUTHORITY_CONFLICT` | none | `REQUIRED` |
| `INSUFFICIENT_EVIDENCE` | none | `REQUIRED` |

Malformed base authority, malformed candidate authority, unsafe parser state, and self-authorization separation violations still fail the policy gate. Product Impact never waives an existing architecture, dependency, security, performance, scientific-output, or promotion failure.

## Verification

- `node --check tools/check-web-change-budget.mjs`
- `node --check tests/web/architecture-contracts.test.mjs`
- `node --test tests/web/product-impact-ratchet-fixtures.test.mjs` (pass)
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs` (pass)
- `node --test tests/web/architecture-contracts.test.mjs` (131 pass)
- `node tools/check-web-change-budget.mjs --base HEAD --head HEAD` (`Gate: PASS`, `Review: CLEAR`)
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD` (`Gate: PASS`, `Review: REQUIRED` for the checker implementation change)
- `git diff --check`
- `git diff --name-only origin/dev...HEAD`

Generated reports were inspected for the unchanged path, safe mapped substitution, ordinary regression, unresolved Decision Pack, candidate self-authorization attempt, and mapped contract modification.

### Timing observations

One unchanged comparison on this WSL/NTFS workspace took 15.04 seconds before integration and 15.31 seconds after integration, a 0.27-second observed difference. In the same focused test process, the existing architecture-only substitution fixture took 172.82 ms and the corresponding Product Impact report fixture took 173.56 ms, a 0.74 ms observed difference. These are local observations rather than timing assertions; no flaky performance threshold was added.

The integration performs no network request, browser run, wheel preparation, candidate checkout, or second full detector scan.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because `tools/check-web-change-budget.mjs` changes governance checker behavior.
- Architecture impact: **This is not architecture-bearing**. Web runtime owners, production paths, compatibility paths, and their OE/PE/CB sets are unchanged; checker orchestration remains owned by `tools/check-web-change-budget.mjs`.
- `architecture-change` label, if relevant: not applicable.

The main risks are accidentally trusting candidate authority, parsing an untrusted body in the wrong context, or changing exit status during the pilot. The integration fixtures exercise all three boundaries, including malformed candidate data, an untrusted candidate body, exact-head and stale decisions, non-maintainer decisions, conflict, and all four hard-mode blocking observations.

## Rollback

Revert this commit to remove the Product Impact join and report section from `tools/check-web-change-budget.mjs`. The inert Product Impact authority, pure evaluator, bounded parser, Architecture Ratchet, workflows, and existing Web policy behavior remain available for a corrected integration.

## Conditional Product Impact

- Product-impact role: EVIDENCE_ONLY
- Affected concern(s), if known: `product.canonical-render-request-boundary`
- Authority and decision references: trusted base `tools/web-product-impact-map.json` and `tools/web-product-decisions.json`; no current product decision is requested by this PR.
- Behavior contracts and residual risk: the existing `PR_GATE` architecture contract and `DEV_STAGING` Session round-trip contract remain unchanged. This PR changes reporting mechanics only and does not strengthen their coverage.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: none.
- Checker implementation files touched: `tools/check-web-change-budget.mjs` and its contract fixture owner `tests/web/architecture-contracts.test.mjs`.
- Self-authorization separation evidence: candidate rule/map changes cannot authorize candidate runtime; authority plus runtime and checker plus authority changes remain blocked; the candidate `pull_request` path ignores a malformed Product Impact decision body.
- Branch-protection or ruleset impact, including unchanged settings: none. No workflow, event type, status context, required check, or branch-protection setting changes.
- Governance-specific rollback or protection restore point: revert this single checker-integration commit; no external protection state needs restoration.
