### PR TITLE
Rerun trusted policy on pull request edits

### DIFF
--- a/.github/workflows/web-base-policy.yml
+++ b/.github/workflows/web-base-policy.yml
@@ -3,7 +3,7 @@ name: Web base policy
 on:
   pull_request_target:
     branches: ["dev", "main"]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:
   contents: read

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -804,7 +804,8 @@ test('report-only source facts preserve the characterized masking behavior', () 
 });
 
 test('workflow triggers separate dev admission, dev staging, promotion, and deployment', () => {
-  const activityTypes = /types: \[opened, synchronize, reopened, labeled, unlabeled\]/;
+  const candidateActivityTypes = /types: \[opened, synchronize, reopened, labeled, unlabeled\]/;
+  const trustedActivityTypes = /types: \[opened, synchronize, reopened, edited, labeled, unlabeled\]/;
   const triggerBranches = (workflow, trigger) => {
     const match = workflow.match(new RegExp(
       `\\r?\\n  ${trigger}:\\r?\\n    branches: (\\[[^\\r\\n]+\\])`
@@ -816,7 +817,8 @@ test('workflow triggers separate dev admission, dev staging, promotion, and depl
   assert.match(TEST_WORKFLOW, /\n  pull_request:\n/);
   assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'pull_request'), ['dev']);
   assert.deepEqual(triggerBranches(TEST_WORKFLOW, 'push'), ['dev']);
-  assert.match(TEST_WORKFLOW, activityTypes);
+  assert.match(TEST_WORKFLOW, candidateActivityTypes);
+  assert.doesNotMatch(TEST_WORKFLOW, /types: \[[^\]\r\n]*\bedited\b/);
   assert.match(TEST_WORKFLOW, /name: Run core tests/);
   assert.match(
     TEST_WORKFLOW,
@@ -828,10 +830,20 @@ test('workflow triggers separate dev admission, dev staging, promotion, and depl
     triggerBranches(BASE_POLICY_WORKFLOW, 'pull_request_target'),
     ['dev', 'main']
   );
-  assert.match(BASE_POLICY_WORKFLOW, activityTypes);
+  assert.match(BASE_POLICY_WORKFLOW, trustedActivityTypes);
   assert.match(
     BASE_POLICY_WORKFLOW,
     /permissions:\n  contents: read\n  pull-requests: read\n  actions: read/
+  );
+  assert.match(
+    BASE_POLICY_WORKFLOW,
+    /group: web-base-policy-\$\{\{ github\.event\.pull_request\.number \}\}/
+  );
+  assert.deepEqual(
+    WORKFLOW_NAMES.filter((name, index) => (
+      /types: \[[^\]\r\n]*\bedited\b/.test(WORKFLOW_SOURCES[index])
+    )),
+    ['web-base-policy.yml']
   );
 
   assert.deepEqual(triggerBranches(GALLERY_PUBLICATION_WORKFLOW, 'push'), ['dev']);
@@ -1054,6 +1066,15 @@ test('trusted promotion uses base code for topology, exact-SHA evidence, and tre
   const devPolicy = workflowJob('trusted-base-policy', BASE_POLICY_WORKFLOW);
   assert.match(devPolicy, /\n    name: Web base policy \(trusted base\)\n/);
   assert.match(devPolicy, /if: github\.event\.pull_request\.base\.ref == 'dev'/);
+  assert.equal([...devPolicy.matchAll(/uses: actions\/checkout@/g)].length, 1);
+  assert.match(devPolicy, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.match(devPolicy, /fetch-depth: 0/);
+  assert.match(devPolicy, /persist-credentials: false/);
+  assert.match(devPolicy, /git fetch --no-tags origin "\$HEAD_SHA"/);
+  assert.doesNotMatch(
+    devPolicy,
+    /ref:.*pull_request\.head|git (?:checkout|switch) |uses: \.\//
+  );
 
   const promotion = workflowJob('promotion-gate', BASE_POLICY_WORKFLOW);
   assert.match(promotion, /\n    name: Promotion \/ gate\n/);


### PR DESCRIPTION
## Plain-language summary

This PR adds `edited` to the `pull_request_target` activity list in `.github/workflows/web-base-policy.yml`. When Codex serializes an explicit Product Decision Owner choice into a pull request body, the edit will rerun `Web base policy (trusted base)` so it can revalidate the exact head, rationale, maintainer eligibility, and evidence. `.github/workflows/test.yml` keeps its current activity list, so a body-only edit does not schedule candidate tests, Playwright, Gallery, or wheel preparation.

## Change class

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

An exact-head Product Impact decision is machine-readable only after Codex writes the Product Decision Owner's explicit choice into the pull request body. The trusted policy workflow must rerun on that edit to evaluate the new decision block without rerunning the candidate test graph.

## User-visible impact

There is no change to gbdraw runtime behavior or output. Maintainers can update a pull request decision block and receive a fresh trusted policy result for the unchanged head.

## Changes

- Add `edited` to the existing `pull_request_target` activity list in `.github/workflows/web-base-policy.yml`.
- Keep `.github/workflows/test.yml` unchanged, including its `pull_request` activity list.
- Extend `tests/web/architecture-contracts.test.mjs` to prove that only `web-base-policy.yml` receives `edited`, while trusted base checkout, candidate-head non-execution, permissions, concurrency, branch filters, status names, promotion topology, and workflow count remain fixed.
- Keep Product Impact report-only. The existing checker continues to reject a stale `headSha`, require a bounded product-level rationale, and validate maintainer eligibility and mapped evidence.

The resulting decision flow is: Product Decision Owner chooses an outcome, Codex serializes it into the body, the body edit schedules `Web base policy (trusted base)`, and the trusted checker reevaluates the exact current head.

## Verification

- `node --test tests/web/architecture-contracts.test.mjs` (131 passed)
- `node --test tests/web/product-impact-ratchet-fixtures.test.mjs` (passed)
- `node --test tests/web/architecture-ratchet-fixtures.test.mjs` (passed)
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD` (`Gate: PASS`, `Review: REQUIRED` for the governance workflow change)
- `git diff --check origin/dev...HEAD` (passed)
- `git diff --name-only origin/dev...HEAD` (only `.github/workflows/web-base-policy.yml` and `tests/web/architecture-contracts.test.mjs`)
- `git diff --exit-code origin/dev...HEAD -- .github/workflows/test.yml` (passed; no diff)

`actionlint` is not installed in the local environment. The source-level workflow contract passed; hosted GitHub Actions remains the workflow parser and event execution check.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because `.github/workflows/web-base-policy.yml` is governance and workflow authority.
- Architecture impact: **This is not architecture-bearing**. No semantic owner, canonical production path, compatibility path, or runtime responsibility changes.
- `architecture-change` label, if relevant: not applicable.

This change adds no workflow, job, status context, permission, Product Impact authority, runtime behavior, or Gate semantic. The trusted workflow still checks out `github.event.pull_request.base.sha`, fetches the head only as Git data, and never checks out or executes candidate code. Existing `dev -> main` promotion behavior is unchanged.

## Rollback

Remove `edited` from `.github/workflows/web-base-policy.yml` and remove the matching activity and trust assertions from `tests/web/architecture-contracts.test.mjs`.

## Conditional Product Impact

- Product-impact role: N/A
- Affected concern(s), if known: none
- Authority and decision references: none
- Behavior contracts and residual risk: The workflow contracts cover event routing and trust boundaries. Hosted event scheduling remains the residual integration boundary.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/web-base-policy.yml` and `tests/web/architecture-contracts.test.mjs`.
- Checker implementation files touched: none.
- Self-authorization separation evidence: The trusted checker, Product Impact map, decision registry, pull request template, Web runtime, and `.github/workflows/test.yml` are unchanged. The workflow still executes the checker from the trusted base checkout.
- Branch-protection or ruleset impact, including unchanged settings: none. Required status names and the existing workflow count remain unchanged.
- Governance-specific rollback or protection restore point: remove the one `edited` activity and its contract assertions; the base restore point is `04689eabbf84d80b6288ae0d9ed822a8bedfe594`.
