### PR TITLE
Skip unrelated staging tests after changes reach dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      plan: ${{ steps.pr_plan.outputs.plan || steps.shadow_plan.outputs.plan }}
+      plan: ${{ steps.pr_plan.outputs.plan || steps.dev_plan.outputs.plan }}
     steps:
       - name: Checkout complete history
         uses: actions/checkout@v4
@@ -62,9 +62,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node .ci-trusted-base/tools/ci-impact.mjs plan
 
-      - name: Build shadow dev CI impact plan
+      - name: Build dev CI impact plan
         if: github.event_name != 'pull_request'
-        id: shadow_plan
+        id: dev_plan
         env:
           CI_IMPACT_PROFILE: dev
           CI_IMPACT_EVENT_NAME: ${{ github.event_name }}
@@ -81,9 +81,9 @@ jobs:
     needs: ci-impact
     if: >-
       !cancelled() &&
-      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
       needs.ci-impact.result == 'success' &&
-      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-change-budget')) ||
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-change-budget') &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
@@ -126,9 +126,13 @@ jobs:
 
   core:
     name: Core (Python ${{ matrix.python-version }})
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'core') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -199,9 +203,9 @@ jobs:
     needs: ci-impact
     if: >-
       !cancelled() &&
-      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
       needs.ci-impact.result == 'success' &&
-      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'recipes-standard')) ||
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'recipes-standard') &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-24.04
@@ -231,9 +235,9 @@ jobs:
     needs: ci-impact
     if: >-
       !cancelled() &&
-      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
       needs.ci-impact.result == 'success' &&
-      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'gallery')) ||
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'gallery') &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
@@ -260,9 +264,13 @@ jobs:
 
   browser:
     name: Browser (Python 3.11)
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'browser') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -374,9 +382,13 @@ jobs:
 
   playwright-functional:
     name: Playwright functional (shard ${{ matrix.shard }}/4)
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'playwright-functional') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -423,9 +435,13 @@ jobs:
 
   playwright-performance:
     name: Playwright performance
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'playwright-performance') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -468,9 +484,13 @@ jobs:
 
   acceptance-supported-main:
     name: ${{ matrix.surface }} acceptance (Python ${{ matrix.python-version }})
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'acceptance-supported-main') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
@@ -514,9 +534,13 @@ jobs:
 
   slow-main:
     name: Slow (Python ${{ matrix.python-version }})
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'slow-main') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -556,9 +580,9 @@ jobs:
     needs: ci-impact
     if: >-
       !cancelled() &&
-      ((github.event_name == 'pull_request' && github.base_ref == 'dev' &&
       needs.ci-impact.result == 'success' &&
-      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'lint')) ||
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'lint') &&
+      ((github.event_name == 'pull_request' && github.base_ref == 'dev') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
@@ -581,9 +605,13 @@ jobs:
 
   losat-cache-browser-acceptance:
     name: LOSAT cache browser acceptance
+    needs: ci-impact
     if: >-
-      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+      !cancelled() &&
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'losat-cache-browser-acceptance') &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -671,18 +699,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - name: Require all exact-SHA staging evidence
-        run: |
-          set -euo pipefail
-          test "${{ needs.ci-impact.result }}" = "success"
-          test "${{ needs.web-change-budget.result }}" = "success"
-          test "${{ needs.core.result }}" = "success"
-          test "${{ needs.recipes-standard.result }}" = "success"
-          test "${{ needs.gallery.result }}" = "success"
-          test "${{ needs.browser.result }}" = "success"
-          test "${{ needs.playwright-functional.result }}" = "success"
-          test "${{ needs.playwright-performance.result }}" = "success"
-          test "${{ needs.acceptance-supported-main.result }}" = "success"
-          test "${{ needs.slow-main.result }}" = "success"
-          test "${{ needs.lint.result }}" = "success"
-          test "${{ needs.losat-cache-browser-acceptance.result }}" = "success"
+      - name: Checkout protected dev CI policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate required dev staging evidence
+        env:
+          CI_IMPACT_PLAN_JSON: ${{ needs.ci-impact.outputs.plan }}
+          CI_IMPACT_NEEDS_JSON: ${{ toJSON(needs) }}
+          CI_IMPACT_EXPECTED_PROFILE: dev
+          CI_IMPACT_EXPECTED_WORKFLOW_SHA: ${{ github.sha }}
+        run: node tools/ci-impact.mjs gate

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -1,7 +1,7 @@
 # Selective CI impact planning
 
-Status: pull-request routing is active; `dev` staging remains in shadow mode, and the
-Gallery workflow is not connected to the planner.
+Status: pull-request and `dev` staging routing are active. The Gallery workflow is not
+connected to the planner.
 
 ## Purpose
 
