### PR TITLE
Preauthorize the Option Integrity Product Decision lifecycle and contract path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,8 @@ Select exactly one:
 
 ## Purpose
 
+- Applicable baseline: base branch and exact SHA; current required checks and trusted CI profile; focused test owners or behavior contracts:
+
 ## User-visible impact
 
 ## Changes
@@ -33,6 +35,10 @@ Select exactly one:
 - Architecture impact: state whether **This is not architecture-bearing** or
   **This is architecture-bearing**, and identify the affected owner, path, or
   responsibility.
+- Architecture baseline and changed-scope conclusion, if architecture-bearing:
+  semantic owners; canonical and compatibility paths; `OE`/`PE`/`CB` before and
+  after conclusion. Use `N/A` when not applicable; full tables remain limited
+  to `ARCHITECTURE_EXCEPTION`.
 - `architecture-change` label, if relevant:
 
 ## Rollback
@@ -50,6 +56,7 @@ This block does not waive any other gate. Product change or retirement requires 
 - Product-impact role: N/A | EVIDENCE_ONLY | DECISION_ONLY | IMPLEMENTATION
 - Product preflight classification: N/A | IMPLEMENT_EXISTING_AUTHORITY | EVIDENCE_REQUIRED | PRODUCT_DECISION_REQUIRED | NOT_ALLOWED
 - Affected concern(s), if known:
+- Affected journey/checkpoint effects:
 - Authority and decision references:
 - Decision Pack or evidence reference, if required:
 - Behavior contracts and residual risk:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,8 +48,10 @@ This block does not waive any other gate. Product change or retirement requires 
 -->
 
 - Product-impact role: N/A | EVIDENCE_ONLY | DECISION_ONLY | IMPLEMENTATION
+- Product preflight classification: N/A | IMPLEMENT_EXISTING_AUTHORITY | EVIDENCE_REQUIRED | PRODUCT_DECISION_REQUIRED | NOT_ALLOWED
 - Affected concern(s), if known:
 - Authority and decision references:
+- Decision Pack or evidence reference, if required:
 - Behavior contracts and residual risk:
 
 <!-- gbdraw-product-impact-decision:start -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,11 @@ For changes affecting Web runtime or normative Web behavior contracts:
   domain rules, and accepted base-branch decisions. Current code and tests are
   evidence, not automatic product authority. Cite a `BD-###` only when it exists
   in the base branch.
+- Before implementation, use the same policy's developer preflight when a
+  proposed change may alter a material user effect but no registered concern is
+  triggered. Use
+  [`docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md`](docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md)
+  when evidence or Product judgment is required.
 - Compare option realization with AND-of-OR requirements. Matching option IDs do
   not prove that independent behavior contributions remain satisfied.
 - Keep the common path automatic for changes with no registered Product Impact

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,13 @@ Substantial implementation must wait for maintainer confirmation. Agreement
 that a problem exists is not approval of a patch. The maintainer may first ask
 for a smaller evidence-producing change or an explicit behavior decision.
 
+Before implementation, maintainers and developers apply the
+[Product Impact Ratchet](./docs/internal/PRODUCT_IMPACT_RATCHET.md) to both
+registered architecture-subject changes and unmapped material user-effect
+ambiguity. Unresolved evidence or Product judgment uses the non-normative
+[Product Decision Pack template](./docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md);
+the completed working template does not itself authorize an outcome.
+
 ## Development setup
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,6 +302,14 @@ Policy reports distinguish `Gate: PASS | FAIL` from `Review: CLEAR | REQUIRED`.
 Gate controls the CI exit status. `Review: REQUIRED` means a human must examine
 the identified risk; by itself it exits zero and is not a CI failure.
 
+Record pull request baselines in proportion to the change. Ordinary
+non-architecture pull requests use the normal concise template. Product-impact
+work additionally records the applicable Product authority and affected
+journey effects. Architecture-bearing work additionally records the relevant
+semantic owners, canonical paths, compatibility paths, and changed-scope
+`OE`/`PE`/`CB` conclusion. Mark non-applicable fields `N/A`; they do not require
+an expanded packet.
+
 ## Submitting a pull request
 
 Submit a non-trivial pull request only after its scope has been agreed in the

