### PR TITLE
Add render-request round-trip evidence to the PR gate

### DIFF
--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -343,7 +343,8 @@ const state = {
     features: ['CDS'], feature_shapes: { CDS: 'arrow' }, nt: 'GC', evalue: '1e-5',
     arrow_head_length_ratio: null, arrow_shaft_width_ratio: 1.0,
     min_bitscore: 50, identity: 70, alignment_length: 0, plot_title_position: 'none',
-    gc_content_mode: 'deviation', gc_content_show_axis: true, gc_content_show_ticks: true,
+    gc_content_mode: 'deviation', gc_content_min_percent: 0, gc_content_max_percent: 100,
+    gc_content_show_axis: true, gc_content_show_ticks: true,
     depth_color: '#4A90E2', depth_show_axis: true, depth_show_ticks: true,
     depth_large_tick_interval: 25,
     pairwise_match_style: 'ribbon', multi_record_size_mode: 'auto',
@@ -1402,6 +1403,15 @@ assert.equal(
 );
 
 const projection = projectCanonicalSessionRequest(canonical);
+const roundTripCanonical = buildCanonicalRenderRequest({
+  state: stateForCanonicalProjection(projection),
+  filesData: projection.files
+});
+assert.deepEqual(
+  roundTripCanonical.renderRequest,
+  canonical.renderRequest,
+  'canonical Session projection rebuilds the same render request'
+);
 assert.equal(projection.mode, 'circular');
 assert.equal(projection.inputType, 'gb');
 assert.equal(projection.files.c_gb.data, genbank.data);


### PR DESCRIPTION
## Plain-language summary

This PR adds a PR-gate assertion that a representative canonical Session request rebuilds to the same render request after projection. The assertion supplies direct round-trip evidence before the two render-request Product Impact rules can move from report-only evaluation to blocking enforcement. It does not change Web runtime behavior or policy authority.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

The hard Product Impact validator requires an unmodified automated `PR_GATE` contract for every hard requirement checkpoint. `JRN-RENDER-001:roundtrip-regeneration` previously had browser coverage in `DEV_STAGING`, but no direct PR-gate contract.

## User-visible impact

None. The change adds test evidence only.

## Changes

- Add the current GC-content bounds to the representative Session state fixture.
- Project the canonical Session request, rebuild it, and compare the complete `renderRequest` objects with `assert.deepEqual`.

## Verification

- `node tests/web/session-request.test.mjs`
- `node --test tests/web/architecture-contracts.test.mjs` (131 passed)
- `node tools/check-web-change-budget.mjs --base origin/dev` (`PASS`, `CLEAR`)
- `git diff --check`

The combined fast-JavaScript command emitted 41 passing files but its control session did not exit after the child processes ended. I stopped that orphaned control session and do not count it as a completed check.

Three body updates, including a Pull Request REST update after the initial run completed, did not start another workflow. GitHub reads `pull_request_target` triggers from the default branch, and `main` does not contain the `edited` trigger merged into `dev` by PR #403. The fixture contract covers the post-promotion behavior; #404 started one `Tests` run.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; production code, architecture authority, and runtime behavior are unchanged.
- Architecture impact: **This is not architecture-bearing**. The only changed file is `tests/web/session-request.test.mjs`.
- `architecture-change` label, if relevant: not applicable.

## Rollback

Revert commit `12aac7c1` to remove the assertion and restore the previous fixture fields.

## Conditional Product Impact

- Product-impact role: EVIDENCE_ONLY
- Affected concern(s), if known: `JRN-RENDER-001:roundtrip-regeneration`
- Authority and decision references: no authority or decision files change in this PR.
- Behavior contracts and residual risk: `tests/web/session-request.test.mjs::canonical Session projection rebuilds the same render request` directly compares one representative current Circular request. Browser admission, alternate diagram modes, and Session migrations remain separate contracts.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

Not applicable for the selected `STANDARD` change class.