@@ -11,8 +11,9 @@ when the changed paths are clearly lightweight and the directly preceding truste
 revision already has successful exact-SHA aggregate evidence.
 
 The `Tests` workflow routes pull-request jobs from a plan produced by the trusted base
-revision. Pushes to `dev` still run the existing full staging inventory. The Gallery
-workflow does not yet use the plan for job selection.
+revision. Pushes to `dev` use the planner from the protected branch and inherit only
+successful evidence from the direct parent commit. The Gallery workflow does not yet
+use the plan for job selection.
 
 ## Impact classes
 
@@ -87,6 +88,31 @@ API errors; and insufficient token access produce `decision=full` with
 planner. Invalid inputs, malformed schemas, unsafe output writes, and programming errors
 remain control-plane failures and do not get hidden by a full fallback.
 
+## Active dev staging routing
+
+For a push to `dev`, the planner compares `github.event.before` with the current SHA.
+When the direct parent has successful exact-SHA `Dev staging / gate` evidence, the
+`dev` profile selects these project-owned jobs:
+
+| `dev` impact | Jobs that run |
+| --- | --- |
+| `metadata` | `CI impact plan`, `Dev staging / gate` |
+| `documentation` | `CI impact plan`, `Recipes standard (Python 3.11)`, `Dev staging / gate` |
+| `full` | `CI impact plan`, all 11 staging job IDs, `Dev staging / gate` |
+
+The 11 staging job IDs and their existing commands, matrices, timeouts, and artifact
+steps are unchanged. `workflow_dispatch` always produces a full plan.
+
+The direct-parent requirement handles rapid consecutive pushes. If a later push
+cancels the parent's run, or reaches the planner before the parent completes, the
+current run cannot inherit that evidence and runs the full staging profile. This keeps
+`cancel-in-progress: true` without admitting untested runtime changes.
+
+`Dev staging / gate` validates the plan and every result from the current workflow run
+with the protected branch's `tools/ci-impact.mjs`. It always creates aggregate evidence
+for the current SHA. The promotion verifier continues to require that exact current-SHA
+job; it does not accept the parent's job directly.
+
 ## Direct evidence only
 
 Selective planning inherits evidence from exactly one revision:
@@ -117,10 +143,10 @@ The following display names are external admission contracts and stay fixed:
 - `Promotion / gate`
 
 Each workflow continues to start on every relevant event and creates its aggregate job
-for the current SHA. Pull-request selection happens at job level. `dev` staging and
-Gallery selection are not active. Keeping the aggregate names and current-SHA jobs
-stable avoids branch-protection changes and allows the existing promotion verifier to
-continue checking exact staging evidence.
+for the current SHA. Pull-request and `dev` staging selection happen at job level. The
+Gallery workflow still runs its full inventory. Keeping the aggregate names and
+current-SHA jobs stable avoids branch-protection changes and allows the existing
+promotion verifier to continue checking exact staging evidence.
 
 Workflow-level `paths` and `paths-ignore` filters are not used. Such filters can prevent
 a required check from being created, leaving a pull request pending, and would remove
@@ -143,6 +169,17 @@ the CI planner tests classify as full.
 The `pull_request_target` workflow remains separate. It checks candidate Git data with
 trusted base code and never executes the candidate checkout.
 
+## Dev trust boundary
+
+Code merged to protected `dev` is the staging control plane. Push and manual-dispatch
+plans run the current checkout's helper. A change to the workflow, planner, policy, or
+planner tests classifies as `full`, so the commit that changes routing must run the full
+staging profile before its aggregate can succeed.
+
+This trust boundary differs from pull requests, where the candidate helper is tested
+but the base revision decides the route. The Gallery workflow has its own gate and is
+not routed by the `Tests` workflow's dev plan.
+
 ## Aggregate validation
 
 The shared gate validator fails closed unless:
@@ -156,8 +193,9 @@ The shared gate validator fails closed unless:
 An unexpected failure or cancellation remains blocking even for a job the plan did not
 require. Malformed plan or `needs` JSON is also blocking.
 
-`PR / gate` runs the validator from `.ci-trusted-base`. The existing fixed shell
-aggregate remains in `Dev staging / gate` while `dev` routing is in shadow mode.
+`PR / gate` runs the validator from `.ci-trusted-base`. `Dev staging / gate` runs the
+same validator from the current protected-branch checkout with expected profile `dev`
+and the current workflow SHA.
 
 ## Rollout
 
@@ -166,7 +204,7 @@ Selective CI uses four separately reviewed stages:
 1. Implemented: deterministic policy, adapter, validator, tests, documentation, and
    shadow summary.
 2. Active: selective pull-request routing with the trusted base planner and validator.
