### PR TITLE
Run pull request tests according to changed surfaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      plan: ${{ steps.plan.outputs.plan }}
+      plan: ${{ steps.pr_plan.outputs.plan || steps.shadow_plan.outputs.plan }}
     steps:
       - name: Checkout complete history
         uses: actions/checkout@v4
@@ -38,25 +38,54 @@ jobs:
       - name: Test CI impact policy and adapters
         run: node --test tests/ci/*.test.mjs
 
-      - name: Build shadow CI impact plan
-        id: plan
+      - name: Checkout trusted CI policy
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .ci-trusted-base
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Build trusted PR CI impact plan
+        if: github.event_name == 'pull_request'
+        id: pr_plan
         env:
-          CI_IMPACT_PROFILE: ${{ github.event_name == 'pull_request' && 'pr' || 'dev' }}
+          CI_IMPACT_PROFILE: pr
+          CI_IMPACT_EVENT_NAME: pull_request
+          CI_IMPACT_REPOSITORY: ${{ github.repository }}
+          CI_IMPACT_REPOSITORY_ROOT: ${{ github.workspace }}
+          CI_IMPACT_CHANGE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CI_IMPACT_CHANGE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CI_IMPACT_WORKFLOW_SHA: ${{ github.sha }}
+          CI_IMPACT_ARCHITECTURE_CHANGE: ${{ contains(github.event.pull_request.labels.*.name, 'architecture-change') && 'true' || 'false' }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node .ci-trusted-base/tools/ci-impact.mjs plan
+
+      - name: Build shadow dev CI impact plan
+        if: github.event_name != 'pull_request'
+        id: shadow_plan
+        env:
+          CI_IMPACT_PROFILE: dev
           CI_IMPACT_EVENT_NAME: ${{ github.event_name }}
           CI_IMPACT_REPOSITORY: ${{ github.repository }}
-          CI_IMPACT_CHANGE_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'push' && github.event.before || github.sha }}
-          CI_IMPACT_CHANGE_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          CI_IMPACT_CHANGE_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.sha }}
+          CI_IMPACT_CHANGE_HEAD_SHA: ${{ github.sha }}
           CI_IMPACT_WORKFLOW_SHA: ${{ github.sha }}
-          CI_IMPACT_ARCHITECTURE_CHANGE: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'architecture-change') && 'true' || 'false' }}
+          CI_IMPACT_ARCHITECTURE_CHANGE: 'false'
           GITHUB_TOKEN: ${{ github.token }}
         run: node tools/ci-impact.mjs plan
 
   web-change-budget:
     name: Web change budget
+    needs: ci-impact
     if: >-
-      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      !cancelled() &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-change-budget')) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -133,7 +162,11 @@ jobs:
 
   core-pr:
     name: Core PR (Python 3.11)
-    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
+    needs: ci-impact
+    if: >-
+      github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'core-pr')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -163,10 +196,14 @@ jobs:
 
   recipes-standard:
     name: Recipes standard (Python 3.11)
+    needs: ci-impact
     if: >-
-      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      !cancelled() &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'recipes-standard')) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -191,10 +228,14 @@ jobs:
 
   gallery:
     name: Gallery (Python 3.11)
+    needs: ci-impact
     if: >-
-      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      !cancelled() &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'gallery')) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -273,7 +314,11 @@ jobs:
 
   web-pr-smoke:
     name: Web PR smoke
-    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
+    needs: ci-impact
+    if: >-
+      github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-pr-smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -508,10 +553,14 @@ jobs:
 
   lint:
     name: Lint
+    needs: ci-impact
     if: >-
-      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      !cancelled() &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'lint')) ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -584,16 +633,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - name: Require all fast PR evidence
-        run: |
-          set -euo pipefail
-          test "${{ needs.ci-impact.result }}" = "success"
-          test "${{ needs.web-change-budget.result }}" = "success"
-          test "${{ needs.core-pr.result }}" = "success"
-          test "${{ needs.recipes-standard.result }}" = "success"
-          test "${{ needs.gallery.result }}" = "success"
-          test "${{ needs.lint.result }}" = "success"
-          test "${{ needs.web-pr-smoke.result }}" = "success"
+      - name: Checkout trusted CI policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .ci-trusted-base
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate required PR evidence
+        env:
+          CI_IMPACT_PLAN_JSON: ${{ needs.ci-impact.outputs.plan }}
+          CI_IMPACT_NEEDS_JSON: ${{ toJSON(needs) }}
+          CI_IMPACT_EXPECTED_PROFILE: pr
+          CI_IMPACT_EXPECTED_WORKFLOW_SHA: ${{ github.sha }}
+        run: node .ci-trusted-base/tools/ci-impact.mjs gate
 
   dev-staging-gate:
     name: Dev staging / gate

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -1,6 +1,7 @@
 # Selective CI impact planning
 
-Status: staged rollout; the planner currently runs in shadow mode.
+Status: pull-request routing is active; `dev` staging remains in shadow mode, and the
+Gallery workflow is not connected to the planner.
 
 ## Purpose
 
@@ -9,8 +10,9 @@ classifier is deliberately coarse and conservative. It can avoid unrelated work 
 when the changed paths are clearly lightweight and the directly preceding trusted
 revision already has successful exact-SHA aggregate evidence.
 
-The first rollout stage records the plan in the GitHub Actions job summary but does not
-route test jobs. All existing pull-request and `dev` staging test conditions still run.
+The `Tests` workflow routes pull-request jobs from a plan produced by the trusted base
+revision. Pushes to `dev` still run the existing full staging inventory. The Gallery
+workflow does not yet use the plan for job selection.
 
 ## Impact classes
 
@@ -46,14 +48,33 @@ objects all fail closed to `full`.
 
 The planner emits one versioned `ImpactPlan` JSON object. It records the profile,
 impact, decision, stable basis code, change and workflow SHAs, required job IDs,
-changed-path count, and inherited evidence when present. Job IDs—not display names or
-human-readable reason text—form the routing contract.
+changed-path count, and inherited evidence when present. Job IDs, not display names or
+human-readable reason text, form the routing contract.
 
-Profiles cover the three eventual consumers:
+The policy defines three profiles:
 
 - `pr`: the `Tests` workflow for a pull request into `dev`
 - `dev`: the `Tests` workflow for a push to `dev`
 - `gallery`: the `Gallery publication` workflow for a push to `dev`
+
+## Active pull-request routing
+
+When the pull-request base has successful exact-SHA `Dev staging / gate` evidence, the
+`pr` profile selects these project-owned jobs:
+
+| Pull-request impact | Jobs that run |
+| --- | --- |
+| `metadata` | `CI impact plan`, `PR / gate` |
+| `documentation` | `CI impact plan`, `Recipes standard (Python 3.11)`, `PR / gate` |
+| `full` | `CI impact plan`, `Web change budget`, `Core PR (Python 3.11)`, `Recipes standard (Python 3.11)`, `Gallery (Python 3.11)`, `Lint`, `Web PR smoke`, `PR / gate` |
+
+Documentation changes run the recipe suite because it owns documented-contract,
+tutorial, CLI reference, and session compatibility checks. A full plan keeps the six
+existing pull-request test commands unchanged.
+
+`Web base policy (trusted base)` remains a separate required check. It evaluates Web
+change policy from `pull_request_target`; it does not select tests or replace
+`PR / gate`.
 
 A full-impact change always produces a full plan without calling the GitHub Actions
 API. Manual dispatch and a pull request carrying the `architecture-change` label also
@@ -96,9 +117,10 @@ The following display names are external admission contracts and stay fixed:
 - `Promotion / gate`
 
 Each workflow continues to start on every relevant event and creates its aggregate job
-for the current SHA. Selection happens at job level in later rollout stages. Keeping the
-aggregate names and current-SHA jobs stable avoids branch-protection changes and allows
-the existing promotion verifier to continue checking exact staging evidence.
+for the current SHA. Pull-request selection happens at job level. `dev` staging and
+Gallery selection are not active. Keeping the aggregate names and current-SHA jobs
+stable avoids branch-protection changes and allows the existing promotion verifier to
+continue checking exact staging evidence.
 
 Workflow-level `paths` and `paths-ignore` filters are not used. Such filters can prevent
 a required check from being created, leaving a pull request pending, and would remove
@@ -106,15 +128,17 @@ the current-SHA aggregate evidence required for promotion.
 
 ## Pull-request trust boundary
 
-A pull request is untrusted input. Candidate code is tested, but it must not decide its
-own admission route. Once selective pull-request routing is enabled, the workflow will
-execute the planner and gate validator from the pull-request base SHA in a separate
-trusted checkout. Candidate versions of the planner remain test inputs only.
+A pull request is untrusted input. Candidate code is tested, but it does not decide its
+own admission route. The workflow checks out the pull-request base SHA under
+`.ci-trusted-base` and runs that revision's `tools/ci-impact.mjs` for both planning and
+aggregate validation. The planner reads Git history from the candidate repository root.
+Candidate versions of `tools/ci-impact*.mjs` remain unit-test inputs only.
 
-The initial shadow-mode pull request is the bootstrap exception: no planner exists on
-its base, so the candidate planner produces an observational summary while all existing
-jobs still run. Changes below `.github/workflows/**`, `tools/ci-impact*.mjs`, and the CI
-planner tests classify as full.
+The bootstrap pull request ran the candidate planner only because its base had no
+helper. That exception is no longer used. If the trusted base helper is absent,
+unusable, or emits an invalid plan, `ci-impact` or `PR / gate` fails instead of guessing
+a lightweight route. Changes below `.github/workflows/**`, `tools/ci-impact*.mjs`, and
+the CI planner tests classify as full.
 
 The `pull_request_target` workflow remains separate. It checks candidate Git data with
 trusted base code and never executes the candidate checkout.
@@ -132,18 +156,18 @@ The shared gate validator fails closed unless:
 An unexpected failure or cancellation remains blocking even for a job the plan did not
 require. Malformed plan or `needs` JSON is also blocking.
 
-The validator is implemented and tested during shadow mode. Existing shell aggregate
-checks remain in place until the rollout stage that connects selective routing.
+`PR / gate` runs the validator from `.ci-trusted-base`. The existing fixed shell
+aggregate remains in `Dev staging / gate` while `dev` routing is in shadow mode.
 
 ## Rollout
 
-Selective CI is introduced in four separately reviewed pull requests:
+Selective CI uses four separately reviewed stages:
 
-1. Add the deterministic policy, adapter, validator, tests, documentation, and shadow
-   summary. Keep all existing test routing.
-2. Enable selective routing for pull requests using the trusted base planner.
-3. Enable evidence-aware routing for exact `dev` staging runs.
-4. Enable evidence-aware routing for Gallery readiness runs.
+1. Implemented: deterministic policy, adapter, validator, tests, documentation, and
+   shadow summary.
+2. Active: selective pull-request routing with the trusted base planner and validator.
+3. Not implemented: evidence-aware selection for exact `dev` staging runs.
+4. Not implemented: evidence-aware selection for Gallery readiness runs.
 
 Each stage keeps the aggregate check names stable and can be reverted independently.
 Reverting a routing stage restores the previous full-suite conditions without a
@@ -160,8 +184,10 @@ The `CI impact plan` summary includes:
 - inherited run and aggregate links when evidence succeeds; and
 - the fallback code and bounded reason when evidence is unavailable.
 
-In shadow mode the summary explicitly states that routing is observational. Tokens are
-never included in the plan or summary and are redacted from CLI diagnostics.
+The `pr` summary states that routing is active. The `dev` summary states that routing is
+observational. The Gallery workflow does not produce a planner summary while its stage
+is unimplemented. Tokens are never included in the plan or summary and are redacted
+from CLI diagnostics.
 
 ## Troubleshooting
 
@@ -196,6 +222,19 @@ Compare the plan profile and workflow SHA with the gate environment. Confirm tha
 known job is present in `needs`, required jobs succeeded, and unrequired jobs did not
 fail or get cancelled unexpectedly. Do not weaken the validator to accept a missing or
 skipped required job.
+
+### Pull-request jobs are all skipped
+
+Open `CI impact plan` first. If the planner failed or its `plan` output is missing,
+`PR / gate` must fail even though the six test jobs are skipped. If the plan is valid,
+compare its `requiredJobs` array with each job's result in the aggregate summary.
+
+### The trusted helper cannot run
+
+Confirm that the pull-request base SHA contains `tools/ci-impact.mjs`,
+`tools/ci-impact-policy.mjs`, and `tools/check-promotion-readiness.mjs`. Do not run the
+candidate helper as a fallback. Restore the trusted base prerequisite or keep the
+control job failing.
 
 ## Policy-extension review checklist
 

--- a/tests/ci/ci-impact-cli.test.mjs
+++ b/tests/ci/ci-impact-cli.test.mjs
@@ -250,6 +250,8 @@ test('plan command writes one compact output line and escapes summary paths', as
   const summary = writes.get('/tmp/ci-impact-summary');
   assert.match(summary, /docs\/&lt;unsafe&gt;\\nname\.md/);
   assert.doesNotMatch(summary, /docs\/<unsafe>/);
+  assert.match(summary, /Routing: active; pull-request jobs use the trusted-base plan/);
+  assert.doesNotMatch(summary, /shadow mode/);
   assert.doesNotMatch(stdout.value(), /test-token/);
 });
 
@@ -293,31 +295,71 @@ test('CLI rejects unknown arguments and invalid profile/event contracts', async 
   );
 });
 
-test('shadow workflow exposes the plan without routing existing test jobs', () => {
+test('workflow routes PR jobs with the trusted base plan and keeps dev routing full', () => {
   const workflow = readFileSync(resolve(REPOSITORY_ROOT, '.github/workflows/test.yml'), 'utf8');
+  const workflowJob = (jobId) => workflow.match(
+    new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
+  )?.[0];
+
   assert.match(workflow, /actions: read/);
-  assert.match(workflow, /\n  ci-impact:\n[\s\S]*?name: CI impact plan/);
-  assert.match(workflow, /node --test tests\/ci\/\*\.test\.mjs/);
-  assert.match(workflow, /id: plan[\s\S]*node tools\/ci-impact\.mjs plan/);
+  assert.doesNotMatch(workflow, /\n    paths(?:-ignore)?:/);
+
+  const planner = workflowJob('ci-impact');
+  assert.ok(planner);
+  assert.match(planner, /name: CI impact plan/);
+  assert.match(planner, /Checkout complete history[\s\S]*fetch-depth: 0/);
+  assert.match(planner, /node --test tests\/ci\/\*\.test\.mjs/);
+  assert.match(
+    planner,
+    /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}[\s\S]*path: \.ci-trusted-base[\s\S]*persist-credentials: false/
+  );
+  assert.match(planner, /CI_IMPACT_REPOSITORY_ROOT: \$\{\{ github\.workspace \}\}/);
+  assert.match(planner, /run: node \.ci-trusted-base\/tools\/ci-impact\.mjs plan/);
+  assert.match(planner, /Build shadow dev CI impact plan[\s\S]*run: node tools\/ci-impact\.mjs plan/);
+
   for (const jobId of [
     'web-change-budget',
-    'core',
     'core-pr',
     'recipes-standard',
     'gallery',
+    'lint',
+    'web-pr-smoke'
+  ]) {
+    const job = workflowJob(jobId);
+    assert.ok(job, jobId);
+    assert.match(job, /needs: ci-impact/);
+    assert.match(job, /needs\.ci-impact\.result == 'success'/);
+    assert.match(
+      job,
+      new RegExp(`contains\\(fromJSON\\(needs\\.ci-impact\\.outputs\\.plan\\)\\.requiredJobs, '${jobId}'\\)`)
+    );
+    if (['web-change-budget', 'recipes-standard', 'gallery', 'lint'].includes(jobId)) {
+      assert.match(job, /!cancelled\(\)/);
+      assert.match(job, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/);
+      assert.match(
+        job,
+        /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
+      );
+    }
+  }
+
+  for (const jobId of [
+    'core',
     'browser',
-    'web-pr-smoke',
     'playwright-functional',
     'playwright-performance',
     'acceptance-supported-main',
     'slow-main',
-    'lint',
     'losat-cache-browser-acceptance'
   ]) {
-    const job = workflow.match(
-      new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
-    )?.[0];
-    assert.ok(job, jobId);
-    assert.doesNotMatch(job, /needs(?:\.[a-z-]+)?\.ci-impact|needs:\s+ci-impact/);
+    assert.doesNotMatch(workflowJob(jobId), /requiredJobs/);
   }
+
+  const gate = workflowJob('pr-gate');
+  assert.match(gate, /name: PR \/ gate/);
+  assert.match(gate, /path: \.ci-trusted-base/);
+  assert.match(gate, /CI_IMPACT_PLAN_JSON: \$\{\{ needs\.ci-impact\.outputs\.plan \}\}/);
+  assert.match(gate, /CI_IMPACT_NEEDS_JSON: \$\{\{ toJSON\(needs\) \}\}/);
+  assert.match(gate, /run: node \.ci-trusted-base\/tools\/ci-impact\.mjs gate/);
+  assert.doesNotMatch(gate, /test "\$\{\{ needs\./);
 });

--- a/tests/ci/ci-impact-gate.test.mjs
+++ b/tests/ci/ci-impact-gate.test.mjs
@@ -49,11 +49,34 @@ const validate = (impactPlan, needs) => validateGateResults({
   expected: { profile: impactPlan.profile, workflowSha: SHA.workflow }
 });
 
-test('gate accepts required success and unrequired skipped or success', () => {
-  const impactPlan = plan();
-  const skipped = validate(impactPlan, needsFor(impactPlan));
-  assert.equal(skipped.ok, true);
+test('gate accepts metadata, documentation, and full PR routes', () => {
+  const routes = [
+    plan({ impact: 'metadata' }),
+    plan(),
+    plan({
+      impact: 'full',
+      decision: 'full',
+      basis: 'FULL_CHANGE',
+      inheritedEvidence: null
+    })
+  ];
+  assert.deepEqual(routes.map(({ requiredJobs }) => requiredJobs), [
+    [],
+    ['recipes-standard'],
+    [
+      'web-change-budget',
+      'core-pr',
+      'recipes-standard',
+      'gallery',
+      'lint',
+      'web-pr-smoke'
+    ]
+  ]);
+  routes.forEach((impactPlan) => {
+    assert.equal(validate(impactPlan, needsFor(impactPlan)).ok, true);
+  });
 
+  const impactPlan = plan();
   const successfulNeeds = needsFor(impactPlan);
   successfulNeeds.gallery.result = 'success';
   const successful = validate(impactPlan, successfulNeeds);
@@ -107,7 +130,7 @@ test('unknown jobs may succeed or skip but may not fail', () => {
   assert.throws(() => validate(impactPlan, failed), /unknown CI job failed unexpectedly/);
 });
 
-test('gate rejects wrong profile, workflow SHA, and schema', () => {
+test('trusted gate rejects wrong profile, workflow SHA, and helper schema', () => {
   const impactPlan = plan();
   const needs = needsFor(impactPlan);
   assert.throws(() => validateGateResults({
@@ -162,6 +185,22 @@ test('gate CLI rejects malformed plan and needs JSON', async () => {
     assert.equal(stdout.value(), '');
     assert.match(stderr.value(), /MALFORMED_JSON/);
   }
+});
+
+test('gate CLI rejects a missing plan', async () => {
+  const stderr = textWriter();
+  const status = await runCiImpactCli({
+    argv: ['gate'],
+    env: {
+      CI_IMPACT_NEEDS_JSON: JSON.stringify(needsFor()),
+      CI_IMPACT_EXPECTED_PROFILE: 'pr',
+      CI_IMPACT_EXPECTED_WORKFLOW_SHA: SHA.workflow
+    },
+    stdout: textWriter().stream,
+    stderr: stderr.stream
+  });
+  assert.equal(status, 1);
+  assert.match(stderr.value(), /MISSING_ENVIRONMENT/);
 });
 
 test('gate CLI emits a passing summary for a valid payload', async () => {

--- a/tests/ci/ci-impact-policy.test.mjs
+++ b/tests/ci/ci-impact-policy.test.mjs
@@ -144,6 +144,16 @@ test('profile job registries are exact and centralized', () => {
   assert.deepEqual(requiredJobsFor({
     profile: 'pr', impact: 'documentation', decision: 'selective'
   }), ['recipes-standard']);
+  assert.deepEqual(requiredJobsFor({
+    profile: 'pr', impact: 'full', decision: 'full'
+  }), [
+    'web-change-budget',
+    'core-pr',
+    'recipes-standard',
+    'gallery',
+    'lint',
+    'web-pr-smoke'
+  ]);
   assert.deepEqual(knownJobsFor('pr'), [
     'web-change-budget',
     'core-pr',

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -863,23 +863,33 @@ test('workflow triggers separate dev admission, dev staging, promotion, and depl
   assert.doesNotMatch(GALLERY_PUBLICATION_WORKFLOW, /"main"|"refactoring"/);
 });
 
-test('PR-to-dev fast candidates and aggregate fail closed over the mandatory evidence', () => {
+test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
+  const planner = workflowJob('ci-impact');
+  assert.match(planner, /Checkout complete history[\s\S]*fetch-depth: 0/);
+  assert.match(planner, /node --test tests\/ci\/\*\.test\.mjs/);
+  assert.match(
+    planner,
+    /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}[\s\S]*path: \.ci-trusted-base[\s\S]*persist-credentials: false/
+  );
+  assert.match(planner, /CI_IMPACT_REPOSITORY_ROOT: \$\{\{ github\.workspace \}\}/);
+  assert.match(planner, /node \.ci-trusted-base\/tools\/ci-impact\.mjs plan/);
+  assert.match(planner, /Build shadow dev CI impact plan[\s\S]*node tools\/ci-impact\.mjs plan/);
+  assert.doesNotMatch(TEST_WORKFLOW, /\n    paths(?:-ignore)?:/);
+
   const corePr = workflowJob('core-pr');
   assert.match(corePr, /\n    name: Core PR \(Python 3\.11\)\n/);
-  assert.match(
-    corePr,
-    /if: github\.event_name == 'pull_request' && github\.base_ref == 'dev'/
-  );
+  assert.match(corePr, /needs: ci-impact/);
+  assert.match(corePr, /needs\.ci-impact\.result == 'success'/);
+  assert.match(corePr, /requiredJobs, 'core-pr'/);
   assert.match(corePr, /-m "not slow and not \(recipe or gallery or browser\)"/);
   assert.match(corePr, /git diff --exit-code -- tests\/reference_outputs\//);
   assert.doesNotMatch(corePr, /matrix:/);
 
   const webPrSmoke = workflowJob('web-pr-smoke');
   assert.match(webPrSmoke, /\n    name: Web PR smoke\n/);
-  assert.match(
-    webPrSmoke,
-    /if: github\.event_name == 'pull_request' && github\.base_ref == 'dev'/
-  );
+  assert.match(webPrSmoke, /needs: ci-impact/);
+  assert.match(webPrSmoke, /needs\.ci-impact\.result == 'success'/);
+  assert.match(webPrSmoke, /requiredJobs, 'web-pr-smoke'/);
   assert.match(webPrSmoke, /timeout-minutes: 5/);
   assert.equal([...webPrSmoke.matchAll(/uses: actions\/checkout@/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/npm ci/g)].length, 1);
@@ -913,20 +923,41 @@ test('PR-to-dev fast candidates and aggregate fail closed over the mandatory evi
     gate,
     /if: >-\n      always\(\) &&\n      github\.event_name == 'pull_request' &&\n      github\.base_ref == 'dev'/
   );
-  dependencies.forEach((jobId) => {
-    assert.ok(
-      gate.includes(`test "\${{ needs.${jobId}.result }}" = "success"`),
-      `${jobId} must fail the aggregate unless it succeeds`
-    );
-  });
+  assert.match(
+    gate,
+    /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}[\s\S]*path: \.ci-trusted-base[\s\S]*persist-credentials: false/
+  );
+  assert.match(gate, /CI_IMPACT_PLAN_JSON: \$\{\{ needs\.ci-impact\.outputs\.plan \}\}/);
+  assert.match(gate, /CI_IMPACT_NEEDS_JSON: \$\{\{ toJSON\(needs\) \}\}/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_PROFILE: pr/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(gate, /node \.ci-trusted-base\/tools\/ci-impact\.mjs gate/);
+  assert.doesNotMatch(gate, /test "\$\{\{ needs\./);
   assert.doesNotMatch(gate, /gh api|curl|check-web-change-budget|pull_request_target/);
 
-  for (const jobId of ['web-change-budget', 'recipes-standard', 'gallery', 'lint']) {
+  for (const jobId of [
+    'web-change-budget',
+    'core-pr',
+    'recipes-standard',
+    'gallery',
+    'lint',
+    'web-pr-smoke'
+  ]) {
+    const job = workflowJob(jobId);
+    assert.match(job, /needs: ci-impact/, `${jobId} must wait for the plan`);
     assert.match(
-      workflowJob(jobId),
-      /github\.event_name == 'pull_request' && github\.base_ref == 'dev'/,
-      `${jobId} must remain in the fast dev-PR graph`
+      job,
+      new RegExp(`requiredJobs, '${jobId}'`),
+      `${jobId} must read its selection from the plan`
     );
+    if (['web-change-budget', 'recipes-standard', 'gallery', 'lint'].includes(jobId)) {
+      assert.match(job, /!cancelled\(\)/, `${jobId} must remain runnable on dev`);
+      assert.match(job, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/);
+      assert.match(
+        job,
+        /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
+      );
+    }
   }
   for (const jobId of [
     'core',

--- a/tools/ci-impact.mjs
+++ b/tools/ci-impact.mjs
@@ -365,8 +365,11 @@ const html = (source) => visiblePath(source)
 
 export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => {
   const requiredJobs = plan.requiredJobs.length ? plan.requiredJobs.map((job) => `\`${job}\``).join(', ') : 'none';
+  const routing = plan.profile === 'pr'
+    ? 'active; pull-request jobs use the trusted-base plan'
+    : 'observation only; existing test job conditions are unchanged';
   const lines = [
-    '## CI impact plan (shadow mode)',
+    `## CI impact plan${plan.profile === 'pr' ? '' : ' (shadow mode)'}`,
     '',
     `- Profile: \`${plan.profile}\``,
     `- Impact: \`${plan.impact}\``,
@@ -376,7 +379,7 @@ export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => 
     `- Workflow SHA: \`${plan.workflowSha}\``,
     `- Changed paths: ${plan.changedPathCount}`,
     `- Planned required job IDs: ${requiredJobs}`,
-    '- Routing: observation only; existing test job conditions are unchanged',
+    `- Routing: ${routing}`,
     ''
   ];
   if (plan.inheritedEvidence) {


### PR DESCRIPTION
## Plain-language summary

Pull requests now run the test groups required by the files they change instead of running every pull-request job unconditionally. Documentation-only changes keep the standard recipe tests because recipes are executable user guidance, while changes to CI policy, application code, or uncertain inputs use the full route. The existing `Web base policy (trusted base)` check continues to validate Web changes separately.

## What changes

- Run only the planner and `PR / gate` for metadata-only pull requests.
- Add `Recipes standard (Python 3.11)` for documentation-only pull requests.
- Run all six existing pull-request job groups for full changes: Web change budget, core tests, standard recipes, Gallery tests, lint, and Web smoke tests.
- Treat missing comparison evidence, failed base-staging evidence, API errors, and unrecognized inputs as full changes.
- Validate the completed job set in `PR / gate` instead of maintaining a second fixed list of expected statuses in the workflow.

This pull request changes the workflow, planner adapter, and CI tests, so it selects the full route itself.

## Trust and scope

The pull-request workflow checks out the target branch at the event's base SHA and runs both planning and gate validation from that trusted checkout. Candidate code supplies the changed files but cannot weaken the required job set or the final gate. The planner also binds its output to the expected profile and workflow SHA before the gate accepts it.

Pushes to `dev` remain full and continue to use `Dev staging / gate`. Gallery publication, deployment, promotion handling, and the names and commands of existing test jobs are unchanged. Gallery selective execution remains disconnected until its separate rollout.

## Architecture evidence

- The policy owner remains `tools/ci-impact-policy.mjs`.
- The GitHub adapter and plan validator remain `tools/ci-impact.mjs`.
- Workflow orchestration remains `.github/workflows/test.yml`.
- The trusted-base helper is now the sole owner of pull-request routing and gate validation.
- This removes the six unconditional pull-request conditions and the duplicated fixed status list from `PR / gate`.
- The existing full `dev` path remains because this change is limited to pull requests.

The change adds no owner, persistence path, or compatibility branch. It is an ordinary non-increasing architecture change: `delta(OE) <= 0`, `delta(PE) <= 0`, and `delta(CB) <= 0`. Reverting this pull request restores the previous full pull-request route without changing branch settings.

## Verification

- `node --test tests/ci/*.test.mjs` (3 suites passed)
- `node --test tests/web/architecture-contracts.test.mjs` (131 tests passed)
- `python -m pytest tests/ -m "not slow and not (recipe or gallery or browser)" -n auto --dist loadfile` (2649 passed, 17 skipped)
- `python -m pytest tests/ -m "recipe and not slow"` (186 passed)
- `ruff check gbdraw/`
- Parsed `.github/workflows/test.yml` with PyYAML
- `git diff --check`
- Confirmed no changes to reference outputs, generated package artifacts, Gallery publication, deployment, or promotion handling
