### PR TITLE
Skip Gallery readiness tests for unrelated changes

### DIFF
--- a/.github/workflows/gallery-publication.yml
+++ b/.github/workflows/gallery-publication.yml
@@ -2,6 +2,7 @@ name: Gallery publication
 
 permissions:
   contents: read
+  actions: read
 
 on:
   push:
@@ -19,8 +20,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci-impact:
+    name: CI impact plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      plan: ${{ steps.plan.outputs.plan }}
+    steps:
+      - name: Checkout exact workflow SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Build Gallery CI impact plan
+        id: plan
+        env:
+          CI_IMPACT_PROFILE: gallery
+          CI_IMPACT_EVENT_NAME: ${{ github.event_name }}
+          CI_IMPACT_REPOSITORY: ${{ github.repository }}
+          CI_IMPACT_CHANGE_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.sha }}
+          CI_IMPACT_CHANGE_HEAD_SHA: ${{ github.sha }}
+          CI_IMPACT_WORKFLOW_SHA: ${{ github.sha }}
+          CI_IMPACT_ARCHITECTURE_CHANGE: 'false'
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node tools/ci-impact.mjs plan
+
   browser:
     name: Gallery browser (${{ matrix.example }})
+    needs: ci-impact
+    if: >-
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'browser')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -54,6 +91,10 @@ jobs:
 
   performance:
     name: Gallery publication performance (projection)
+    needs: ci-impact
+    if: >-
+      needs.ci-impact.result == 'success' &&
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'performance')
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -85,14 +126,24 @@ jobs:
   readiness-gate:
     name: Gallery readiness / gate
     needs:
+      - ci-impact
       - browser
       - performance
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
-      - name: Require all Gallery readiness evidence
-        run: |
-          set -euo pipefail
-          test "${{ needs.browser.result }}" = "success"
-          test "${{ needs.performance.result }}" = "success"
+      - name: Checkout protected dev CI policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate required Gallery readiness evidence
+        env:
+          CI_IMPACT_PLAN_JSON: ${{ needs.ci-impact.outputs.plan }}
+          CI_IMPACT_NEEDS_JSON: ${{ toJSON(needs) }}
+          CI_IMPACT_EXPECTED_PROFILE: gallery
+          CI_IMPACT_EXPECTED_WORKFLOW_SHA: ${{ github.sha }}
+        run: node tools/ci-impact.mjs gate

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -1,7 +1,6 @@
 # Selective CI impact planning
 
-Status: pull-request and `dev` staging routing are active. The Gallery workflow is not
-connected to the planner.
+Status: pull-request, `dev` staging, and Gallery readiness routing are active.
 
 ## Purpose
 
@@ -12,8 +11,9 @@ revision already has successful exact-SHA aggregate evidence.
 
 The `Tests` workflow routes pull-request jobs from a plan produced by the trusted base
 revision. Pushes to `dev` use the planner from the protected branch and inherit only
-successful evidence from the direct parent commit. The Gallery workflow does not yet
-use the plan for job selection.
+successful evidence from the direct parent commit. The `Gallery publication` workflow
+uses the same protected-branch planner and direct-parent rule for its browser and
+performance jobs.
 
 ## Impact classes
 
@@ -113,6 +113,33 @@ with the protected branch's `tools/ci-impact.mjs`. It always creates aggregate e
 for the current SHA. The promotion verifier continues to require that exact current-SHA
 job; it does not accept the parent's job directly.
 
+## Active Gallery readiness routing
+
+For a push to `dev`, the Gallery planner compares `github.event.before` with the current
+SHA. When the direct parent has successful exact-SHA `Gallery readiness / gate`
+evidence, the `gallery` profile selects these jobs:
+
+| Gallery impact | Jobs that run |
+| --- | --- |
+| `metadata` | `CI impact plan`, `Gallery readiness / gate` |
+| `documentation` | `CI impact plan`, `Gallery readiness / gate` |
+| `full` | `CI impact plan`, both `Gallery browser` matrix entries, `Gallery publication performance (projection)`, `Gallery readiness / gate` |
+
+Documentation tests remain in the `Tests` workflow's recipe suite. Public Markdown and
+files under `docs/` do not change the packaged Gallery sessions, Web bundle, browser
+generation path, or performance projection, so the Gallery profile does not rerun
+either Gallery test job for those changes.
+
+The `browser` and `performance` job IDs retain their existing commands, matrices,
+timeouts, and performance baseline. Every `workflow_dispatch` run is full. When
+`complete_refresh=true`, the full performance job still runs its three-trial projection
+and complete-refresh gates.
+
+`Gallery readiness / gate` validates the Gallery plan and current-run job results with
+the protected branch's shared gate validator. A selective run therefore still creates
+successful aggregate evidence for the current SHA. Promotion continues to check that
+current-SHA job rather than the inherited parent job.
+
 ## Direct evidence only
 
 Selective planning inherits evidence from exactly one revision:
@@ -143,10 +170,10 @@ The following display names are external admission contracts and stay fixed:
 - `Promotion / gate`
 
 Each workflow continues to start on every relevant event and creates its aggregate job
-for the current SHA. Pull-request and `dev` staging selection happen at job level. The
-Gallery workflow still runs its full inventory. Keeping the aggregate names and
-current-SHA jobs stable avoids branch-protection changes and allows the existing
-promotion verifier to continue checking exact staging evidence.
+for the current SHA. Pull-request, `dev` staging, and Gallery selection happen at job
+level. Keeping the aggregate names and current-SHA jobs stable avoids branch-protection
+changes and allows the existing promotion verifier to continue checking exact staging
+evidence.
 
 Workflow-level `paths` and `paths-ignore` filters are not used. Such filters can prevent
 a required check from being created, leaving a pull request pending, and would remove
@@ -172,13 +199,13 @@ trusted base code and never executes the candidate checkout.
 ## Dev trust boundary
 
 Code merged to protected `dev` is the staging control plane. Push and manual-dispatch
-plans run the current checkout's helper. A change to the workflow, planner, policy, or
-planner tests classifies as `full`, so the commit that changes routing must run the full
-staging profile before its aggregate can succeed.
+plans run the current checkout's helper. A change to a workflow, planner, policy, or
+planner test classifies as `full`, so the commit that changes routing must run the full
+staging and Gallery profiles before their aggregates can succeed.
 
 This trust boundary differs from pull requests, where the candidate helper is tested
-but the base revision decides the route. The Gallery workflow has its own gate and is
-not routed by the `Tests` workflow's dev plan.
+but the base revision decides the route. The Gallery workflow creates its own `gallery`
+plan and gate; it does not consume the `Tests` workflow's `dev` plan.
 
 ## Aggregate validation
 
@@ -193,9 +220,9 @@ The shared gate validator fails closed unless:
 An unexpected failure or cancellation remains blocking even for a job the plan did not
 require. Malformed plan or `needs` JSON is also blocking.
 
-`PR / gate` runs the validator from `.ci-trusted-base`. `Dev staging / gate` runs the
-same validator from the current protected-branch checkout with expected profile `dev`
-and the current workflow SHA.
+`PR / gate` runs the validator from `.ci-trusted-base`. `Dev staging / gate` and
+`Gallery readiness / gate` run the same validator from the current protected-branch
+checkout with their expected profile and the current workflow SHA.
 
 ## Rollout
 
@@ -205,11 +232,19 @@ Selective CI uses four separately reviewed stages:
    shadow summary.
 2. Active: selective pull-request routing with the trusted base planner and validator.
 3. Active: evidence-aware selection for exact `dev` staging runs.
-4. Not implemented: evidence-aware selection for Gallery readiness runs.
+4. Active: evidence-aware selection for exact Gallery readiness runs.
 
 Each stage keeps the aggregate check names stable and can be reverted independently.
 Reverting a routing stage restores the previous full-suite conditions without a
 repository-settings change.
+
+To roll back only Gallery selection, restore the `browser` and `performance` jobs to
+their unconditional event behavior and restore the fixed two-job readiness check.
+`Gallery readiness / gate` keeps the same display name, so repository settings do not
+need to change. The planner and the other two profiles can remain active.
+
+Selective CI does not alter `.github/workflows/deploy_web.yml`, deployment triggering,
+or GitHub's CodeQL setup. Those systems remain outside the impact planner.
 
 ## Observability
 
@@ -222,10 +257,9 @@ The `CI impact plan` summary includes:
 - inherited run and aggregate links when evidence succeeds; and
 - the fallback code and bounded reason when evidence is unavailable.
 
-The `pr` and `dev` summaries state that routing is active and name the applicable trust
-boundary. The Gallery workflow does not produce a planner summary while its stage is
-unimplemented. Tokens are never included in the plan or summary and are redacted from
-CLI diagnostics.
+The `pr`, `dev`, and `gallery` summaries state that routing is active and name the
+applicable trust boundary. Tokens are never included in the plan or summary and are
+redacted from CLI diagnostics.
 
 ## Troubleshooting
 
@@ -261,13 +295,14 @@ known job is present in `needs`, required jobs succeeded, and unrequired jobs di
 fail or get cancelled unexpectedly. Do not weaken the validator to accept a missing or
 skipped required job.
 
-### Consecutive dev pushes run the full profile
+### Consecutive dev pushes run a full profile
 
 Inspect `basis` and the evidence failure in `CI impact plan`. If the direct parent's