-3. Not implemented: evidence-aware selection for exact `dev` staging runs.
+3. Active: evidence-aware selection for exact `dev` staging runs.
 4. Not implemented: evidence-aware selection for Gallery readiness runs.
 
 Each stage keeps the aggregate check names stable and can be reverted independently.
@@ -184,10 +222,10 @@ The `CI impact plan` summary includes:
 - inherited run and aggregate links when evidence succeeds; and
 - the fallback code and bounded reason when evidence is unavailable.
 
-The `pr` summary states that routing is active. The `dev` summary states that routing is
-observational. The Gallery workflow does not produce a planner summary while its stage
-is unimplemented. Tokens are never included in the plan or summary and are redacted
-from CLI diagnostics.
+The `pr` and `dev` summaries state that routing is active and name the applicable trust
+boundary. The Gallery workflow does not produce a planner summary while its stage is
+unimplemented. Tokens are never included in the plan or summary and are redacted from
+CLI diagnostics.
 
 ## Troubleshooting
 
@@ -222,6 +260,14 @@ Compare the plan profile and workflow SHA with the gate environment. Confirm tha
 known job is present in `needs`, required jobs succeeded, and unrequired jobs did not
 fail or get cancelled unexpectedly. Do not weaken the validator to accept a missing or
 skipped required job.
+
+### Consecutive dev pushes run the full profile
+
+Inspect `basis` and the evidence failure in `CI impact plan`. If the direct parent's
+workflow is queued, running, cancelled, failed, or absent, the current push must use
+`INHERITED_EVIDENCE_UNAVAILABLE` and run the full profile. Wait for a successful direct
+parent before using a lightweight commit when selective staging is important. Do not
+replace the direct parent with an older green SHA or disable concurrency.
 
 ### Pull-request jobs are all skipped
 

--- a/tests/ci/ci-impact-cli.test.mjs
+++ b/tests/ci/ci-impact-cli.test.mjs
@@ -137,6 +137,134 @@ test('dev and Gallery planning use a two-commit diff and direct parent evidence'
   }
 });
 