--- a/docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md
+++ b/docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md
@@ -1,0 +1,157 @@
+# Product Decision Pack — <title>
+
+Status: non-normative working template
+
+Use this template for either a registered Product Impact change or developer
+preflight that finds unmapped material user-effect ambiguity. The normative
+lifecycle, classifications, authority rules, and routes are defined by the
+[Product Impact Ratchet](./PRODUCT_IMPACT_RATCHET.md); this working document is
+not Product authority.
+
+## Identity
+
+- Concern key: <stable dotted key>
+- Scenario revision: <positive integer>
+- Discovery lane: <Product Impact Ratchet | developer preflight>
+- Prepared from base SHA:
+- Prepared for proposed branch/head:
+- Prepared by:
+- Related issue/PR:
+
+## Trigger
+
+<What proposed change exposed the unresolved Product outcome?>
+
+## Authority search
+
+| Source inspected | Result | Conflict or gap |
+| --- | --- | --- |
+| Product Impact concern/map | | |
+| Active durable `BD-###` | | |
+| Static Product Contract, when available | | |
+| Domain/scientific/integrity rule | | |
+| Released compatibility evidence | | |
+| Eligible exact-head current decision | | |
+| Current code/tests as evidence only | | |
+
+Result: <UNRESOLVED | CONFLICT | INSUFFICIENT_EVIDENCE>
+
+Procedural classification:
+<IMPLEMENT_EXISTING_AUTHORITY | EVIDENCE_REQUIRED | PRODUCT_DECISION_REQUIRED | NOT_ALLOWED>
+
+## User journey
+
+- Actor:
+- Context:
+- Goal:
+- Journey ID/title:
+- Entry point:
+- Preconditions:
+- Major steps:
+- Affected checkpoints:
+- Failure/recovery path:
+- Persistence/export implications:
+- Next available action after each candidate outcome:
+
+## Current observed behavior
+
+<Describe observable behavior and evidence. Do not call it correct merely
+because it exists.>
+
+## Non-waivable constraints
+
+- Architecture:
+- Security/privacy:
+- Scientific correctness:
+- Persisted compatibility:
+- Performance/resource safety:
+- Required contracts/evidence:
+
+## Choice A — <stable outcome ID and title>
+
+Describe the complete product outcome without using implementation filenames as
+the choice.
+
+- Complete normative outcome:
+- Preserved effects:
+- Added effects:
+- Lost effects:
+- Retired effects:
+- Discoverability/accessibility:
+- Canonical state update:
+- Undo/Redo consequence:
+- Session/regeneration consequence:
+- Export/artifact consequence:
+- Validation/error consequence:
+- Failure/recovery consequence:
+- Scientific-output consequence:
+- Cache/provenance consequence:
+- Performance consequence:
+- Compatibility consequence:
+- Architecture consequence:
+- Evidence available/missing:
+- Residual risk:
+- Route: <PR_LOCAL_ALLOWED | DURABLE_AUTHORITY_REQUIRED | EVIDENCE_REQUIRED | NOT_ALLOWED>
+- Next action if selected:
+
+## Choice B — <stable outcome ID and title>
+
+<Repeat every Choice A field. Add Choice C only when it is materially
+distinct.>
+
+## Comparison matrix
+
+| Dimension | Choice A | Choice B | Choice C |
+| --- | --- | --- | --- |
+| Entry point / discoverability | | | |
+| Immediate feedback | | | |
+| Canonical state update | | | |
+| Undo / Redo | | | |
+| Session round trip | | | |
+| Regeneration | | | |
+| Export / output | | | |
+| Validation / error | | | |
+| Failure recovery | | | |
+| Accessibility | | | |
+| Performance | | | |
+| Compatibility | | | |
+| Scientific-output consequence | | | |
+| Cache / provenance consequence | | | |
+| Preserved / added / lost / retired effects | | | |
+| Residual risk | | | |
+| Route | | | |
+| Next available action | | | |
+
+## Evidence-first option, when applicable
+
+- Question evidence must answer:
+- Representative deterministic inputs:
+- Compared explicit values/outcomes:
+- Required measurements and outputs:
+- Limitations:
+- Runtime/default/authority changes prohibited in the evidence PR:
+
+## Engineering recommendation
+
+- Recommended option, if any:
+- Engineering reason:
+- Explicit warning: This recommendation is not Product authority.
+
+## Product Decision Owner response
+
+```text
+PRODUCT_DECISION
+Concern: <concern key/title>
+Scenario revision: <revision>
+Choice: <stable choice code and outcome ID>
+Rationale: <product-level reason>
+Must preserve: <effects and affordances>
+May retire: <none or explicit scope>
+Accepted residual risk: <bounded risk or none>
+Owner: <maintainer identity>
+Decision date: <YYYY-MM-DD>
+```
+
+A choice letter or value alone is insufficient. Complete wording controls. A
+coding agent may serialize this explicit receipt but must not infer omitted
+rationale, preservation intent, retirement scope, risk, owner, or date.