-workflow is queued, running, cancelled, failed, or absent, the current push must use
-`INHERITED_EVIDENCE_UNAVAILABLE` and run the full profile. Wait for a successful direct
-parent before using a lightweight commit when selective staging is important. Do not
-replace the direct parent with an older green SHA or disable concurrency.
+`Tests` or `Gallery publication` workflow is queued, running, cancelled, failed, or
+absent, the current push must use `INHERITED_EVIDENCE_UNAVAILABLE` and run the full
+profile for that workflow. Wait for a successful direct parent before using a
+lightweight commit when selective staging is important. Do not replace the direct
+parent with an older green SHA or disable concurrency.
 
 ### Pull-request jobs are all skipped
 

--- a/tests/ci/ci-impact-cli.test.mjs
+++ b/tests/ci/ci-impact-cli.test.mjs
@@ -165,6 +165,64 @@ test('dev metadata and documentation changes select only changed surfaces', asyn
   }
 });
 
+test('Gallery metadata and documentation changes skip browser and performance', async () => {
+  for (const [path, impact] of [
+    ['.agents/skills/example/SKILL.md', 'metadata'],
+    ['docs/FAQ.md', 'documentation']
+  ]) {
+    let evidenceArguments;
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'gallery',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', path),
+      verifyWorkflowEvidenceImpl: async (args) => {
+        evidenceArguments = args;
+        return successfulEvidence({
+          workflowPath: '.github/workflows/gallery-publication.yml',
+          aggregateName: 'Gallery readiness / gate'
+        });
+      }
+    });
+    assert.equal(evidenceArguments.expectedHeadSha, SHA.base);
+    assert.equal(evidenceArguments.workflowPath, '.github/workflows/gallery-publication.yml');
+    assert.equal(evidenceArguments.expectedAggregateName, 'Gallery readiness / gate');
+    assert.equal(outcome.plan.impact, impact);
+    assert.equal(outcome.plan.decision, 'selective');
+    assert.equal(outcome.plan.basis, 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE');
+    assert.deepEqual(outcome.plan.requiredJobs, []);
+  }
+});
+
+test('Gallery-impacting surfaces select the full Gallery profile without evidence lookup', async () => {
+  for (const path of [
+    '.github/workflows/gallery-publication.yml',
+    'gbdraw/web/gallery/sessions/example.gbdraw-session.json',
+    'gbdraw/web/js/app.js',
+    'pyproject.toml',
+    'tools/ci-impact.mjs',
+    'tests/ci/ci-impact-cli.test.mjs'
+  ]) {
+    let evidenceCalls = 0;
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'gallery',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', path),
+      verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
+    });
+    assert.equal(evidenceCalls, 0, path);
+    assert.equal(outcome.plan.impact, 'full', path);
+    assert.equal(outcome.plan.decision, 'full', path);
+    assert.equal(outcome.plan.basis, 'FULL_CHANGE', path);
+    assert.deepEqual(outcome.plan.requiredJobs, ['browser', 'performance'], path);
+  }
+});
+
 test('dev control-plane changes run the full profile without inherited evidence', async () => {
   for (const path of ['tools/ci-impact.mjs', '.github/workflows/test.yml']) {
     let evidenceCalls = 0;
@@ -243,26 +301,79 @@ test('rapid dev pushes fall back to full while the direct parent is running or c
   }
 });
 
-test('a zero dev before SHA fails closed without querying inherited evidence', async () => {
-  let evidenceCalls = 0;
+test('Gallery direct-parent evidence failures fall back to both Gallery jobs', async () => {
+  for (const [code, state] of [
+    ['NO_MATCHING_RUN', 'missing'],
+    ['RUN_NOT_SUCCESSFUL', 'in progress'],
+    ['RUN_NOT_SUCCESSFUL', 'cancelled'],
+    ['RUN_NOT_SUCCESSFUL', 'failure'],
+    ['API_REQUEST_FAILED', 'API error']
+  ]) {
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: 'gallery',
+        CI_IMPACT_EVENT_NAME: 'push'
+      }),
+      token: 'test-token',
+      runGitImpl: () => gitResult('M', 'docs/FAQ.md'),
+      verifyWorkflowEvidenceImpl: async () => {
+        throw new PromotionReadinessError(code, `Direct parent Gallery run is ${state}.`);
+      }
+    });
+    assert.equal(outcome.plan.impact, 'documentation', state);
+    assert.equal(outcome.plan.decision, 'full', state);
+    assert.equal(outcome.plan.basis, 'INHERITED_EVIDENCE_UNAVAILABLE', state);
+    assert.deepEqual(outcome.plan.requiredJobs, ['browser', 'performance'], state);
+  }
+});
+
+test('a successful exact parent aggregate can extend a selective Gallery evidence chain', async () => {
   const outcome = await buildImpactPlan({
     configuration: configuration({
-      CI_IMPACT_PROFILE: 'dev',
-      CI_IMPACT_EVENT_NAME: 'push',
-      CI_IMPACT_CHANGE_BASE_SHA: '0'.repeat(40)
+      CI_IMPACT_PROFILE: 'gallery',
+      CI_IMPACT_EVENT_NAME: 'push'
     }),
     token: 'test-token',
-    runGitImpl: () => ({
-      status: 128,
-      stdout: Buffer.alloc(0),
-      stderr: Buffer.from('bad object 0000000000000000000000000000000000000000')
-    }),
-    verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
+    runGitImpl: () => gitResult('M', '.gitignore'),
+    verifyWorkflowEvidenceImpl: async ({ expectedHeadSha }) => ({
+      ...successfulEvidence({
+        workflowPath: '.github/workflows/gallery-publication.yml',
+        aggregateName: 'Gallery readiness / gate'
+      }),
+      run: {
+        ...successfulEvidence().run,
+        headSha: expectedHeadSha,
+        composedFromSelectiveEvidence: true
+      }
+    })
   });
-  assert.equal(evidenceCalls, 0);
-  assert.equal(outcome.plan.impact, 'full');
-  assert.equal(outcome.plan.decision, 'full');
-  assert.equal(outcome.plan.basis, 'UNKNOWN_OR_INVALID_CHANGE');
+  assert.equal(outcome.plan.decision, 'selective');
+  assert.equal(outcome.plan.inheritedEvidence.headSha, SHA.base);
+  assert.deepEqual(outcome.plan.requiredJobs, []);
+});
+
+test('a zero push before SHA fails closed without querying inherited evidence', async () => {
+  for (const profile of ['dev', 'gallery']) {
+    let evidenceCalls = 0;
+    const outcome = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: profile,
+        CI_IMPACT_EVENT_NAME: 'push',
+        CI_IMPACT_CHANGE_BASE_SHA: '0'.repeat(40)
+      }),
+      token: 'test-token',
+      runGitImpl: () => ({
+        status: 128,
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.from('bad object 0000000000000000000000000000000000000000')
+      }),
+      verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
+    });
+    assert.equal(evidenceCalls, 0, profile);
+    assert.equal(outcome.plan.impact, 'full', profile);
+    assert.equal(outcome.plan.decision, 'full', profile);
+    assert.equal(outcome.plan.basis, 'UNKNOWN_OR_INVALID_CHANGE', profile);
+  }
 });
 
 test('evidence verifier failures fall back to the full profile', async () => {
@@ -331,17 +442,35 @@ test('invalid and empty diffs fail closed without querying evidence', async () =
 
 test('manual runs and architecture-change labels force full execution', async () => {
   let calls = 0;
-  const manual = await buildImpactPlan({
-    configuration: configuration({
-      CI_IMPACT_PROFILE: 'dev',
-      CI_IMPACT_EVENT_NAME: 'workflow_dispatch'
-    }),
-    token: 'test-token',
-    runGitImpl: () => { calls += 1; },
-    verifyWorkflowEvidenceImpl: async () => { calls += 1; }
-  });
+  for (const [profile, requiredJobs] of [
+    ['dev', [
+      'web-change-budget',
+      'core',
+      'recipes-standard',
+      'gallery',
+      'browser',
+      'playwright-functional',
+      'playwright-performance',
+      'acceptance-supported-main',
+      'slow-main',
+      'lint',
+      'losat-cache-browser-acceptance'
+    ]],
+    ['gallery', ['browser', 'performance']]
+  ]) {
+    const manual = await buildImpactPlan({
+      configuration: configuration({
+        CI_IMPACT_PROFILE: profile,
+        CI_IMPACT_EVENT_NAME: 'workflow_dispatch'
+      }),
+      token: 'test-token',
+      runGitImpl: () => { calls += 1; },
+      verifyWorkflowEvidenceImpl: async () => { calls += 1; }
+    });
+    assert.equal(manual.plan.basis, 'MANUAL_FULL_RUN', profile);
+    assert.deepEqual(manual.plan.requiredJobs, requiredJobs, profile);
+  }
   assert.equal(calls, 0);
-  assert.equal(manual.plan.basis, 'MANUAL_FULL_RUN');
 
   const architecture = await buildImpactPlan({
     configuration: configuration({ CI_IMPACT_ARCHITECTURE_CHANGE: 'true' }),
@@ -402,6 +531,33 @@ test('dev plan summary reports active protected-branch routing', async () => {
   const summary = writes.get('/tmp/ci-impact-dev-summary');
   assert.match(summary, /Routing: active; dev staging jobs use the protected-branch plan/);
   assert.doesNotMatch(summary, /shadow mode/);
+});
+
+test('Gallery plan summary reports active protected-branch routing', async () => {
+  const writes = new Map();
+  const status = await runCiImpactCli({
+    argv: ['plan'],
+    env: environment({
+      CI_IMPACT_PROFILE: 'gallery',
+      CI_IMPACT_EVENT_NAME: 'push',
+      GITHUB_STEP_SUMMARY: '/tmp/ci-impact-gallery-summary'
+    }),
+    stdout: textWriter().stream,
+    stderr: textWriter().stream,
+    appendFileImpl: (path, content) => writes.set(path, (writes.get(path) || '') + content),
+    runGitImpl: () => gitResult('M', '.gitignore'),
+    verifyWorkflowEvidenceImpl: async () => successfulEvidence({
+      workflowPath: '.github/workflows/gallery-publication.yml',
+      aggregateName: 'Gallery readiness / gate'
+    })
+  });
+  assert.equal(status, 0);
+  const summary = writes.get('/tmp/ci-impact-gallery-summary');
+  assert.match(
+    summary,
+    /Routing: active; Gallery readiness jobs use the protected-branch plan/
+  );
+  assert.doesNotMatch(summary, /shadow mode|observation only/);
 });
 
 test('unexpected failures are not converted to full plans and redact tokens', async () => {

--- a/tests/ci/ci-impact-gate.test.mjs
+++ b/tests/ci/ci-impact-gate.test.mjs
@@ -40,6 +40,17 @@ const devPlan = (overrides = {}) => plan({
   ...overrides
 });
 
+const galleryPlan = (overrides = {}) => plan({
+  profile: 'gallery',
+  basis: 'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE',
+  inheritedEvidence: {
+    ...plan().inheritedEvidence,
+    workflowPath: '.github/workflows/gallery-publication.yml',
+    aggregateName: 'Gallery readiness / gate'
+  },
+  ...overrides
+});
+
 const needsFor = (impactPlan = plan()) => Object.fromEntries([
   ['ci-impact', { result: 'success' }],
   ...knownJobsFor(impactPlan.profile).map((jobId) => [
@@ -120,6 +131,66 @@ test('gate accepts metadata, documentation, and full dev staging routes', () => 
   routes.forEach((impactPlan) => {
     assert.equal(validate(impactPlan, needsFor(impactPlan)).ok, true);
   });
+});
+
+test('Gallery gate accepts both light routes and requires both full jobs', () => {
+  const routes = [
+    galleryPlan({ impact: 'metadata' }),
+    galleryPlan(),
+    galleryPlan({
+      impact: 'full',
+      decision: 'full',
+      basis: 'FULL_CHANGE',
+      inheritedEvidence: null
+    })
+  ];
+  assert.deepEqual(routes.map(({ requiredJobs }) => requiredJobs), [
+    [],
+    [],
+    ['browser', 'performance']
+  ]);
+  routes.forEach((impactPlan) => {
+    assert.equal(validate(impactPlan, needsFor(impactPlan)).ok, true);
+  });
+
+  const full = routes[2];
+  for (const jobId of ['browser', 'performance']) {
+    for (const result of ['skipped', 'failure', 'cancelled']) {
+      const needs = needsFor(full);
+      needs[jobId].result = result;
+      assert.throws(
+        () => validate(full, needs),
+        /required CI job did not succeed/,
+        `${jobId}: ${result}`
+      );
+    }
+  }
+
+  const optionalFailure = needsFor(routes[0]);
+  optionalFailure.browser.result = 'failure';
+  assert.throws(
+    () => validate(routes[0], optionalFailure),
+    /unrequired CI job failed unexpectedly/
+  );
+});
+
+test('Gallery gate rejects the wrong profile, workflow SHA, and schema', () => {
+  const impactPlan = galleryPlan();
+  const needs = needsFor(impactPlan);
+  for (const [candidate, expected, message] of [
+    [impactPlan, { profile: 'dev', workflowSha: SHA.workflow }, /profile does not match/],
+    [impactPlan, { profile: 'gallery', workflowSha: 'd'.repeat(40) }, /workflow SHA does not match/],
+    [{ ...impactPlan, schemaVersion: 2 }, {
+      profile: 'gallery', workflowSha: SHA.workflow
+    }, /schema version is not supported/]
+  ]) {
+    assert.throws(() => validateGateResults({
+      plan: candidate,
+      needs,
+      knownJobs: knownJobsFor('gallery'),
+      expected
+    }), message);
+  }
 });
 
 test('dev gate treats each matrix aggregate as one required job result', () => {

--- a/tests/ci/ci-impact-policy.test.mjs
+++ b/tests/ci/ci-impact-policy.test.mjs
@@ -177,8 +177,14 @@ test('profile job registries are exact and centralized', () => {
   ]);
   assert.deepEqual(knownJobsFor('gallery'), ['browser', 'performance']);
   assert.deepEqual(requiredJobsFor({
+    profile: 'gallery', impact: 'metadata', decision: 'selective'
+  }), []);
+  assert.deepEqual(requiredJobsFor({
     profile: 'gallery', impact: 'documentation', decision: 'selective'
   }), []);
+  assert.deepEqual(requiredJobsFor({
+    profile: 'gallery', impact: 'full', decision: 'full'
+  }), ['browser', 'performance']);
 });
 
 test('impact plans are strict, policy-derived, and immutable', () => {

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1086,29 +1086,70 @@ test('exact dev staging routes every job through the protected-branch plan', () 
   assert.doesNotMatch(gate, /test "\$\{\{ needs\.|gh api|curl|check-promotion-readiness/);
 });
 
-test('Gallery readiness aggregates common, Vibrio, and projection evidence on dev', () => {
+test('Gallery readiness routes jobs from direct-parent evidence and aggregates the current SHA', () => {
+  assert.match(
+    GALLERY_PUBLICATION_WORKFLOW,
+    /permissions:\n  contents: read\n  actions: read/
+  );
+  assert.doesNotMatch(GALLERY_PUBLICATION_WORKFLOW, /\n    paths(?:-ignore)?:/);
+
+  const planner = workflowJob('ci-impact', GALLERY_PUBLICATION_WORKFLOW);
+  assert.match(planner, /\n    name: CI impact plan\n/);
+  assert.match(planner, /timeout-minutes: 5/);
+  assert.match(planner, /plan: \$\{\{ steps\.plan\.outputs\.plan \}\}/);
+  assert.match(
+    planner,
+    /Checkout exact workflow SHA[\s\S]*ref: \$\{\{ github\.sha \}\}[\s\S]*fetch-depth: 0[\s\S]*persist-credentials: false/
+  );
+  assert.match(planner, /node-version: "20"/);
+  assert.match(planner, /CI_IMPACT_PROFILE: gallery/);
+  assert.match(planner, /CI_IMPACT_EVENT_NAME: \$\{\{ github\.event_name \}\}/);
+  assert.match(
+    planner,
+    /CI_IMPACT_CHANGE_BASE_SHA: \$\{\{ github\.event_name == 'push' && github\.event\.before \|\| github\.sha \}\}/
+  );
+  assert.match(planner, /CI_IMPACT_CHANGE_HEAD_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(planner, /CI_IMPACT_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(planner, /GITHUB_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(planner, /node tools\/ci-impact\.mjs plan/);
+  assert.doesNotMatch(planner, /node --test/);
+
   const browser = workflowJob('browser', GALLERY_PUBLICATION_WORKFLOW);
+  assert.match(browser, /needs: ci-impact/);
+  assert.match(browser, /needs\.ci-impact\.result == 'success'/);
+  assert.match(browser, /requiredJobs, 'browser'/);
   assert.match(browser, /example: common 9\n            command: test:web:gallery-publication/);
   assert.match(browser, /example: Vibrio\n            command: test:web:vibrio-generate/);
   assert.match(browser, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(browser, /npm run \$\{\{ matrix\.command \}\}/);
 
   const performance = workflowJob('performance', GALLERY_PUBLICATION_WORKFLOW);
   assert.match(performance, /\n    name: Gallery publication performance \(projection\)\n/);
+  assert.match(performance, /needs: ci-impact/);
+  assert.match(performance, /needs\.ci-impact\.result == 'success'/);
+  assert.match(performance, /requiredJobs, 'performance'/);
   assert.match(performance, /measure_gallery_publication_performance\.py projection/);
   assert.match(performance, /github\.event_name == 'workflow_dispatch' && inputs\.complete_refresh/);
   assert.match(performance, /measure_gallery_publication_performance\.py refresh/);
+  assert.equal(
+    [...performance.matchAll(/--baseline-revision 574b33b83962949397839e2aaa862a8b96667625/g)].length,
+    2
+  );
 
   const gate = workflowJob('readiness-gate', GALLERY_PUBLICATION_WORKFLOW);
   assert.match(gate, /\n    name: Gallery readiness \/ gate\n/);
-  assert.match(gate, /\n    needs:\n      - browser\n      - performance\n/);
+  assert.match(gate, /\n    needs:\n      - ci-impact\n      - browser\n      - performance\n/);
   assert.match(gate, /\n    if: always\(\)\n/);
-  for (const jobId of ['browser', 'performance']) {
-    assert.ok(
-      gate.includes(`test "\${{ needs.${jobId}.result }}" = "success"`),
-      `${jobId} must fail the Gallery aggregate unless all matrix jobs succeed`
-    );
-  }
-  assert.doesNotMatch(gate, /gh api|curl|check-promotion-readiness/);
+  assert.match(gate, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(gate, /CI_IMPACT_PLAN_JSON: \$\{\{ needs\.ci-impact\.outputs\.plan \}\}/);
+  assert.match(gate, /CI_IMPACT_NEEDS_JSON: \$\{\{ toJSON\(needs\) \}\}/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_PROFILE: gallery/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(gate, /node tools\/ci-impact\.mjs gate/);
+  assert.doesNotMatch(
+    gate,
+    /test "\$\{\{ needs\.|gh api|curl|check-promotion-readiness/
+  );
 });
 
 test('trusted promotion uses base code for topology, exact-SHA evidence, and tree proof', () => {

--- a/tools/ci-impact.mjs
+++ b/tools/ci-impact.mjs
@@ -369,9 +369,9 @@ export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => 
     ? 'active; pull-request jobs use the trusted-base plan'
     : plan.profile === 'dev'
       ? 'active; dev staging jobs use the protected-branch plan'
-      : 'observation only; existing test job conditions are unchanged';
+      : 'active; Gallery readiness jobs use the protected-branch plan';
   const lines = [
-    `## CI impact plan${plan.profile === 'gallery' ? ' (shadow mode)' : ''}`,
+    '## CI impact plan',
     '',
     `- Profile: \`${plan.profile}\``,
     `- Impact: \`${plan.impact}\``,


### PR DESCRIPTION
## Plain-language summary

This PR stops rerunning Gallery browser and performance tests after unrelated metadata or documentation changes reach `dev`. Those jobs are skipped only when the direct parent commit already has successful exact-SHA `Gallery readiness / gate` evidence; missing or unsuccessful parent evidence runs both jobs. Every current SHA still gets `CI impact plan` and `Gallery readiness / gate`, and manual runs remain full.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Connect `.github/workflows/gallery-publication.yml` to the merged CI impact planner without changing the current-SHA evidence that `Promotion / gate` requires. Metadata and documentation changes can reuse direct-parent Gallery evidence, while runtime, Web, Gallery, test, tool, package, workflow, unknown, and evidence-unavailable changes keep the full Gallery route.

## User-visible impact

Application behavior, rendering, packaging, Web UI, Gallery output, and scientific output are unchanged. Maintainers should see `Gallery browser` and `Gallery publication performance (projection)` skipped after eligible metadata or documentation changes.

## Changes

| `dev` change | Gallery workflow jobs |
| --- | --- |
| Metadata with successful parent evidence | `CI impact plan`, `Gallery readiness / gate` |
| Documentation with successful parent evidence | `CI impact plan`, `Gallery readiness / gate` |
| Full or parent evidence unavailable | `CI impact plan`, both `Gallery browser` matrix entries, `Gallery publication performance (projection)`, `Gallery readiness / gate` |

- Add the `gallery` planner job to `.github/workflows/gallery-publication.yml` with complete history and Actions read permission.
- Route the existing `browser` and `performance` job IDs through the centralized `requiredJobs` plan.
- Replace the fixed two-line shell gate with the shared validator and keep `Gallery readiness / gate` on the current workflow SHA.
- Keep both browser commands, matrix entries, timeouts, performance baseline `574b33b83962949397839e2aaa862a8b96667625`, and `complete_refresh` step unchanged.
- Keep every `workflow_dispatch` run full, including runs with `complete_refresh=true`.
- Report Gallery routing as active and update `docs/internal/SELECTIVE_CI.md` for the final three-profile state.
- Leave `.github/workflows/test.yml`, `.github/workflows/web-base-policy.yml`, `.github/workflows/deploy_web.yml`, and `tools/check-promotion-readiness.mjs` unchanged.

This commit changes CI control-plane files, so the trusted pull-request planner must select the full PR route. After merge, the protected `dev` planner must also select the full staging and Gallery routes for this commit.

## Verification

- `node --test tests/ci/*.test.mjs`: 3 test files passed.
- `node --test tests/web/architecture-contracts.test.mjs`: 131 tests passed.
- `node --test tests/web/promotion-readiness.test.mjs tests/web/web-promotion-context.test.mjs`: 2 test files passed.
- `python -m pytest tests/ -m "not slow and not (recipe or gallery or browser)" -n auto --dist loadfile`: 2,649 passed, 17 skipped.
- `python -m pytest tests/ -m "recipe and not slow"`: 186 passed.
- `ruff check gbdraw/`: passed.
- `node --check tools/ci-impact.mjs`: passed.
- PyYAML parse of `.github/workflows/gallery-publication.yml`: passed.
- `git diff --check`: passed.
- `git diff --exit-code origin/dev...HEAD -- tests/reference_outputs/`: no reference-output changes.
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD`: Gate `PASS`; Review `REQUIRED` because `.github/workflows/gallery-publication.yml` produces governance evidence.
- [Hosted pull-request Tests run](https://github.com/satoshikawato/gbdraw/actions/runs/33145237154): passed for exact head `054f46266756eec6c3080f563199af7b3943228b`. The trusted-base planner returned `impact=full`, `decision=full`, and `basis=FULL_CHANGE`; all six pull-request job groups ran and `PR / gate` passed. CodeQL, `Web base policy (trusted base)`, and Workers Builds also passed.

## Risk and review notes

- Gate result and any blocker: Local deterministic gates and hosted pull-request CI pass. No blocker remains before merge.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because `.github/workflows/gallery-publication.yml` produces `Gallery readiness / gate`, which is required for promotion.
- Architecture impact: **This is architecture-bearing**. Before this change, `.github/workflows/gallery-publication.yml` ran both test jobs unconditionally and owned a fixed result check even though the Gallery profile and shared validator already existed. After this change, `tools/ci-impact-policy.mjs` owns the Gallery required-job registry, `tools/ci-impact.mjs` owns plan and gate validation, and the workflow only connects those owners to the existing jobs.
- `architecture-change` label, if relevant: Not applied. No Web runtime owner, privileged boundary, persistence contract, compatibility path, or production module changes.

Ordinary non-increasing architecture evidence:

- Owner/path responsibility: the existing policy and adapter become the active owners for Gallery selection and aggregate validation; the workflow remains the event and job-orchestration owner.
- Canonical location before/after: `.github/workflows/gallery-publication.yml` fixed execution and shell validation become `.github/workflows/gallery-publication.yml` -> `tools/ci-impact.mjs` -> `tools/ci-impact-policy.mjs`.
- Superseded locations: unconditional Gallery test execution and the fixed two-result shell check are removed. No parallel route remains.
- User-visible verification: application output is unchanged; contracts cover metadata, documentation, full, missing/running/cancelled/failed parent evidence, zero parent SHA, manual dispatch, exact-SHA chaining, and current-SHA gate behavior.
- Deterministic checks: CI impact tests, architecture contracts, promotion helper tests, core and recipe suites, Ruff, YAML parsing, and Web change policy pass.
- Debt bounds: owner excess does not increase, path excess does not increase, and compatibility burden remains unchanged. No compatibility reader or fallback path is added.
- Rollback: reverting this commit restores unconditional Gallery jobs and the fixed shell check without changing check names or repository settings.

## Rollback

Revert commit `054f46266756eec6c3080f563199af7b3943228b`. This restores the previous Gallery workflow graph. `Gallery readiness / gate`, `Promotion / gate`, branch protection, concurrency, browser commands, the performance baseline, and `complete_refresh` semantics require no repository-setting changes.

## Conditional Product Impact

- Product-impact role: N/A
- Affected concern(s), if known: None; no mapped application behavior or user journey changes.
- Authority and decision references: N/A
- Behavior contracts and residual risk: Application contracts are unchanged. Residual risk is limited to GitHub Actions routing and direct-parent evidence availability; every uncertain case returns to the full Gallery profile.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/gallery-publication.yml`, which selects Gallery verification jobs and produces `Gallery readiness / gate` for the current SHA.
- Checker implementation files touched: `tools/ci-impact.mjs` changes only the Gallery active-routing summary. The policy registry and promotion verifier are unchanged. Scenario coverage is extended in `tests/ci/` and `tests/web/architecture-contracts.test.mjs`.
- Self-authorization separation evidence: Pull-request admission still executes the planner and gate from the trusted base SHA, which classifies this workflow/control-plane diff as full. After merge, the protected `dev` checkout becomes the Gallery routing authority; the same diff classifies the merge commit as full before current-SHA staging and Gallery aggregates can succeed.
- Branch-protection or ruleset impact, including unchanged settings: None. `PR / gate`, `Dev staging / gate`, `Gallery readiness / gate`, `Promotion / gate`, and `Web base policy (trusted base)` keep their names and roles.
- Governance-specific rollback or protection restore point: Reverting `054f46266756eec6c3080f563199af7b3943228b` restores the previous workflow graph. No repository-setting rollback is required.

### ARCHITECTURE_EXCEPTION

N/A. This ordinary change removes duplicated routing and validation decisions without adding owner excess, path excess, or compatibility burden.

### PROMOTION

N/A. This is an implementation pull request to `dev`, not a `dev`-to-`main` promotion.