+test('dev metadata and documentation changes select only changed surfaces', async () => {
+  for (const [path, impact, requiredJobs] of [
+    ['.agents/skills/example/SKILL.md', 'metadata', []],
+    ['docs/FAQ.md', 'documentation', ['recipes-standard']]
+  ]) {
+    let evidenceArguments;
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'dev',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', path),
+      verifyWorkflowEvidenceImpl: async (args) => {
+        evidenceArguments = args;
+        return successfulEvidence();
+      }
+    });
+    assert.equal(evidenceArguments.expectedHeadSha, SHA.base);
+    assert.equal(evidenceArguments.workflowPath, '.github/workflows/test.yml');
+    assert.equal(evidenceArguments.expectedAggregateName, 'Dev staging / gate');
+    assert.equal(outcome.plan.impact, impact);
+    assert.equal(outcome.plan.decision, 'selective');
+    assert.equal(outcome.plan.basis, 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE');
+    assert.deepEqual(outcome.plan.requiredJobs, requiredJobs);
+  }
+});
+
+test('dev control-plane changes run the full profile without inherited evidence', async () => {
+  for (const path of ['tools/ci-impact.mjs', '.github/workflows/test.yml']) {
+    let evidenceCalls = 0;
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'dev',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', path),
+      verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
+    });
+    assert.equal(evidenceCalls, 0, path);
+    assert.equal(outcome.plan.impact, 'full', path);
+    assert.equal(outcome.plan.decision, 'full', path);
+    assert.equal(outcome.plan.basis, 'FULL_CHANGE', path);
+  }
+});
+
+test('dev direct-parent staging failures force the current run to full', async () => {
+  for (const code of [
+    'NO_MATCHING_RUN',
+    'RUN_NOT_SUCCESSFUL',
+    'AGGREGATE_JOB_NOT_SUCCESSFUL',
+    'API_REQUEST_FAILED'
+  ]) {
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'dev',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', '.gitignore'),
+      verifyWorkflowEvidenceImpl: async () => {
+        throw new PromotionReadinessError(code, `Direct parent evidence unavailable: ${code}`);
+      }
+    });
+    assert.equal(outcome.plan.impact, 'metadata', code);
+    assert.equal(outcome.plan.decision, 'full', code);
+    assert.equal(outcome.plan.basis, 'INHERITED_EVIDENCE_UNAVAILABLE', code);
+    assert.deepEqual(outcome.plan.requiredJobs, [
+      'web-change-budget',
+      'core',
+      'recipes-standard',
+      'gallery',
+      'browser',
+      'playwright-functional',
+      'playwright-performance',
+      'acceptance-supported-main',
+      'slow-main',
+      'lint',
+      'losat-cache-browser-acceptance'
+    ], code);
+  }
+});
+
+test('rapid dev pushes fall back to full while the direct parent is running or cancelled', async () => {
+  for (const state of ['in progress', 'cancelled']) {
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'dev',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', 'docs/FAQ.md'),
+      verifyWorkflowEvidenceImpl: async () => {
+        throw new PromotionReadinessError(
+          'RUN_NOT_SUCCESSFUL',
+          `Direct parent run is ${state}.`
+        );
+      }
+    });
+    assert.equal(outcome.plan.impact, 'documentation', state);
+    assert.equal(outcome.plan.decision, 'full', state);
+    assert.equal(outcome.plan.basis, 'INHERITED_EVIDENCE_UNAVAILABLE', state);
+  }
+});
+
+test('a zero dev before SHA fails closed without querying inherited evidence', async () => {
+  let evidenceCalls = 0;
+  const outcome = await buildImpactPlan({
+    configuration: configuration({
+      CI_IMPACT_PROFILE: 'dev',
+      CI_IMPACT_EVENT_NAME: 'push',
+      CI_IMPACT_CHANGE_BASE_SHA: '0'.repeat(40)
+    }),
+    token: 'test-token',
+    runGitImpl: () => ({
+      status: 128,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.from('bad object 0000000000000000000000000000000000000000')
+    }),
+    verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
+  });
+  assert.equal(evidenceCalls, 0);
+  assert.equal(outcome.plan.impact, 'full');
+  assert.equal(outcome.plan.decision, 'full');
+  assert.equal(outcome.plan.basis, 'UNKNOWN_OR_INVALID_CHANGE');
+});
+
 test('evidence verifier failures fall back to the full profile', async () => {
   const unavailableToken = 'unavailable-token';
   const outcome = await buildImpactPlan({
@@ -255,6 +383,27 @@ test('plan command writes one compact output line and escapes summary paths', as
   assert.doesNotMatch(stdout.value(), /test-token/);
 });
 
+test('dev plan summary reports active protected-branch routing', async () => {
+  const writes = new Map();
+  const status = await runCiImpactCli({
+    argv: ['plan'],
+    env: environment({
+      CI_IMPACT_PROFILE: 'dev',
+      CI_IMPACT_EVENT_NAME: 'push',
+      GITHUB_STEP_SUMMARY: '/tmp/ci-impact-dev-summary'
+    }),
+    stdout: textWriter().stream,
+    stderr: textWriter().stream,
+    appendFileImpl: (path, content) => writes.set(path, (writes.get(path) || '') + content),
+    runGitImpl: () => gitResult('M', '.gitignore'),
+    verifyWorkflowEvidenceImpl: async () => successfulEvidence()
+  });
+  assert.equal(status, 0);
+  const summary = writes.get('/tmp/ci-impact-dev-summary');
+  assert.match(summary, /Routing: active; dev staging jobs use the protected-branch plan/);
+  assert.doesNotMatch(summary, /shadow mode/);
+});
+
 test('unexpected failures are not converted to full plans and redact tokens', async () => {
   const secret = 'token-with-secret-value';
   const stdout = textWriter();
@@ -295,7 +444,7 @@ test('CLI rejects unknown arguments and invalid profile/event contracts', async 
   );
 });
 
-test('workflow routes PR jobs with the trusted base plan and keeps dev routing full', () => {
+test('workflow keeps trusted PR routing and activates protected dev routing', () => {
   const workflow = readFileSync(resolve(REPOSITORY_ROOT, '.github/workflows/test.yml'), 'utf8');
   const workflowJob = (jobId) => workflow.match(
     new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
@@ -315,7 +464,7 @@ test('workflow routes PR jobs with the trusted base plan and keeps dev routing f
   );
   assert.match(planner, /CI_IMPACT_REPOSITORY_ROOT: \$\{\{ github\.workspace \}\}/);
   assert.match(planner, /run: node \.ci-trusted-base\/tools\/ci-impact\.mjs plan/);
-  assert.match(planner, /Build shadow dev CI impact plan[\s\S]*run: node tools\/ci-impact\.mjs plan/);
+  assert.match(planner, /Build dev CI impact plan[\s\S]*run: node tools\/ci-impact\.mjs plan/);
 
   for (const jobId of [
     'web-change-budget',
@@ -343,16 +492,34 @@ test('workflow routes PR jobs with the trusted base plan and keeps dev routing f
     }
   }
 
-  for (const jobId of [
+  const devJobs = [
+    'web-change-budget',
     'core',
+    'recipes-standard',
+    'gallery',
     'browser',
     'playwright-functional',
     'playwright-performance',
     'acceptance-supported-main',
     'slow-main',
+    'lint',
     'losat-cache-browser-acceptance'
-  ]) {
-    assert.doesNotMatch(workflowJob(jobId), /requiredJobs/);
+  ];
+  for (const jobId of devJobs) {
+    const job = workflowJob(jobId);
+    assert.match(job, /needs: ci-impact/, jobId);
+    assert.match(job, /needs\.ci-impact\.result == 'success'/, jobId);
+    assert.match(
+      job,
+      new RegExp(`contains\\(fromJSON\\(needs\\.ci-impact\\.outputs\\.plan\\)\\.requiredJobs, '${jobId}'\\)`),
+      jobId
+    );
+    assert.match(job, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/, jobId);
+    assert.match(
+      job,
+      /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/,
+      jobId
+    );
   }
 
   const gate = workflowJob('pr-gate');
@@ -362,4 +529,14 @@ test('workflow routes PR jobs with the trusted base plan and keeps dev routing f
   assert.match(gate, /CI_IMPACT_NEEDS_JSON: \$\{\{ toJSON\(needs\) \}\}/);
   assert.match(gate, /run: node \.ci-trusted-base\/tools\/ci-impact\.mjs gate/);
   assert.doesNotMatch(gate, /test "\$\{\{ needs\./);
+
+  const devGate = workflowJob('dev-staging-gate');
+  assert.match(devGate, /name: Dev staging \/ gate/);
+  assert.match(devGate, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(devGate, /CI_IMPACT_PLAN_JSON: \$\{\{ needs\.ci-impact\.outputs\.plan \}\}/);
+  assert.match(devGate, /CI_IMPACT_NEEDS_JSON: \$\{\{ toJSON\(needs\) \}\}/);
+  assert.match(devGate, /CI_IMPACT_EXPECTED_PROFILE: dev/);
+  assert.match(devGate, /CI_IMPACT_EXPECTED_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(devGate, /run: node tools\/ci-impact\.mjs gate/);
+  assert.doesNotMatch(devGate, /test "\$\{\{ needs\./);
 });

--- a/tests/ci/ci-impact-gate.test.mjs
+++ b/tests/ci/ci-impact-gate.test.mjs
@@ -34,6 +34,12 @@ const plan = (overrides = {}) => createImpactPlan({
   ...overrides
 });
 
+const devPlan = (overrides = {}) => plan({
+  profile: 'dev',
+  basis: 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE',
+  ...overrides
+});
+
 const needsFor = (impactPlan = plan()) => Object.fromEntries([
   ['ci-impact', { result: 'success' }],
   ...knownJobsFor(impactPlan.profile).map((jobId) => [
@@ -81,6 +87,88 @@ test('gate accepts metadata, documentation, and full PR routes', () => {
   successfulNeeds.gallery.result = 'success';
   const successful = validate(impactPlan, successfulNeeds);
   assert.equal(successful.ok, true);
+});
+
+test('gate accepts metadata, documentation, and full dev staging routes', () => {
+  const routes = [
+    devPlan({ impact: 'metadata' }),
+    devPlan(),
+    devPlan({
+      impact: 'full',
+      decision: 'full',
+      basis: 'FULL_CHANGE',
+      inheritedEvidence: null
+    })
+  ];
+  assert.deepEqual(routes.map(({ requiredJobs }) => requiredJobs), [
+    [],
+    ['recipes-standard'],
+    [
+      'web-change-budget',
+      'core',
+      'recipes-standard',
+      'gallery',
+      'browser',
+      'playwright-functional',
+      'playwright-performance',
+      'acceptance-supported-main',
+      'slow-main',
+      'lint',
+      'losat-cache-browser-acceptance'
+    ]
+  ]);
+  routes.forEach((impactPlan) => {
+    assert.equal(validate(impactPlan, needsFor(impactPlan)).ok, true);
+  });
+});
+
+test('dev gate treats each matrix aggregate as one required job result', () => {
+  const full = devPlan({
+    impact: 'full',
+    decision: 'full',
+    basis: 'FULL_CHANGE',
+    inheritedEvidence: null
+  });
+  const fullNeeds = needsFor(full);
+  assert.equal(validate(full, fullNeeds).ok, true);
+  for (const result of ['skipped', 'failure']) {
+    const invalid = needsFor(full);
+    invalid['playwright-functional'].result = result;
+    assert.throws(
+      () => validate(full, invalid),
+      /required CI job did not succeed/,
+      result
+    );
+  }
+
+  const metadata = devPlan({ impact: 'metadata' });
+  const optionalSuccess = needsFor(metadata);
+  optionalSuccess['playwright-functional'].result = 'success';
+  assert.equal(validate(metadata, optionalSuccess).ok, true);
+  const optionalFailure = needsFor(metadata);
+  optionalFailure['playwright-functional'].result = 'failure';
+  assert.throws(() => validate(metadata, optionalFailure), /unrequired CI job failed unexpectedly/);
+});
+
+test('dev gate rejects the wrong current SHA and malformed inherited evidence', () => {
+  const impactPlan = devPlan();
+  assert.throws(() => validateGateResults({
+    plan: impactPlan,
+    needs: needsFor(impactPlan),
+    knownJobs: knownJobsFor('dev'),
+    expected: { profile: 'dev', workflowSha: 'd'.repeat(40) }
+  }), /workflow SHA does not match/);
+
+  const malformed = {
+    ...impactPlan,
+    inheritedEvidence: { ...impactPlan.inheritedEvidence, runId: '101' }
+  };
+  assert.throws(() => validateGateResults({
+    plan: malformed,
+    needs: needsFor(impactPlan),
+    knownJobs: knownJobsFor('dev'),
+    expected: { profile: 'dev', workflowSha: SHA.workflow }
+  }), /Inherited evidence identity is invalid/);
 });
 
 test('gate rejects required skipped, failure, and cancellation', () => {

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -832,6 +832,7 @@ test('workflow triggers separate dev admission, dev staging, promotion, and depl
     TEST_WORKFLOW,
     /group: tests-\$\{\{ github\.event_name \}\}-\$\{\{ github\.event\.pull_request\.number \|\| github\.ref \}\}/
   );
+  assert.match(TEST_WORKFLOW, /cancel-in-progress: true/);
 
   assert.match(BASE_POLICY_WORKFLOW, /\n  pull_request_target:\n/);
   assert.deepEqual(
@@ -873,7 +874,7 @@ test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
   );
   assert.match(planner, /CI_IMPACT_REPOSITORY_ROOT: \$\{\{ github\.workspace \}\}/);
   assert.match(planner, /node \.ci-trusted-base\/tools\/ci-impact\.mjs plan/);
-  assert.match(planner, /Build shadow dev CI impact plan[\s\S]*node tools\/ci-impact\.mjs plan/);
+  assert.match(planner, /Build dev CI impact plan[\s\S]*node tools\/ci-impact\.mjs plan/);
   assert.doesNotMatch(TEST_WORKFLOW, /\n    paths(?:-ignore)?:/);
 
   const corePr = workflowJob('core-pr');
@@ -1014,18 +1015,25 @@ test('PR smoke selection is explicit while the full functional inventory stays w
   assert.ok(selectedCount >= 6 && selectedCount <= 10, `selected ${selectedCount} smoke tests`);
 });
 
-test('exact dev staging runs the full inventory with four mandatory Playwright shards', () => {
-  const stagingOnly = [
+test('exact dev staging routes every job through the protected-branch plan', () => {
+  const stagingJobs = [
+    'web-change-budget',
     'core',
+    'recipes-standard',
+    'gallery',
     'browser',
     'playwright-functional',
     'playwright-performance',
     'acceptance-supported-main',
     'slow-main',
+    'lint',
     'losat-cache-browser-acceptance'
   ];
-  for (const jobId of stagingOnly) {
+  for (const jobId of stagingJobs) {
     const job = workflowJob(jobId);
+    assert.match(job, /needs: ci-impact/, jobId);
+    assert.match(job, /needs\.ci-impact\.result == 'success'/, jobId);
+    assert.match(job, new RegExp(`requiredJobs, '${jobId}'`), jobId);
     assert.match(job, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/);
     assert.match(
       job,
@@ -1069,13 +1077,13 @@ test('exact dev staging runs the full inventory with four mandatory Playwright s
     gate,
     /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
   );
-  dependencies.forEach((jobId) => {
-    assert.ok(
-      gate.includes(`test "\${{ needs.${jobId}.result }}" = "success"`),
-      `${jobId} must fail the staging aggregate unless it succeeds`
-    );
-  });
-  assert.doesNotMatch(gate, /gh api|curl|check-promotion-readiness/);
+  assert.match(gate, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(gate, /CI_IMPACT_PLAN_JSON: \$\{\{ needs\.ci-impact\.outputs\.plan \}\}/);
+  assert.match(gate, /CI_IMPACT_NEEDS_JSON: \$\{\{ toJSON\(needs\) \}\}/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_PROFILE: dev/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(gate, /node tools\/ci-impact\.mjs gate/);
+  assert.doesNotMatch(gate, /test "\$\{\{ needs\.|gh api|curl|check-promotion-readiness/);
 });
 
 test('Gallery readiness aggregates common, Vibrio, and projection evidence on dev', () => {
@@ -1306,18 +1314,19 @@ test('dev staging Web checks scope only the newly integrated change', () => {
 });
 
 test('supported-version and slow matrices cover exact dev staging', () => {
-  const stagingCondition = [
-    "    if: >-",
-    "      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||",
-    "      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')"
-  ].join('\n');
-
   for (const jobName of ['acceptance-supported-main', 'slow-main']) {
     const job = TEST_WORKFLOW.match(
       new RegExp(`\\n  ${jobName}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
     )?.[0];
     assert.ok(job, `${jobName} job must exist`);
-    assert.ok(job.includes(stagingCondition), `${jobName} must use the exact dev staging condition`);
+    assert.match(job, /needs: ci-impact/);
+    assert.match(job, /needs\.ci-impact\.result == 'success'/);
+    assert.match(job, new RegExp(`requiredJobs, '${jobName}'`));
+    assert.match(job, /github\.event_name == 'push' && github\.ref == 'refs\/heads\/dev'/);
+    assert.match(
+      job,
+      /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
+    );
   }
 });
 

--- a/tools/ci-impact.mjs
+++ b/tools/ci-impact.mjs
@@ -367,9 +367,11 @@ export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => 
   const requiredJobs = plan.requiredJobs.length ? plan.requiredJobs.map((job) => `\`${job}\``).join(', ') : 'none';
   const routing = plan.profile === 'pr'
     ? 'active; pull-request jobs use the trusted-base plan'
-    : 'observation only; existing test job conditions are unchanged';
+    : plan.profile === 'dev'
+      ? 'active; dev staging jobs use the protected-branch plan'
+      : 'observation only; existing test job conditions are unchanged';
   const lines = [
-    `## CI impact plan${plan.profile === 'pr' ? '' : ' (shadow mode)'}`,
+    `## CI impact plan${plan.profile === 'gallery' ? ' (shadow mode)' : ''}`,
     '',
     `- Profile: \`${plan.profile}\``,
     `- Impact: \`${plan.impact}\``,


### PR DESCRIPTION
## Plain-language summary

This PR stops rerunning unrelated staging tests after a change reaches `dev`. Metadata-only changes run the planner and `Dev staging / gate`, documentation-only changes also run `Recipes standard (Python 3.11)`, and every other change keeps the full staging inventory. A lightweight route is allowed only when the direct parent commit already has successful exact-SHA `Dev staging / gate` evidence.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Use the merged CI impact policy for `dev` push routing while preserving the current-SHA aggregate evidence required for promotion. A rapid push falls back to the full profile when the direct parent's run is missing, running, cancelled, failed, or otherwise unavailable.

## User-visible impact

Application behavior, rendering, packaging, Web UI, Gallery output, and scientific output are unchanged. Maintainers should see fewer staging jobs after metadata or documentation changes when the direct parent has successful evidence.

## Changes

| `dev` change | Project-owned jobs |
| --- | --- |
| Metadata | `CI impact plan`, `Dev staging / gate` |
| Documentation | `CI impact plan`, `Recipes standard (Python 3.11)`, `Dev staging / gate` |
| Full or evidence unavailable | The existing 11 staging job IDs and `Dev staging / gate` |

- Route all 11 staging job IDs through the existing `requiredJobs` plan in `.github/workflows/test.yml`.
- Replace the fixed shell status list in `Dev staging / gate` with the shared validator from the current protected-branch checkout.
- Keep `cancel-in-progress: true`; a cancelled or incomplete direct-parent run forces the current push to full.
- Keep `PR / gate` on the trusted base helper. Pull-request routing is unchanged.
- Leave `.github/workflows/gallery-publication.yml`, `.github/workflows/web-base-policy.yml`, and `tools/check-promotion-readiness.mjs` unchanged.
- Report dev routing as active in the planner summary and document the active trust boundary and troubleshooting path.

The test commands, matrices, timeouts, artifact uploads, aggregate display names, and promotion evidence contract are unchanged. This PR changes CI control-plane paths, so its own `CI impact plan` must select the full pull-request route.

## Verification

- `node --test tests/ci/*.test.mjs`: 3 test files passed.
- `node --test tests/web/architecture-contracts.test.mjs`: 131 tests passed.
- `node --test tests/web/promotion-readiness.test.mjs tests/web/web-promotion-context.test.mjs`: 2 test files passed.
- `python -m pytest tests/ -m "not slow and not (recipe or gallery or browser)" -n auto --dist loadfile`: 2,649 passed, 17 skipped.
- `python -m pytest tests/ -m "recipe and not slow"`: 186 passed.
- `ruff check gbdraw/`: passed.
- PyYAML parse of `.github/workflows/test.yml`: passed.
- `git diff --check`: passed.
- `git diff --exit-code -- tests/reference_outputs/`: no reference-output changes.
- `node tools/check-web-change-budget.mjs --base a61db7a2e66f3f6a5ccb153fe82075bd9400ee55 --head fb039b07`: Gate `PASS`; Review `REQUIRED` because `.github/workflows/test.yml` is governance authority.
- [Hosted pull-request CI](https://github.com/satoshikawato/gbdraw/actions/runs/33143669527): passed for exact head `fb039b074e3c12deb7cc2735c97b2a3205ac7176`. The trusted-base planner returned `impact=full`, `decision=full`, and `basis=FULL_CHANGE`; all six pull-request job groups ran and `PR / gate` passed.

## Risk and review notes

- Gate result and any blocker: Local deterministic gates and hosted pull-request CI pass. No blocker remains before merge.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because this changes `.github/workflows/test.yml`, which produces staging admission evidence.
- Architecture impact: **This is architecture-bearing**. Before this change, the dev profile existed in `tools/ci-impact-policy.mjs`, but `.github/workflows/test.yml` still selected every staging job with fixed event conditions and validated a second fixed status list. After this change, the existing policy registry and shared gate validator are the single routing and validation owners for `dev`; the superseded fixed conditions and shell status list are removed.
- `architecture-change` label, if relevant: Not applied. The control-plane paths already classify this PR as full, and no Web runtime owner, privileged boundary, persistence contract, or production module changes.

Ordinary non-increasing architecture evidence:

- Owner/path responsibility: `tools/ci-impact-policy.mjs` continues to own the dev required-job registry, `tools/ci-impact.mjs` validates the plan and results, and `.github/workflows/test.yml` only connects those owners to jobs.
- Canonical location before/after: fixed workflow event conditions and a fixed shell aggregate become `.github/workflows/test.yml` -> `tools/ci-impact.mjs` -> `tools/ci-impact-policy.mjs`.
- Superseded locations: the 11 unconditional dev job conditions and the fixed `Dev staging / gate` status list are removed.
- User-visible verification: there is no application output change; workflow contracts cover metadata, documentation, full, evidence-unavailable, rapid-push, and current-SHA gate behavior.
- Deterministic checks: focused CI tests, architecture contracts, promotion helper tests, core and recipe suites, Ruff, YAML parsing, and the Web change policy pass.
- Debt bounds: owner excess decreases by removing duplicated workflow decisions; path excess and compatibility burden do not increase. No compatibility reader or fallback path is added.

## Rollback

Revert commit `fb039b074e3c12deb7cc2735c97b2a3205ac7176`. This restores unconditional full staging and the fixed shell aggregate without changing branch protection, required check names, concurrency, or repository settings.

## Conditional Product Impact

- Product-impact role: N/A
- Affected concern(s), if known: None; no mapped application behavior or user journey changes.
- Authority and decision references: N/A
- Behavior contracts and residual risk: Application contracts are unchanged. Residual risk is limited to GitHub Actions routing and direct-parent evidence availability; every uncertain case returns to full staging.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/test.yml`, which selects staging jobs and produces `Dev staging / gate` for the current SHA.
- Checker implementation files touched: `tools/ci-impact.mjs` changes only its active-routing summary. The policy and promotion verifier are unchanged. Scenario coverage is extended in `tests/ci/` and `tests/web/architecture-contracts.test.mjs`.
- Self-authorization separation evidence: Pull-request admission still runs the planner and gate from the trusted base SHA, and this workflow/control-plane diff selects the full route. After merge, the protected `dev` checkout becomes the staging authority; the same control-plane paths classify the merge commit as full before the current-SHA aggregate can succeed.
- Branch-protection or ruleset impact, including unchanged settings: None. `PR / gate`, `Dev staging / gate`, `Gallery readiness / gate`, `Promotion / gate`, and `Web base policy (trusted base)` keep their names and roles.
- Governance-specific rollback or protection restore point: Reverting `fb039b074e3c12deb7cc2735c97b2a3205ac7176` restores the previous workflow graph. No repository-setting rollback is required.

### ARCHITECTURE_EXCEPTION

N/A. This ordinary change removes duplicated routing and validation decisions without adding owner excess, path excess, or compatibility burden.

### PROMOTION

N/A. This is an implementation pull request to `dev`, not a `dev`-to-`main` promotion.