--- a/docs/internal/PRODUCT_IMPACT_RATCHET.md
+++ b/docs/internal/PRODUCT_IMPACT_RATCHET.md
@@ -2,11 +2,15 @@
 
 Status: normative repository policy
 
-This policy defines how an architecture change is traced to supported product
-behavior. It governs product-impact classification, authority resolution,
-Decision Pack content, and product-decision eligibility. The repository now
-implements the version 1 map, decision authority, evaluator, bounded decision
-source, trusted checker integration, and two-rule hard pilot described here.
+This policy defines how a registered architecture change is traced to supported
+product behavior and how a developer handles material user-effect ambiguity
+that is not yet mapped to an architecture subject. It governs product-impact
+classification, procedural preflight, authority resolution, Decision Pack
+content, and product-decision eligibility. The repository now implements the
+version 1 map, decision authority, evaluator, bounded decision source, trusted
+checker integration, and two-rule hard pilot described here. Unmapped
+developer preflight remains a procedural intake into this same model; it is not
+a second evaluator or machine-readable decision store.
 
 ## Scope and delegated authority
 
@@ -22,7 +26,8 @@ The Product Impact Ratchet joins existing policies without replacing them:
 - [`gbdraw/web/CLAUDE.md`](../../gbdraw/web/CLAUDE.md) records the current Web
   runtime boundaries and explicit supported behavior.
 - This policy owns architecture-to-behavior traceability, product-impact
-  classification, Product Impact Packet and Decision Pack semantics, and
+  classification, developer preflight for unmapped material user-effect
+  ambiguity, Product Impact Packet and Decision Pack semantics, and
   product-decision eligibility.
 
 A Product Impact decision cannot waive an architecture, security, performance,
@@ -129,6 +134,26 @@ A Product Impact Packet is the deterministic report for one changed concern. A
 Decision Pack is the additional, outcome-oriented report produced when human
 product judgment is required.
 
+The non-normative working template is
+[`PRODUCT_DECISION_PACKET_TEMPLATE.md`](./PRODUCT_DECISION_PACKET_TEMPLATE.md).
+It applies to both registered Product Impact changes and developer preflight
+for unmapped ambiguity. This policy, not the template, defines the lifecycle.
+
+### Procedural preflight classification
+
+A procedural preflight classification selects the developer's next action when
+the proposed change exposes a product question:
+
+```text
+IMPLEMENT_EXISTING_AUTHORITY
+EVIDENCE_REQUIRED
+PRODUCT_DECISION_REQUIRED
+NOT_ALLOWED
+```
+
+These classifications do not replace or combine the impact class, authority
+resolution, evaluation observation, or per-choice Decision Pack route.
+
 ### Complete coverage
 
 Complete coverage means every allowed subject for the registered architecture
@@ -153,6 +178,11 @@ The roles are separate:
 - A reviewer confirms that the machine representation matches the human choice
   and that the cited evidence covers the proposed head.
 
+One maintainer may act as both developer and Product Decision Owner, but the
+roles and sequence remain separate: prepare the Decision Pack as developer,
+issue the explicit human receipt as Product Decision Owner, serialize only
+that receipt, and implement only after required durable authority has merged.
+
 Version 1 uses a GitHub Actions Summary and a Codex-mediated response. It adds
 no dedicated decision UI, external service, general end-user vote, or comment
 bot. Humans do not enter `headSha`, architecture subjects, requirement
@@ -170,13 +200,118 @@ Rationale: <product-level reason>
 Must preserve: <effects/affordances>
 May retire: <none or explicit scope>
 Accepted residual risk: <bounded risk or none>
