### PR TITLE
Ignore inactive orthogroup alignment in resolved protein renders

### DIFF
--- a/gbdraw/session_request_codec.py
+++ b/gbdraw/session_request_codec.py
@@ -3034,6 +3034,7 @@ def _decode_comparisons(
     explicit_comparisons: list[LinearComparison] = []
     result: dict[str, Any] = {}
     singleton_kinds: set[str] = set()
+    has_orthogroup_metadata = False
     for index, raw in enumerate(comparisons):
         path = f"renderRequest.comparisons[{index}]"
         item = _object(raw, path=path, required={"kind"}, exact=False)
@@ -3090,6 +3091,13 @@ def _decode_comparisons(
                     resource_paths=resource_paths,
                 ),
                 context=path,
+            )
+            has_orthogroup_metadata |= (
+                any(
+                    str(value).strip().lower() not in {"", "nan"}
+                    for value in table.get("orthogroup_id", ())
+                )
+                or "orthogroup" in set(table.get("group_kind", ()))
             )
             if schema >= 2:
                 query_index = _non_negative_index(
@@ -3151,6 +3159,12 @@ def _decode_comparisons(
             raise CanonicalRequestDecodingError(
                 f"Unsupported comparison kind at {path}: {kind!r}."
             )
+    if (
+        result.get("protein_blastp_mode") != "orthogroup"
+        and not has_orthogroup_metadata
+        and not result.get("orthogroups")
+    ):
+        result.pop("align_orthogroup_feature", None)
     if blast_files:
         result["blast_files"] = tuple(blast_files)
     if protein_tables:

--- a/tests/test_session_request_codec.py
+++ b/tests/test_session_request_codec.py
@@ -924,6 +924,50 @@ def test_standard_collinearity_embedded_max_paralog_is_inert_in_orthogroup_mode(
     assert decoded.options.collinear_max_paralog_links_per_orthogroup == 2
 
 
+@pytest.mark.parametrize("mode", ("pairwise", "collinear", "none"))
+def test_orthogroup_alignment_draft_is_inert_outside_orthogroup_mode(
+    tmp_path: Path,
+    mode: str,
+) -> None:
+    sources = tuple(
+        _source_file(tmp_path / f"inactive-alignment-{index}.gbk")
+        for index in range(2)
+    )
+    encoded = encode_canonical_request(
+        LinearDiagramRequest(
+            records=tuple(
+                RecordInput(source=GenBankInputSource(source))
+                for source in sources
+            ),
+            options=LinearDiagramOptions(
+                protein_blastp_mode="orthogroup",
+                align_orthogroup_feature="saved-orthogroup-anchor",
+                protein_comparisons=(
+                    pd.DataFrame({"orthogroup_id": [""], "group_kind": [""]}),
+                ),
+            ),
+        )
+    )
+    pipeline = next(
+        item
+        for item in encoded.payload["comparisons"]
+        if item["kind"] == "generatedProteinComparison"
+    )
+    pipeline["mode"] = mode
+
+    decoded = decode_canonical_request(
+        encoded.payload,
+        resource_paths=_materialize_resources(
+            encoded,
+            tmp_path / f"inactive-alignment-{mode}-resources",
+        ),
+        output_directory=tmp_path / f"inactive-alignment-{mode}-output",
+    )
+
+    assert decoded.options.protein_blastp_mode == mode
+    assert decoded.options.align_orthogroup_feature is None
+
+
 def test_current_schema_rejects_standard_collinearity_parameters(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Plain-language summary

Switching an imported orthogroup-aligned Gallery session to pairwise protein comparison could leave the saved alignment target active after the pairwise artifacts had replaced the orthogroup artifacts. The final render then failed because `align_orthogroup_feature` had no usable orthogroup metadata. This change makes the canonical Python decoder ignore that inactive draft while preserving alignment when a request is generating orthogroups or carries actual orthogroup metadata.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `7d2ad92f0fcf465069951dee564c5763802f2f96`; the exact-staging matrix exposed the failure in [run 33200317511](https://github.com/satoshikawato/gbdraw/actions/runs/33200317511). Focused owners are the canonical request decoder, its schema contracts, and the Gallery protein regeneration browser contract.

## User-visible impact

An imported session can switch from an orthogroup-aligned result to pairwise or collinear protein comparison without failing on the saved orthogroup alignment draft. Resolved orthogroup comparisons still preserve and apply their alignment setting.

## Changes

- Detect usable orthogroup metadata from a typed orthogroup result, non-empty `orthogroup_id` values, or canonical rows identified as orthogroup results.
- Drop `align_orthogroup_feature` only when the request is not generating orthogroups and none of those artifacts is present.
- Add schema-6 regression coverage for pairwise, collinear, and resolved `none` markers with empty compatibility columns.
- Keep the existing Worker, Pyodide runtime, request schema, cache identities, controls, and one final render unchanged.

## Verification

- `python -m pytest tests/test_session_request_codec.py tests/test_api_request_render.py tests/test_protein_colinearity.py tests/test_api_session.py::test_web_resolved_protein_writer_preserves_alignment_settings -q` — 299 passed, 1 skipped.
- `npx playwright test tests/web/gallery-session-regeneration.playwright.spec.js --config=playwright.functional.config.js --grep "uncached protein LOSAT helpers"` — 1 passed against a freshly prepared browser wheel.
- `node tests/web/architecture-contracts.test.mjs` — 133 passed.
- `ruff check gbdraw/` — passed.
- `node tools/check-web-change-budget.mjs` — Gate PASS, Review CLEAR.
- `git diff --check` — passed.

## Risk and review notes

- Gate result and any blocker: local focused gates pass; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; this is an owner-internal correction with no Web architecture inventory change.
- Architecture impact: **This is not architecture-bearing**. The canonical decoder keeps its existing responsibility and path; no owner, protocol, cache stage, or render topology changes.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: N/A. `OE`, `PE`, and `CB` are unchanged.
- `architecture-change` label, if relevant: N/A.

## Rollback

Revert `c7a9614ebec611ec9a6d2c4fa3573a908fd091c7`. That would restore the post-merge Gallery pairwise regeneration failure without changing stored sessions or artifacts.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Affected concern(s), if known: `product.canonical-render-request-boundary`
- Affected journey/checkpoint effects: `JRN-RENDER-001`; the existing Generate action completes after changing the protein comparison mode.
- Authority and decision references: Option Integrity Product Contract revision 2 and accepted base decisions `PD-OI-001` through `PD-OI-007`, `PD-OI-009`, `PD-OI-016`, and `PD-OI-017`. This correction does not broaden deferred `PD-OI-014`.
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: the active comparison outcome remains authoritative, while inactive saved drafts remain round-trippable when their matching metadata is present. Residual risk is limited to malformed third-party canonical tables whose metadata labels disagree with their rows; existing render validation still rejects unusable metadata.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

N/A

### ARCHITECTURE_EXCEPTION

N/A

### PROMOTION

N/A
