### PR TITLE
Converge protein options onto one Python argument path

### DIFF
--- a/gbdraw/analysis/collinearity.py
+++ b/gbdraw/analysis/collinearity.py
@@ -22,8 +22,7 @@ from gbdraw.analysis.protein_colinearity import (
     OrthogroupMembershipMode,
     OrthogroupResult,
     ProteinExtractionResult,
-    _cache_runner_for_search,
-    _run_losatp_search,
+    _execute_losatp_search,
     extract_cds_proteins,
     filter_protein_hits_by_thresholds,
     normalize_orthogroup_membership_mode,
@@ -151,7 +150,7 @@ class LosslessCollinearityParameters:
     min_anchors: int = 1
     max_unit_gap: int = 0
     max_diagonal_drift: int = 0
-    max_conflicts: int = 0
+    max_conflicts: int = 1
     merge_orientation: Literal["strand", "order", "either"] = "either"
 
     def validate(self) -> None:
@@ -1274,7 +1273,7 @@ def build_orthogroup_collinearity_blocks(
     directional_tables: dict[tuple[int, int], DataFrame] = {}
     for record_index in range(len(records)):
         record_fasta = proteins_to_fasta(extraction.proteins_by_record[record_index])
-        same_record_hits = _run_losatp_search(
+        same_record_hits = _execute_losatp_search(
             record_fasta,
             record_fasta,
             losatp_bin=losatp_bin,
@@ -1282,16 +1281,9 @@ def build_orthogroup_collinearity_blocks(
             losatp_threads=losatp_threads,
             candidate_limit=search_candidate_limit,
             max_hsps_per_subject=None,
-            runner=_cache_runner_for_search(
-                losatp_cache,
-                runner=runner,
-                losatp_bin=losatp_bin,
-                ncbi_blastp_bin=ncbi_blastp_bin,
-                losatp_threads=losatp_threads,
-                candidate_limit=search_candidate_limit,
-                max_hsps_per_subject=None,
-                display=False,
-            ),
+            runner=runner,
+            losatp_cache=losatp_cache,
+            display=False,
         )
         directional_tables[(record_index, record_index)] = filter_protein_hits_by_thresholds(
             same_record_hits,
@@ -1311,7 +1303,7 @@ def build_orthogroup_collinearity_blocks(
     for query_index, subject_index in search_pairs:
         query_fasta = proteins_to_fasta(extraction.proteins_by_record[query_index])
         subject_fasta = proteins_to_fasta(extraction.proteins_by_record[subject_index])
-        forward_hits = _run_losatp_search(
+        forward_hits = _execute_losatp_search(
             query_fasta,
             subject_fasta,
             losatp_bin=losatp_bin,
@@ -1319,21 +1311,14 @@ def build_orthogroup_collinearity_blocks(
             losatp_threads=losatp_threads,
             candidate_limit=search_candidate_limit,
             max_hsps_per_subject=None,
-            runner=_cache_runner_for_search(
-                losatp_cache,
-                runner=runner,
-                losatp_bin=losatp_bin,
-                ncbi_blastp_bin=ncbi_blastp_bin,
-                losatp_threads=losatp_threads,
-                candidate_limit=search_candidate_limit,
-                max_hsps_per_subject=None,
-                filename=(
-                    str(cache_filenames[query_index])
-                    if cache_filenames is not None and query_index < len(cache_filenames)
-                    else ""
-                ),
-                display=subject_index == query_index + 1,
+            runner=runner,
+            losatp_cache=losatp_cache,
+            filename=(
+                str(cache_filenames[query_index])
+                if cache_filenames is not None and query_index < len(cache_filenames)
+                else ""
             ),
+            display=subject_index == query_index + 1,
         )
         directional_tables[(query_index, subject_index)] = filter_protein_hits_by_thresholds(
             forward_hits,
@@ -1342,7 +1327,7 @@ def build_orthogroup_collinearity_blocks(
             identity=identity,
             alignment_length=alignment_length,
         )
-        reverse_hits = _run_losatp_search(
+        reverse_hits = _execute_losatp_search(
             subject_fasta,
             query_fasta,
             losatp_bin=losatp_bin,
@@ -1350,16 +1335,9 @@ def build_orthogroup_collinearity_blocks(
             losatp_threads=losatp_threads,
             candidate_limit=search_candidate_limit,
             max_hsps_per_subject=None,
-            runner=_cache_runner_for_search(
-                losatp_cache,
-                runner=runner,
-                losatp_bin=losatp_bin,
-                ncbi_blastp_bin=ncbi_blastp_bin,
-                losatp_threads=losatp_threads,
-                candidate_limit=search_candidate_limit,
-                max_hsps_per_subject=None,
-                display=False,
-            ),
+            runner=runner,
+            losatp_cache=losatp_cache,
+            display=False,
         )
         directional_tables[(subject_index, query_index)] = filter_protein_hits_by_thresholds(
             reverse_hits,

--- a/gbdraw/analysis/protein_colinearity.py
+++ b/gbdraw/analysis/protein_colinearity.py
@@ -2449,14 +2449,16 @@ class LosatpCacheManager:
                     return promoted_result
 
             raw_text_holder: dict[str, str] = {}
-            result = run_losatp_blastp(
+            result = _execute_losatp_search(
                 query_fasta,
                 subject_fasta,
                 losatp_bin=losatp_bin,
                 ncbi_blastp_bin=ncbi_blastp_bin,
-                max_hits=candidate_limit,
+                candidate_limit=candidate_limit,
                 max_hsps_per_subject=max_hsps_per_subject,
-                threads=losatp_threads,
+                losatp_threads=losatp_threads,
+                runner=None,
+                losatp_cache=None,
                 raw_output_callback=lambda text: raw_text_holder.__setitem__("text", text),
             )
             entry = {
@@ -3350,6 +3352,21 @@ def select_top_hits_per_query(
         .head(int(max_hits))
         .reset_index(drop=True)
     )
+
+
+def _select_member_candidate_hits_per_query(
+    hits: DataFrame,
+    *,
+    max_hits: int,
+) -> DataFrame:
+    """Keep every HSP for the strongest distinct member candidates."""
+
+    selected_pairs = select_top_hits_per_query(hits, max_hits=max_hits)
+    if selected_pairs.empty:
+        return hits.iloc[0:0].copy()
+    pair_index = pd.MultiIndex.from_frame(selected_pairs[["query", "subject"]])
+    hit_index = pd.MultiIndex.from_frame(hits[["query", "subject"]])
+    return hits.loc[hit_index.isin(pair_index)].reset_index(drop=True)
 
 
 def select_reciprocal_best_hits(hits: DataFrame) -> DataFrame:
@@ -6024,30 +6041,6 @@ def _validate_extraction_has_proteins(
         )
 
 
-def _run_losatp_search(
-    query_fasta: str,
-    subject_fasta: str,
-    *,
-    losatp_bin: str,
-    ncbi_blastp_bin: str | None,
-    losatp_threads: int | None,
-    candidate_limit: int | None,
-    max_hsps_per_subject: int | None = 1,
-    runner: LosatpRunner | None,
-) -> DataFrame:
-    if runner is not None:
-        return runner(query_fasta, subject_fasta)
-    return run_losatp_blastp(
-        query_fasta,
-        subject_fasta,
-        losatp_bin=losatp_bin,
-        ncbi_blastp_bin=ncbi_blastp_bin,
-        max_hits=candidate_limit,
-        max_hsps_per_subject=max_hsps_per_subject,
-        threads=losatp_threads,
-    )
-
-
 def _losatp_cache_args(
     *,
     candidate_limit: int | None,
@@ -6061,32 +6054,49 @@ def _losatp_cache_args(
     return args
 
 
-def _cache_runner_for_search(
-    losatp_cache: LosatpCacheManager | None,
+def _execute_losatp_search(
+    query_fasta: str,
+    subject_fasta: str,
     *,
-    runner: LosatpRunner | None,
     losatp_bin: str,
     ncbi_blastp_bin: str | None,
     losatp_threads: int | None,
     candidate_limit: int | None,
     max_hsps_per_subject: int | None,
+    runner: LosatpRunner | None,
+    losatp_cache: LosatpCacheManager | None,
     filename: str = "",
     display: bool = False,
-) -> LosatpRunner | None:
-    if runner is not None or losatp_cache is None:
-        return runner
-    return losatp_cache.runner_for_search(
-        losatp_bin=losatp_bin,
-        ncbi_blastp_bin=ncbi_blastp_bin,
-        losatp_threads=losatp_threads,
-        candidate_limit=candidate_limit,
-        max_hsps_per_subject=max_hsps_per_subject,
-        args=_losatp_cache_args(
+    raw_output_callback: Callable[[str], None] | None = None,
+) -> DataFrame:
+    """Build one raw-search invocation from already resolved values."""
+
+    resolved_runner = runner
+    if resolved_runner is None and losatp_cache is not None:
+        resolved_runner = losatp_cache.runner_for_search(
+            losatp_bin=losatp_bin,
+            ncbi_blastp_bin=ncbi_blastp_bin,
+            losatp_threads=losatp_threads,
             candidate_limit=candidate_limit,
             max_hsps_per_subject=max_hsps_per_subject,
-        ),
-        filename=filename,
-        display=display,
+            args=_losatp_cache_args(
+                candidate_limit=candidate_limit,
+                max_hsps_per_subject=max_hsps_per_subject,
+            ),
+            filename=filename,
+            display=display,
+        )
+    if resolved_runner is not None:
+        return resolved_runner(query_fasta, subject_fasta)
+    return run_losatp_blastp(
+        query_fasta,
+        subject_fasta,
+        losatp_bin=losatp_bin,
+        ncbi_blastp_bin=ncbi_blastp_bin,
+        max_hits=candidate_limit,
+        max_hsps_per_subject=max_hsps_per_subject,
+        threads=losatp_threads,
+        raw_output_callback=raw_output_callback,
     )
 
 
@@ -6500,8 +6510,19 @@ def select_rbh_orthogroup_edges_from_directional_hits(
     """Select anchor-core orthogroups and their adjacent display edges."""
 
     normalize_orthogroup_membership_mode(str(orthogroup_membership_mode))
+    _validate_max_hits(
+        orthogroup_member_max_hits,
+        option_name="orthogroup_member_max_hits",
+    )
+    member_hits = {
+        pair: _select_member_candidate_hits_per_query(
+            hits,
+            max_hits=int(orthogroup_member_max_hits),
+        )
+        for pair, hits in directional_hits_by_pair.items()
+    }
     return _select_anchor_core_orthogroup_edges_from_directional_hits(
-        directional_hits_by_pair,
+        member_hits,
         protein_map,
         record_count=record_count,
         include_singletons=include_singletons,
@@ -6551,7 +6572,7 @@ def build_pairwise_protein_blastp_comparisons(
     for record_index in range(len(records) - 1):
         query_fasta = proteins_to_fasta(extraction.proteins_by_record[record_index])
         subject_fasta = proteins_to_fasta(extraction.proteins_by_record[record_index + 1])
-        protein_hits = _run_losatp_search(
+        protein_hits = _execute_losatp_search(
             query_fasta,
             subject_fasta,
             losatp_bin=losatp_bin,
@@ -6559,21 +6580,14 @@ def build_pairwise_protein_blastp_comparisons(
             losatp_threads=losatp_threads,
             candidate_limit=candidate_limit,
             max_hsps_per_subject=1,
-            runner=_cache_runner_for_search(
-                losatp_cache,
-                runner=runner,
-                losatp_bin=losatp_bin,
-                ncbi_blastp_bin=ncbi_blastp_bin,
-                losatp_threads=losatp_threads,
-                candidate_limit=candidate_limit,
-                max_hsps_per_subject=1,
-                filename=(
-                    str(cache_filenames[record_index])
-                    if cache_filenames is not None and record_index < len(cache_filenames)
-                    else ""
-                ),
-                display=True,
+            runner=runner,
+            losatp_cache=losatp_cache,
+            filename=(
+                str(cache_filenames[record_index])
+                if cache_filenames is not None and record_index < len(cache_filenames)
+                else ""
             ),
+            display=True,
         )
         filtered_hits = filter_protein_hits_by_thresholds(
             protein_hits,
@@ -6643,7 +6657,7 @@ def build_rbh_orthogroup_protein_blastp_comparisons(
             query_fasta = proteins_to_fasta(extraction.proteins_by_record[query_index])
             subject_fasta = proteins_to_fasta(extraction.proteins_by_record[subject_index])
 
-            forward_hits = _run_losatp_search(
+            forward_hits = _execute_losatp_search(
                 query_fasta,
                 subject_fasta,
                 losatp_bin=losatp_bin,
@@ -6651,21 +6665,14 @@ def build_rbh_orthogroup_protein_blastp_comparisons(
                 losatp_threads=losatp_threads,
                 candidate_limit=search_candidate_limit,
                 max_hsps_per_subject=None,
-                runner=_cache_runner_for_search(
-                    losatp_cache,
-                    runner=runner,
-                    losatp_bin=losatp_bin,
-                    ncbi_blastp_bin=ncbi_blastp_bin,
-                    losatp_threads=losatp_threads,
-                    candidate_limit=search_candidate_limit,
-                    max_hsps_per_subject=None,
-                    filename=(
-                        str(cache_filenames[query_index])
-                        if cache_filenames is not None and query_index < len(cache_filenames)
-                        else ""
-                    ),
-                    display=subject_index == query_index + 1,
+                runner=runner,
+                losatp_cache=losatp_cache,
+                filename=(
+                    str(cache_filenames[query_index])
+                    if cache_filenames is not None and query_index < len(cache_filenames)
+                    else ""
                 ),
+                display=subject_index == query_index + 1,
             )
             filtered_forward_hits = filter_protein_hits_by_thresholds(
                 forward_hits,
@@ -6677,7 +6684,7 @@ def build_rbh_orthogroup_protein_blastp_comparisons(
             directional_hits_by_pair[(query_index, subject_index)] = filtered_forward_hits
             if query_index == subject_index:
                 continue
-            reverse_hits = _run_losatp_search(
+            reverse_hits = _execute_losatp_search(
                 subject_fasta,
                 query_fasta,
                 losatp_bin=losatp_bin,
@@ -6685,16 +6692,9 @@ def build_rbh_orthogroup_protein_blastp_comparisons(
                 losatp_threads=losatp_threads,
                 candidate_limit=search_candidate_limit,
                 max_hsps_per_subject=None,
-                runner=_cache_runner_for_search(
-                    losatp_cache,
-                    runner=runner,
-                    losatp_bin=losatp_bin,
-                    ncbi_blastp_bin=ncbi_blastp_bin,
-                    losatp_threads=losatp_threads,
-                    candidate_limit=search_candidate_limit,
-                    max_hsps_per_subject=None,
-                    display=False,
-                ),
+                runner=runner,
+                losatp_cache=losatp_cache,
+                display=False,
             )
             filtered_reverse_hits = filter_protein_hits_by_thresholds(
                 reverse_hits,

--- a/gbdraw/api/diagram.py
+++ b/gbdraw/api/diagram.py
@@ -50,6 +50,7 @@ from gbdraw.analysis.protein_colinearity import (  # type: ignore[reportMissingI
     LosatpCacheManager,
     OrthogroupMembershipMode,
     OrthogroupResult,
+    ProteinBlastpResult,
     ProteinExtractionResult,
     ProteinBlastpMode,
     build_pairwise_protein_blastp_comparisons,
@@ -1462,6 +1463,97 @@ def _linear_losat_cache_filenames(
     )
 
 
+def _invoke_protein_analysis_helper(
+    mode: ProteinBlastpMode,
+    records: Sequence[SeqRecord],
+    *,
+    losatp_bin: str,
+    ncbi_blastp_bin: str | None,
+    losatp_threads: int | None,
+    pairwise_max_hits: int,
+    candidate_limit: int | None,
+    orthogroup_membership_mode: OrthogroupMembershipMode,
+    orthogroup_member_max_hits: int,
+    max_paralog_links_per_orthogroup: int,
+    evalue: float,
+    bitscore: float,
+    identity: float,
+    alignment_length: int,
+    collinearity_params: LosslessCollinearityParameters | None,
+    collinearity_unit_mode: CollinearityUnitMode | str,
+    collinearity_anchor_mode: CollinearityAnchorMode,
+    collinearity_search_scope: CollinearitySearchScope,
+    collinearity_comparison_pairs: Sequence[tuple[int, int]] | None,
+    losatp_cache: LosatpCacheManager | None,
+    protein_extraction: ProteinExtractionResult | None,
+    feature_visibility_rules: list[dict[str, object]] | None,
+    cache_filenames: Sequence[str] | None,
+) -> ProteinBlastpResult | CollinearityResult:
+    """Translate resolved typed values into one real analysis-helper call."""
+
+    if mode == "pairwise":
+        return build_pairwise_protein_blastp_comparisons(
+            records,
+            losatp_bin=losatp_bin,
+            ncbi_blastp_bin=ncbi_blastp_bin,
+            losatp_threads=losatp_threads,
+            max_hits=pairwise_max_hits,
+            candidate_limit=candidate_limit,
+            evalue=evalue,
+            bitscore=bitscore,
+            identity=identity,
+            alignment_length=alignment_length,
+            losatp_cache=losatp_cache,
+            protein_extraction=protein_extraction,
+            feature_visibility_rules=feature_visibility_rules,
+            cache_filenames=cache_filenames,
+        )
+    if mode == "orthogroup":
+        return build_rbh_orthogroup_protein_blastp_comparisons(
+            records,
+            losatp_bin=losatp_bin,
+            ncbi_blastp_bin=ncbi_blastp_bin,
+            losatp_threads=losatp_threads,
+            candidate_limit=candidate_limit,
+            orthogroup_membership_mode=orthogroup_membership_mode,
+            orthogroup_member_max_hits=orthogroup_member_max_hits,
+            max_related_edges_per_orthogroup=max_paralog_links_per_orthogroup,
+            evalue=evalue,
+            bitscore=bitscore,
+            identity=identity,
+            alignment_length=alignment_length,
+            losatp_cache=losatp_cache,
+            protein_extraction=protein_extraction,
+            feature_visibility_rules=feature_visibility_rules,
+            cache_filenames=cache_filenames,
+        )
+    if mode == "collinear":
+        return build_orthogroup_collinearity_blocks(
+            records,
+            losatp_bin=losatp_bin,
+            ncbi_blastp_bin=ncbi_blastp_bin,
+            losatp_threads=losatp_threads,
+            candidate_limit=candidate_limit,
+            orthogroup_membership_mode=orthogroup_membership_mode,
+            orthogroup_member_max_hits=orthogroup_member_max_hits,
+            max_paralog_links_per_orthogroup=max_paralog_links_per_orthogroup,
+            evalue=evalue,
+            bitscore=bitscore,
+            identity=identity,
+            alignment_length=alignment_length,
+            params=collinearity_params,
+            unit_mode=collinearity_unit_mode,
+            edge_mode=collinearity_anchor_mode,
+            search_scope=collinearity_search_scope,
+            comparison_pairs=collinearity_comparison_pairs,
+            losatp_cache=losatp_cache,
+            protein_extraction=protein_extraction,
+            feature_visibility_rules=feature_visibility_rules,
+            cache_filenames=cache_filenames,
+        )
+    raise ValidationError(f"Unsupported protein analysis mode: {mode!r}.")
+
+
 def assemble_linear_diagram_from_records(
     records: Sequence[SeqRecord],
     *,
@@ -1774,6 +1866,41 @@ def assemble_linear_diagram_from_records(
         )
         return None
 
+    def invoke_protein_analysis(
+        mode: ProteinBlastpMode,
+        analysis_records: Sequence[SeqRecord],
+        *,
+        analysis_extraction: ProteinExtractionResult | None = protein_extraction,
+        analysis_cache_filenames: Sequence[str] | None = losat_cache_filenames,
+    ) -> ProteinBlastpResult | CollinearityResult:
+        return _invoke_protein_analysis_helper(
+            mode,
+            analysis_records,
+            losatp_bin=losatp_bin,
+            ncbi_blastp_bin=ncbi_blastp_bin,
+            losatp_threads=losatp_threads,
+            pairwise_max_hits=int(protein_blastp_max_hits),
+            candidate_limit=protein_blastp_candidate_limit,
+            orthogroup_membership_mode=normalized_orthogroup_membership_mode,
+            orthogroup_member_max_hits=int(orthogroup_member_max_hits),
+            max_paralog_links_per_orthogroup=int(
+                collinear_max_paralog_links_per_orthogroup
+            ),
+            evalue=evalue,
+            bitscore=bitscore,
+            identity=identity,
+            alignment_length=alignment_length,
+            collinearity_params=collinearity_params,
+            collinearity_unit_mode=collinearity_unit_mode,
+            collinearity_anchor_mode=normalized_collinearity_anchor_mode,
+            collinearity_search_scope=normalized_collinearity_search_scope,
+            collinearity_comparison_pairs=collinearity_comparison_pairs,
+            losatp_cache=losatp_cache,
+            protein_extraction=analysis_extraction,
+            feature_visibility_rules=feature_visibility_rules,
+            cache_filenames=analysis_cache_filenames,
+        )
+
     if protein_comparisons is not None:
         resolved_protein_comparisons = list(protein_comparisons)
     elif collinearity_blocks is not None:
@@ -1802,22 +1929,15 @@ def assemble_linear_diagram_from_records(
                     if protein_extraction is not None
                     else None
                 )
-                protein_blastp_result = build_pairwise_protein_blastp_comparisons(
-                    (records[query_index], records[subject_index]),
-                    losatp_bin=losatp_bin,
-                    ncbi_blastp_bin=ncbi_blastp_bin,
-                    losatp_threads=losatp_threads,
-                    max_hits=int(protein_blastp_max_hits),
-                    candidate_limit=protein_blastp_candidate_limit,
-                    evalue=evalue,
-                    bitscore=bitscore,
-                    identity=identity,
-                    alignment_length=alignment_length,
-                    losatp_cache=losatp_cache,
-                    protein_extraction=pair_extraction,
-                    feature_visibility_rules=feature_visibility_rules,
-                    cache_filenames=_linear_losat_cache_filenames(
-                        (records[query_index], records[subject_index])
+                protein_blastp_result = cast(
+                    ProteinBlastpResult,
+                    invoke_protein_analysis(
+                        "pairwise",
+                        (records[query_index], records[subject_index]),
+                        analysis_extraction=pair_extraction,
+                        analysis_cache_filenames=_linear_losat_cache_filenames(
+                            (records[query_index], records[subject_index])
+                        ),
                     ),
                 )
                 resolved_linear_comparisons.append(
@@ -1828,67 +1948,22 @@ def assemble_linear_diagram_from_records(
                     )
                 )
         else:
-            protein_blastp_result = build_pairwise_protein_blastp_comparisons(
-                records,
-                losatp_bin=losatp_bin,
-                ncbi_blastp_bin=ncbi_blastp_bin,
-                losatp_threads=losatp_threads,
-                max_hits=int(protein_blastp_max_hits),
-                candidate_limit=protein_blastp_candidate_limit,
-                evalue=evalue,
-                bitscore=bitscore,
-                identity=identity,
-                alignment_length=alignment_length,
-                losatp_cache=losatp_cache,
-                protein_extraction=protein_extraction,
-                feature_visibility_rules=feature_visibility_rules,
-                cache_filenames=losat_cache_filenames,
+            protein_blastp_result = cast(
+                ProteinBlastpResult,
+                invoke_protein_analysis("pairwise", records),
             )
             resolved_protein_comparisons = protein_blastp_result.comparisons
     elif normalized_protein_blastp_mode == "orthogroup":
-        protein_blastp_result = build_rbh_orthogroup_protein_blastp_comparisons(
-            records,
-            losatp_bin=losatp_bin,
-            ncbi_blastp_bin=ncbi_blastp_bin,
-            losatp_threads=losatp_threads,
-            candidate_limit=protein_blastp_candidate_limit,
-            orthogroup_membership_mode=normalized_orthogroup_membership_mode,
-            orthogroup_member_max_hits=int(orthogroup_member_max_hits),
-            max_related_edges_per_orthogroup=int(collinear_max_paralog_links_per_orthogroup),
-            evalue=evalue,
-            bitscore=bitscore,
-            identity=identity,
-            alignment_length=alignment_length,
-            losatp_cache=losatp_cache,
-            protein_extraction=protein_extraction,
-            feature_visibility_rules=feature_visibility_rules,
-            cache_filenames=losat_cache_filenames,
+        protein_blastp_result = cast(
+            ProteinBlastpResult,
+            invoke_protein_analysis("orthogroup", records),
         )
         resolved_protein_comparisons = protein_blastp_result.comparisons
         resolved_orthogroups = protein_blastp_result.orthogroups
     elif normalized_protein_blastp_mode == "collinear":
-        collinearity_result = build_orthogroup_collinearity_blocks(
-            records,
-            losatp_bin=losatp_bin,
-            ncbi_blastp_bin=ncbi_blastp_bin,
-            losatp_threads=losatp_threads,
-            candidate_limit=protein_blastp_candidate_limit,
-            orthogroup_membership_mode=normalized_orthogroup_membership_mode,
-            orthogroup_member_max_hits=int(orthogroup_member_max_hits),
-            max_paralog_links_per_orthogroup=int(collinear_max_paralog_links_per_orthogroup),
-            evalue=evalue,
-            bitscore=bitscore,
-            identity=identity,
-            alignment_length=alignment_length,
-            params=collinearity_params,
-            unit_mode=collinearity_unit_mode,
-            edge_mode=normalized_collinearity_anchor_mode,
-            search_scope=normalized_collinearity_search_scope,
-            comparison_pairs=collinearity_comparison_pairs,
-            losatp_cache=losatp_cache,
-            protein_extraction=protein_extraction,
-            feature_visibility_rules=feature_visibility_rules,
-            cache_filenames=losat_cache_filenames,
+        collinearity_result = cast(
+            CollinearityResult,
+            invoke_protein_analysis("collinear", records),
         )
         resolved_collinearity_result = collinearity_result
         resolved_orthogroups = collinearity_result.orthogroups

--- a/gbdraw/interface.py
+++ b/gbdraw/interface.py
@@ -318,6 +318,9 @@ ConservationTrackOptions = ComparisonRingTrackOptions
 ConservationOptions = ComparisonRingOptions
 
 
+_LINEAR_DIAGRAM_DEFAULTS = _LinearDiagramOptions()
+
+
 @dataclass(frozen=True)
 class LinearComparisonOptions:
     """Precomputed or in-process comparison inputs for a linear diagram."""
@@ -326,23 +329,41 @@ class LinearComparisonOptions:
     comparisons: Sequence[LinearComparison] | None = None
     protein_comparisons: Sequence[DataFrame] | None = None
     orthogroups: OrthogroupResult | None = None
-    protein_mode: Literal["none", "pairwise", "orthogroup", "collinear"] = "none"
+    protein_mode: Literal["none", "pairwise", "orthogroup", "collinear"] = (
+        _LINEAR_DIAGRAM_DEFAULTS.protein_blastp_mode
+    )
     pairs: Sequence[tuple[int, int]] | None = None
     match_style: Literal["ribbon", "curve"] = "ribbon"
     collinearity_blocks: CollinearityResult | Sequence[CollinearityBlock] | None = None
     collinearity_params: LosslessCollinearityParameters | None = None
-    collinearity_unit: CollinearityUnitMode | str = "auto"
-    collinearity_anchor: CollinearityAnchorMode | str = "rbh"
-    collinearity_scope: CollinearitySearchScope | str = "adjacent"
-    collinearity_color: CollinearityColorMode | str = "orientation"
-    losat_executable: str = "losat"
-    blastp_executable: str | None = None
-    threads: int | None = None
-    max_hits: int = 5
-    candidate_limit: int | None = None
-    orthogroup_membership: OrthogroupMembershipMode | str = "anchor_core_v1"
-    orthogroup_member_max_hits: int = 5
-    max_paralog_links: int = 2
+    collinearity_unit: CollinearityUnitMode | str = (
+        _LINEAR_DIAGRAM_DEFAULTS.collinearity_unit_mode
+    )
+    collinearity_anchor: CollinearityAnchorMode | str = (
+        _LINEAR_DIAGRAM_DEFAULTS.collinearity_anchor_mode
+    )
+    collinearity_scope: CollinearitySearchScope | str = (
+        _LINEAR_DIAGRAM_DEFAULTS.collinearity_search_scope
+    )
+    collinearity_color: CollinearityColorMode | str = (
+        _LINEAR_DIAGRAM_DEFAULTS.collinearity_color_mode
+    )
+    losat_executable: str = _LINEAR_DIAGRAM_DEFAULTS.losatp_bin
+    blastp_executable: str | None = _LINEAR_DIAGRAM_DEFAULTS.ncbi_blastp_bin
+    threads: int | None = _LINEAR_DIAGRAM_DEFAULTS.losatp_threads
+    max_hits: int = _LINEAR_DIAGRAM_DEFAULTS.protein_blastp_max_hits
+    candidate_limit: int | None = (
+        _LINEAR_DIAGRAM_DEFAULTS.protein_blastp_candidate_limit
+    )
+    orthogroup_membership: OrthogroupMembershipMode | str = (
+        _LINEAR_DIAGRAM_DEFAULTS.orthogroup_membership_mode
+    )
+    orthogroup_member_max_hits: int = (
+        _LINEAR_DIAGRAM_DEFAULTS.orthogroup_member_max_hits
+    )
+    max_paralog_links: int = (
+        _LINEAR_DIAGRAM_DEFAULTS.collinear_max_paralog_links_per_orthogroup
+    )
     align_feature: str | None = None
 
 

--- a/gbdraw/linear.py
+++ b/gbdraw/linear.py
@@ -45,7 +45,6 @@ from .analysis.collinearity import (
     normalize_collinearity_search_scope,
 )
 from .analysis.protein_colinearity import (
-    ORTHOGROUP_INFERENCE_VERSION,
     PROTEIN_BLASTP_MODES,
     hydrate_protein_losat_tsv,
     is_protein_losat_cache_entry,
@@ -118,6 +117,9 @@ def _parse_optional_positive_int(value: str) -> int | None:
 # Setup for the logging system
 logger = logging.getLogger()
 setup_logging()
+
+_LINEAR_OPTION_DEFAULTS = LinearDiagramOptions()
+_COLLINEARITY_PARAMETER_DEFAULTS = LosslessCollinearityParameters()
 
 
 def _linear_cli_record_cardinality(
@@ -263,37 +265,37 @@ def _get_args(args) -> argparse.Namespace:
         dest='losatp_bin',
         help='Native LOSAT executable for --protein_blastp_mode pairwise/orthogroup/collinear (default: losat).',
         type=str,
-        default='losat')
+        default=_LINEAR_OPTION_DEFAULTS.losatp_bin)
     parser.add_argument(
         '--ncbi_blastp_bin',
         dest='ncbi_blastp_bin',
         help='NCBI BLAST+ blastp executable for --protein_blastp_mode pairwise/orthogroup/collinear (default: use automatic runtime resolution).',
         type=str,
-        default=None)
+        default=_LINEAR_OPTION_DEFAULTS.ncbi_blastp_bin)
     parser.add_argument(
         '--losatp_threads',
         dest='losatp_threads',
         help='Threads passed to the selected protein blastp runtime for --protein_blastp_mode pairwise/orthogroup/collinear (default: runtime default).',
         type=int,
-        default=None)
+        default=_LINEAR_OPTION_DEFAULTS.losatp_threads)
     parser.add_argument(
         '--protein_blastp_mode',
         dest='protein_blastp_mode',
         help='Protein blastp comparison mode: none, pairwise adjacent ribbons, all-record similarity groups (orthogroup), or collinear blocks (default: none).',
         choices=PROTEIN_BLASTP_MODES,
-        default='none')
+        default=_LINEAR_OPTION_DEFAULTS.protein_blastp_mode)
     parser.add_argument(
         '--protein_blastp_max_hits',
         dest='protein_blastp_max_hits',
         help='Maximum distinct subject protein hits per query protein for pairwise protein blastp display links (default: 5).',
         type=int,
-        default=5)
+        default=_LINEAR_OPTION_DEFAULTS.protein_blastp_max_hits)
     parser.add_argument(
         '--protein_blastp_candidate_limit',
         dest='protein_blastp_candidate_limit',
         help="Optional protein blastp candidate cap per query; use 'none' for no cap (default: none).",
         type=_parse_optional_positive_int,
-        default=None)
+        default=_LINEAR_OPTION_DEFAULTS.protein_blastp_candidate_limit)
     parser.add_argument(
         '--protein_blastp_output',
         metavar='TSV',
@@ -315,7 +317,7 @@ def _get_args(args) -> argparse.Namespace:
         dest='collinear_unit_mode',
         help=argparse.SUPPRESS,
         choices=["auto", "cds", "locus"],
-        default='auto')
+        default=_LINEAR_OPTION_DEFAULTS.collinearity_unit_mode)
     parser.add_argument(
         '--collinear_search_scope',
         dest='collinear_search_scope',
@@ -328,44 +330,44 @@ def _get_args(args) -> argparse.Namespace:
         ),
         type=_parse_collinear_search_scope,
         choices=["adjacent", "all"],
-        default='adjacent')
+        default=_LINEAR_OPTION_DEFAULTS.collinearity_search_scope)
     parser.add_argument(
         '--collinear_min_anchors',
         dest='collinear_min_anchors',
         help='Minimum anchors/genes required for a rendered Collinear block; 1 allows singleton links (default: 1).',
         type=int,
-        default=1)
+        default=_COLLINEARITY_PARAMETER_DEFAULTS.min_anchors)
     parser.add_argument(
         '--collinear_max_unit_gap',
         dest='collinear_max_unit_gap',
         help='Maximum unit gap between neighboring collinear anchors (default: 0).',
         type=int,
-        default=0)
+        default=_COLLINEARITY_PARAMETER_DEFAULTS.max_unit_gap)
     parser.add_argument(
         '--collinear_max_diagonal_drift',
         dest='collinear_max_diagonal_drift',
         help='Maximum order-space diagonal drift allowed within or between collinear runs (default: 0).',
         type=int,
-        default=0)
+        default=_COLLINEARITY_PARAMETER_DEFAULTS.max_diagonal_drift)
     parser.add_argument(
         '--collinear_max_conflicts_in_merge_gap',
         dest='collinear_max_conflicts_in_merge_gap',
         help=argparse.SUPPRESS,
         type=int,
-        default=1)
+        default=_COLLINEARITY_PARAMETER_DEFAULTS.max_conflicts)
     parser.add_argument(
         '--collinear_max_paralog_links_per_orthogroup',
         dest='collinear_max_paralog_links_per_orthogroup',
         help=argparse.SUPPRESS,
         type=int,
-        default=2)
+        default=_LINEAR_OPTION_DEFAULTS.collinear_max_paralog_links_per_orthogroup)
     parser.add_argument(
         '--collinear_color_mode',
         dest='collinear_color_mode',
         help='Collinear ribbon color mode: average_identity, orientation, or orientation_identity (default: orientation).',
         type=_parse_collinear_color_mode,
         choices=["average_identity", "orientation", "orientation_identity"],
-        default='orientation')
+        default=_LINEAR_OPTION_DEFAULTS.collinearity_color_mode)
     parser.add_argument(
         '-t',
         '--table',
@@ -1036,19 +1038,34 @@ def run_linear_from_namespace(args: argparse.Namespace) -> DiagramRunResult:
         source_session = None
     out_file_prefix: str = args.output
     blast_files: list[str] | None = args.blast
-    protein_blastp_mode: str = str(args.protein_blastp_mode or "none")
+    protein_blastp_mode: str = str(
+        args.protein_blastp_mode or _LINEAR_OPTION_DEFAULTS.protein_blastp_mode
+    )
     losatp_bin: str = args.losatp_bin
     ncbi_blastp_bin: str | None = getattr(args, "ncbi_blastp_bin", None)
     losatp_threads: int | None = args.losatp_threads
     protein_blastp_max_hits: int = args.protein_blastp_max_hits
     protein_blastp_candidate_limit: int | None = args.protein_blastp_candidate_limit
-    orthogroup_membership_mode: str = ORTHOGROUP_INFERENCE_VERSION
-    orthogroup_member_max_hits: int = 5
+    orthogroup_membership_mode: str = str(
+        _LINEAR_OPTION_DEFAULTS.orthogroup_membership_mode
+    )
+    orthogroup_member_max_hits: int = (
+        _LINEAR_OPTION_DEFAULTS.orthogroup_member_max_hits
+    )
     align_orthogroup_feature: str = str(args.align_orthogroup_feature or "").strip()
-    collinear_unit_mode: str = str(args.collinear_unit_mode or "auto")
-    collinear_anchor_mode: str = "rbh"
-    collinear_search_scope: str = str(args.collinear_search_scope or "adjacent")
-    collinear_color_mode: str = str(args.collinear_color_mode or "orientation")
+    collinear_unit_mode: str = str(
+        args.collinear_unit_mode or _LINEAR_OPTION_DEFAULTS.collinearity_unit_mode
+    )
+    collinear_anchor_mode: str = str(
+        _LINEAR_OPTION_DEFAULTS.collinearity_anchor_mode
+    )
+    collinear_search_scope: str = str(
+        args.collinear_search_scope
+        or _LINEAR_OPTION_DEFAULTS.collinearity_search_scope
+    )
+    collinear_color_mode: str = str(
+        args.collinear_color_mode or _LINEAR_OPTION_DEFAULTS.collinearity_color_mode
+    )
     collinearity_params = LosslessCollinearityParameters(
         min_anchors=args.collinear_min_anchors,
         max_unit_gap=args.collinear_max_unit_gap,

--- a/tests/test_api_library_usage.py
+++ b/tests/test_api_library_usage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -29,7 +30,10 @@ from gbdraw.api.options import (
     LinearOutputOptions,
     LinearTrackOptions,
 )
-from gbdraw.analysis.collinearity import CollinearityResult
+from gbdraw.analysis.collinearity import (
+    CollinearityResult,
+    LosslessCollinearityParameters,
+)
 from gbdraw.config.models import GbdrawConfig
 from gbdraw.config.toml import load_config_toml
 from gbdraw.exceptions import ValidationError
@@ -135,6 +139,141 @@ def test_linear_assembler_forwards_normalized_collinearity_anchor_mode(
     )
 
     assert captured["edge_mode"] == expected
+
+
+@pytest.mark.parametrize(
+    ("option_name", "value", "helper_name"),
+    [
+        ("collinearity_unit_mode", "auto", "unit_mode"),
+        ("collinearity_unit_mode", "cds", "unit_mode"),
+        ("collinearity_unit_mode", "locus", "unit_mode"),
+        ("collinearity_anchor_mode", "all", "edge_mode"),
+        ("collinearity_anchor_mode", "one_to_one", "edge_mode"),
+        ("collinearity_anchor_mode", "rbh", "edge_mode"),
+        ("collinearity_search_scope", "adjacent", "search_scope"),
+        ("collinearity_search_scope", "all", "search_scope"),
+        ("merge_orientation", "strand", "params"),
+        ("merge_orientation", "order", "params"),
+        ("merge_orientation", "either", "params"),
+    ],
+)
+def test_each_collinearity_enum_reaches_real_analysis_helper(
+    option_name: str,
+    value: str,
+    helper_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_build(*_args, **kwargs):
+        captured.update(kwargs)
+        return CollinearityResult(blocks=())
+
+    monkeypatch.setattr(
+        api_diagram_module,
+        "build_orthogroup_collinearity_blocks",
+        fake_build,
+    )
+    options: dict[str, object] = {"protein_blastp_mode": "collinear"}
+    if option_name == "merge_orientation":
+        options["collinearity_params"] = LosslessCollinearityParameters(
+            merge_orientation=value,
+        )
+    else:
+        options[option_name] = value
+
+    api_diagram_module.assemble_linear_diagram_from_records(
+        [
+            SeqRecord(Seq("ATGC" * 25), id="rec1"),
+            SeqRecord(Seq("ATGC" * 25), id="rec2"),
+        ],
+        cfg=apply_config_overrides(None, None),
+        legend="none",
+        **options,
+    )
+
+    if helper_name == "params":
+        params = captured[helper_name]
+        assert isinstance(params, LosslessCollinearityParameters)
+        assert params.merge_orientation == value
+    else:
+        assert captured[helper_name] == value
+
+
+@pytest.mark.parametrize(
+    "color_mode",
+    ("average_identity", "orientation", "orientation_identity"),
+)
+def test_each_collinearity_color_mode_reaches_projection_consumer(
+    color_mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_convert(_result, *, records, color_mode, search_scope):
+        captured.update(
+            records=records,
+            color_mode=color_mode,
+            search_scope=search_scope,
+        )
+        return []
+
+    monkeypatch.setattr(
+        api_diagram_module,
+        "convert_collinearity_blocks_to_comparisons",
+        fake_convert,
+    )
+    api_diagram_module.assemble_linear_diagram_from_records(
+        [
+            SeqRecord(Seq("ATGC" * 25), id="rec1"),
+            SeqRecord(Seq("ATGC" * 25), id="rec2"),
+        ],
+        cfg=apply_config_overrides(None, None),
+        collinearity_blocks=CollinearityResult(blocks=()),
+        collinearity_color_mode=color_mode,
+        legend="none",
+    )
+
+    assert captured["color_mode"] == color_mode
+    assert captured["search_scope"] == "adjacent"
+
+
+def _production_call_owners(path: Path, target: str) -> list[str]:
+    owners: list[str] = []
+    stack: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            stack.append(node.name)
+            self.generic_visit(node)
+            stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if isinstance(node.func, ast.Name) and node.func.id == target:
+                owners.append(stack[-1] if stack else "<module>")
+            self.generic_visit(node)
+
+    Visitor().visit(ast.parse(path.read_text(encoding="utf-8")))
+    return owners
+
+
+def test_protein_helpers_have_no_parallel_invocation_builder() -> None:
+    root = Path(__file__).parents[1]
+    diagram_path = root / "gbdraw" / "api" / "diagram.py"
+    protein_path = root / "gbdraw" / "analysis" / "protein_colinearity.py"
+
+    for helper_name in (
+        "build_pairwise_protein_blastp_comparisons",
+        "build_rbh_orthogroup_protein_blastp_comparisons",
+        "build_orthogroup_collinearity_blocks",
+    ):
+        assert _production_call_owners(diagram_path, helper_name) == [
+            "_invoke_protein_analysis_helper"
+        ]
+    assert _production_call_owners(protein_path, "run_losatp_blastp") == [
+        "_execute_losatp_search"
+    ]
+    assert "_cache_runner_for_search" not in protein_path.read_text(encoding="utf-8")
 
 
 def test_typed_config_override_preserves_label_filtering_dataframes() -> None:

--- a/tests/test_api_request_render.py
+++ b/tests/test_api_request_render.py
@@ -233,7 +233,7 @@ def test_derived_identity_includes_hidden_reverse_and_self_raw_inputs(
         LosslessCollinearityParameters(min_anchors=2),
         LosslessCollinearityParameters(max_unit_gap=1),
         LosslessCollinearityParameters(max_diagonal_drift=1),
-        LosslessCollinearityParameters(max_conflicts=1),
+        LosslessCollinearityParameters(max_conflicts=0),
         LosslessCollinearityParameters(merge_orientation="strand"),
     ),
     ids=(
@@ -271,7 +271,7 @@ def test_derived_identity_changes_with_each_lossless_collinearity_parameter(
         "minAnchors": 1,
         "maxGeneGap": 0,
         "maxDiagonalDrift": 0,
-        "maxConflictsInMergeGap": 0,
+        "maxConflictsInMergeGap": 1,
         "mergeOrientation": "either",
     }
     assert collinear["parameterIdentity"] == {
@@ -280,12 +280,18 @@ def test_derived_identity_changes_with_each_lossless_collinearity_parameter(
             "minAnchors": 1,
             "maxUnitGap": 0,
             "maxDiagonalDrift": 0,
-            "maxConflicts": 0,
+            "maxConflicts": 1,
             "mergeOrientation": "either",
         },
     }
     assert unchanged["key"] == baseline["key"]
     assert changed["key"] != baseline["key"]
+
+
+def test_omitted_and_explicit_collinearity_defaults_share_derived_identity() -> None:
+    assert _derived_entry_for_params(None)["key"] == _derived_entry_for_params(
+        LosslessCollinearityParameters()
+    )["key"]
 
 @pytest.mark.parametrize("mode", ("orthogroup", "collinear"))
 def test_empty_api_derived_result_passes_current_session_validation(

--- a/tests/test_api_requests.py
+++ b/tests/test_api_requests.py
@@ -8,6 +8,7 @@ import pytest
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
+from gbdraw.analysis.collinearity import LosslessCollinearityParameters
 from gbdraw.api.options import (
     CircularDiagramOptions,
     CircularMultiRecordOptions,
@@ -410,6 +411,34 @@ def test_linear_options_normalize_supported_mode_aliases() -> None:
     assert options.collinearity_anchor_mode == "one_to_one"
     assert options.collinearity_color_mode == "average_identity"
     assert options.orthogroup_membership_mode == "anchor_core_v1"
+
+
+def test_linear_protein_option_defaults_match_explicit_typed_values() -> None:
+    omitted = LinearDiagramOptions()
+    explicit = LinearDiagramOptions(
+        protein_blastp_mode="none",
+        collinearity_unit_mode="auto",
+        collinearity_anchor_mode="rbh",
+        collinearity_search_scope="adjacent",
+        collinearity_color_mode="orientation",
+        losatp_bin="losat",
+        ncbi_blastp_bin=None,
+        losatp_threads=None,
+        protein_blastp_max_hits=5,
+        protein_blastp_candidate_limit=None,
+        orthogroup_membership_mode="anchor_core_v1",
+        orthogroup_member_max_hits=5,
+        collinear_max_paralog_links_per_orthogroup=2,
+    )
+
+    assert omitted == explicit
+    assert LosslessCollinearityParameters() == LosslessCollinearityParameters(
+        min_anchors=1,
+        max_unit_gap=0,
+        max_diagonal_drift=0,
+        max_conflicts=1,
+        merge_orientation="either",
+    )
 
 
 def test_render_output_request_normalizes_formats_and_paths() -> None:

--- a/tests/test_collinearity.py
+++ b/tests/test_collinearity.py
@@ -14,6 +14,7 @@ from Bio.SeqRecord import SeqRecord
 from svgwrite import Drawing
 
 import gbdraw.analysis.collinearity as collinearity_module
+import gbdraw.analysis.protein_colinearity as protein_colinearity_module
 import gbdraw.api.request_render as request_render_module
 import gbdraw.diagrams.linear.assemble as linear_assemble_module
 from gbdraw.analysis.collinearity import (
@@ -764,39 +765,51 @@ def test_typed_request_max_conflicts_reaches_real_collinearity_consumer(
         ]
         return pd.DataFrame.from_records(rows, columns=COMPARISON_COLUMNS)
 
-    monkeypatch.setattr(collinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
-    results: dict[int, CollinearityResult] = {}
-    for max_conflicts in (0, 1):
-        params = LosslessCollinearityParameters(
+    params_by_case = {
+        "explicit-zero": LosslessCollinearityParameters(
             max_unit_gap=1,
-            max_conflicts=max_conflicts,
+            max_conflicts=0,
             merge_orientation="strand",
-        )
+        ),
+        "default": LosslessCollinearityParameters(
+            max_unit_gap=1,
+            merge_orientation="strand",
+        ),
+    }
+    results: dict[str, CollinearityResult] = {}
+    for case, params in params_by_case.items():
         request = LinearDiagramRequest(
             records=tuple(
                 RecordInput(source=InMemoryRecordSource(record)) for record in records
             ),
             options=LinearDiagramOptions(
                 protein_blastp_mode="collinear",
-                collinearity_unit_mode="cds",
+                collinearity_unit_mode="auto",
                 collinearity_params=params,
             ),
         )
         prepared = request_render_module.build_request_diagram(request)
         assert prepared.request.options.collinearity_params is params
+        assert prepared.request.options.collinearity_unit_mode == "auto"
         assert prepared.linear_metadata is not None
         result = prepared.linear_metadata.collinearity_result
         assert result is not None
-        results[max_conflicts] = result
+        assert {
+            anchor.query_unit_kind
+            for block in result.blocks
+            for anchor in block.anchors
+        } == {"cds"}
+        results[case] = result
 
     assert [
         [anchor.query_order for anchor in block.anchors]
-        for block in results[0].blocks
+        for block in results["explicit-zero"].blocks
     ] == [[0, 1], [2], [3, 4]]
     assert [
         [anchor.query_order for anchor in block.anchors]
-        for block in results[1].blocks
+        for block in results["default"].blocks
     ] == [[0, 1, 3, 4], [2]]
 
 
@@ -1332,7 +1345,7 @@ def test_anchor_core_record_local_ids_are_deterministic_after_cross_record_group
 
 
 @pytest.mark.linear
-def test_anchor_core_record_local_member_hit_limit_does_not_change_membership() -> None:
+def test_anchor_core_record_local_membership_survives_when_hits_fit_limit() -> None:
     records = [
         _record(
             "record_a",
@@ -1448,7 +1461,7 @@ def test_anchor_core_record_local_edges_do_not_create_collinearity_anchors() -> 
 
 
 @pytest.mark.linear
-def test_anchor_core_member_hit_limit_does_not_change_inferred_membership() -> None:
+def test_anchor_core_membership_survives_reciprocal_candidates_within_limit() -> None:
     records = [
         _record("record_a", [_cds(0, 9, {"locus_tag": ["a0"], "protein_id": ["a0"]})]),
         _record(
@@ -1731,7 +1744,7 @@ def test_build_blocks_from_hits_can_render_selected_non_adjacent_pairs() -> None
 
 
 @pytest.mark.linear
-def test_orthogroup_collinearity_rbh_search_defaults_to_top_candidate(monkeypatch) -> None:
+def test_orthogroup_collinearity_rbh_search_defaults_to_uncapped_candidates(monkeypatch) -> None:
     records = [
         _record("record_a", [_cds(0, 9, {"locus_tag": ["qa0"], "protein_id": ["qa0"]})]),
         _record("record_b", [_cds(0, 9, {"locus_tag": ["sb0"], "protein_id": ["sb0"]})]),
@@ -1740,18 +1753,25 @@ def test_orthogroup_collinearity_rbh_search_defaults_to_top_candidate(monkeypatc
     observed_limits: list[int | None] = []
     observed_pairs: list[tuple[str, str]] = []
 
-    def fake_search(query_fasta, subject_fasta, *, losatp_bin, ncbi_blastp_bin, losatp_threads, candidate_limit, max_hsps_per_subject, runner):
+    def fake_search(
+        query_fasta,
+        subject_fasta,
+        *,
+        ncbi_blastp_bin,
+        max_hits,
+        max_hsps_per_subject,
+        **_kwargs,
+    ):
         assert ncbi_blastp_bin is None
-        assert losatp_threads is None
         assert max_hsps_per_subject is None
-        observed_limits.append(candidate_limit)
+        observed_limits.append(max_hits)
         observed_pairs.append((_first_fasta_id(query_fasta), _first_fasta_id(subject_fasta)))
         return pd.DataFrame.from_records(
             [_hit_row(_first_fasta_id(query_fasta), _first_fasta_id(subject_fasta))],
             columns=COMPARISON_COLUMNS,
         )
 
-    monkeypatch.setattr(collinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
     result = collinearity_module.build_orthogroup_collinearity_blocks(
         records,
@@ -1774,7 +1794,7 @@ def test_orthogroup_collinearity_rbh_search_defaults_to_top_candidate(monkeypatc
 
 
 @pytest.mark.linear
-def test_orthogroup_collinearity_anchor_core_ignores_member_hit_depth(monkeypatch) -> None:
+def test_orthogroup_collinearity_member_hit_depth_is_post_search(monkeypatch) -> None:
     records = [
         _record("record_a", [_cds(0, 9, {"locus_tag": ["qa0"], "protein_id": ["qa0"]})]),
         _record("record_b", [_cds(0, 9, {"locus_tag": ["sb0"], "protein_id": ["sb0"]})]),
@@ -1782,16 +1802,24 @@ def test_orthogroup_collinearity_anchor_core_ignores_member_hit_depth(monkeypatc
     ]
     observed_limits: list[int | None] = []
 
-    def fake_search(query_fasta, subject_fasta, *, losatp_bin, ncbi_blastp_bin, losatp_threads, candidate_limit, max_hsps_per_subject, runner):
+    def fake_search(
+        query_fasta,
+        subject_fasta,
+        *,
+        ncbi_blastp_bin,
+        max_hits,
+        max_hsps_per_subject,
+        **_kwargs,
+    ):
         assert ncbi_blastp_bin is None
         assert max_hsps_per_subject is None
-        observed_limits.append(candidate_limit)
+        observed_limits.append(max_hits)
         return pd.DataFrame.from_records(
             [_hit_row(_first_fasta_id(query_fasta), _first_fasta_id(subject_fasta))],
             columns=COMPARISON_COLUMNS,
         )
 
-    monkeypatch.setattr(collinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
     collinearity_module.build_orthogroup_collinearity_blocks(
         records,
@@ -1814,18 +1842,25 @@ def test_orthogroup_collinearity_all_hits_keeps_uncapped_search(monkeypatch) -> 
     observed_limits: list[int | None] = []
     observed_pairs: list[tuple[str, str]] = []
 
-    def fake_search(query_fasta, subject_fasta, *, losatp_bin, ncbi_blastp_bin, losatp_threads, candidate_limit, max_hsps_per_subject, runner):
+    def fake_search(
+        query_fasta,
+        subject_fasta,
+        *,
+        ncbi_blastp_bin,
+        max_hits,
+        max_hsps_per_subject,
+        **_kwargs,
+    ):
         assert ncbi_blastp_bin is None
-        assert losatp_threads is None
         assert max_hsps_per_subject is None
-        observed_limits.append(candidate_limit)
+        observed_limits.append(max_hits)
         observed_pairs.append((_first_fasta_id(query_fasta), _first_fasta_id(subject_fasta)))
         return pd.DataFrame.from_records(
             [_hit_row(_first_fasta_id(query_fasta), _first_fasta_id(subject_fasta))],
             columns=COMPARISON_COLUMNS,
         )
 
-    monkeypatch.setattr(collinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
     result = collinearity_module.build_orthogroup_collinearity_blocks(
         records,
@@ -1861,9 +1896,15 @@ def test_orthogroup_collinearity_all_scope_rbh_searches_every_direction(monkeypa
     ]
     observed_pairs: list[tuple[str, str]] = []
 
-    def fake_search(query_fasta, subject_fasta, *, losatp_bin, ncbi_blastp_bin, losatp_threads, candidate_limit, max_hsps_per_subject, runner):
+    def fake_search(
+        query_fasta,
+        subject_fasta,
+        *,
+        ncbi_blastp_bin,
+        max_hsps_per_subject,
+        **_kwargs,
+    ):
         assert ncbi_blastp_bin is None
-        assert losatp_threads is None
         assert max_hsps_per_subject is None
         observed_pairs.append((_first_fasta_id(query_fasta), _first_fasta_id(subject_fasta)))
         return pd.DataFrame.from_records(
@@ -1871,7 +1912,7 @@ def test_orthogroup_collinearity_all_scope_rbh_searches_every_direction(monkeypa
             columns=COMPARISON_COLUMNS,
         )
 
-    monkeypatch.setattr(collinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
     collinearity_module.build_orthogroup_collinearity_blocks(
         records,

--- a/tests/test_protein_colinearity.py
+++ b/tests/test_protein_colinearity.py
@@ -2173,7 +2173,14 @@ def test_pairwise_blastp_search_keeps_one_hsp_cap(monkeypatch: pytest.MonkeyPatc
     ]
     observed_caps: list[int | None] = []
 
-    def fake_search(query_fasta, subject_fasta, *, losatp_bin, ncbi_blastp_bin, losatp_threads, candidate_limit, max_hsps_per_subject, runner):
+    def fake_search(
+        query_fasta,
+        subject_fasta,
+        *,
+        ncbi_blastp_bin,
+        max_hsps_per_subject,
+        **_kwargs,
+    ):
         assert ncbi_blastp_bin is None
         observed_caps.append(max_hsps_per_subject)
         return pd.DataFrame.from_records(
@@ -2181,7 +2188,7 @@ def test_pairwise_blastp_search_keeps_one_hsp_cap(monkeypatch: pytest.MonkeyPatc
             columns=COMPARISON_COLUMNS,
         )
 
-    monkeypatch.setattr(protein_colinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
     build_pairwise_protein_blastp_comparisons(records)
 
@@ -2196,7 +2203,14 @@ def test_orthogroup_blastp_search_omits_one_hsp_cap(monkeypatch: pytest.MonkeyPa
     ]
     observed_caps: list[int | None] = []
 
-    def fake_search(query_fasta, subject_fasta, *, losatp_bin, ncbi_blastp_bin, losatp_threads, candidate_limit, max_hsps_per_subject, runner):
+    def fake_search(
+        query_fasta,
+        subject_fasta,
+        *,
+        ncbi_blastp_bin,
+        max_hsps_per_subject,
+        **_kwargs,
+    ):
         assert ncbi_blastp_bin is None
         observed_caps.append(max_hsps_per_subject)
         query_id = query_fasta.splitlines()[0][1:].split()[0]
@@ -2206,11 +2220,106 @@ def test_orthogroup_blastp_search_omits_one_hsp_cap(monkeypatch: pytest.MonkeyPa
             columns=COMPARISON_COLUMNS,
         )
 
-    monkeypatch.setattr(protein_colinearity_module, "_run_losatp_search", fake_search)
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
 
     build_rbh_orthogroup_protein_blastp_comparisons(records)
 
     assert observed_caps == [None, None, None, None]
+
+
+@pytest.mark.linear
+@pytest.mark.parametrize("candidate_limit", (None, 7))
+def test_candidate_and_pairwise_display_limits_reach_independent_consumers(
+    candidate_limit: int | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = [
+        _record("record_a", features=[_cds(0, 9)]),
+        _record(
+            "record_b",
+            features=[_cds(index * 12, index * 12 + 9) for index in range(3)],
+        ),
+    ]
+    observed_raw_limits: list[int | None] = []
+
+    def fake_search(query_fasta, subject_fasta, *, max_hits, **_kwargs):
+        observed_raw_limits.append(max_hits)
+        query_id = query_fasta.splitlines()[0][1:].split()[0]
+        subject_ids = [
+            line[1:].split()[0]
+            for line in subject_fasta.splitlines()
+            if line.startswith(">")
+        ]
+        return pd.DataFrame.from_records(
+            [
+                _hit_row(query_id, subject_id, bitscore=300 - index)
+                for index, subject_id in enumerate(subject_ids)
+            ],
+            columns=COMPARISON_COLUMNS,
+        )
+
+    monkeypatch.setattr(protein_colinearity_module, "run_losatp_blastp", fake_search)
+
+    result = build_pairwise_protein_blastp_comparisons(
+        records,
+        max_hits=2,
+        candidate_limit=candidate_limit,
+    )
+
+    assert observed_raw_limits == [candidate_limit]
+    assert len(result.comparisons[0]) == 2
+
+
+@pytest.mark.linear
+def test_member_hit_limit_bounds_derived_candidates_and_preserves_their_hsps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    records = [
+        _record("record_a", features=[_cds(0, 9)]),
+        _record(
+            "record_b",
+            features=[_cds(index * 12, index * 12 + 9) for index in range(3)],
+        ),
+    ]
+    extraction = extract_cds_proteins(records)
+    query_id = extraction.proteins_by_record[0][0].protein_id
+    subject_ids = [protein.protein_id for protein in extraction.proteins_by_record[1]]
+    directional_hits = {
+        (0, 1): pd.DataFrame.from_records(
+            [
+                _hit_row(query_id, subject_ids[0], bitscore=300),
+                _hit_row(query_id, subject_ids[1], bitscore=250),
+                _hit_row(query_id, subject_ids[1], bitscore=240),
+                _hit_row(query_id, subject_ids[2], bitscore=200),
+            ],
+            columns=COMPARISON_COLUMNS,
+        ),
+    }
+    captured: dict[tuple[int, int], pd.DataFrame] = {}
+    real_consumer = (
+        protein_colinearity_module._select_anchor_core_orthogroup_edges_from_directional_hits
+    )
+
+    def spy_consumer(member_hits, *args, **kwargs):
+        captured.update({pair: hits.copy() for pair, hits in member_hits.items()})
+        return real_consumer(member_hits, *args, **kwargs)
+
+    monkeypatch.setattr(
+        protein_colinearity_module,
+        "_select_anchor_core_orthogroup_edges_from_directional_hits",
+        spy_consumer,
+    )
+
+    select_rbh_orthogroup_edges_from_directional_hits(
+        directional_hits,
+        extraction.protein_map,
+        record_count=2,
+        orthogroup_member_max_hits=2,
+    )
+
+    observed = captured[(0, 1)]
+    assert set(observed["subject"]) == set(subject_ids[:2])
+    assert len(observed.loc[observed["subject"] == subject_ids[1]]) == 2
 
 
 def _long_cds(protein_id: str, length: int = 1000) -> SeqFeature:


### PR DESCRIPTION
## Plain-language summary

This PR makes the existing typed Linear options the source of truth for protein-analysis defaults and routes resolved values through one Python invocation builder at each real helper stage. It implements accepted Option Integrity decisions `PD-OI-001` through `PD-OI-007`: Candidate, Pairwise display, and member-hit limits remain independent; every supported Collinear value reaches its consumer; and fresh `max_conflicts` omission now means one while explicit zero remains supported.

## Change class

Select exactly one:

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `44a23ed91410050d5dcad0832008d4babd71c93a`; head `08609565bd7fcfbeec76833505f740089783c836`; trusted CI profile `pr` with impact `full`; required job IDs `web-change-budget`, `core-pr`, `recipes-standard`, `gallery`, `lint`, and `web-pr-smoke`, plus trusted-base `Web base policy (trusted base)`.
- Prerequisites: the PR-00 through PR-04 first-parent sequence is present at `87970c66a46133ef032a2287291f584dbb6165ec`, `3f309756fcb1e63fe2ce23e49cd0d09d499c4cb4`, `8bc18e12f235ba6798c2ad7021d66bb73688c781` (PR `#420`), `db197786` (PR `#421`), `878c62ba` (PR `#422`), and `44a23ed9` (PR `#423`).
- Focused behavior owners: `LinearDiagramOptions`, `LosslessCollinearityParameters`, typed request planning, the three real protein-analysis helpers, and `run_losatp_blastp`.

## User-visible impact

- Fresh Collinear requests now use accepted `max_conflicts=1`; explicit zero still reaches clustering and keeps its distinct merge behavior.
- `orthogroup_member_max_hits` now bounds distinct directional member candidates during derived Similarity/Collinear construction while retaining every HSP for selected candidates. It does not cap raw search.
- Candidate `None` remains unbounded; finite Candidate values alone enter raw helper arguments. Pairwise max hits remains a post-threshold display limit with default `5`.
- Requested `collinearity_unit_mode="auto"` remains in the request while resolved anchors separately record effective `cds` or `locus` kinds.
- Invalid values still raise the existing `ValidationError`; CLI error handling and released aliases remain unchanged.

Actor and journey: a CLI, simple Python, or typed Python user creates a Linear protein comparison, optionally changes an advanced value, and renders through the typed request plan. Checkpoints are typed validation/normalization, request-plan preservation, canonical helper invocation, and result/provenance construction. Invalid input stops before execution with an actionable error; the user corrects the field and reruns. After success, the next action is to inspect or export the diagram/result, or rerun with an explicit alternate such as `max_conflicts=0`.

## Changes

- Keep public defaults and validation in `LinearDiagramOptions` and `LosslessCollinearityParameters`; make the CLI and `LinearComparisonOptions` read those values instead of owning duplicate literals.
- Add `_invoke_protein_analysis_helper` as the single keyword-translation point for Pairwise, Similarity-group, and Collinear real helpers.
- Replace six repeated raw-search/cache argument packs with `_execute_losatp_search`, the sole caller translating resolved values into `run_losatp_blastp` arguments.
- Consume `orthogroup_member_max_hits` in derived candidate selection, after threshold filtering, while preserving multi-HSP coverage evidence.
- Set the accepted `LosslessCollinearityParameters.max_conflicts` fresh default to one.
- Add real-boundary contracts for defaults, Candidate/display/member independence, all public Collinear enums, requested/effective auto separation, explicit zero, aliases, cache identity, and absence of parallel helper invocation builders.
- Add no new execution carrier, schema, cache field, artifact field, Session path, Worker protocol, Web state, or public API symbol.

## Verification

- `python -m pytest tests/test_api_requests.py tests/test_api_request_render.py tests/test_api_library_usage.py tests/test_dead_api_cleanup.py tests/test_public_contract.py tests/test_python_interface.py tests/test_documentation_reference_contracts.py tests/test_collinearity.py tests/test_collinearity_units.py tests/test_protein_colinearity.py -q`: `570 passed, 1 skipped`.
- `python -m pytest tests/ -v -m "not slow"`: `2973 passed, 17 skipped, 11 deselected`; includes all read-only `TestOutputComparison` cases.
- `ruff check gbdraw/`: pass.
- `node tests/web/architecture-contracts.test.mjs`: `133 passed`.
- `node tests/web/architecture-ratchet-fixtures.test.mjs`: `14 passed`.
- `node tests/web/product-impact-ratchet-fixtures.test.mjs`: `36 passed`.
- `node tools/check-web-change-budget.mjs --base 44a23ed91410050d5dcad0832008d4babd71c93a --head 08609565`: `Gate: PASS`; `Review: CLEAR`; no blocking violations or review reasons.
- `git diff --check`: pass.
- Public contract snapshot: unchanged. Tracked reference/scientific SVG outputs: unchanged.

## Risk and review notes

- Gate result and any blocker: `PASS`; none.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; the trusted ordinary checker reports no changed Web authority, registered contract, dependency, guard, privileged owner, or architecture rule.
- Architecture impact: **This is architecture-bearing**. It consolidates Python semantic defaults and the helper invocation path without changing Web architecture authority.
- Architecture baseline and changed-scope conclusion, if architecture-bearing:
  - Semantic owners before: typed owners plus duplicate CLI and simple-API literals. After: `LinearDiagramOptions` owns protein option defaults and `LosslessCollinearityParameters` owns clustering defaults; CLI/simple API are references only. Changed-scope owner excess is `OE 2 -> 0`.
  - Request carriers before/after: `LinearDiagramRequest.options` through `LinearRequestPlan.request` and `PreparedDiagramRequest.request`; unchanged.
  - Helper paths before: four high-level keyword packs and six repeated raw/cache invocation packs. After: one builder branch per real high-level helper and one raw builder; changed-scope path excess is `PE 6 -> 0`.
  - Compatibility paths before/after: released mode aliases remain in their existing normalizers; simple API names and low-level helper signatures are unchanged. No compatibility path is added or removed; `CB 0 -> 0`.
  - Superseded active decisions removed: CLI/simple default literals, direct high-level helper keyword packs, repeated cache-runner construction, and the accepted-but-unused member-hit parameter branch.
  - Necessity gate: existing typed owners and request-plan carriers were reused; no resolved-value carrier was added.
- `architecture-change` label, if relevant: apply to this PR.
- Product reference: Option Integrity Product Contract revision `2`; accepted `PD-OI-001` through `PD-OI-007`; acceptance contracts `OIC-001` through `OIC-005` as applicable.
- Reference/scientific-output note: tracked SVG references do not change. Fresh Collinear analysis can intentionally differ because `max_conflicts=1` may merge across one retained interior singleton, and explicit member limits now affect derived grouping; both outcomes are accepted authority and covered at the real consumer.
- Residual risk: low-level compatibility entry points remain callable directly, but their signatures are unchanged and no-bypass AST contracts prevent a second production invocation builder. The broad regression suite covers representative scientific and rendering outputs, not every possible protein dataset.

## Rollback

Correct or disable the faulty translation inside `_invoke_protein_analysis_helper` or `_execute_losatp_search`, and change any affected typed default and derived selector in the same follow-up. Keep CLI/simple adapters pointed at the typed owner and keep one helper path; do not restore removed literals, direct keyword packs, or an ignored accepted field. A Product-authorized default change would require a later authority supersession before its matching single-path implementation.

## Conditional Product Impact

- Product-impact role: `IMPLEMENTATION`
- Product preflight classification: `IMPLEMENT_EXISTING_AUTHORITY`
- Affected concern(s), if known: `diagram-generation.losatp-candidate-limit-default`, `diagram-generation.losatp-candidate-limit-scope`, `diagram-generation.pairwise-display-max-hits`, `diagram-generation.member-hits-per-protein`, `diagram-generation.collinear-value-domains`, `diagram-generation.collinear-search-scope-default`, and `diagram-generation.collinear-max-conflicts-default`.
- Affected journey/checkpoint effects: typed validation, request preservation, real raw/derived/display helper arguments, requested/effective Collinear unit reporting, and deterministic clustering output.
- Authority and decision references: Option Integrity Product Contract revision `2`; accepted `PD-OI-001`, `PD-OI-002`, `PD-OI-003`, `PD-OI-004`, `PD-OI-005`, `PD-OI-006`, and `PD-OI-007` on the exact base.
- Decision Pack or evidence reference, if required: implementation uses merged authority; `PD-OI-007` evidence is `docs/internal/COLLINEAR_MAX_CONFLICTS_COMPARISON_EVIDENCE_2026-08-28.md`, merged by PR `#422` at `878c62ba17c61c45cd0adbd05cbd9fb36306db9d`.
- Behavior contracts and residual risk: `OIC-001` through `OIC-005`; accepted unbounded-search cost, Pairwise display omission, derived grouping sensitivity, enum-combination coverage concentration, and explicit `all`/default-scope differences remain as documented.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

N/A; this is a `STANDARD` implementation PR and changes no authority or evidence-producer file.

### ARCHITECTURE_EXCEPTION

N/A; changed-scope `OE`, `PE`, and `CB` do not increase, so no exception is requested.

### PROMOTION

N/A; this is not a promotion PR.
