### PR TITLE
Add a deterministic CI impact planner in shadow mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Tests
 
 permissions:
   contents: read
+  actions: read
 
 on:
   push:
@@ -17,6 +18,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci-impact:
+    name: CI impact plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      plan: ${{ steps.plan.outputs.plan }}
+    steps:
+      - name: Checkout complete history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Test CI impact policy and adapters
+        run: node --test tests/ci/*.test.mjs
+
+      - name: Build shadow CI impact plan
+        id: plan
+        env:
+          CI_IMPACT_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || 'dev' }}
+          CI_IMPACT_EVENT_NAME: ${{ github.event_name }}
+          CI_IMPACT_REPOSITORY: ${{ github.repository }}
+          CI_IMPACT_CHANGE_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
+          CI_IMPACT_CHANGE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          CI_IMPACT_WORKFLOW_SHA: ${{ github.sha }}
+          CI_IMPACT_ARCHITECTURE_CHANGE: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'architecture-change') && 'true' || 'false' }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node tools/ci-impact.mjs plan
+
   web-change-budget:
     name: Web change budget
     if: >-
@@ -536,6 +570,7 @@ jobs:
   pr-gate:
     name: PR / gate
     needs:
+      - ci-impact
       - web-change-budget
       - core-pr
       - recipes-standard
@@ -552,6 +587,7 @@ jobs:
       - name: Require all fast PR evidence
         run: |
           set -euo pipefail
+          test "${{ needs.ci-impact.result }}" = "success"
           test "${{ needs.web-change-budget.result }}" = "success"
           test "${{ needs.core-pr.result }}" = "success"
           test "${{ needs.recipes-standard.result }}" = "success"
@@ -562,6 +598,7 @@ jobs:
   dev-staging-gate:
     name: Dev staging / gate
     needs:
+      - ci-impact
       - web-change-budget
       - core
       - recipes-standard
@@ -583,6 +620,7 @@ jobs:
       - name: Require all exact-SHA staging evidence
         run: |
           set -euo pipefail
+          test "${{ needs.ci-impact.result }}" = "success"
           test "${{ needs.web-change-budget.result }}" = "success"
           test "${{ needs.core.result }}" = "success"
           test "${{ needs.recipes-standard.result }}" = "success"

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -1,0 +1,217 @@
+# Selective CI impact planning
+
+Status: staged rollout; the planner currently runs in shadow mode.
+
+## Purpose
+
+gbdraw classifies each change before deciding which existing CI jobs are needed. The
+classifier is deliberately coarse and conservative. It can avoid unrelated work only
+when the changed paths are clearly lightweight and the directly preceding trusted
+revision already has successful exact-SHA aggregate evidence.
+
+The first rollout stage records the plan in the GitHub Actions job summary but does not
+route test jobs. All existing pull-request and `dev` staging test conditions still run.
+
+## Impact classes
+
+The three impact classes, from least to most consequential, are:
+
+1. `metadata`: repository and development-support files that do not affect the
+   application, package, Web bundle, Gallery output, or public operating instructions.
+2. `documentation`: root Markdown files and files below `docs/`. These may participate
+   in documented-contract tests, so they are not treated as no-ops.
+3. `full`: runtime, tests, dependencies, build and packaging inputs, Web and Gallery
+   files, workflow and planner control files, and every unknown path.
+
+`tools/ci-impact-policy.mjs` is the only owner of the path allowlist and profile job
+registries. The initial metadata allowlist is:
+
+- `.agents/**`, `.claude/**`, `.codex/**`, and `.cursor/**`
+- `.github/pull_request_template.md`
+- `.dockerignore`, `.gitattributes`, and `.gitignore`
+- `CITATION.cff`, `LICENSE.txt`, and `LICENSE_LIBERATION_FONTS.txt`
+
+Root `*.md` files and `docs/**` are documentation. Everything else is full by default.
+For multiple paths, the strongest class wins:
+
+```text
+metadata < documentation < full
+```
+
+Rename and copy records classify both the old and new path. Deletes classify the old
+path. Unknown Git statuses, invalid paths, malformed or empty diffs, and missing Git
+objects all fail closed to `full`.
+
+## Plans and full fallback
+
+The planner emits one versioned `ImpactPlan` JSON object. It records the profile,
+impact, decision, stable basis code, change and workflow SHAs, required job IDs,
+changed-path count, and inherited evidence when present. Job IDs—not display names or
+human-readable reason text—form the routing contract.
+
+Profiles cover the three eventual consumers:
+
+- `pr`: the `Tests` workflow for a pull request into `dev`
+- `dev`: the `Tests` workflow for a push to `dev`
+- `gallery`: the `Gallery publication` workflow for a push to `dev`
+
+A full-impact change always produces a full plan without calling the GitHub Actions
+API. Manual dispatch and a pull request carrying the `architecture-change` label also
+force a full plan.
+
+A metadata or documentation candidate can be selective only after inherited evidence
+is verified. Missing, queued, in-progress, failed, cancelled, or malformed evidence;
+API errors; and insufficient token access produce `decision=full` with
+`basis=INHERITED_EVIDENCE_UNAVAILABLE`. These operational failures do not crash the
+planner. Invalid inputs, malformed schemas, unsafe output writes, and programming errors
+remain control-plane failures and do not get hidden by a full fallback.
+
+## Direct evidence only
+
+Selective planning inherits evidence from exactly one revision:
+
+| Profile | Evidence revision | Workflow | Aggregate job |
+| --- | --- | --- | --- |
+| `pr` | pull-request base SHA | `.github/workflows/test.yml` | `Dev staging / gate` |
+| `dev` | `github.event.before` | `.github/workflows/test.yml` | `Dev staging / gate` |
+| `gallery` | `github.event.before` | `.github/workflows/gallery-publication.yml` | `Gallery readiness / gate` |
+
+The planner reuses `verifyWorkflowEvidence()` from
+`tools/check-promotion-readiness.mjs`. It does not copy GitHub API pagination or
+workflow/job identity logic.
+
+Only the direct base or parent is eligible because it proves that every unchanged
+surface in the current revision was covered immediately before the lightweight change.
+Searching for an older green run could cross an intervening unverified runtime change.
+If the direct run was cancelled by concurrency, is still running, or did not succeed,
+the current revision runs the full profile.
+
+## Stable aggregate checks
+
+The following display names are external admission contracts and stay fixed:
+
+- `PR / gate`
+- `Dev staging / gate`
+- `Gallery readiness / gate`
+- `Promotion / gate`
+
+Each workflow continues to start on every relevant event and creates its aggregate job
+for the current SHA. Selection happens at job level in later rollout stages. Keeping the
+aggregate names and current-SHA jobs stable avoids branch-protection changes and allows
+the existing promotion verifier to continue checking exact staging evidence.
+
+Workflow-level `paths` and `paths-ignore` filters are not used. Such filters can prevent
+a required check from being created, leaving a pull request pending, and would remove
+the current-SHA aggregate evidence required for promotion.
+
+## Pull-request trust boundary
+
+A pull request is untrusted input. Candidate code is tested, but it must not decide its
+own admission route. Once selective pull-request routing is enabled, the workflow will
+execute the planner and gate validator from the pull-request base SHA in a separate
+trusted checkout. Candidate versions of the planner remain test inputs only.
+
+The initial shadow-mode pull request is the bootstrap exception: no planner exists on
+its base, so the candidate planner produces an observational summary while all existing
+jobs still run. Changes below `.github/workflows/**`, `tools/ci-impact*.mjs`, and the CI
+planner tests classify as full.
+
+The `pull_request_target` workflow remains separate. It checks candidate Git data with
+trusted base code and never executes the candidate checkout.
+
+## Aggregate validation
+
+The shared gate validator fails closed unless:
+
+- the plan schema, profile, required job list, and workflow SHA are valid;
+- `ci-impact` succeeded;
+- every required known job exists and succeeded;
+- every unrequired known job exists and either succeeded or was skipped; and
+- any additional job either succeeded or was skipped.
+
+An unexpected failure or cancellation remains blocking even for a job the plan did not
+require. Malformed plan or `needs` JSON is also blocking.
+
+The validator is implemented and tested during shadow mode. Existing shell aggregate
+checks remain in place until the rollout stage that connects selective routing.
+
+## Rollout
+
+Selective CI is introduced in four separately reviewed pull requests:
+
+1. Add the deterministic policy, adapter, validator, tests, documentation, and shadow
+   summary. Keep all existing test routing.
+2. Enable selective routing for pull requests using the trusted base planner.
+3. Enable evidence-aware routing for exact `dev` staging runs.
+4. Enable evidence-aware routing for Gallery readiness runs.
+
+Each stage keeps the aggregate check names stable and can be reverted independently.
+Reverting a routing stage restores the previous full-suite conditions without a
+repository-settings change.
+
+## Observability
+
+The `CI impact plan` summary includes:
+
+- profile, impact, decision, and stable basis;
+- change base/head and workflow SHAs;
+- changed-path count and a bounded, escaped path sample;
+- planned required job IDs;
+- inherited run and aggregate links when evidence succeeds; and
+- the fallback code and bounded reason when evidence is unavailable.
+
+In shadow mode the summary explicitly states that routing is observational. Tokens are
+never included in the plan or summary and are redacted from CLI diagnostics.
+
+## Troubleshooting
+
+### A lightweight change produces a full plan
+
+Check `basis` in the `CI impact plan` summary.
+
+- `FULL_CHANGE`: at least one path is outside the two light allowlists.
+- `UNKNOWN_OR_INVALID_CHANGE`: the diff was empty, malformed, unavailable, or contained
+  an unsupported status/path.
+- `MANUAL_FULL_RUN`: manual dispatch is intentionally full.
+- `ARCHITECTURE_CHANGE`: the label intentionally forces full verification.
+- `INHERITED_EVIDENCE_UNAVAILABLE`: inspect the listed evidence code and the direct
+  base/parent workflow run. Do not substitute an older successful run.
+
+### The planner job fails
+
+Run the network-free focused tests first:
+
+```bash
+node --test tests/ci/*.test.mjs
+```
+
+Then verify that every required environment value is a correctly typed string and that
+base, head, and workflow SHAs are complete object IDs. A failure to write
+`GITHUB_OUTPUT` or `GITHUB_STEP_SUMMARY` is a control-plane error, not a reason to emit a
+selective plan.
+
+### The aggregate validator fails
+
+Compare the plan profile and workflow SHA with the gate environment. Confirm that every
+known job is present in `needs`, required jobs succeeded, and unrequired jobs did not
+fail or get cancelled unexpectedly. Do not weaken the validator to accept a missing or
+skipped required job.
+
+## Policy-extension review checklist
+
+Before making a path or profile less conservative, verify all of the following:
+
+- The structural reason that the path cannot change runtime, packaging, Web, Gallery,
+  public instructions, or another independently tested surface is documented.
+- Historical changes and failures support the proposed classification.
+- The unchanged surface is covered by the exact direct-parent/base evidence contract.
+- A current-revision test owns every changed surface that will no longer use the full
+  profile.
+- Rename, copy, delete, mixed-change, unknown-path, and API-failure cases still fall back
+  safely.
+- The policy remains in `tools/ci-impact-policy.mjs`; no duplicate YAML or JSON owner is
+  introduced.
+- Existing full-profile commands, aggregate names, and promotion evidence contracts are
+  unchanged.
+- Focused policy, CLI, gate, workflow architecture, and applicable full regression tests
+  pass without network access for unit coverage.

--- a/tests/ci/ci-impact-cli.test.mjs
+++ b/tests/ci/ci-impact-cli.test.mjs
@@ -1,0 +1,323 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { PromotionReadinessError } from '../../tools/check-promotion-readiness.mjs';
+import {
+  buildImpactPlan,
+  parseNameStatusZ,
+  readPlanConfiguration,
+  runCiImpactCli
+} from '../../tools/ci-impact.mjs';
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const SHA = Object.freeze({
+  base: 'a'.repeat(40),
+  head: 'b'.repeat(40),
+  workflow: 'c'.repeat(40)
+});
+
+const environment = (overrides = {}) => ({
+  CI_IMPACT_PROFILE: 'pr',
+  CI_IMPACT_EVENT_NAME: 'pull_request',
+  CI_IMPACT_REPOSITORY: 'satoshikawato/gbdraw',
+  CI_IMPACT_REPOSITORY_ROOT: REPOSITORY_ROOT,
+  CI_IMPACT_CHANGE_BASE_SHA: SHA.base,
+  CI_IMPACT_CHANGE_HEAD_SHA: SHA.head,
+  CI_IMPACT_WORKFLOW_SHA: SHA.workflow,
+  CI_IMPACT_ARCHITECTURE_CHANGE: 'false',
+  GITHUB_TOKEN: 'test-token',
+  ...overrides
+});
+
+const configuration = (overrides = {}) => readPlanConfiguration(
+  environment(overrides),
+  REPOSITORY_ROOT
+);
+
+const gitResult = (...tokens) => ({
+  status: 0,
+  stdout: Buffer.from(`${tokens.join('\0')}\0`),
+  stderr: Buffer.alloc(0)
+});
+
+const successfulEvidence = ({
+  workflowPath = '.github/workflows/test.yml',
+  aggregateName = 'Dev staging / gate'
+} = {}) => ({
+  workflow: { path: workflowPath },
+  run: {
+    id: 101,
+    headSha: SHA.base,
+    url: 'https://github.com/satoshikawato/gbdraw/actions/runs/101'
+  },
+  aggregateJob: {
+    id: 202,
+    name: aggregateName,
+    url: 'https://github.com/satoshikawato/gbdraw/actions/runs/101/job/202'
+  }
+});
+
+const textWriter = () => {
+  let value = '';
+  return {
+    stream: { write: (chunk) => { value += chunk; } },
+    value: () => value
+  };
+};
+
+test('NUL name-status parsing preserves newlines and rename endpoints', () => {
+  const changes = parseNameStatusZ(Buffer.from(
+    'M\0docs/line\nbreak.md\0R100\0docs/old.md\0gbdraw/new.md\0'
+  ));
+  assert.deepEqual(changes, [
+    { status: 'M', paths: ['docs/line\nbreak.md'] },
+    { status: 'R100', paths: ['docs/old.md', 'gbdraw/new.md'] }
+  ]);
+  assert.throws(() => parseNameStatusZ(Buffer.from('M\0docs/no-terminator.md')), /NUL-terminated/);
+});
+
+test('PR planning uses a three-dot diff and direct base evidence', async () => {
+  let gitArgs;
+  let evidenceArguments;
+  const outcome = await buildImpactPlan({
+    configuration: configuration(),
+    token: 'test-token',
+    runGitImpl: (_root, args) => {
+      gitArgs = args;
+      return gitResult('M', 'docs/FAQ.md');
+    },
+    verifyWorkflowEvidenceImpl: async (args) => {
+      evidenceArguments = args;
+      return successfulEvidence();
+    }
+  });
+  assert.deepEqual(gitArgs, [
+    'diff',
+    '--name-status',
+    '-z',
+    '--find-renames',
+    `${SHA.base}...${SHA.head}`,
+    '--'
+  ]);
+  assert.equal(evidenceArguments.expectedHeadSha, SHA.base);
+  assert.equal(evidenceArguments.workflowPath, '.github/workflows/test.yml');
+  assert.equal(outcome.plan.impact, 'documentation');
+  assert.equal(outcome.plan.decision, 'selective');
+  assert.equal(outcome.plan.basis, 'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE');
+  assert.deepEqual(outcome.plan.requiredJobs, ['recipes-standard']);
+});
+
+test('dev and Gallery planning use a two-commit diff and direct parent evidence', async () => {
+  for (const [profile, workflowPath, aggregateName] of [
+    ['dev', '.github/workflows/test.yml', 'Dev staging / gate'],
+    ['gallery', '.github/workflows/gallery-publication.yml', 'Gallery readiness / gate']
+  ]) {
+    let gitArgs;
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: profile,
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: (_root, args) => {
+        gitArgs = args;
+        return gitResult('M', '.gitignore');
+      },
+      verifyWorkflowEvidenceImpl: async (args) => {
+        assert.equal(args.workflowPath, workflowPath);
+        assert.equal(args.expectedAggregateName, aggregateName);
+        return successfulEvidence({ workflowPath, aggregateName });
+      }
+    });
+    assert.deepEqual(gitArgs.slice(-3), [SHA.base, SHA.head, '--']);
+    assert.equal(outcome.plan.basis, 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE');
+    assert.deepEqual(outcome.plan.requiredJobs, []);
+  }
+});
+
+test('evidence verifier failures fall back to the full profile', async () => {
+  const unavailableToken = 'unavailable-token';
+  const outcome = await buildImpactPlan({
+    configuration: configuration(),
+    token: unavailableToken,
+    runGitImpl: () => gitResult('M', '.gitignore'),
+    verifyWorkflowEvidenceImpl: async () => {
+      throw new PromotionReadinessError(
+        'API_REQUEST_FAILED',
+        `GitHub Actions API request failed for ${unavailableToken}.`
+      );
+    }
+  });
+  assert.equal(outcome.plan.impact, 'metadata');
+  assert.equal(outcome.plan.decision, 'full');
+  assert.equal(outcome.plan.basis, 'INHERITED_EVIDENCE_UNAVAILABLE');
+  assert.deepEqual(outcome.plan.requiredJobs, [
+    'web-change-budget',
+    'core-pr',
+    'recipes-standard',
+    'gallery',
+    'lint',
+    'web-pr-smoke'
+  ]);
+  assert.deepEqual(outcome.evidenceFailure, {
+    code: 'API_REQUEST_FAILED',
+    reason: 'GitHub Actions API request failed for [REDACTED].'
+  });
+});
+
+test('full changes never query inherited evidence', async () => {
+  let evidenceCalls = 0;
+  const outcome = await buildImpactPlan({
+    configuration: configuration(),
+    token: 'test-token',
+    runGitImpl: () => gitResult('M', 'tools/ci-impact.mjs'),
+    verifyWorkflowEvidenceImpl: async () => {
+      evidenceCalls += 1;
+      return successfulEvidence();
+    }
+  });
+  assert.equal(evidenceCalls, 0);
+  assert.equal(outcome.plan.impact, 'full');
+  assert.equal(outcome.plan.basis, 'FULL_CHANGE');
+});
+
+test('invalid and empty diffs fail closed without querying evidence', async () => {
+  for (const result of [
+    { status: 128, stdout: Buffer.alloc(0), stderr: Buffer.from('missing object') },
+    { status: 0, stdout: Buffer.alloc(0), stderr: Buffer.alloc(0) }
+  ]) {
+    let evidenceCalls = 0;
+    const outcome = await buildImpactPlan({
+      configuration: configuration(),
+      token: 'test-token',
+      runGitImpl: () => result,
+      verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
+    });
+    assert.equal(evidenceCalls, 0);
+    assert.equal(outcome.plan.impact, 'full');
+    assert.equal(outcome.plan.basis, 'UNKNOWN_OR_INVALID_CHANGE');
+  }
+});
+
+test('manual runs and architecture-change labels force full execution', async () => {
+  let calls = 0;
+  const manual = await buildImpactPlan({
+    configuration: configuration({
+      CI_IMPACT_PROFILE: 'dev',
+      CI_IMPACT_EVENT_NAME: 'workflow_dispatch'
+    }),
+    token: 'test-token',
+    runGitImpl: () => { calls += 1; },
+    verifyWorkflowEvidenceImpl: async () => { calls += 1; }
+  });
+  assert.equal(calls, 0);
+  assert.equal(manual.plan.basis, 'MANUAL_FULL_RUN');
+
+  const architecture = await buildImpactPlan({
+    configuration: configuration({ CI_IMPACT_ARCHITECTURE_CHANGE: 'true' }),
+    token: 'test-token',
+    runGitImpl: () => gitResult('M', 'docs/FAQ.md'),
+    verifyWorkflowEvidenceImpl: async () => { calls += 1; }
+  });
+  assert.equal(calls, 0);
+  assert.equal(architecture.plan.impact, 'documentation');
+  assert.equal(architecture.plan.decision, 'full');
+  assert.equal(architecture.plan.basis, 'ARCHITECTURE_CHANGE');
+});
+
+test('plan command writes one compact output line and escapes summary paths', async () => {
+  const stdout = textWriter();
+  const stderr = textWriter();
+  const writes = new Map();
+  const status = await runCiImpactCli({
+    argv: ['plan'],
+    env: environment({
+      GITHUB_OUTPUT: '/tmp/ci-impact-output',
+      GITHUB_STEP_SUMMARY: '/tmp/ci-impact-summary'
+    }),
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    appendFileImpl: (path, content) => writes.set(path, (writes.get(path) || '') + content),
+    runGitImpl: () => gitResult('M', 'docs/<unsafe>\nname.md'),
+    verifyWorkflowEvidenceImpl: async () => successfulEvidence()
+  });
+  assert.equal(status, 0, stderr.value());
+  const output = writes.get('/tmp/ci-impact-output');
+  assert.equal(output.split('\n').filter(Boolean).length, 1);
+  assert.match(output, /^plan=\{"schemaVersion":1,/);
+  const summary = writes.get('/tmp/ci-impact-summary');
+  assert.match(summary, /docs\/&lt;unsafe&gt;\\nname\.md/);
+  assert.doesNotMatch(summary, /docs\/<unsafe>/);
+  assert.doesNotMatch(stdout.value(), /test-token/);
+});
+
+test('unexpected failures are not converted to full plans and redact tokens', async () => {
+  const secret = 'token-with-secret-value';
+  const stdout = textWriter();
+  const stderr = textWriter();
+  const status = await runCiImpactCli({
+    argv: ['plan'],
+    env: environment({ GITHUB_TOKEN: secret }),
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    runGitImpl: () => gitResult('M', '.gitignore'),
+    verifyWorkflowEvidenceImpl: async () => {
+      throw Object.assign(new Error('programming error'), {
+        code: 'INJECTED_ERROR',
+        details: { diagnostic: secret }
+      });
+    }
+  });
+  assert.equal(status, 1);
+  assert.equal(stdout.value(), '');
+  assert.match(stderr.value(), /INJECTED_ERROR/);
+  assert.match(stderr.value(), /\[REDACTED\]/);
+  assert.doesNotMatch(stderr.value(), new RegExp(secret));
+});
+
+test('CLI rejects unknown arguments and invalid profile/event contracts', async () => {
+  const stderr = textWriter();
+  const status = await runCiImpactCli({
+    argv: ['plan', '--unknown'],
+    env: environment(),
+    stdout: textWriter().stream,
+    stderr: stderr.stream
+  });
+  assert.equal(status, 1);
+  assert.match(stderr.value(), /INVALID_ARGUMENTS/);
+  assert.throws(
+    () => readPlanConfiguration(environment({ CI_IMPACT_PROFILE: 'gallery' })),
+    /PR profile must match/
+  );
+});
+
+test('shadow workflow exposes the plan without routing existing test jobs', () => {
+  const workflow = readFileSync(resolve(REPOSITORY_ROOT, '.github/workflows/test.yml'), 'utf8');
+  assert.match(workflow, /actions: read/);
+  assert.match(workflow, /\n  ci-impact:\n[\s\S]*?name: CI impact plan/);
+  assert.match(workflow, /node --test tests\/ci\/\*\.test\.mjs/);
+  assert.match(workflow, /id: plan[\s\S]*node tools\/ci-impact\.mjs plan/);
+  for (const jobId of [
+    'web-change-budget',
+    'core',
+    'core-pr',
+    'recipes-standard',
+    'gallery',
+    'browser',
+    'web-pr-smoke',
+    'playwright-functional',
+    'playwright-performance',
+    'acceptance-supported-main',
+    'slow-main',
+    'lint',
+    'losat-cache-browser-acceptance'
+  ]) {
+    const job = workflow.match(
+      new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
+    )?.[0];
+    assert.ok(job, jobId);
+    assert.doesNotMatch(job, /needs(?:\.[a-z-]+)?\.ci-impact|needs:\s+ci-impact/);
+  }
+});

--- a/tests/ci/ci-impact-gate.test.mjs
+++ b/tests/ci/ci-impact-gate.test.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createImpactPlan,
+  knownJobsFor,
+  validateGateResults
+} from '../../tools/ci-impact-policy.mjs';
+import { runCiImpactCli } from '../../tools/ci-impact.mjs';
+
+const SHA = Object.freeze({
+  base: 'a'.repeat(40),
+  head: 'b'.repeat(40),
+  workflow: 'c'.repeat(40)
+});
+
+const plan = (overrides = {}) => createImpactPlan({
+  profile: 'pr',
+  impact: 'documentation',
+  decision: 'selective',
+  basis: 'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE',
+  changeBaseSha: SHA.base,
+  changeHeadSha: SHA.head,
+  workflowSha: SHA.workflow,
+  changedPathCount: 1,
+  inheritedEvidence: {
+    workflowPath: '.github/workflows/test.yml',
+    aggregateName: 'Dev staging / gate',
+    headSha: SHA.base,
+    runId: 101,
+    aggregateJobId: 202,
+    runUrl: 'https://github.com/satoshikawato/gbdraw/actions/runs/101',
+    aggregateJobUrl: 'https://github.com/satoshikawato/gbdraw/actions/runs/101/job/202'
+  },
+  ...overrides
+});
+
+const needsFor = (impactPlan = plan()) => Object.fromEntries([
+  ['ci-impact', { result: 'success' }],
+  ...knownJobsFor(impactPlan.profile).map((jobId) => [
+    jobId,
+    { result: impactPlan.requiredJobs.includes(jobId) ? 'success' : 'skipped' }
+  ])
+]);
+
+const validate = (impactPlan, needs) => validateGateResults({
+  plan: impactPlan,
+  needs,
+  knownJobs: knownJobsFor(impactPlan.profile),
+  expected: { profile: impactPlan.profile, workflowSha: SHA.workflow }
+});
+
+test('gate accepts required success and unrequired skipped or success', () => {
+  const impactPlan = plan();
+  const skipped = validate(impactPlan, needsFor(impactPlan));
+  assert.equal(skipped.ok, true);
+
+  const successfulNeeds = needsFor(impactPlan);
+  successfulNeeds.gallery.result = 'success';
+  const successful = validate(impactPlan, successfulNeeds);
+  assert.equal(successful.ok, true);
+});
+
+test('gate rejects required skipped, failure, and cancellation', () => {
+  for (const result of ['skipped', 'failure', 'cancelled']) {
+    const impactPlan = plan();
+    const needs = needsFor(impactPlan);
+    needs['recipes-standard'].result = result;
+    assert.throws(
+      () => validate(impactPlan, needs),
+      /required CI job did not succeed/,
+      result
+    );
+  }
+});
+
+test('gate rejects planner failures and unrequired failures', () => {
+  const impactPlan = plan();
+  const plannerFailure = needsFor(impactPlan);
+  plannerFailure['ci-impact'].result = 'failure';
+  assert.throws(() => validate(impactPlan, plannerFailure), /planner did not succeed/);
+
+  for (const result of ['failure', 'cancelled', 'timed_out']) {
+    const needs = needsFor(impactPlan);
+    needs.gallery.result = result;
+    assert.throws(
+      () => validate(impactPlan, needs),
+      /unrequired CI job failed unexpectedly/,
+      result
+    );
+  }
+});
+
+test('gate rejects missing expected jobs', () => {
+  const impactPlan = plan();
+  const needs = needsFor(impactPlan);
+  delete needs.lint;
+  assert.throws(() => validate(impactPlan, needs), /result is missing or invalid/);
+});
+
+test('unknown jobs may succeed or skip but may not fail', () => {
+  const impactPlan = plan();
+  for (const result of ['success', 'skipped']) {
+    const needs = { ...needsFor(impactPlan), future: { result } };
+    assert.equal(validate(impactPlan, needs).ok, true);
+  }
+  const failed = { ...needsFor(impactPlan), future: { result: 'failure' } };
+  assert.throws(() => validate(impactPlan, failed), /unknown CI job failed unexpectedly/);
+});
+
+test('gate rejects wrong profile, workflow SHA, and schema', () => {
+  const impactPlan = plan();
+  const needs = needsFor(impactPlan);
+  assert.throws(() => validateGateResults({
+    plan: impactPlan,
+    needs,
+    knownJobs: knownJobsFor('pr'),
+    expected: { profile: 'dev', workflowSha: SHA.workflow }
+  }), /profile does not match/);
+  assert.throws(() => validateGateResults({
+    plan: impactPlan,
+    needs,
+    knownJobs: knownJobsFor('pr'),
+    expected: { profile: 'pr', workflowSha: 'd'.repeat(40) }
+  }), /workflow SHA does not match/);
+  assert.throws(() => validateGateResults({
+    plan: { ...impactPlan, schemaVersion: 2 },
+    needs,
+    knownJobs: knownJobsFor('pr'),
+    expected: { profile: 'pr', workflowSha: SHA.workflow }
+  }), /schema version is not supported/);
+});
+
+const textWriter = () => {
+  let value = '';
+  return {
+    stream: { write: (chunk) => { value += chunk; } },
+    value: () => value
+  };
+};
+
+test('gate CLI rejects malformed plan and needs JSON', async () => {
+  for (const [field, value] of [
+    ['CI_IMPACT_PLAN_JSON', '{'],
+    ['CI_IMPACT_NEEDS_JSON', '[not-json]']
+  ]) {
+    const stdout = textWriter();
+    const stderr = textWriter();
+    const impactPlan = plan();
+    const status = await runCiImpactCli({
+      argv: ['gate'],
+      env: {
+        CI_IMPACT_PLAN_JSON: JSON.stringify(impactPlan),
+        CI_IMPACT_NEEDS_JSON: JSON.stringify(needsFor(impactPlan)),
+        CI_IMPACT_EXPECTED_PROFILE: 'pr',
+        CI_IMPACT_EXPECTED_WORKFLOW_SHA: SHA.workflow,
+        [field]: value
+      },
+      stdout: stdout.stream,
+      stderr: stderr.stream
+    });
+    assert.equal(status, 1);
+    assert.equal(stdout.value(), '');
+    assert.match(stderr.value(), /MALFORMED_JSON/);
+  }
+});
+
+test('gate CLI emits a passing summary for a valid payload', async () => {
+  const stdout = textWriter();
+  const stderr = textWriter();
+  const impactPlan = plan();
+  let summary = '';
+  const status = await runCiImpactCli({
+    argv: ['gate'],
+    env: {
+      CI_IMPACT_PLAN_JSON: JSON.stringify(impactPlan),
+      CI_IMPACT_NEEDS_JSON: JSON.stringify(needsFor(impactPlan)),
+      CI_IMPACT_EXPECTED_PROFILE: 'pr',
+      CI_IMPACT_EXPECTED_WORKFLOW_SHA: SHA.workflow,
+      GITHUB_STEP_SUMMARY: '/tmp/ci-impact-gate-summary'
+    },
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    appendFileImpl: (_path, content) => { summary += content; }
+  });
+  assert.equal(status, 0, stderr.value());
+  assert.equal(JSON.parse(stdout.value()).ok, true);
+  assert.match(summary, /Gate result: pass/);
+  assert.match(summary, /`recipes-standard`: `success` \(required\)/);
+  assert.match(summary, /`gallery`: `skipped` \(not required\)/);
+});

--- a/tests/ci/ci-impact-policy.test.mjs
+++ b/tests/ci/ci-impact-policy.test.mjs
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  classifyChanges,
+  classifyPath,
+  createImpactPlan,
+  knownJobsFor,
+  requiredJobsFor,
+  validateImpactPlan
+} from '../../tools/ci-impact-policy.mjs';
+
+const SHA = Object.freeze({
+  base: 'a'.repeat(40),
+  head: 'b'.repeat(40),
+  workflow: 'c'.repeat(40)
+});
+
+const evidence = () => ({
+  workflowPath: '.github/workflows/test.yml',
+  aggregateName: 'Dev staging / gate',
+  headSha: SHA.base,
+  runId: 101,
+  aggregateJobId: 202,
+  runUrl: 'https://github.com/satoshikawato/gbdraw/actions/runs/101',
+  aggregateJobUrl: 'https://github.com/satoshikawato/gbdraw/actions/runs/101/job/202'
+});
+
+const selectivePlan = (overrides = {}) => createImpactPlan({
+  profile: 'pr',
+  impact: 'documentation',
+  decision: 'selective',
+  basis: 'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE',
+  changeBaseSha: SHA.base,
+  changeHeadSha: SHA.head,
+  workflowSha: SHA.workflow,
+  changedPathCount: 1,
+  inheritedEvidence: evidence(),
+  ...overrides
+});
+
+test('metadata allowlist is deliberately narrow', () => {
+  for (const path of [
+    '.agents/skills/example/SKILL.md',
+    '.claude/settings.json',
+    '.codex/config.toml',
+    '.cursor/rules/example.mdc',
+    '.github/pull_request_template.md',
+    '.dockerignore',
+    '.gitattributes',
+    '.gitignore',
+    'CITATION.cff',
+    'LICENSE.txt',
+    'LICENSE_LIBERATION_FONTS.txt'
+  ]) {
+    assert.equal(classifyPath(path).impact, 'metadata', path);
+  }
+  assert.equal(classifyPath('.github/ISSUE_TEMPLATE/bug.md').impact, 'full');
+  assert.equal(classifyPath('reports/ci.md').impact, 'full');
+});
+
+test('root Markdown and docs tree are documentation', () => {
+  assert.equal(classifyPath('README.md').impact, 'documentation');
+  assert.equal(classifyPath('NEW_PLAN.md').impact, 'documentation');
+  assert.equal(classifyPath('docs/internal/policy.md').impact, 'documentation');
+  assert.equal(classifyPath('nested/README.md').impact, 'full');
+  assert.equal(classifyPath('README.MD').impact, 'full');
+});
+
+test('runtime, tests, workflows, dependencies, and unknown paths are full', () => {
+  for (const path of [
+    'gbdraw/core/sequence.py',
+    'tests/test_regression.py',
+    'tools/helper.mjs',
+    '.github/workflows/test.yml',
+    'pyproject.toml',
+    'setup.py',
+    'MANIFEST.in',
+    'package.json',
+    'package-lock.json',
+    'playwright.config.js',
+    'recipe/meta.yaml',
+    'examples/example.gb',
+    '_reproduced/result.svg',
+    'wrangler.toml',
+    'reports/result.json',
+    'future/unknown.file'
+  ]) {
+    assert.equal(classifyPath(path).impact, 'full', path);
+  }
+});
+
+test('mixed changes use the strongest impact', () => {
+  const metadata = classifyChanges([
+    { status: 'M', paths: ['.gitignore'] },
+    { status: 'A', paths: ['.agents/skills/new/SKILL.md'] }
+  ]);
+  assert.equal(metadata.impact, 'metadata');
+
+  const documentation = classifyChanges([
+    { status: 'M', paths: ['.gitignore'] },
+    { status: 'M', paths: ['docs/FAQ.md'] }
+  ]);
+  assert.equal(documentation.impact, 'documentation');
+
+  const full = classifyChanges([
+    { status: 'M', paths: ['docs/FAQ.md'] },
+    { status: 'M', paths: ['gbdraw/cli.py'] }
+  ]);
+  assert.equal(full.impact, 'full');
+});
+
+test('rename, copy, and delete classify every relevant path', () => {
+  const rename = classifyChanges([
+    { status: 'R100', paths: ['docs/FAQ.md', 'gbdraw/FAQ.md'] }
+  ]);
+  assert.equal(rename.impact, 'full');
+  assert.equal(rename.changedPathCount, 2);
+
+  const copy = classifyChanges([
+    { status: 'C75', paths: ['.agents/source.md', 'docs/copied.md'] }
+  ]);
+  assert.equal(copy.impact, 'documentation');
+  assert.equal(copy.changedPathCount, 2);
+
+  const deleted = classifyChanges([{ status: 'D', paths: ['docs/retired.md'] }]);
+  assert.equal(deleted.impact, 'documentation');
+  assert.equal(deleted.changedPathCount, 1);
+});
+
+test('empty, invalid, and unknown Git changes fail closed', () => {
+  assert.deepEqual(
+    { impact: classifyChanges([]).impact, valid: classifyChanges([]).valid },
+    { impact: 'full', valid: false }
+  );
+  assert.equal(classifyChanges([{ status: 'T', paths: ['docs/FAQ.md'] }]).valid, false);
+  assert.equal(classifyChanges([{ status: 'R101', paths: ['a', 'b'] }]).valid, false);
+  assert.equal(classifyChanges([{ status: 'M', paths: ['../outside.md'] }]).valid, false);
+});
+
+test('profile job registries are exact and centralized', () => {
+  assert.deepEqual(requiredJobsFor({
+    profile: 'pr', impact: 'metadata', decision: 'selective'
+  }), []);
+  assert.deepEqual(requiredJobsFor({
+    profile: 'pr', impact: 'documentation', decision: 'selective'
+  }), ['recipes-standard']);
+  assert.deepEqual(knownJobsFor('pr'), [
+    'web-change-budget',
+    'core-pr',
+    'recipes-standard',
+    'gallery',
+    'lint',
+    'web-pr-smoke'
+  ]);
+  assert.deepEqual(knownJobsFor('dev'), [
+    'web-change-budget',
+    'core',
+    'recipes-standard',
+    'gallery',
+    'browser',
+    'playwright-functional',
+    'playwright-performance',
+    'acceptance-supported-main',
+    'slow-main',
+    'lint',
+    'losat-cache-browser-acceptance'
+  ]);
+  assert.deepEqual(knownJobsFor('gallery'), ['browser', 'performance']);
+  assert.deepEqual(requiredJobsFor({
+    profile: 'gallery', impact: 'documentation', decision: 'selective'
+  }), []);
+});
+
+test('impact plans are strict, policy-derived, and immutable', () => {
+  const plan = selectivePlan();
+  assert.equal(validateImpactPlan(plan, {
+    profile: 'pr', workflowSha: SHA.workflow
+  }), true);
+  assert.deepEqual(plan.requiredJobs, ['recipes-standard']);
+  assert.equal(Object.isFrozen(plan), true);
+  assert.equal(Object.isFrozen(plan.requiredJobs), true);
+  assert.equal(Object.isFrozen(plan.inheritedEvidence), true);
+
+  const wrongJobs = { ...plan, requiredJobs: [] };
+  assert.throws(() => validateImpactPlan(wrongJobs), /required jobs do not match policy/);
+  assert.throws(
+    () => validateImpactPlan({ ...plan, schemaVersion: 2 }),
+    /schema version is not supported/
+  );
+  assert.throws(
+    () => validateImpactPlan({ ...plan, profile: 'future' }),
+    /profile is not supported/
+  );
+  assert.throws(
+    () => validateImpactPlan({ ...plan, workflowSha: 'd'.repeat(40) }, {
+      workflowSha: SHA.workflow
+    }),
+    /workflow SHA does not match/
+  );
+  assert.throws(
+    () => validateImpactPlan({ ...plan, unexpected: true }),
+    /invalid schema/
+  );
+});

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -901,6 +901,7 @@ test('PR-to-dev fast candidates and aggregate fail closed over the mandatory evi
     /\n    needs:\n((?:      - [a-z0-9-]+\n)+)/
   )?.[1].trim().split('\n').map((line) => line.replace('- ', '').trim());
   assert.deepEqual(dependencies, [
+    'ci-impact',
     'web-change-budget',
     'core-pr',
     'recipes-standard',
@@ -1017,6 +1018,7 @@ test('exact dev staging runs the full inventory with four mandatory Playwright s
     /\n    needs:\n((?:      - [a-z0-9-]+\n)+)/
   )?.[1].trim().split('\n').map((line) => line.replace('- ', '').trim());
   assert.deepEqual(dependencies, [
+    'ci-impact',
     'web-change-budget',
     'core',
     'recipes-standard',

--- a/tools/ci-impact-policy.mjs
+++ b/tools/ci-impact-policy.mjs
@@ -1,0 +1,420 @@
+const freeze = (value) => Object.freeze(value);
+
+export const IMPACT_PLAN_SCHEMA_VERSION = 1;
+
+export const IMPACT_CLASSES = freeze([
+  'metadata',
+  'documentation',
+  'full'
+]);
+
+export const IMPACT_DECISIONS = freeze(['selective', 'full']);
+
+export const IMPACT_PLAN_BASES = freeze([
+  'FULL_CHANGE',
+  'UNKNOWN_OR_INVALID_CHANGE',
+  'MANUAL_FULL_RUN',
+  'ARCHITECTURE_CHANGE',
+  'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE',
+  'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE',
+  'INHERITED_EVIDENCE_UNAVAILABLE'
+]);
+
+const PROFILE_REQUIRED_JOBS = freeze({
+  pr: freeze({
+    selective: freeze({
+      metadata: freeze([]),
+      documentation: freeze(['recipes-standard'])
+    }),
+    full: freeze([
+      'web-change-budget',
+      'core-pr',
+      'recipes-standard',
+      'gallery',
+      'lint',
+      'web-pr-smoke'
+    ])
+  }),
+  dev: freeze({
+    selective: freeze({
+      metadata: freeze([]),
+      documentation: freeze(['recipes-standard'])
+    }),
+    full: freeze([
+      'web-change-budget',
+      'core',
+      'recipes-standard',
+      'gallery',
+      'browser',
+      'playwright-functional',
+      'playwright-performance',
+      'acceptance-supported-main',
+      'slow-main',
+      'lint',
+      'losat-cache-browser-acceptance'
+    ])
+  }),
+  gallery: freeze({
+    selective: freeze({
+      metadata: freeze([]),
+      documentation: freeze([])
+    }),
+    full: freeze(['browser', 'performance'])
+  })
+});
+
+const IMPACT_WEIGHT = freeze({ metadata: 0, documentation: 1, full: 2 });
+const FULL_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
+const ROOT_MARKDOWN = /^[^/]+\.md$/;
+const METADATA_DIRECTORIES = freeze(['.agents', '.claude', '.codex', '.cursor']);
+const METADATA_FILES = new Set([
+  '.github/pull_request_template.md',
+  '.dockerignore',
+  '.gitattributes',
+  '.gitignore',
+  'CITATION.cff',
+  'LICENSE.txt',
+  'LICENSE_LIBERATION_FONTS.txt'
+]);
+const PLAN_KEYS = freeze([
+  'schemaVersion',
+  'profile',
+  'impact',
+  'decision',
+  'basis',
+  'changeBaseSha',
+  'changeHeadSha',
+  'workflowSha',
+  'requiredJobs',
+  'changedPathCount',
+  'inheritedEvidence'
+]);
+const EVIDENCE_KEYS = freeze([
+  'workflowPath',
+  'aggregateName',
+  'headSha',
+  'runId',
+  'aggregateJobId',
+  'runUrl',
+  'aggregateJobUrl'
+]);
+
+const isPlainObject = (value) => value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value)
+  && (Object.getPrototypeOf(value) === Object.prototype
+    || Object.getPrototypeOf(value) === null);
+
+const sameKeys = (value, expectedKeys) => isPlainObject(value)
+  && Object.keys(value).length === expectedKeys.length
+  && expectedKeys.every((key) => Object.hasOwn(value, key));
+
+const fail = (code, message, details = {}) => {
+  throw Object.assign(new Error(message), {
+    name: 'CiImpactPolicyError',
+    code,
+    details
+  });
+};
+
+const assertProfile = (profile) => {
+  if (!Object.hasOwn(PROFILE_REQUIRED_JOBS, profile)) {
+    fail('UNKNOWN_PROFILE', 'CI impact profile is not supported.', { profile });
+  }
+};
+
+const assertImpact = (impact) => {
+  if (!IMPACT_CLASSES.includes(impact)) {
+    fail('UNKNOWN_IMPACT', 'CI impact class is not supported.', { impact });
+  }
+};
+
+export const isFullObjectId = (value) => typeof value === 'string'
+  && FULL_OBJECT_ID.test(value);
+
+const isValidRepositoryPath = (path) => typeof path === 'string'
+  && path.length > 0
+  && !path.startsWith('/')
+  && !path.endsWith('/')
+  && !path.includes('\\')
+  && !path.includes('\0')
+  && path.split('/').every((part) => part && part !== '.' && part !== '..');
+
+export const classifyPath = (path) => {
+  if (!isValidRepositoryPath(path)) {
+    return freeze({ path, impact: 'full', reason: 'INVALID_REPOSITORY_PATH' });
+  }
+  if (METADATA_FILES.has(path)) {
+    return freeze({ path, impact: 'metadata', reason: 'METADATA_FILE_ALLOWLIST' });
+  }
+  if (METADATA_DIRECTORIES.some((directory) => path.startsWith(`${directory}/`))) {
+    return freeze({ path, impact: 'metadata', reason: 'METADATA_DIRECTORY_ALLOWLIST' });
+  }
+  if (ROOT_MARKDOWN.test(path)) {
+    return freeze({ path, impact: 'documentation', reason: 'ROOT_MARKDOWN' });
+  }
+  if (path.startsWith('docs/')) {
+    return freeze({ path, impact: 'documentation', reason: 'DOCUMENTATION_TREE' });
+  }
+  return freeze({ path, impact: 'full', reason: 'FULL_BY_DEFAULT' });
+};
+
+const validScoredStatus = (status) => {
+  const match = status.match(/^([RC])(\d{1,3})$/);
+  return Boolean(match) && Number(match[2]) <= 100;
+};
+
+const pathsForChange = (change) => {
+  if (!isPlainObject(change) || typeof change.status !== 'string'
+      || !Array.isArray(change.paths)) {
+    return null;
+  }
+  if (['A', 'M', 'D'].includes(change.status) && change.paths.length === 1) {
+    return change.paths;
+  }
+  if (validScoredStatus(change.status) && change.paths.length === 2) {
+    return change.paths;
+  }
+  return null;
+};
+
+export const classifyChanges = (changes) => {
+  if (!Array.isArray(changes) || changes.length === 0) {
+    return freeze({
+      impact: 'full',
+      valid: false,
+      changedPathCount: 0,
+      paths: freeze([]),
+      reason: 'EMPTY_OR_INVALID_DIFF'
+    });
+  }
+
+  const classifiedPaths = [];
+  for (const change of changes) {
+    const paths = pathsForChange(change);
+    if (paths === null) {
+      return freeze({
+        impact: 'full',
+        valid: false,
+        changedPathCount: classifiedPaths.length,
+        paths: freeze(classifiedPaths),
+        reason: 'UNKNOWN_OR_INVALID_GIT_STATUS'
+      });
+    }
+    for (const path of paths) classifiedPaths.push(classifyPath(path));
+  }
+
+  const invalidPath = classifiedPaths.some(({ reason }) => reason === 'INVALID_REPOSITORY_PATH');
+  const impact = classifiedPaths.reduce(
+    (current, entry) => IMPACT_WEIGHT[entry.impact] > IMPACT_WEIGHT[current]
+      ? entry.impact
+      : current,
+    'metadata'
+  );
+  return freeze({
+    impact: invalidPath ? 'full' : impact,
+    valid: !invalidPath,
+    changedPathCount: classifiedPaths.length,
+    paths: freeze(classifiedPaths),
+    reason: invalidPath ? 'INVALID_REPOSITORY_PATH' : 'CLASSIFIED'
+  });
+};
+
+export const requiredJobsFor = ({ profile, impact, decision }) => {
+  assertProfile(profile);
+  assertImpact(impact);
+  if (!IMPACT_DECISIONS.includes(decision)) {
+    fail('UNKNOWN_DECISION', 'CI impact decision is not supported.', { decision });
+  }
+  if (decision === 'selective' && impact === 'full') {
+    fail('INVALID_SELECTIVE_PLAN', 'A full impact cannot use selective execution.');
+  }
+  const jobs = decision === 'full'
+    ? PROFILE_REQUIRED_JOBS[profile].full
+    : PROFILE_REQUIRED_JOBS[profile].selective[impact];
+  return freeze([...jobs]);
+};
+
+export const knownJobsFor = (profile) => {
+  assertProfile(profile);
+  return freeze([...PROFILE_REQUIRED_JOBS[profile].full]);
+};
+
+const validateInheritedEvidence = (evidence, expectedHeadSha) => {
+  if (!sameKeys(evidence, EVIDENCE_KEYS)) {
+    fail('INVALID_EVIDENCE_SCHEMA', 'Inherited evidence has an invalid schema.');
+  }
+  if (typeof evidence.workflowPath !== 'string' || !evidence.workflowPath
+      || typeof evidence.aggregateName !== 'string' || !evidence.aggregateName
+      || evidence.headSha !== expectedHeadSha
+      || !Number.isSafeInteger(evidence.runId) || evidence.runId <= 0
+      || !Number.isSafeInteger(evidence.aggregateJobId) || evidence.aggregateJobId <= 0
+      || typeof evidence.runUrl !== 'string' || !evidence.runUrl
+      || typeof evidence.aggregateJobUrl !== 'string' || !evidence.aggregateJobUrl) {
+    fail('INVALID_EVIDENCE', 'Inherited evidence identity is invalid.');
+  }
+};
+
+const validateBasis = (plan) => {
+  if (!IMPACT_PLAN_BASES.includes(plan.basis)) {
+    fail('UNKNOWN_BASIS', 'CI impact basis is not supported.', { basis: plan.basis });
+  }
+  const selectiveBasis = plan.profile === 'pr'
+    ? 'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE'
+    : 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE';
+  if (plan.decision === 'selective' && plan.basis !== selectiveBasis) {
+    fail('BASIS_DECISION_MISMATCH', 'Selective decision does not match its evidence basis.');
+  }
+  if (plan.decision === 'full' && [
+    'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE',
+    'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE'
+  ].includes(plan.basis)) {
+    fail('BASIS_DECISION_MISMATCH', 'Full decision cannot claim inherited evidence.');
+  }
+  if (['FULL_CHANGE', 'UNKNOWN_OR_INVALID_CHANGE', 'MANUAL_FULL_RUN'].includes(plan.basis)
+      && plan.impact !== 'full') {
+    fail('BASIS_IMPACT_MISMATCH', 'Full or invalid change basis requires full impact.');
+  }
+  if (plan.basis === 'INHERITED_EVIDENCE_UNAVAILABLE' && plan.impact === 'full') {
+    fail('BASIS_IMPACT_MISMATCH', 'Evidence fallback requires a light impact candidate.');
+  }
+};
+
+export const validateImpactPlan = (plan, expected = {}) => {
+  if (!sameKeys(plan, PLAN_KEYS)) {
+    fail('INVALID_PLAN_SCHEMA', 'Impact plan has an invalid schema.');
+  }
+  if (plan.schemaVersion !== IMPACT_PLAN_SCHEMA_VERSION) {
+    fail('UNKNOWN_SCHEMA_VERSION', 'Impact plan schema version is not supported.', {
+      schemaVersion: plan.schemaVersion
+    });
+  }
+  assertProfile(plan.profile);
+  assertImpact(plan.impact);
+  if (!IMPACT_DECISIONS.includes(plan.decision)) {
+    fail('UNKNOWN_DECISION', 'CI impact decision is not supported.', {
+      decision: plan.decision
+    });
+  }
+  validateBasis(plan);
+  for (const field of ['changeBaseSha', 'changeHeadSha', 'workflowSha']) {
+    if (!isFullObjectId(plan[field])) {
+      fail('INVALID_OBJECT_ID', `${field} must be a full Git object ID.`, { field });
+    }
+  }
+  if (!Number.isSafeInteger(plan.changedPathCount) || plan.changedPathCount < 0) {
+    fail('INVALID_PATH_COUNT', 'changedPathCount must be a nonnegative integer.');
+  }
+  const expectedJobs = requiredJobsFor(plan);
+  if (!Array.isArray(plan.requiredJobs)
+      || plan.requiredJobs.length !== expectedJobs.length
+      || plan.requiredJobs.some((job, index) => job !== expectedJobs[index])) {
+    fail('REQUIRED_JOBS_MISMATCH', 'Impact plan required jobs do not match policy.', {
+      expected: expectedJobs,
+      observed: plan.requiredJobs
+    });
+  }
+  if (plan.decision === 'selective') {
+    validateInheritedEvidence(plan.inheritedEvidence, plan.changeBaseSha);
+  } else if (plan.inheritedEvidence !== null) {
+    fail('UNEXPECTED_EVIDENCE', 'Full plans cannot contain inherited evidence.');
+  }
+  if (expected.profile !== undefined && plan.profile !== expected.profile) {
+    fail('PROFILE_MISMATCH', 'Impact plan profile does not match the gate.', {
+      expected: expected.profile,
+      observed: plan.profile
+    });
+  }
+  if (expected.workflowSha !== undefined
+      && plan.workflowSha.toLowerCase() !== String(expected.workflowSha).toLowerCase()) {
+    fail('WORKFLOW_SHA_MISMATCH', 'Impact plan workflow SHA does not match the gate.', {
+      expected: expected.workflowSha,
+      observed: plan.workflowSha
+    });
+  }
+  return true;
+};
+
+export const createImpactPlan = (fields) => {
+  const plan = {
+    schemaVersion: IMPACT_PLAN_SCHEMA_VERSION,
+    profile: fields.profile,
+    impact: fields.impact,
+    decision: fields.decision,
+    basis: fields.basis,
+    changeBaseSha: fields.changeBaseSha,
+    changeHeadSha: fields.changeHeadSha,
+    workflowSha: fields.workflowSha,
+    requiredJobs: requiredJobsFor(fields),
+    changedPathCount: fields.changedPathCount,
+    inheritedEvidence: fields.inheritedEvidence
+  };
+  validateImpactPlan(plan);
+  if (plan.inheritedEvidence !== null) freeze(plan.inheritedEvidence);
+  freeze(plan.requiredJobs);
+  return freeze(plan);
+};
+
+const jobResult = (needs, jobId) => {
+  const entry = needs[jobId];
+  if (!isPlainObject(entry) || typeof entry.result !== 'string') {
+    fail('MISSING_OR_INVALID_JOB', 'Expected CI job result is missing or invalid.', { jobId });
+  }
+  return entry.result;
+};
+
+export const validateGateResults = ({
+  plan,
+  needs,
+  knownJobs = knownJobsFor(plan?.profile),
+  expected = {}
+}) => {
+  validateImpactPlan(plan, expected);
+  if (!isPlainObject(needs)) {
+    fail('INVALID_NEEDS', 'Gate needs payload must be an object.');
+  }
+  if (!Array.isArray(knownJobs) || knownJobs.some((job) => typeof job !== 'string' || !job)
+      || new Set(knownJobs).size !== knownJobs.length) {
+    fail('INVALID_KNOWN_JOBS', 'Known CI job IDs must be a unique string array.');
+  }
+
+  if (jobResult(needs, 'ci-impact') !== 'success') {
+    fail('PLANNER_NOT_SUCCESSFUL', 'CI impact planner did not succeed.');
+  }
+
+  const required = new Set(plan.requiredJobs);
+  const observed = [];
+  for (const jobId of knownJobs) {
+    const result = jobResult(needs, jobId);
+    if (required.has(jobId) && result !== 'success') {
+      fail('REQUIRED_JOB_NOT_SUCCESSFUL', 'A required CI job did not succeed.', {
+        jobId,
+        result
+      });
+    }
+    if (!required.has(jobId) && !['success', 'skipped'].includes(result)) {
+      fail('UNREQUIRED_JOB_FAILED', 'An unrequired CI job failed unexpectedly.', {
+        jobId,
+        result
+      });
+    }
+    observed.push(freeze({ jobId, required: required.has(jobId), result }));
+  }
+
+  for (const [jobId, entry] of Object.entries(needs)) {
+    if (jobId === 'ci-impact' || knownJobs.includes(jobId)) continue;
+    const result = isPlainObject(entry) ? entry.result : undefined;
+    if (!['success', 'skipped'].includes(result)) {
+      fail('UNKNOWN_JOB_FAILED', 'An unknown CI job failed unexpectedly.', { jobId, result });
+    }
+    observed.push(freeze({ jobId, required: false, result }));
+  }
+
+  return freeze({
+    ok: true,
+    profile: plan.profile,
+    workflowSha: plan.workflowSha,
+    inheritedEvidence: plan.inheritedEvidence !== null,
+    jobs: freeze(observed)
+  });
+};

--- a/tools/ci-impact.mjs
+++ b/tools/ci-impact.mjs
@@ -1,0 +1,534 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { TextDecoder } from 'node:util';
+import { pathToFileURL } from 'node:url';
+import {
+  PromotionReadinessError,
+  verifyWorkflowEvidence
+} from './check-promotion-readiness.mjs';
+import {
+  classifyChanges,
+  createImpactPlan,
+  isFullObjectId,
+  knownJobsFor,
+  validateGateResults
+} from './ci-impact-policy.mjs';
+
+const SUPPORTED_PROFILES = new Set(['pr', 'dev', 'gallery']);
+const SUPPORTED_EVENTS = new Set(['pull_request', 'push', 'workflow_dispatch']);
+const REPOSITORY_NAME = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})\/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/;
+const SUMMARY_PATH_LIMIT = 20;
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+const EVIDENCE_CONTRACTS = Object.freeze({
+  pr: Object.freeze({
+    workflowPath: '.github/workflows/test.yml',
+    aggregateName: 'Dev staging / gate'
+  }),
+  dev: Object.freeze({
+    workflowPath: '.github/workflows/test.yml',
+    aggregateName: 'Dev staging / gate'
+  }),
+  gallery: Object.freeze({
+    workflowPath: '.github/workflows/gallery-publication.yml',
+    aggregateName: 'Gallery readiness / gate'
+  })
+});
+
+const isPlainObject = (value) => value !== null
+  && typeof value === 'object'
+  && !Array.isArray(value);
+
+const fail = (code, message, details = {}) => {
+  throw Object.assign(new Error(message), {
+    name: 'CiImpactCliError',
+    code,
+    details
+  });
+};
+
+const boundedText = (value, limit = 300) => {
+  const source = typeof value === 'string' ? value : String(value ?? '');
+  const normalized = source.replace(/[\r\n\t]+/g, ' ').trim();
+  return normalized.length <= limit ? normalized : `${normalized.slice(0, limit)}...`;
+};
+
+const redact = (text, env) => {
+  const token = typeof env.GITHUB_TOKEN === 'string' ? env.GITHUB_TOKEN : '';
+  return token ? text.replaceAll(token, '[REDACTED]') : text;
+};
+
+const requiredEnvironment = (env, name) => {
+  const value = env[name];
+  if (typeof value !== 'string' || !value) {
+    fail('MISSING_ENVIRONMENT', `Required environment variable ${name} is missing.`, { name });
+  }
+  return value;
+};
+
+const booleanEnvironment = (env, name) => {
+  const value = requiredEnvironment(env, name);
+  if (!['true', 'false'].includes(value)) {
+    fail('INVALID_BOOLEAN', `${name} must be true or false.`, { name, value: boundedText(value) });
+  }
+  return value === 'true';
+};
+
+const objectIdEnvironment = (env, name) => {
+  const value = requiredEnvironment(env, name).toLowerCase();
+  if (!isFullObjectId(value)) {
+    fail('INVALID_OBJECT_ID', `${name} must be a full Git object ID.`, { name });
+  }
+  return value;
+};
+
+export const readPlanConfiguration = (env, cwd = process.cwd()) => {
+  const profile = requiredEnvironment(env, 'CI_IMPACT_PROFILE');
+  const eventName = requiredEnvironment(env, 'CI_IMPACT_EVENT_NAME');
+  const repository = requiredEnvironment(env, 'CI_IMPACT_REPOSITORY');
+  if (!SUPPORTED_PROFILES.has(profile)) {
+    fail('INVALID_PROFILE', 'CI_IMPACT_PROFILE is not supported.', { profile });
+  }
+  if (!SUPPORTED_EVENTS.has(eventName)) {
+    fail('INVALID_EVENT', 'CI_IMPACT_EVENT_NAME is not supported.', { eventName });
+  }
+  if ((profile === 'pr') !== (eventName === 'pull_request')) {
+    fail('PROFILE_EVENT_MISMATCH', 'PR profile must match a pull_request event.');
+  }
+  if (!REPOSITORY_NAME.test(repository)) {
+    fail('INVALID_REPOSITORY', 'CI_IMPACT_REPOSITORY must be OWNER/REPOSITORY.');
+  }
+  return Object.freeze({
+    profile,
+    eventName,
+    repository,
+    repositoryRoot: resolve(env.CI_IMPACT_REPOSITORY_ROOT || cwd),
+    changeBaseSha: objectIdEnvironment(env, 'CI_IMPACT_CHANGE_BASE_SHA'),
+    changeHeadSha: objectIdEnvironment(env, 'CI_IMPACT_CHANGE_HEAD_SHA'),
+    workflowSha: objectIdEnvironment(env, 'CI_IMPACT_WORKFLOW_SHA'),
+    architectureChange: booleanEnvironment(env, 'CI_IMPACT_ARCHITECTURE_CHANGE')
+  });
+};
+
+const splitNulTokens = (source) => {
+  const bytes = Buffer.isBuffer(source) ? source : Buffer.from(source);
+  if (bytes.length === 0 || bytes[bytes.length - 1] !== 0) {
+    fail('MALFORMED_GIT_DIFF', 'Git name-status output is empty or not NUL-terminated.');
+  }
+  const tokens = [];
+  let start = 0;
+  for (let index = 0; index < bytes.length; index += 1) {
+    if (bytes[index] !== 0) continue;
+    const token = bytes.subarray(start, index);
+    try {
+      tokens.push(utf8Decoder.decode(token));
+    } catch (_error) {
+      fail('INVALID_PATH_ENCODING', 'Git path is not valid UTF-8.');
+    }
+    start = index + 1;
+  }
+  if (tokens.at(-1) === '') tokens.pop();
+  return tokens;
+};
+
+export const parseNameStatusZ = (source) => {
+  const tokens = splitNulTokens(source);
+  if (tokens.length === 0) {
+    fail('MALFORMED_GIT_DIFF', 'Git name-status output contains no changes.');
+  }
+  const changes = [];
+  for (let index = 0; index < tokens.length;) {
+    const status = tokens[index];
+    index += 1;
+    const pathCount = /^[RC]/.test(status) ? 2 : 1;
+    if (index + pathCount > tokens.length) {
+      fail('MALFORMED_GIT_DIFF', 'Git name-status output ended before its paths.');
+    }
+    changes.push(Object.freeze({
+      status,
+      paths: Object.freeze(tokens.slice(index, index + pathCount))
+    }));
+    index += pathCount;
+  }
+  return Object.freeze(changes);
+};
+
+export const runGit = (repositoryRoot, args) => spawnSync('git', args, {
+  cwd: repositoryRoot,
+  encoding: null,
+  stdio: ['ignore', 'pipe', 'pipe']
+});
+
+const readGitChanges = ({ configuration, runGitImpl }) => {
+  const range = configuration.profile === 'pr'
+    ? [`${configuration.changeBaseSha}...${configuration.changeHeadSha}`]
+    : [configuration.changeBaseSha, configuration.changeHeadSha];
+  let result;
+  try {
+    result = runGitImpl(configuration.repositoryRoot, [
+      'diff',
+      '--name-status',
+      '-z',
+      '--find-renames',
+      ...range,
+      '--'
+    ]);
+  } catch (error) {
+    return Object.freeze({
+      valid: false,
+      reason: 'GIT_DIFF_FAILED',
+      diagnostic: boundedText(error?.message || error)
+    });
+  }
+  if (!isPlainObject(result) || !Number.isInteger(result.status)
+      || !(Buffer.isBuffer(result.stdout) || result.stdout instanceof Uint8Array)) {
+    return Object.freeze({
+      valid: false,
+      reason: 'MALFORMED_GIT_RESULT',
+      diagnostic: 'Git runner returned an invalid result.'
+    });
+  }
+  if (result.status !== 0) {
+    return Object.freeze({
+      valid: false,
+      reason: 'GIT_DIFF_FAILED',
+      diagnostic: boundedText(Buffer.from(result.stderr || '').toString('utf8'))
+    });
+  }
+  try {
+    return Object.freeze({ valid: true, changes: parseNameStatusZ(result.stdout) });
+  } catch (error) {
+    return Object.freeze({
+      valid: false,
+      reason: error?.code || 'MALFORMED_GIT_DIFF',
+      diagnostic: boundedText(error?.message || error)
+    });
+  }
+};
+
+const planFields = ({ configuration, classification, decision, basis, inheritedEvidence }) => ({
+  profile: configuration.profile,
+  impact: classification.impact,
+  decision,
+  basis,
+  changeBaseSha: configuration.changeBaseSha,
+  changeHeadSha: configuration.changeHeadSha,
+  workflowSha: configuration.workflowSha,
+  changedPathCount: classification.changedPathCount,
+  inheritedEvidence
+});
+
+const fullClassification = (reason) => Object.freeze({
+  impact: 'full',
+  valid: false,
+  changedPathCount: 0,
+  paths: Object.freeze([]),
+  reason
+});
+
+const normalizeEvidence = (evidence, contract, expectedHeadSha) => {
+  if (!isPlainObject(evidence) || !isPlainObject(evidence.run)
+      || !isPlainObject(evidence.aggregateJob)
+      || evidence.workflow?.path !== contract.workflowPath
+      || evidence.run.headSha !== expectedHeadSha
+      || !Number.isSafeInteger(evidence.run.id) || evidence.run.id <= 0
+      || !Number.isSafeInteger(evidence.aggregateJob.id) || evidence.aggregateJob.id <= 0
+      || evidence.aggregateJob.name !== contract.aggregateName
+      || typeof evidence.run.url !== 'string' || !evidence.run.url
+      || typeof evidence.aggregateJob.url !== 'string' || !evidence.aggregateJob.url) {
+    fail('MALFORMED_EVIDENCE', 'Evidence verifier returned an invalid success result.');
+  }
+  return {
+    workflowPath: contract.workflowPath,
+    aggregateName: contract.aggregateName,
+    headSha: expectedHeadSha,
+    runId: evidence.run.id,
+    aggregateJobId: evidence.aggregateJob.id,
+    runUrl: evidence.run.url,
+    aggregateJobUrl: evidence.aggregateJob.url
+  };
+};
+
+export const buildImpactPlan = async ({
+  configuration,
+  token,
+  runGitImpl = runGit,
+  verifyWorkflowEvidenceImpl = verifyWorkflowEvidence
+}) => {
+  if (configuration.eventName === 'workflow_dispatch') {
+    const classification = fullClassification('MANUAL_FULL_RUN');
+    return Object.freeze({
+      plan: createImpactPlan(planFields({
+        configuration,
+        classification,
+        decision: 'full',
+        basis: 'MANUAL_FULL_RUN',
+        inheritedEvidence: null
+      })),
+      classification
+    });
+  }
+
+  const gitChanges = readGitChanges({ configuration, runGitImpl });
+  const classification = gitChanges.valid
+    ? classifyChanges(gitChanges.changes)
+    : fullClassification(gitChanges.reason);
+
+  if (configuration.architectureChange) {
+    return Object.freeze({
+      plan: createImpactPlan(planFields({
+        configuration,
+        classification,
+        decision: 'full',
+        basis: 'ARCHITECTURE_CHANGE',
+        inheritedEvidence: null
+      })),
+      classification
+    });
+  }
+
+  if (!classification.valid || classification.impact === 'full') {
+    return Object.freeze({
+      plan: createImpactPlan(planFields({
+        configuration,
+        classification,
+        decision: 'full',
+        basis: classification.valid ? 'FULL_CHANGE' : 'UNKNOWN_OR_INVALID_CHANGE',
+        inheritedEvidence: null
+      })),
+      classification
+    });
+  }
+
+  const contract = EVIDENCE_CONTRACTS[configuration.profile];
+  let evidence;
+  try {
+    evidence = await verifyWorkflowEvidenceImpl({
+      repository: configuration.repository,
+      workflowPath: contract.workflowPath,
+      expectedHeadSha: configuration.changeBaseSha,
+      expectedAggregateName: contract.aggregateName,
+      token
+    });
+  } catch (error) {
+    if (!(error instanceof PromotionReadinessError)) throw error;
+    return Object.freeze({
+      plan: createImpactPlan(planFields({
+        configuration,
+        classification,
+        decision: 'full',
+        basis: 'INHERITED_EVIDENCE_UNAVAILABLE',
+        inheritedEvidence: null
+      })),
+      classification,
+      evidenceFailure: Object.freeze({
+        code: error.code,
+        reason: token
+          ? boundedText(error.message).replaceAll(token, '[REDACTED]')
+          : boundedText(error.message)
+      })
+    });
+  }
+
+  const inheritedEvidence = normalizeEvidence(
+    evidence,
+    contract,
+    configuration.changeBaseSha
+  );
+  return Object.freeze({
+    plan: createImpactPlan(planFields({
+      configuration,
+      classification,
+      decision: 'selective',
+      basis: configuration.profile === 'pr'
+        ? 'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE'
+        : 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE',
+      inheritedEvidence
+    })),
+    classification
+  });
+};
+
+const visiblePath = (path) => String(path)
+  .replaceAll('\\', '\\\\')
+  .replaceAll('\r', '\\r')
+  .replaceAll('\n', '\\n')
+  .replaceAll('\t', '\\t');
+
+const html = (source) => visiblePath(source)
+  .replaceAll('&', '&amp;')
+  .replaceAll('<', '&lt;')
+  .replaceAll('>', '&gt;');
+
+export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => {
+  const requiredJobs = plan.requiredJobs.length ? plan.requiredJobs.map((job) => `\`${job}\``).join(', ') : 'none';
+  const lines = [
+    '## CI impact plan (shadow mode)',
+    '',
+    `- Profile: \`${plan.profile}\``,
+    `- Impact: \`${plan.impact}\``,
+    `- Decision: \`${plan.decision}\``,
+    `- Basis: \`${plan.basis}\``,
+    `- Change base/head: \`${plan.changeBaseSha}\` / \`${plan.changeHeadSha}\``,
+    `- Workflow SHA: \`${plan.workflowSha}\``,
+    `- Changed paths: ${plan.changedPathCount}`,
+    `- Planned required job IDs: ${requiredJobs}`,
+    '- Routing: observation only; existing test job conditions are unchanged',
+    ''
+  ];
+  if (plan.inheritedEvidence) {
+    lines.push(
+      `- Inherited run: [${plan.inheritedEvidence.runId}](${plan.inheritedEvidence.runUrl})`,
+      `- Inherited aggregate: [${html(plan.inheritedEvidence.aggregateName)}](${plan.inheritedEvidence.aggregateJobUrl})`,
+      `- Evidence SHA: \`${plan.inheritedEvidence.headSha}\``,
+      ''
+    );
+  }
+  if (evidenceFailure) {
+    lines.push(
+      `- Full fallback: \`${html(evidenceFailure.code)}\` — ${html(evidenceFailure.reason)}`,
+      ''
+    );
+  }
+  if (classification.paths.length) {
+    lines.push('### Classified paths', '');
+    classification.paths.slice(0, SUMMARY_PATH_LIMIT).forEach((entry) => {
+      lines.push(`- <code>${html(entry.path)}</code> — \`${entry.impact}\` / \`${entry.reason}\``);
+    });
+    if (classification.paths.length > SUMMARY_PATH_LIMIT) {
+      lines.push(`- … ${classification.paths.length - SUMMARY_PATH_LIMIT} more path(s)`);
+    }
+    lines.push('');
+  } else if (!classification.valid) {
+    lines.push(`- Diff fallback reason: \`${html(classification.reason)}\``, '');
+  }
+  return lines.join('\n');
+};
+
+export const formatGateSummary = ({ plan, result }) => [
+  '## CI impact aggregate validation',
+  '',
+  `- Profile: \`${plan.profile}\``,
+  `- Workflow SHA: \`${plan.workflowSha}\``,
+  `- Inherited evidence: ${result.inheritedEvidence ? 'yes' : 'no'}`,
+  ...result.jobs.map(({ jobId, required, result: jobStatus }) => (
+    `- \`${jobId}\`: \`${jobStatus}\` (${required ? 'required' : 'not required'})`
+  )),
+  '- Gate result: pass',
+  ''
+].join('\n');
+
+const appendOutput = (path, content, appendFileImpl) => {
+  try {
+    appendFileImpl(resolve(path), content, 'utf8');
+  } catch (_error) {
+    fail('OUTPUT_WRITE_FAILED', 'CI output file could not be written.');
+  }
+};
+
+const parseJsonEnvironment = (env, name) => {
+  const source = requiredEnvironment(env, name);
+  try {
+    return JSON.parse(source);
+  } catch (_error) {
+    fail('MALFORMED_JSON', `${name} must contain valid JSON.`, { name });
+  }
+};
+
+const runPlanCommand = async ({
+  env,
+  cwd,
+  stdout,
+  appendFileImpl,
+  runGitImpl,
+  verifyWorkflowEvidenceImpl
+}) => {
+  const configuration = readPlanConfiguration(env, cwd);
+  const outcome = await buildImpactPlan({
+    configuration,
+    token: env.GITHUB_TOKEN,
+    runGitImpl,
+    verifyWorkflowEvidenceImpl
+  });
+  const compact = JSON.stringify(outcome.plan);
+  stdout.write(`${compact}\n`);
+  if (env.GITHUB_OUTPUT) appendOutput(env.GITHUB_OUTPUT, `plan=${compact}\n`, appendFileImpl);
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendOutput(
+      env.GITHUB_STEP_SUMMARY,
+      formatPlanSummary(outcome),
+      appendFileImpl
+    );
+  }
+};
+
+const runGateCommand = ({ env, stdout, appendFileImpl }) => {
+  const plan = parseJsonEnvironment(env, 'CI_IMPACT_PLAN_JSON');
+  const needs = parseJsonEnvironment(env, 'CI_IMPACT_NEEDS_JSON');
+  const expectedProfile = requiredEnvironment(env, 'CI_IMPACT_EXPECTED_PROFILE');
+  const expectedWorkflowSha = objectIdEnvironment(env, 'CI_IMPACT_EXPECTED_WORKFLOW_SHA');
+  const result = validateGateResults({
+    plan,
+    needs,
+    knownJobs: knownJobsFor(expectedProfile),
+    expected: { profile: expectedProfile, workflowSha: expectedWorkflowSha }
+  });
+  stdout.write(`${JSON.stringify(result)}\n`);
+  if (env.GITHUB_STEP_SUMMARY) {
+    appendOutput(env.GITHUB_STEP_SUMMARY, formatGateSummary({ plan, result }), appendFileImpl);
+  }
+};
+
+export const runCiImpactCli = async ({
+  argv = process.argv.slice(2),
+  env = process.env,
+  cwd = process.cwd(),
+  stdout = process.stdout,
+  stderr = process.stderr,
+  appendFileImpl = appendFileSync,
+  runGitImpl = runGit,
+  verifyWorkflowEvidenceImpl = verifyWorkflowEvidence
+} = {}) => {
+  try {
+    if (argv.length !== 1 || !['plan', 'gate'].includes(argv[0])) {
+      fail('INVALID_ARGUMENTS', 'Command must be exactly plan or gate.', {
+        arguments: argv.map((argument) => boundedText(argument))
+      });
+    }
+    if (argv[0] === 'plan') {
+      await runPlanCommand({
+        env,
+        cwd,
+        stdout,
+        appendFileImpl,
+        runGitImpl,
+        verifyWorkflowEvidenceImpl
+      });
+    } else {
+      runGateCommand({ env, stdout, appendFileImpl });
+    }
+    return 0;
+  } catch (error) {
+    const code = typeof error?.code === 'string' ? error.code : 'UNEXPECTED_ERROR';
+    const message = error?.name === 'CiImpactPolicyError'
+      || error?.name === 'CiImpactCliError'
+      || error instanceof PromotionReadinessError
+      ? error.message
+      : 'Unexpected CI impact planner failure.';
+    const details = isPlainObject(error?.details) ? error.details : {};
+    const diagnostic = [
+      `CI impact command failed [${code}]: ${message}`,
+      `Details: ${JSON.stringify(details)}`,
+      ''
+    ].join('\n');
+    stderr.write(redact(diagnostic, env));
+    return 1;
+  }
+};
+
+const isDirectExecution = process.argv[1]
+  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+if (isDirectExecution) process.exitCode = await runCiImpactCli();


### PR DESCRIPTION
## Plain-language summary

This PR adds a deterministic planner that classifies CI changes as metadata, documentation, or full impact and records the resulting plan in the `CI impact plan` job summary. It is intentionally observational: every existing pull-request and `dev` staging test job still runs under its previous condition. The planner falls back to the full job profile whenever a change or its direct base/parent evidence cannot be verified safely.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Establish the trusted, tested control-plane foundation needed for later selective-CI pull requests without changing test selection in this bootstrap change. The new planner can be observed on pull requests and exact `dev` pushes before any job routing depends on it.

## User-visible impact

There is no application, rendering, packaging, Web UI, Gallery, or scientific-output change. Maintainers gain a `CI impact plan` summary that shows the classified paths, planned job IDs, exact SHAs, evidence links when available, and full-fallback reason.

## Changes

- Add `tools/ci-impact-policy.mjs` as the I/O-free owner of the three path classes, profile job registries, `ImpactPlan` validation, and aggregate gate validation.
- Add `tools/ci-impact.mjs` as the Git/GitHub/output adapter and `plan`/`gate` CLI. It parses NUL-delimited Git changes, reuses `verifyWorkflowEvidence()` from `tools/check-promotion-readiness.mjs`, and redacts tokens from diagnostics and summaries.
- Add network-free Node tests for policy, CLI, diff parsing, evidence fallback, output escaping, and fail-closed gate behavior under `tests/ci/`.
- Add `docs/internal/SELECTIVE_CI.md` with the classification contract, direct-evidence model, trust boundary, staged rollout, troubleshooting, and policy-extension checklist.
- Add the always-running `CI impact plan` job to `.github/workflows/test.yml`, grant read-only Actions access, and require planner success in `PR / gate` and `Dev staging / gate`.
- Keep all existing leaf-job `if` conditions, test commands, aggregate display names, `.github/workflows/gallery-publication.yml`, `.github/workflows/web-base-policy.yml`, and the promotion verifier unchanged.

## Verification

- `npx --yes node@20.20.2 --test tests/ci/*.test.mjs` — 27 passed.
- `npx --yes node@20.20.2 --test tests/web/architecture-contracts.test.mjs` — 131 passed.
- `python -m pytest tests/ -m "not slow and not (recipe or gallery or browser)" -n auto --dist loadfile` — 2649 passed, 17 skipped.
- `python -m pytest tests/ -m "recipe and not slow"` — 186 passed.
- `ruff check gbdraw/` — passed.
- `node tools/check-web-change-budget.mjs` — Gate `PASS`; Review `REQUIRED` because `.github/workflows/test.yml` is governance/authority.
- YAML parse of `.github/workflows/test.yml` — passed.
- `git diff --exit-code -- tests/reference_outputs/` — no reference-output changes.
- Direct CLI probe against `2254b1c9..e7254da5` — `impact=full`, `decision=full`, `basis=FULL_CHANGE`, eight changed paths, and the unchanged full PR job list.

## Risk and review notes

- Gate result and any blocker: Local deterministic gates pass; no known blocker. Hosted CI must confirm the actual pull-request merge SHA and job summary.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because this adds a CI control-plane responsibility and changes `.github/workflows/test.yml`.
- Architecture impact: **This is architecture-bearing**. Before this change there is no CI-impact classification owner or execution path. After it, `tools/ci-impact-policy.mjs` is the single semantic owner and `.github/workflows/test.yml` → `tools/ci-impact.mjs` → `tools/ci-impact-policy.mjs` is the single observational path; exact-SHA evidence delegates to the unchanged promotion verifier. No superseded owner/path remains because this is a new capability, and no compatibility path is added.
- `architecture-change` label, if relevant: Not applied. This changes CI governance, not a Web runtime owner, privileged boundary, resource lifecycle, or measured Web production surface; the change is already full-impact by path policy.

Ordinary non-increasing architecture evidence:

- Owner/path responsibility: one new CI-impact policy owner and one new observational adapter path.
- Canonical location before/after: absent → `tools/ci-impact-policy.mjs`; absent → `.github/workflows/test.yml` calling `tools/ci-impact.mjs`.
- Superseded locations: none; this is a new capability with one owner and one path.
- User-visible verification: application/runtime output is unchanged; the only new visible result is the maintainer-facing shadow summary.
- Deterministic checks: focused Node 20 policy/CLI/gate tests, Web architecture contracts, full non-slow core tests, recipe contracts, Ruff, and Web policy Gate all pass.
- Debt bounds: owner excess, path excess, and compatibility burden do not increase; the new capability starts with one owner, one path, and no compatibility reader or fallback path.

## Rollback

Revert commit `e7254da5`. This removes the planner job, its aggregate dependencies, helper modules, tests, and documentation, restoring the previous full-suite workflow without changing branch protection or required check names.

## Conditional Product Impact

- Product-impact role: N/A
- Affected concern(s), if known: None; no mapped application behavior or user journey changes.
- Authority and decision references: N/A
- Behavior contracts and residual risk: Existing runtime, Web, Gallery, recipe, and output contracts remain unchanged. Residual risk is limited to planner observability and hosted Actions API/environment differences before later routing is enabled.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/test.yml`; `tests/web/architecture-contracts.test.mjs` updates the exact aggregate dependency contract.
- Checker implementation files touched: new `tools/ci-impact-policy.mjs`, `tools/ci-impact.mjs`, and their network-free tests under `tests/ci/`. Existing Web and promotion checkers are unchanged.
- Self-authorization separation evidence: This bootstrap planner is shadow-only and cannot skip or replace any existing mandatory job. `PR / gate` and `Dev staging / gate` still enumerate and require every prior job, while the independent `Web base policy (trusted base)` remains unchanged. Subsequent routing work can use this merged base implementation rather than candidate routing code.
- Branch-protection or ruleset impact, including unchanged settings: None. `PR / gate`, `Dev staging / gate`, `Gallery readiness / gate`, `Promotion / gate`, and `Web base policy (trusted base)` keep their existing display names and roles.
- Governance-specific rollback or protection restore point: Reverting `e7254da5` restores the prior workflow graph; no repository-setting rollback is required.

### ARCHITECTURE_EXCEPTION

N/A — this ordinary change adds one owner and one canonical path for a new capability without owner/path excess or compatibility burden.

### PROMOTION

N/A — this is an implementation pull request to `dev`, not a `dev`-to-`main` promotion.
