### PR TITLE
Add the Session round-trip contract to checker fixtures

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1371,6 +1371,10 @@ const BUDGET_FIXTURE = Object.freeze({
   'tests/web/contracts/session-regenerate-intent.playwright.spec.js': (
     "test('no-draft session preserves preview, active config, canonical request, and catalog', () => {});\n"
   ),
+  'tests/web/session-request.test.mjs': (
+    "assert.deepEqual(roundTripCanonical.renderRequest, canonical.renderRequest,\n"
+      + "  'canonical Session projection rebuilds the same render request');\n"
+  ),
   'tests/web/promotion-readiness.test.mjs': readFileSync(
     PROMOTION_READINESS_TEST,
     'utf8'
@@ -1697,6 +1701,10 @@ const TRUSTED_ARCHITECTURE_FIXTURE_FILES = Object.freeze({
   ),
   'tests/web/contracts/session-regenerate-intent.playwright.spec.js': (
     "test('no-draft session preserves preview, active config, canonical request, and catalog', () => {});\n"
+  ),
+  'tests/web/session-request.test.mjs': (
+    "assert.deepEqual(roundTripCanonical.renderRequest, canonical.renderRequest,\n"
+      + "  'canonical Session projection rebuilds the same render request');\n"
   ),
   'tools/check-web-change-budget.mjs': readFileSync(CHANGE_BUDGET_CHECKER, 'utf8'),
   'tools/web-architecture-detectors.mjs': readFileSync(


### PR DESCRIPTION
## Plain-language summary

This PR adds the Session round-trip contract file to both synthetic repositories used by the Web checker tests. A later authority-only PR can then reference the contract without making the checker fixtures report that trusted-base evidence is missing. Runtime behavior and Product Impact authority do not change here.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

PR #404 added the direct `PR_GATE` assertion in `tests/web/session-request.test.mjs`. When a prospective map referenced that file, 50 of 131 architecture-contract tests failed because their temporary Git repositories did not contain the new trusted-base evidence path.

## User-visible impact

None. This change updates test fixtures only.

## Changes

- Add the round-trip assertion stub to `BUDGET_FIXTURE`.
- Add the same trusted evidence path to `TRUSTED_ARCHITECTURE_FIXTURE_FILES`.

## Verification

- Current report-only map: `node --test tests/web/architecture-contracts.test.mjs` (131 passed, 99.864 seconds)
- Prospective map with the new contract reference: `node --test tests/web/architecture-contracts.test.mjs` (131 passed, 92.527 seconds)
- Prospective hard map validation: `{"valid":true,"errors":[]}`
- `node tools/check-web-change-budget.mjs --base origin/dev` (`PASS`, `CLEAR`)
- `git diff --check`

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; the change adds no production or authority delta.
- Architecture impact: **This is not architecture-bearing**. The synthetic checker repositories gain one evidence file path.
- `architecture-change` label, if relevant: not applicable.

The fixture stub proves trusted-base presence and candidate-integrity handling. The semantic round-trip comparison remains owned by the real assertion merged in PR #404.

## Rollback

Revert commit `e0a28ede` to remove the two synthetic-repository entries.

## Conditional Product Impact

- Product-impact role: EVIDENCE_ONLY
- Affected concern(s), if known: `JRN-RENDER-001:roundtrip-regeneration`
- Authority and decision references: no authority or decision files change in this PR.
- Behavior contracts and residual risk: the fixture mirrors `tests/web/session-request.test.mjs::canonical Session projection rebuilds the same render request`. It does not replace the real assertion or broaden its coverage beyond the representative current Circular request.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

Not applicable for the selected `STANDARD` change class.