+Owner: <maintainer identity>
+Decision date: <YYYY-MM-DD>
 ```
 
 CI does not parse this response. After the human chooses an outcome, Codex may
 convert it to bounded machine JSON in the pull request body or prepare an
 authority-only pull request. The trusted checker parses only that machine
 representation. Missing rationale, retirement intent, or accepted risk remains
-unresolved; Codex does not fill it by inference.
+unresolved; Codex does not fill it by inference. Owner and decision date are
+also explicit for a durable authority receipt.
+
+The initial bounded authority set may use one receipt only when it identifies
+the exact candidate content and every included, excluded, or modified record:
+
+```text
+PRODUCT_DECISION_SET
+Candidate file: <candidate file>
+Candidate SHA-256: <exact digest>
+Approved decision IDs: <complete explicit list>
+Records remaining EVIDENCE_REQUIRED: <complete explicit list>
+Excluded or modified records: <none or complete wording>
+Rationale / Must preserve / May retire / Accepted residual risk:
+  Approved exactly as written for the listed records, except for the explicit modifications above.
+Owner: <maintainer identity>
+Decision date: <YYYY-MM-DD>
+```
+
+This bounded receipt is a human review aid for the initial authority-only
+bootstrap, not a new machine-readable store. A missing digest, complete ID
+accounting, owner, or date leaves the authority unresolved.
+
+## Product Decision intake
+
+The lifecycle has two trigger lanes:
+
+```text
+Lane A: a registered Product Impact architecture subject changes
+  -> deterministic Product Impact evaluation
+
+Lane B: developer preflight finds unmapped material user-effect ambiguity
+  -> procedural intake into the same Product Decision model
+```
+
+Both lanes use one authority search, procedural classification, Decision Pack,
+Product Decision Owner response, storage rule, supersession rule, and
+trusted-base sequence. Lane B does not add an evaluator state machine, JSON
+registry, or automatic Gate result.
+
+### Mandatory developer preflight
+
+Perform preflight before implementation when a proposed change may alter any of
+the following and merged authority does not select one complete outcome:
+
+- a fresh public or persisted default;
+- accepted names, types, enum domains, ranges, aliases, or omission semantics;
+- GUI discoverability, editability, read-only preservation, or unsupported
+  disposition;
+- Session reconstruction, replacement, clearing, migration, or replay;
+- Result replacement, failed-generation recovery, cancellation, supersession,
+  or stale completion;
+- compatibility retention or retirement;
+- scientific-output selection or interpretation;
+- cache reuse that can change output correctness;
+- a user actor, goal, entry point, checkpoint, failure path, or next available
+  action;
+- which product behavior survives semantic-owner or canonical-path
+  convergence; or
+- a current implementation accident that might otherwise become a durable
+  promise.
+
+The developer decides whether Product judgment is required but does not
+silently select the outcome.
+
+### Cases that normally need no Product Decision
+
+Use `IMPLEMENT_EXISTING_AUTHORITY` without a new Product Decision when:
+
+- runtime or a test plainly violates unambiguous merged authority;
+- a private refactor preserves every product effect, checkpoint, public
+  contract, compatibility commitment, and next action;
+- a duplicate owner or path is removed while the same authorized outcome
+  remains;
+- a named deterministic integrity, safety, specification, security, or
+  scientific rule permits only one correct result; or
+- documentation or evidence is corrected to match authority without changing
+  the product outcome.
+
+An incorrect test does not turn a bug into a product choice. Correct the test
+and implementation against merged authority.
+
+### Required procedural classification
+
+Select exactly one classification and explain why the others do not apply:
+
+- `IMPLEMENT_EXISTING_AUTHORITY`: one merged authority or non-waivable rule
+  selects the complete outcome.
+- `EVIDENCE_REQUIRED`: deterministic evidence is needed before choosing among
+  product-valid outcomes.
+- `PRODUCT_DECISION_REQUIRED`: two or more product-valid outcomes remain after
+  available evidence.
+- `NOT_ALLOWED`: the candidate violates an architecture, security, integrity,
+  scientific-output, persisted-compatibility, or required-evidence constraint
+  that a Product Decision cannot waive.
+
+`PRODUCT_DECISION_REQUIRED` is mandatory when the authority search and required
+evidence leave two or more materially different product-valid outcomes. It is
+also mandatory before intentionally selecting a new outcome or retiring an
+existing default, affordance, continuation, compatibility promise, or
+scientific-output behavior that merged authority does not already decide.
+
+When the classification is `EVIDENCE_REQUIRED` or
+`PRODUCT_DECISION_REQUIRED`, dependent runtime work stops.
 
 ## Independent state axes
 
@@ -250,6 +385,16 @@ Neither is automatic product authority. If recognized authorities select
 incompatible options, the result is `CONFLICT` and `AUTHORITY_CONFLICT`; the
 checker does not choose one by precedence.
 
+Search all relevant base-branch sources rather than treating this list as a
+precedence order: an applicable Product Impact concern and its static
+authority, an active `BD-###`, the static Product Contract when it exists, a
+named domain or non-waivable rule, released compatibility evidence, and an
+eligible exact-head decision for its existing narrow route. Current code,
+tests, fixtures, screenshots, reports, and historical behavior remain evidence
+only. At most one active authority selects one concern and scenario revision;
+incompatible active authorities are a conflict, not a tie to resolve by file
+order, timestamp, current implementation, or convenience.
+
 ## Durable decisions
 
 The durable authority path is:
@@ -267,6 +412,26 @@ A material product change, public-contract change, affordance or compatibility
 retirement requires durable base authority before runtime implementation.
 Codex cannot author an accepted product choice without an explicit Product
 Decision Owner disposition.
+
+### Future static Product Contract authority
+
+The exact preauthorized future static Product authority path for broad or
+currently unmapped durable Option Integrity outcomes is:
+
+```text
+docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md
+```
+
+This path is bounded to durable Product outcomes that are not already
+faithfully owned by the Product Impact map and `BD-###` store. It is not a
+parallel evaluator or machine-readable decision store. Mapped concerns continue
+to use the existing authority model, and documentation or tests may restate or
+protect an outcome but may not become a competing authority.
+
+The path declaration selects no Option Integrity outcome. The file is absent
+at this policy revision and therefore supplies no authority. The declaration
+also provides no executable protection until a later checker-only pull request
+adds exact-path enforcement and that checker change has merged.
 
 ## Current decisions
 
@@ -321,6 +486,41 @@ mapped contract and use that change as the sole proof of hard safety. When a
 mapped reference must change, first merge an evidence-only pull request, then
 update the authority in a separate authority-only pull request. Unrelated test
 changes are unaffected.
+
+## Evidence before decision
+
+Use `EVIDENCE_REQUIRED` when deterministic evidence can resolve or materially
+bound the choice before Product judgment. An evidence-only pull request:
+
+- states the exact question and compared explicit outcomes;
+- uses deterministic representative inputs;
+- records method, commands, raw observations, interpretation limits,
+  performance where material, and reproducibility data;
+- does not change the disputed default, Product authority, runtime selection,
+  compatibility promise, or expected-output baseline;
+- may state a clearly non-authoritative engineering recommendation; and
+- does not exclude a product-valid alternative merely because it is harder to
+  implement.
+
+Evidence does not select a Product outcome. When evidence still leaves two or
+more product-valid outcomes, prepare the Decision Pack and obtain an explicit
+Product Decision Owner receipt.
+
+## Authority correction and supersession
+
+Correct implementation or evidence against existing authority without creating
+a new Product Decision merely because current code or a test is wrong. To
+replace a wrong durable Product outcome, prepare evidence or a Decision Pack,
+obtain a new explicit receipt, and merge an authority-only supersession before
+dependent runtime changes.
+
+Exactly one authority remains active for the concern. A Product Contract
+replacement increments its scenario revision, identifies the prior decision
+and revision in `Supersedes`, and replaces the complete active outcome; Git
+history preserves the former text. A mapped durable replacement creates a new
+active `BD-###`, removes the prior active record, and relies on Git history for
+the former record. Resolve authority conflicts in an authority-only pull
+request rather than establishing precedence through ordering or timestamps.
 
 ## Trusted-base admission
 
@@ -385,6 +585,23 @@ A production deletion, new module, label, churn threshold, or
 compatibility-like name does not independently create a Product Impact decision
 requirement. Ordinary pull requests with no registered delta leave the decision
 array empty and perform no Product Impact form work.
