### PR TITLE
Apply Collinear max_conflicts at cluster merge boundaries

### DIFF
--- a/docs/REFERENCE/comparison-programs-thresholds-and-results.md
+++ b/docs/REFERENCE/comparison-programs-thresholds-and-results.md
@@ -51,7 +51,9 @@ Display filters are e-value, bit score, identity, and alignment length. Values
 must be finite and non-negative; identity is limited to 0 through 100, and
 alignment length is an integer. Protein modes can also limit candidates or
 hits per query. Collinear mode adds anchor, unit-gap, diagonal-drift, scope,
-and conflict rules.
+and conflict rules. `max_conflicts` limits how many retained singleton anchors
+may lie inside both order intervals when two compatible clusters merge. Those
+singleton anchors remain in the result.
 
 Filters apply to display or derived results after raw search rows exist. A raw
 TSV can therefore contain more rows than the finished diagram. Record the

--- a/docs/internal/COLLINEAR_MAX_CONFLICTS_COMPARISON_EVIDENCE_2026-08-28.md
+++ b/docs/internal/COLLINEAR_MAX_CONFLICTS_COMPARISON_EVIDENCE_2026-08-28.md
@@ -1,0 +1,143 @@
+# Collinear `max_conflicts` consumer and comparison evidence
+
+Status: comparison complete; no fresh default selected
+
+## Result
+
+Explicit `max_conflicts=0` and `max_conflicts=1` now reach the Collinear
+cluster-merge decision through the typed Linear request path. A fixed
+five-anchor fixture produces different block membership at the one-conflict
+boundary. Both values retain every input anchor.
+
+This report does not recommend either value. The fresh defaults, Product
+Contract, and `PD-OI-007` status are unchanged. `PD-OI-007` remains
+`EVIDENCE_REQUIRED`.
+
+## Evidence identity
+
+| Item | Value |
+| --- | --- |
+| Repository | `satoshikawato/gbdraw` |
+| Base branch | `origin/dev` |
+| Base SHA | `db19778648c30fbff921951760dd9c1f9c70f3a6` |
+| Base merge | PR #421, prerequisite report for the missing consumer |
+| Product concern | `diagram-generation.collinear-max-conflicts-default` |
+| Product record | `PD-OI-007`, scenario revision `1`, status `EVIDENCE_REQUIRED` |
+| gbdraw | `0.14.0b0` |
+| Python | `3.13.3` |
+| Biopython | `1.85` |
+| pandas | `2.3.0` |
+| Evidence date | `2026-08-28` |
+
+## Consumer proof
+
+The production path is:
+
+```text
+LinearDiagramRequest
+  -> LinearDiagramOptions.collinearity_params
+  -> build_request_diagram()
+  -> _build_linear_diagram()
+  -> assemble_linear_diagram_from_records()
+  -> build_orthogroup_collinearity_blocks()
+  -> cluster_lossless_collinearity_anchors()
+  -> _lossless_clusters_can_merge()
+  -> params.max_conflicts
+```
+
+`test_typed_request_max_conflicts_reaches_real_collinearity_consumer` follows
+this path for both explicit values. Only the external protein-search process is
+replaced with fixed reciprocal hit tables. The test checks that the same typed
+parameter object survives request resolution and that the algorithm returns
+the value-specific block counts below.
+
+The consumer counts retained anchors located strictly inside both order
+intervals between two compatible cluster boundaries. Merge proceeds when that
+count is less than or equal to `max_conflicts`. Retained singleton anchors are
+not absorbed or discarded by the merge.
+
+## Product impact preflight
+
+The consumer correction is classified `IMPLEMENT_EXISTING_AUTHORITY`.
+`PD-OI-007` requires explicit values `0` and `1` to execute while the fresh
+default is pending. The base implementation violated that requirement because
+the algorithm ignored both explicit values after validation.
+
+The impact class is `PRODUCT_CHANGE`, authority resolution is
+`STATIC_AUTHORITY`, and the corrected head is `CONFORMING`. On inputs with one
+interior conflict, an explicit `1` can now merge two compatible clusters where
+an explicit `0` keeps them separate. Existing CLI and Web fresh settings use
+the numeric value `1`, so their output can change on affected inputs even
+though no surface default is edited. Anchor retention is unchanged.
+
+`EVIDENCE_REQUIRED` still governs selection of the fresh cross-surface default.
+This pull request does not perform that selection. `PRODUCT_DECISION_REQUIRED`
+does not apply to the consumer correction because the Product Contract already
+requires both explicit alternatives to execute. `NOT_ALLOWED` does not apply
+because the correction preserves both alternatives and changes no authority,
+default, or compatibility promise.
+
+## Deterministic fixtures
+
+All fixtures use two record indexes, fixed anchor order, `min_anchors=1`,
+`max_diagonal_drift=0`, and `merge_orientation="strand"`. The only comparison
+variable is `max_conflicts`. The direct fixtures and typed-request fixture use
+the same algorithm consumer.
+
+| Fixture | Interior conflicts | `max_conflicts=0` | `max_conflicts=1` | Retained anchors |
+| --- | ---: | --- | --- | ---: |
+| `zero-interior-conflicts` | `0` | `[q0,q1,q3,q4]`, `[q2]` | `[q0,q1,q3,q4]`, `[q2]` | `5/5` for both |
+| `one-interior-conflict` | `1` | `[q0,q1]`, `[q2]`, `[q3,q4]` | `[q0,q1,q3,q4]`, `[q2]` | `5/5` for both |
+| `two-interior-conflicts` | `2` | `[q0,q1]`, `[q2]`, `[q3]`, `[q4,q5]` | `[q0,q1]`, `[q2]`, `[q3]`, `[q4,q5]` | `6/6` for both |
+
+The one-conflict fixture is also run through `LinearDiagramRequest`. Its two
+records each contain five CDS features. The third subject CDS uses the reverse
+strand, and fixed reciprocal search rows pair features by order.
+
+The observed difference is limited to cluster membership. At `0`, one interior
+singleton prevents the two compatible two-anchor clusters from merging. At
+`1`, those clusters merge and the singleton remains a separate block. The
+zero- and two-conflict controls place the tested values below and above the
+same threshold.
+
+## Repeatability and checks
+
+The focused comparison command was run twice without source changes. Each run
+reported `4 passed, 102 deselected`; the normalized block memberships were
+identical. The complete Collinear test module reported `106 passed`. No fixture
+run raised an error. These small in-memory fixtures were used for correctness,
+not performance comparison.
+
+The repository fast suite reported `2953 passed, 17 skipped, 11 deselected`.
+Its passing tests included all 16 tracked SVG reference-output comparisons,
+the public API/CLI contract snapshot, and the current Session codec checks.
+The Web change-policy checker reported `Gate: PASS` and `Review: CLEAR` with
+no architecture differential.
+
+```bash
+python -m pytest tests/test_collinearity.py -q -k 'max_conflicts'
+python -m pytest tests/test_collinearity.py -q
+ruff check gbdraw/ tests/test_collinearity.py
+python -m pytest tests/ -v -m 'not slow'
+python -m pytest tests/test_output_comparison.py::TestOutputComparison -q
+node tools/check-web-change-budget.mjs
+```
+
+## Scope and architecture review
+
+The change adds one conflict-counting helper under the existing Collinear
+algorithm owner and reads the existing typed field at the existing merge
+decision. It does not add a semantic owner, production path, compatibility
+path, public type, or persisted representation. The reviewed `OE`, `PE`, and
+`CB` sets are unchanged.
+
+No GUI, Session, cache, Worker, renderer, workflow, checker, numeric fresh
+default, or Product Contract file is changed. The earlier prerequisite report
+remains in the repository as the record of why the comparison could not run
+before this consumer was restored.
+
+## Interpretation limit
+
+These fixtures establish parameter reachability and the merge-threshold effect
+for zero, one, and two interior conflicts. They do not select a fresh default
+or claim that either value is preferable for other datasets.

