### PR TITLE
Enforce the Option Integrity Product Contract path

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1441,6 +1441,7 @@ const BUDGET_PROFILES = Object.freeze([
   })
 ]);
 const BUDGET_LINE_CAPACITY = 800;
+const PRODUCT_CONTRACT_AUTHORITY_PATH = 'docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md';
 const budgetLineSource = (changedLines = 0, appendedLines = 0) => [
   ...Array.from(
     { length: BUDGET_LINE_CAPACITY },
@@ -1554,6 +1555,7 @@ const FUTURE_AUTHORITY_PATHS = Object.freeze([
 ]);
 const PRODUCT_IMPACT_GUARD_PATHS = Object.freeze([
   'docs/internal/PRODUCT_IMPACT_RATCHET.md',
+  PRODUCT_CONTRACT_AUTHORITY_PATH,
   'tools/web-product-impact-map.json',
   'tools/web-product-decisions.json',
   'tools/web-product-impact-evaluation.mjs',
@@ -1566,6 +1568,7 @@ const PRODUCT_IMPACT_CHECKER_IMPLEMENTATION_PATHS = Object.freeze([
 ]);
 const PRODUCT_IMPACT_AUTHORITY_PATHS = Object.freeze([
   'docs/internal/PRODUCT_IMPACT_RATCHET.md',
+  PRODUCT_CONTRACT_AUTHORITY_PATH,
   'tools/web-product-impact-map.json',
   'tools/web-product-decisions.json'
 ]);
@@ -3512,6 +3515,42 @@ test('Product Impact checker implementation is separate from Product Impact auth
   });
 });
 
+test('the Product Contract authority path is exact and isolated', () => {
+  const authorityOnly = runChangeBudgetCase((write) => {
+    write(PRODUCT_CONTRACT_AUTHORITY_PATH, '# Option Integrity Product Contract\n');
+  });
+  assert.equal(authorityOnly.status, 0, authorityOnly.output);
+  assert.match(authorityOnly.output, /Gate: \*\*PASS\*\*/);
+  assert.match(authorityOnly.output, /Review: \*\*REQUIRED\*\*/);
+  assert.match(
+    authorityOnly.output,
+    /Changed Product Impact authority paths: `docs\/internal\/OPTION_INTEGRITY_PRODUCT_CONTRACT\.md`/
+  );
+  assert.match(
+    reportSection(authorityOnly.output, 'Guard files touched'),
+    /docs\/internal\/OPTION_INTEGRITY_PRODUCT_CONTRACT\.md/
+  );
+
+  const similarPath = 'docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT_COPY.md';
+  const lookalikeOnly = runChangeBudgetCase((write) => {
+    write(similarPath, '# Similar name, unrelated path\n');
+  });
+  assert.equal(lookalikeOnly.status, 0, lookalikeOnly.output);
+  assert.match(lookalikeOnly.output, /Review: \*\*CLEAR\*\*/);
+  assert.equal(reportSection(lookalikeOnly.output, 'Guard files touched').trim(), '- None');
+
+  const ambiguousBundle = runChangeBudgetCase((write) => {
+    write(PRODUCT_CONTRACT_AUTHORITY_PATH, '# Option Integrity Product Contract\n');
+    write(similarPath, '# Similar name, unrelated path\n');
+  });
+  assert.equal(ambiguousBundle.status, 1, ambiguousBundle.output);
+  assert.match(ambiguousBundle.output, /Gate: \*\*FAIL\*\*/);
+  assert.match(
+    ambiguousBundle.output,
+    /Product Contract authority changes must be isolated from other changed paths: docs\/internal\/OPTION_INTEGRITY_PRODUCT_CONTRACT_COPY\.md/
+  );
+});
+
 test('the narrow inert authority bundle contains only architecture rules, map, and decisions', () => {
   assert.deepEqual(NARROW_PRODUCT_IMPACT_AUTHORITY_BUNDLE, [
     'tools/web-architecture-rules.json',
@@ -3576,6 +3615,7 @@ test('checker implementation and authority files cannot change together', () => 
   ];
   const authorityPaths = [
     'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
+    PRODUCT_CONTRACT_AUTHORITY_PATH,
     'docs/internal/PRODUCT_IMPACT_RATCHET.md',
     'docs/internal/WEB_CHANGE_POLICY.md',
     'tools/web-change-policy.json',
@@ -4271,6 +4311,41 @@ test('trusted-base execution rejects self-authorization despite a successful hea
       /privileged capability owners or importers exceed the base allowlist/
     );
     assert.match(trustedBase.output, /Diagram Worker: owner app\/secondary\.js/);
+  });
+});
+
+test('trusted-base execution rejects runtime plus a candidate Product Contract and checker', () => {
+  withChangeBudgetRepository(({ commit, execute, git, root, write }) => {
+    const base = git(['rev-parse', 'HEAD']).stdout.trim();
+    write(
+      'gbdraw/web/js/services/session-file.js',
+      'export const readSession = () => ({ version: 2 });\n'
+    );
+    write(PRODUCT_CONTRACT_AUTHORITY_PATH, '# Candidate Product Contract\n');
+    write('tools/check-web-change-budget.mjs', 'process.exit(0);\n');
+    const head = commit('candidate Product Contract self-authorizes runtime');
+
+    const headChecker = spawnSync(
+      process.execPath,
+      [join(root, 'tools/check-web-change-budget.mjs'), '--base', base, '--head', head],
+      { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    assert.equal(headChecker.status, 0, `${headChecker.stdout}${headChecker.stderr}`);
+
+    const trustedBase = execute({ base, head });
+    assert.equal(trustedBase.status, 1, trustedBase.output);
+    assert.match(
+      trustedBase.output,
+      /production runtime files and Web guard\/CI files changed together/
+    );
+    assert.match(
+      trustedBase.output,
+      /Web checker\/source parser and authority policy\/workflow files changed together/
+    );
+    assert.match(
+      trustedBase.output,
+      /Product Contract authority changes must be isolated from other changed paths/
+    );
   });
 });
 

--- a/tools/check-web-change-budget.mjs
+++ b/tools/check-web-change-budget.mjs
@@ -370,6 +370,7 @@ const policyPath = 'tools/web-change-policy.json';
 const architectureRulesPath = 'tools/web-architecture-rules.json';
 const acceptedViolationsPath = 'tools/web-architecture-violations.json';
 const productImpactPolicyPath = 'docs/internal/PRODUCT_IMPACT_RATCHET.md';
+const productContractAuthorityPath = 'docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md';
 const productImpactMapPath = 'tools/web-product-impact-map.json';
 const productDecisionAuthorityPath = 'tools/web-product-decisions.json';
 const productImpactEvaluationPath = 'tools/web-product-impact-evaluation.mjs';
@@ -379,6 +380,7 @@ const trustedWorkflowPath = '.github/workflows/web-base-policy.yml';
 const guardPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   productImpactPolicyPath,
+  productContractAuthorityPath,
   '.github/pull_request_template.md',
   'tools/check-web-change-budget.mjs',
   'tools/web-architecture-detectors.mjs',
@@ -418,6 +420,7 @@ const checkerImplementationPaths = new Set([
 const authorityPaths = new Set([
   'docs/internal/ARCHITECTURE_FITNESS_FUNCTION_RATCHET.md',
   productImpactPolicyPath,
+  productContractAuthorityPath,
   'docs/internal/WEB_CHANGE_POLICY.md',
   architectureRulesPath,
   acceptedViolationsPath,
@@ -996,15 +999,21 @@ const productImpactBaseErrors = [];
 const productImpactCandidateErrors = [];
 const productImpactDecisionDeclarationIssues = [];
 const changedProductImpactAuthorityPaths = [
+  productContractAuthorityPath,
   productImpactMapPath,
   productDecisionAuthorityPath
 ].filter((path) => changed.has(path));
-const candidateAuthorityCompanionPaths = changedProductImpactAuthorityPaths.length
-  ? changedPaths.filter((path) => !narrowAuthorityBundlePaths.has(path))
-  : [];
+const productContractAuthorityChanged = changed.has(productContractAuthorityPath);
+const candidateAuthorityCompanionPaths = productContractAuthorityChanged
+  ? changedPaths.filter((path) => path !== productContractAuthorityPath)
+  : changedProductImpactAuthorityPaths.length
+    ? changedPaths.filter((path) => !narrowAuthorityBundlePaths.has(path))
+    : [];
 if (candidateAuthorityCompanionPaths.length) {
   productImpactCandidateErrors.push(
-    'Product Impact authority changes must use only the narrow inert authority bundle: '
+    (productContractAuthorityChanged
+      ? 'Product Contract authority changes must be isolated from other changed paths: '
+      : 'Product Impact authority changes must use only the narrow inert authority bundle: ')
     + candidateAuthorityCompanionPaths.join(', ')
   );
 }


### PR DESCRIPTION
## Plain-language summary

This PR teaches the existing trusted Web checker to recognize `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md` as the one preauthorized static Product authority path declared by merged policy. After merge, a later pull request may add only that file as inert authority, while candidate runtime, checker code, workflows, mapped authority, or similarly named files cannot authorize themselves through it. No Product Contract content, Product outcome, runtime behavior, workflow, job, or required check is added here.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `87970c66a46133ef032a2287291f584dbb6165ec`; head `6ca950f952ab4d6da9aec7e3a718aba3d75d4ce4`; merged prerequisite PR #418, "Preauthorize the Option Integrity Product Decision lifecycle and contract path"; required checks `Web base policy (trusted base)` and `PR / gate`; zero required approving reviews; full selective-CI route for the changed checker/test surfaces; focused owner `tests/web/architecture-contracts.test.mjs`.

## User-visible impact

None. This PR changes trusted checker classification only. It creates no Product Contract, Product decision, runtime behavior, Session or cache format, renderer output, UI behavior, or expected output.

## Changes

- Register the exact case-sensitive path `docs/internal/OPTION_INTEGRITY_PRODUCT_CONTRACT.md` in the existing Web guard, governance/authority, and Product Impact authority-proposal classifications.
- Require a candidate Product Contract change to be the only changed path, while preserving the existing three-file narrow JSON authority bundle unchanged.
- Characterize exact-path authority-only admission, lookalike non-authority classification, ambiguous companion rejection, runtime/checker self-authorization rejection, and trusted-base execution.

## Verification

- `npx --yes node@20 --test tests/web/architecture-contracts.test.mjs` — 133 passed.
- `npx --yes node@20 --test tests/web/architecture-ratchet-fixtures.test.mjs` — 14 passed.
- `npx --yes node@20 --test tests/web/product-impact-ratchet-fixtures.test.mjs` — 36 passed.
- `npx --yes node@20 --test tests/ci/*.test.mjs` — 44 passed.
- `npx --yes node@20 tools/check-web-change-budget.mjs --base origin/dev --head HEAD` — `Gate: PASS`, `Review: REQUIRED`.
- Merged-base `87970c66` checker and modules, run with Node 20 against head `6ca950f952ab4d6da9aec7e3a718aba3d75d4ce4` — `Gate: PASS`, `Review: REQUIRED`; the candidate checker and detector modules were not executed.
- `git diff --check origin/dev...HEAD` — passed.
- Unchanged-byte comparison confirmed `.github/workflows/web-base-policy.yml`, `.github/workflows/test.yml`, `.github/pull_request_template.md`, all three authority JSON files, and all three normative policies are unchanged.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because trusted checker implementation changes are governance work.
- Architecture impact: **This is not architecture-bearing**. The checker implementation owner remains `tools/check-web-change-budget.mjs`; no semantic owner, canonical production path, compatibility path, public contract, persisted representation, or runtime responsibility changes.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: N/A. The checker owner and path are unchanged; no `OE`, `PE`, or `CB` set changes.
- `architecture-change` label, if relevant: N/A.
- Selective-CI and protection: the two changed paths classify as `full`, preserving required PR jobs `web-change-budget`, `core-pr`, `recipes-standard`, `gallery`, `lint`, and `web-pr-smoke`; aggregate names, workflow triggers, commands, required statuses, and branch-protection settings are unchanged.

## Rollback

Remove the exact Product Contract path from the existing guard, authority, and Product Impact authority-proposal classifications, then remove the focused characterization added in this PR. No runtime or persisted data rollback is required.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concern(s), if known: None.
- Affected journey/checkpoint effects: None.
- Authority and decision references: Merged PR #418 and `docs/internal/PRODUCT_IMPACT_RATCHET.md`; no Product outcome or decision is added.
- Decision Pack or evidence reference, if required: N/A.
- Behavior contracts and residual risk: `tests/web/architecture-contracts.test.mjs`; residual risk is limited to exact repository-path classification and is bounded by positive, negative, and trusted-base fixtures.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: None.
- Checker implementation files touched: `tools/check-web-change-budget.mjs`.
- Self-authorization separation evidence: exact authority-only addition passes; runtime plus candidate Product Contract fails; checker plus candidate Product Contract fails; lookalike paths are not authority; Product Contract plus any companion path fails closed; a candidate checker that exits successfully does not change the merged-base rejection; candidate detector execution remains prohibited by unchanged trusted-workflow contracts.
- Branch-protection or ruleset impact, including unchanged settings: None. `dev` still requires `Web base policy (trusted base)` and `PR / gate`; strict status checks and enforced admin protection remain enabled; zero approving reviews are required.
- Governance-specific rollback or protection restore point: revert commit `6ca950f952ab4d6da9aec7e3a718aba3d75d4ce4` before any Product Contract authority-only PR is opened.