+
+Developer preflight for an unmapped material user effect is the procedural Lane
+B defined above. It does not expand executable Product Impact applicability,
+populate the current-decision array, or create a new automatic Gate result.
+
+## Promotion of unmapped concerns into automation
+
+Promote a procedurally handled concern into deterministic Product Impact
+mapping only when it recurs or is predictably high risk, a stable architecture
+subject exists, and a deterministic detector can identify that subject
+faithfully. Actor, goal, checkpoints, effects, requirements, and behavior
+contracts must be complete; false-positive and false-negative behavior must be
+bounded; and report-only evaluation must first demonstrate useful signal.
+
+The map references the active Product authority rather than duplicating it. A
+manual durable contract remains preferable to an inaccurate detector or a
+one-off automatic rule.
 
 ## Product Impact Packet and Decision Pack
 

--- a/docs/internal/WEB_CHANGE_POLICY.md
+++ b/docs/internal/WEB_CHANGE_POLICY.md
@@ -292,6 +292,36 @@ tools/web-product-decisions.json
 mapped behavior contract files
 ```
 
+The exact preauthorized future static Product authority path for broad or
+currently unmapped durable Option Integrity outcomes is:
+
+```text
+docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md
+```
+
+That path is normative preauthorization only at this stage. The file is absent,
+supplies no Product outcome, and is not yet part of executable guard or
+authority path recognition. A later checker-only pull request must add
+exact-path enforcement from a base that contains this policy before any
+authority-only pull request creates the file.
+
+The required bootstrap order is:
+
+```text
+normative process/path preauthorization
+  -> checker-only exact-path enforcement
+      -> explicit human Product Decision receipt
+          -> authority-only Product Contract creation
+              -> dependent runtime implementation
+```
+
+The Product Contract, once correctly created through that sequence, is an inert
+static Product authority surface. It does not add a workflow, required status,
+evaluator, or machine-readable decision store. Candidate Product Contract
+content cannot authorize candidate runtime, and the authority-only creation
+pull request cannot include checker, workflow, evidence-producer, runtime, or
+expected-output changes.
+
 The JSON files are inert authority. The checker loads trusted base authority,
 validates candidate authority as data, and evaluates affected concerns without
 executing candidate modules.


### PR DESCRIPTION
## Plain-language summary

This PR gives mapped Product Impact changes and previously unmapped user-effect ambiguity one documented Product Decision lifecycle. It preauthorizes `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md` as the exact future static authority path, while making clear that the absent file has no Product outcome and no executable protection yet. It also adds one reusable Decision Pack template and proportionate baseline guidance for ordinary, Product-impact-bearing, and architecture-bearing pull requests.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Establish the normative process and path required before a later checker-only PR can protect a static Option Integrity Product Contract. This PR deliberately stops before checker wiring, Product Contract creation, Product outcome selection, or runtime implementation.

- Applicable baseline: `dev` at `62ad749fa309ac4efad12a7d29445348c32acc56`; strict required checks `Web base policy (trusted base)` and `PR / gate`; documentation-selective PR profile; unchanged governance fixture and behavior-contract owners.

## User-visible impact

None. Runtime behavior, rendered or scientific output, saved Sessions, requests, cache behavior, and Web workflows are unchanged.

## Changes

- Extend `docs/internal/PRODUCT_IMPACT_RATCHET.md` with two intake lanes that share one authority search, classification model, Decision Pack, human receipt, storage rule, and supersession sequence.
- Define `IMPLEMENT_EXISTING_AUTHORITY`, `EVIDENCE_REQUIRED`, `PRODUCT_DECISION_REQUIRED`, and `NOT_ALLOWED` as procedural next-action classifications without changing the existing impact, authority-resolution, observation, or per-choice route axes.
- Preauthorize `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md` in `docs/internal/WEB_CHANGE_POLICY.md` and record the required policy -> checker -> receipt -> authority -> runtime bootstrap.
- Add the non-normative `docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md` and concise links from `AGENTS.md`, `CONTRIBUTING.md`, and the pull request template.
- Make baseline evidence proportional: ordinary non-architecture PRs stay concise, Product-impact-bearing PRs record authority and journey effects, architecture-bearing PRs add owner/path/compatibility and `OE`/`PE`/`CB` conclusions, and non-applicable fields use `N/A` without an expanded packet.
- Keep `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md` absent and leave all Product Impact JSON stores, evaluator code, checker code, workflows, runtime, fixtures, and expected outputs unchanged.

## Verification

- `node --test tests/web/product-impact-ratchet-fixtures.test.mjs tests/web/architecture-ratchet-fixtures.test.mjs` — 2/2 files passed.
- `node --test tests/web/architecture-contracts.test.mjs` — 131/131 tests passed.
- `node --test tests/ci/*.test.mjs` — 3/3 files passed.
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD` — `Gate: PASS`, `Review: REQUIRED`; governance/authority-only, no production or architecture delta.
- `git diff origin/dev...HEAD --check` — passed.
- `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md` remains absent.
- CI impact classification for the six changed paths is `documentation`; selective-CI policy and fallback topology are unchanged.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because normative governance and authority documentation changes.
- Architecture impact: **This is not architecture-bearing**. No semantic owner, canonical path, compatibility path, privileged boundary, lifecycle implementation responsibility, or production module changes.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: `N/A`.
- `architecture-change` label, if relevant: not applicable.

## Rollback

Revert this governance commit. That removes the normative lifecycle/path wording, non-normative Decision Pack template, and contributor routes; no runtime, checker, workflow, machine-store, or generated-artifact rollback is needed.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concern(s), if known: none; this PR adds process only.
- Affected journey/checkpoint effects: N/A; no user journey changes.
- Authority and decision references: `docs/internal/PRODUCT_IMPACT_RATCHET.md` and `docs/internal/WEB_CHANGE_POLICY.md`; no Product outcome or `BD-###` is added.
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: current mapped contracts remain unchanged; residual risk is limited to later checker enforcement not existing until its separate PR merges.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `docs/internal/PRODUCT_IMPACT_RATCHET.md`, `docs/internal/WEB_CHANGE_POLICY.md`, `.github/pull_request_template.md`; supporting non-authoritative routes/template are `AGENTS.md`, `CONTRIBUTING.md`, and `docs/internal/PRODUCT_DECISION_PACKET_TEMPLATE.md`.
- Checker implementation files touched: none.
- Self-authorization separation evidence: no checker, detector, evaluator, Product Impact map, durable decision store, workflow, runtime, behavior contract, fixture, or expected output changes; the future Product Contract file is absent and the policy explicitly says its path is not executable-protected yet.
- Branch-protection or ruleset impact, including unchanged settings: none. `dev` still uses strict required checks `Web base policy (trusted base)` and `PR / gate`; required approving reviews remain 0, code-owner and last-push approval are not required, admin enforcement remains enabled, and force pushes/deletions remain disabled. No repository rulesets are present.
- Governance-specific rollback or protection restore point: revert this PR's squash merge (current head `b74f730e20f8259d92f2706e7f12fc6b19faf63a`); branch protection requires no restore action.

## Required PR report

- Base SHA: `62ad749fa309ac4efad12a7d29445348c32acc56`
- Head SHA: `b74f730e20f8259d92f2706e7f12fc6b19faf63a`
- Normative files changed: `docs/internal/PRODUCT_IMPACT_RATCHET.md`, `docs/internal/WEB_CHANGE_POLICY.md`
- Future exact Product Contract path: `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md`
- Mapped/unmapped lifecycle before: registered architecture subject changes used the executable Product Impact evaluator; unmapped material user-effect ambiguity had no shared procedural intake.
- Mapped/unmapped lifecycle after: both lanes share one authority search, procedural classification, Decision Pack, human receipt, storage/supersession rule, and trusted sequence; mapped executable evaluation is unchanged and unmapped intake remains procedural.
- Staged bootstrap order: normative process/path preauthorization -> checker-only exact-path enforcement -> explicit human Product Decision receipt -> authority-only Product Contract creation -> dependent runtime implementation.
- Machine stores/evaluator changes: none.
- Checker/runtime/workflow/Product outcome impact: none.
- Required checks/selective-CI routing: unchanged. Documentation-selective PR routing continues to require `recipes-standard` when trusted direct-base evidence is available, with the existing full fallback; protected `dev` checks remain `Web base policy (trusted base)` and `PR / gate`.
- Rollback: revert governance text and non-normative links/template only.