--- a/gbdraw/analysis/collinearity.py
+++ b/gbdraw/analysis/collinearity.py
@@ -738,12 +738,39 @@ def _lossless_initial_clusters_for_pair(
     return blocks
 
 
+def _lossless_conflicts_between_clusters(
+    left: CollinearityBlock,
+    right: CollinearityBlock,
+    anchors: Sequence[CollinearityAnchor],
+) -> int:
+    left_path = _path_sorted_anchors(left.anchors, left.orientation)
+    right_path = _path_sorted_anchors(right.anchors, right.orientation)
+    if not left_path or not right_path:
+        return 0
+    left_end = left_path[-1]
+    right_start = right_path[0]
+    query_min = min(int(left_end.query_order), int(right_start.query_order))
+    query_max = max(int(left_end.query_order), int(right_start.query_order))
+    subject_min = min(int(left_end.subject_order), int(right_start.subject_order))
+    subject_max = max(int(left_end.subject_order), int(right_start.subject_order))
+    cluster_anchors = {*left.anchors, *right.anchors}
+    return sum(
+        1
+        for anchor in anchors
+        if anchor not in cluster_anchors
+        and query_min < int(anchor.query_order) < query_max
+        and subject_min < int(anchor.subject_order) < subject_max
+    )
+
+
 def _lossless_clusters_can_merge(
     left: CollinearityBlock,
     right: CollinearityBlock,
+    *,
+    anchors: Sequence[CollinearityAnchor],
     params: LosslessCollinearityParameters,
 ) -> bool:
-    if left.kind == "singleton" and right.kind == "singleton":
+    if left.kind != "cluster" or right.kind != "cluster":
         return False
     if left.orientation != right.orientation:
         return False
@@ -751,21 +778,34 @@ def _lossless_clusters_can_merge(
     right_path = _path_sorted_anchors(right.anchors, right.orientation)
     if not left_path or not right_path:
         return False
-    return _lossless_anchors_are_compatible(
+    if not _lossless_anchors_are_compatible(
         left_path[-1],
         right_path[0],
         orientation=left.orientation,
         params=params,
+    ):
+        return False
+    return _lossless_conflicts_between_clusters(left, right, anchors) <= int(
+        params.max_conflicts
     )
 
 
 def _merge_lossless_clusters(
     blocks: Sequence[CollinearityBlock],
+    *,
+    anchors: Sequence[CollinearityAnchor],
     params: LosslessCollinearityParameters,
 ) -> tuple[CollinearityBlock, ...]:
     merged: list[CollinearityBlock] = []
-    for block in sorted(blocks, key=_final_block_sort_key):
-        if not merged or not _lossless_clusters_can_merge(merged[-1], block, params):
+    singleton_blocks = [block for block in blocks if block.kind == "singleton"]
+    cluster_blocks = [block for block in blocks if block.kind == "cluster"]
+    for block in sorted(cluster_blocks, key=_final_block_sort_key):
+        if not merged or not _lossless_clusters_can_merge(
+            merged[-1],
+            block,
+            anchors=anchors,
+            params=params,
+        ):
             merged.append(block)
             continue
         previous = merged[-1]
@@ -775,7 +815,7 @@ def _merge_lossless_clusters(
             orientation=previous.orientation,
             anchors=(*previous.anchors, *block.anchors),
         )
-    return tuple(merged)
+    return tuple(sorted((*merged, *singleton_blocks), key=_final_block_sort_key))
 
 
 def _filter_blocks_by_min_anchors(
@@ -847,7 +887,13 @@ def cluster_lossless_collinearity_anchors(
             anchors_by_pair[pair],
             resolved_params,
         )
-        blocks.extend(_merge_lossless_clusters(pair_blocks, resolved_params))
+        blocks.extend(
+            _merge_lossless_clusters(
+                pair_blocks,
+                anchors=anchors_by_pair[pair],
+                params=resolved_params,
+            )
+        )
     filtered_blocks, unblocked_anchors = _filter_blocks_by_min_anchors(
         blocks,
         min_anchors=resolved_params.min_anchors,

--- a/tests/test_collinearity.py
+++ b/tests/test_collinearity.py
@@ -35,6 +35,12 @@ from gbdraw.analysis.collinearity import (
 )
 from gbdraw.api.config import apply_config_overrides
 from gbdraw.api.diagram import assemble_linear_diagram_from_records
+from gbdraw.api.options import LinearDiagramOptions
+from gbdraw.api.requests import (
+    InMemoryRecordSource,
+    LinearDiagramRequest,
+    RecordInput,
+)
 import gbdraw.linear as linear_cli_module
 from gbdraw.analysis.protein_colinearity import (
     convert_protein_hits_to_genomic_links,
@@ -99,10 +105,20 @@ def _record(record_id: str, features: list[SeqFeature]) -> SeqRecord:
     return record
 
 
-def _cds(start: int, end: int, qualifiers: dict[str, list[str]]) -> SeqFeature:
+def _cds(
+    start: int,
+    end: int,
+    qualifiers: dict[str, list[str]],
+    *,
+    strand: int = 1,
+) -> SeqFeature:
     merged = {"translation": ["MKK"]}
     merged.update(qualifiers)
-    return SeqFeature(FeatureLocation(start, end, strand=1), type="CDS", qualifiers=merged)
+    return SeqFeature(
+        FeatureLocation(start, end, strand=strand),
+        type="CDS",
+        qualifiers=merged,
+    )
 
 
 def _hit_row(
@@ -137,6 +153,14 @@ def _first_fasta_id(fasta_text: str) -> str:
         if line.startswith(">"):
             return line[1:].split(None, 1)[0]
     return ""
+
+
+def _fasta_ids(fasta_text: str) -> list[str]:
+    return [
+        line[1:].split(None, 1)[0]
+        for line in str(fasta_text).splitlines()
+        if line.startswith(">")
+    ]
 
 
 def _hex_distance(color_a: str, color_b: str) -> float:
@@ -620,6 +644,160 @@ def test_lossless_collinearity_preserves_every_adjacent_orthogroup_edge() -> Non
     assert {(query_id, subject_id) for query_id, subject_id, *_ in expected_edge_ids} <= rendered_edge_ids
     assert any(block.kind == "singleton" for block in result.blocks)
     assert any(block.kind == "cluster" and len(block.anchors) > 1 for block in result.blocks)
+
+
+@pytest.mark.linear
+@pytest.mark.parametrize(
+    ("anchors", "max_unit_gap", "expected_zero", "expected_one"),
+    [
+        (
+            [
+                _anchor(0, 0),
+                _anchor(1, 1),
+                _anchor(2, 5, subject_strand=-1),
+                _anchor(3, 3),
+                _anchor(4, 4),
+            ],
+            1,
+            [[0, 1, 3, 4], [2]],
+            [[0, 1, 3, 4], [2]],
+        ),
+        (
+            [
+                _anchor(0, 0),
+                _anchor(1, 1),
+                _anchor(2, 2, subject_strand=-1),
+                _anchor(3, 3),
+                _anchor(4, 4),
+            ],
+            1,
+            [[0, 1], [2], [3, 4]],
+            [[0, 1, 3, 4], [2]],
+        ),
+        (
+            [
+                _anchor(0, 0),
+                _anchor(1, 1),
+                _anchor(2, 3, subject_strand=-1),
+                _anchor(3, 2),
+                _anchor(4, 4),
+                _anchor(5, 5),
+            ],
+            2,
+            [[0, 1], [2], [3], [4, 5]],
+            [[0, 1], [2], [3], [4, 5]],
+        ),
+    ],
+    ids=(
+        "zero-interior-conflicts",
+        "one-interior-conflict",
+        "two-interior-conflicts",
+    ),
+)
+def test_lossless_max_conflicts_threshold_controls(
+    anchors: list[CollinearityAnchor],
+    max_unit_gap: int,
+    expected_zero: list[list[int]],
+    expected_one: list[list[int]],
+) -> None:
+    input_members = {
+        (anchor.query_order, anchor.subject_order) for anchor in anchors
+    }
+    for max_conflicts, expected in enumerate((expected_zero, expected_one)):
+        result = cluster_lossless_collinearity_anchors(
+            anchors,
+            params=LosslessCollinearityParameters(
+                max_unit_gap=max_unit_gap,
+                max_conflicts=max_conflicts,
+                merge_orientation="strand",
+            ),
+        )
+
+        assert [
+            [anchor.query_order for anchor in block.anchors]
+            for block in result.blocks
+        ] == expected
+        assert sum(len(block.anchors) for block in result.blocks) == len(anchors)
+        assert {
+            (anchor.query_order, anchor.subject_order)
+            for block in result.blocks
+            for anchor in block.anchors
+        } == input_members
+
+
+@pytest.mark.linear
+def test_typed_request_max_conflicts_reaches_real_collinearity_consumer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = [
+        _record(
+            "record_a",
+            [
+                _cds(
+                    index * 12,
+                    index * 12 + 9,
+                    {"locus_tag": [f"q{index}"], "protein_id": [f"q{index}"]},
+                )
+                for index in range(5)
+            ],
+        ),
+        _record(
+            "record_b",
+            [
+                _cds(
+                    index * 12,
+                    index * 12 + 9,
+                    {"locus_tag": [f"s{index}"], "protein_id": [f"s{index}"]},
+                    strand=-1 if index == 2 else 1,
+                )
+                for index in range(5)
+            ],
+        ),
+    ]
+
+    def fake_search(query_fasta, subject_fasta, **_kwargs):
+        query_ids = _fasta_ids(query_fasta)
+        subject_ids = _fasta_ids(subject_fasta)
+        rows = [
+            _hit_row(query_id, subject_id)
+            for query_id, subject_id in zip(query_ids, subject_ids, strict=True)
+        ]
+        return pd.DataFrame.from_records(rows, columns=COMPARISON_COLUMNS)
+
+    monkeypatch.setattr(collinearity_module, "_run_losatp_search", fake_search)
+
+    results: dict[int, CollinearityResult] = {}
+    for max_conflicts in (0, 1):
+        params = LosslessCollinearityParameters(
+            max_unit_gap=1,
+            max_conflicts=max_conflicts,
+            merge_orientation="strand",
+        )
+        request = LinearDiagramRequest(
+            records=tuple(
+                RecordInput(source=InMemoryRecordSource(record)) for record in records
+            ),
+            options=LinearDiagramOptions(
+                protein_blastp_mode="collinear",
+                collinearity_unit_mode="cds",
+                collinearity_params=params,
+            ),
+        )
+        prepared = request_render_module.build_request_diagram(request)
+        assert prepared.request.options.collinearity_params is params
+        assert prepared.linear_metadata is not None
+        result = prepared.linear_metadata.collinearity_result
+        assert result is not None
+        results[max_conflicts] = result
+
+    assert [
+        [anchor.query_order for anchor in block.anchors]
+        for block in results[0].blocks
+    ] == [[0, 1], [2], [3, 4]]
+    assert [
+        [anchor.query_order for anchor in block.anchors]
+        for block in results[1].blocks
+    ] == [[0, 1, 3, 4], [2]]
 
 
 @pytest.mark.linear


### PR DESCRIPTION
## Plain-language summary

Collinear requests accept `max_conflicts`, but the clustering algorithm ignored it after validation. This PR counts retained anchors between compatible cluster boundaries and applies explicit values `0` and `1` while keeping singleton links in the result. It does not change any numeric fresh default or select a value for `PD-OI-007`.

## What changed

- `cluster_lossless_collinearity_anchors()` now supplies all retained pair anchors to the existing cluster-merge step.
- The merge decision counts anchors strictly inside both boundary order intervals and compares that count with `LosslessCollinearityParameters.max_conflicts`.
- Singleton blocks remain in the result after compatible clusters merge.
- The comparison reference explains the field's effect, and the dated evidence report records the method, outputs, limits, and Product Impact preflight.

## Observed comparison

The deterministic fixtures hold every other parameter fixed.

| Interior conflicts | `max_conflicts=0` | `max_conflicts=1` |
| ---: | --- | --- |
| `0` | Both compatible clusters merge | Both compatible clusters merge |
| `1` | Clusters stay separate; singleton remains | Clusters merge; singleton remains |
| `2` | Clusters stay separate; both singletons remain | Clusters stay separate; both singletons remain |

The one-conflict fixture also runs through `LinearDiagramRequest`, request resolution, diagram assembly, reciprocal-hit conversion, and the Collinear algorithm consumer. Both values retain all five anchors.

## Authority and scope

`PD-OI-007` requires explicit `0` and `1` to execute while the fresh default remains pending, so the consumer correction is `IMPLEMENT_EXISTING_AUTHORITY`. The default decision remains `EVIDENCE_REQUIRED`; this PR does not recommend or select either value.

Existing CLI and Web fresh settings already use the numeric value `1`, so affected inputs can produce different cluster membership after this correction even though no surface default changes. No GUI, Session, cache, Worker, renderer, workflow, checker, persisted representation, Product Contract, or expected-output baseline is changed.

Architecture review found no new semantic owner, canonical path, compatibility path, or public type. `OE`, `PE`, and `CB` are unchanged.

## Verification

- `python -m pytest tests/test_collinearity.py -q -k 'max_conflicts'` (`4 passed`)
- `python -m pytest tests/test_collinearity.py -q` (`106 passed`)
- `python -m pytest tests/ -v -m 'not slow'` (`2953 passed, 17 skipped, 11 deselected`)
- `python -m pytest tests/test_output_comparison.py::TestOutputComparison -q` (`16 passed`)
- `python -m pytest tests/test_documentation_scenario_contracts.py tests/test_tutorial_documentation_contracts.py -q` (`25 passed`)
- `ruff check gbdraw/ tests/test_collinearity.py`
- `node tools/check-web-change-budget.mjs` (`Gate: PASS`, `Review: CLEAR`)

The full evidence is in `docs/internal/COLLINEAR_MAX_CONFLICTS_COMPARISON_EVIDENCE_2026-08-28.md`.
