### PR TITLE
Make Product Impact fixtures independent of active enforcement

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -717,9 +717,17 @@ test('Product Impact authority bootstrap accepts zero or two inert JSON files', 
     valid: true,
     errors: []
   });
-  assert.deepEqual(
-    map.ruleCoverage.map(({ enforcement }) => enforcement),
-    ['report-only', 'report-only']
+  const pilotEnforcement = map.ruleCoverage
+    .filter(({ ruleKey }) => [
+      'canonical-path.render-request',
+      'semantic-owner.render-request'
+    ].includes(ruleKey))
+    .map(({ enforcement }) => enforcement);
+  assert.equal(pilotEnforcement.length, 2);
+  assert.equal(
+    new Set(pilotEnforcement).size,
+    1,
+    'the two render-request pilot rules must activate in the same stage'
   );
   assert.deepEqual(decisions.decisions, []);
   map.concerns.flatMap(({ contracts }) => contracts).forEach(({ ref }) => {
@@ -1779,6 +1787,11 @@ const preauthorizedCanonicalRulesSource = rulesSource((rules) => {
 const reportOnlyCanonicalRulesSource = rulesSource((rules) => {
   canonicalRule(rules).enforcement = 'report-only';
 });
+const reportOnlyProductImpactMapSource = (() => {
+  const map = JSON.parse(PRODUCT_IMPACT_MAP_SOURCE);
+  map.ruleCoverage.forEach((coverage) => { coverage.enforcement = 'report-only'; });
+  return `${JSON.stringify(map, null, 2)}\n`;
+})();
 const productImpactMapSourceForRules = (architectureSource) => {
   const map = JSON.parse(PRODUCT_IMPACT_MAP_SOURCE);
   const architecture = JSON.parse(architectureSource);
@@ -2445,7 +2458,10 @@ test('report-only Product Impact regression requires review without changing a p
       assert.match(output, /Observation: ORDINARY_REGRESSION/);
       assert.match(output, /Gate contribution: None \(report-only/);
     },
-    { 'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource },
+    {
+      'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource,
+      'tools/web-product-impact-map.json': reportOnlyProductImpactMapSource
+    },
     productImpactPullRequestEnvironment()
   );
 });
@@ -2636,7 +2652,10 @@ test('mapped contract changes are surfaced while unrelated tests add no Product 
       assert.match(output, /mapped contract changed in the candidate/);
       assert.match(output, /Gate contribution: None \(report-only/);
     },
-    { 'tools/web-architecture-rules.json': reportOnlyRules },
+    {
+      'tools/web-architecture-rules.json': reportOnlyRules,
+      'tools/web-product-impact-map.json': reportOnlyProductImpactMapSource
+    },
     productImpactPullRequestEnvironment()
   );
 
@@ -2660,7 +2679,10 @@ test('Product Impact stdout and GitHub summary use the same deterministic report
       assert.equal(output, summary);
       assert.match(summary, /Observation: ORDINARY_REGRESSION/);
     },
-    { 'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource },
+    {
+      'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource,
+      'tools/web-product-impact-map.json': reportOnlyProductImpactMapSource
+    },
     productImpactPullRequestEnvironment({ summary: true })
   );
 });
@@ -2762,6 +2784,7 @@ test('report-only rules report absence without consulting an accepted store or f
     },
     {
       'tools/web-architecture-rules.json': reportOnlyCanonicalRulesSource,
+      'tools/web-product-impact-map.json': reportOnlyProductImpactMapSource,
       'tools/web-architecture-violations.json': 'not valid JSON and must not be loaded\n'
     }
   );


### PR DESCRIPTION
## Plain-language summary

Five integration fixtures that exercise report-only Product Impact behavior inherited the repository's active enforcement values. They would fail when the render-request pilot changes to `hard`, even though the behavior under test remains correct. This PR gives those fixtures an explicit report-only map and checks that both pilot rules move through enforcement stages together.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Keep report-only behavior tests stable across the planned enforcement activation. The failure was found by applying the proposed two-value hard map locally and running the required PR6 integration suite: 5 of 131 tests failed because they read the active map instead of declaring their fixture stage.

## User-visible impact

None. This changes integration fixtures only.

## Changes

- Add a `reportOnlyProductImpactMapSource` fixture derived from the current valid map.
- Pass that fixture to the four checker scenarios that specifically assert report-only behavior.
- Replace the bootstrap assertion that required two literal `report-only` values with an assertion that the two render-request pilot rules activate in the same stage. Map validation continues to reject unsupported enforcement values.

## Verification

- Current report-only map, five affected scenarios: 5 passed, 0 failed in 1.006 s.
- Prospective hard map, full integration suite: 131 passed, 0 failed in 92.709 s.
- Prospective hard map, Product Impact fixture suite: passed in 139 ms.
- Prospective hard map, Architecture Ratchet fixture suite: passed in 114 ms.
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD`: `PASS / CLEAR`.
- `git diff --check origin/dev...HEAD`: clean.

The hard map was applied only as an uncommitted test condition and restored after the run. This PR changes only `tests/web/architecture-contracts.test.mjs`.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; the trusted checker reports no review reason.
- Architecture impact: **This is not architecture-bearing**. Production owners, paths, contracts, and authority are unchanged.
- `architecture-change` label, if relevant: not applicable.

The main risk is accidentally weakening the report-only assertions. Each affected scenario still supplies report-only architecture rules, now also supplies report-only Product Impact authority, and retains its exact Gate, Review, observation, and contract-integrity assertions.

## Rollback

Revert this commit. That would restore the fixture coupling and must be done only if enforcement activation is also abandoned.

## Conditional Product Impact

- Product-impact role: EVIDENCE_ONLY
- Affected concern(s), if known: `product.canonical-render-request-boundary`
- Authority and decision references: no authority or decision change; `tools/web-product-impact-map.json` and `tools/web-product-decisions.json` are untouched.
- Behavior contracts and residual risk: the fixtures cover report-only and prospective hard mechanics; browser behavior and production runtime are unchanged.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
