### PR TITLE
Preserve materialized record cardinality during Gallery publication

### DIFF
--- a/gbdraw/web/js/services/gallery-session-publication.js
+++ b/gbdraw/web/js/services/gallery-session-publication.js
@@ -41,13 +41,25 @@ const publicationConfig = (session, projection) => {
   delete config.blastSource; delete config.adv.losatProgram;
   return config;
 };
+const publicationCanonicalRequest = (request, promoteRequest) => {
+  const current = promoteRequest(request);
+  if (Number(request?.schema) === 5) {
+    current.records.forEach((record) => { record.cardinality = 'exactly_one'; });
+  }
+  return current;
+};
 const rebuildIntent = async (session, owners) => {
-  const projection = owners.projectRequest({ renderRequest: session.renderRequest,
+  const renderRequest = publicationCanonicalRequest(session.renderRequest, owners.promoteRequest);
+  const projection = owners.projectRequest({ renderRequest,
     resources: session.resources, webFiles: session.webFiles || {}, legacyFiles: session.files, storedConfig: session.config,
     fileBindings: session.cliInvocation?.fileBindings, sessionResourceTable: adoptCurrentSessionResources(session.resources),
     deferResourceContent: false, adoptCanonicalPayloads: true });
   const config = publicationConfig(session, projection); validateCurrentWriterActiveConfig({ mode: projection.mode, storedConfig: config });
-  const filesData = projection.files, state = owners.buildRequestState({ session, projection, config, filesData });
+  const filesData = projection.files;
+  if (projection.mode === 'linear') filesData.linearSeqs.forEach((sequence, index) => {
+    sequence.cardinality = renderRequest.records[index]?.cardinality;
+  });
+  const state = owners.buildRequestState({ session, projection, config, filesData });
   const plan = projection.mode === 'linear' ? owners.resolveComparisonPlan({ plan: state.linearComparisonPlan, sequences: filesData.linearSeqs,
     layout: state.linearRecordLayoutEnabled.value ? state.linearRecordRows : [],
     losatProgram: state.losatProgram.value, blastpMode: state.losat?.blastp?.mode }) : null;
@@ -57,7 +69,7 @@ const rebuildIntent = async (session, owners) => {
   if (isObject(session.renderRequest.diagramOptions?.config)) {
     rebuilt.renderRequest.diagramOptions.config = clone(session.renderRequest.diagramOptions.config); delete rebuilt.renderRequest.diagramOptions.configOverrides;
   }
-  return { config, rebuilt, equivalence: await owners.assertRequestsEquivalent({ expectedRequest: session.renderRequest,
+  return { config, rebuilt, equivalence: await owners.assertRequestsEquivalent({ expectedRequest: renderRequest,
     expectedResources: session.resources, actualRequest: rebuilt.renderRequest, actualResources: rebuilt.resources }) };
 };
 const mergeReplayResources = (prepared, replayed) => {

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -541,7 +541,7 @@ const buildRecords = ({ state, filesData, resources }) => {
       const selector = region ? null : selectorPayload(seq.region_record_id);
       return {
         recordKey: String(seq.uid || `record-${index + 1}`),
-        cardinality: selector || region ? 'exactly_one' : 'all',
+        cardinality: seq.cardinality || (selector || region ? 'exactly_one' : 'all'),
         source,
         selector,
         region,

--- a/tests/test_refresh_gallery_sessions.py
+++ b/tests/test_refresh_gallery_sessions.py
@@ -742,6 +742,32 @@ def test_refresh_records_resolved_track_geometry(
     assert geometry["records"][0]["axisRadiusPx"] > 0
 
 
+def test_linear_schema5_publication_preserves_materialized_cardinality_round_trip(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.gbdraw-session.json"
+    destination = tmp_path / "refreshed.gbdraw-session.json"
+    source.write_bytes(
+        _session_path("lambda_basic_linear").read_bytes()
+    )
+    committed = load_session(source)
+
+    assert committed["renderRequest"]["schema"] == 5
+    assert all(
+        "cardinality" not in record
+        for record in committed["renderRequest"]["records"]
+    )
+
+    _refresh_one_session(source, destination_path=destination)
+
+    refreshed = load_session(destination)
+    assert refreshed["renderRequest"]["schema"] == CANONICAL_REQUEST_SCHEMA
+    assert [
+        record["cardinality"]
+        for record in refreshed["renderRequest"]["records"]
+    ] == ["exactly_one"]
+
+
 def test_staged_gallery_validator_accepts_current_artifact_schemas(
     tmp_path: Path,
 ) -> None:

--- a/tests/web/gallery-session-migration.test.mjs
+++ b/tests/web/gallery-session-migration.test.mjs
@@ -46,6 +46,7 @@ const {
   assertCanonicalRenderRequestsEquivalent,
   buildCanonicalRenderRequest,
   buildCanonicalRequestState,
+  promoteCanonicalRenderRequestToCurrent,
   projectCanonicalSessionRequest
 } = await import(
   pathToFileURL(join(tempRoot, 'js', 'services', 'session-request.js'))
@@ -64,6 +65,7 @@ const {
   assertRequestsEquivalent: assertCanonicalRenderRequestsEquivalent,
   buildRequest: buildCanonicalRenderRequest,
   buildRequestState: buildCanonicalRequestState,
+  promoteRequest: promoteCanonicalRenderRequestToCurrent,
   projectRequest: projectCanonicalSessionRequest,
   resolveComparisonPlan: resolveLinearComparisonPlan
 });

--- a/tests/web/gallery-session-publication.test.mjs
+++ b/tests/web/gallery-session-publication.test.mjs
@@ -18,6 +18,7 @@ const {
   buildCanonicalRenderRequest,
   buildCanonicalRequestState,
   compareCanonicalRenderRequests,
+  promoteCanonicalRenderRequestToCurrent,
   projectCanonicalSessionRequest
 } = await import('../../gbdraw/web/js/services/session-request.js');
 const { promoteGallerySessionToCurrent } = await import(
@@ -34,6 +35,7 @@ const {
   assertRequestsEquivalent: assertCanonicalRenderRequestsEquivalent,
   buildRequest: buildCanonicalRenderRequest,
   buildRequestState: buildCanonicalRequestState,
+  promoteRequest: promoteCanonicalRenderRequestToCurrent,
   projectRequest: projectCanonicalSessionRequest,
   resolveComparisonPlan: resolveLinearComparisonPlan
 });
@@ -90,6 +92,11 @@ const [lambdaPrepared, alteredPrepared] = await Promise.all([
   prepareGallerySessionForPublication(lambda),
   prepareGallerySessionForPublication(alteredProvenance)
 ]);
+assert.deepEqual(
+  lambdaPrepared.session.renderRequest.records.map(({ cardinality }) => cardinality),
+  ['exactly_one'],
+  'publication must preserve schema-5 materialized record cardinality'
+);
 assert.equal(
   lambdaPrepared.equivalence.actual.digest,
   alteredPrepared.equivalence.actual.digest

--- a/tools/publish_gallery_session.mjs
+++ b/tools/publish_gallery_session.mjs
@@ -12,6 +12,7 @@ import {
   assertCanonicalRenderRequestsEquivalent,
   buildCanonicalRenderRequest,
   buildCanonicalRequestState,
+  promoteCanonicalRenderRequestToCurrent,
   projectCanonicalSessionRequest
 } from '../gbdraw/web/js/services/session-request.js';
 
@@ -26,6 +27,7 @@ const {
   assertRequestsEquivalent: assertCanonicalRenderRequestsEquivalent,
   buildRequest: buildCanonicalRenderRequest,
   buildRequestState: buildCanonicalRequestState,
+  promoteRequest: promoteCanonicalRenderRequestToCurrent,
   projectRequest: projectCanonicalSessionRequest,
   resolveComparisonPlan: resolveLinearComparisonPlan
 });


### PR DESCRIPTION
## Plain-language summary

This PR keeps Gallery publication record cardinality unchanged across preparation and CLI replay. Schema-5 Gallery sessions already describe materialized one-record inputs, but preparation was rebuilding selectorless Linear records as `all` while replay wrote `exactly_one`; after this change both sides use `exactly_one` and the strict full-request comparison remains enabled. It does not refresh Gallery assets or change comparison, record selection, or rendering semantics.

## Change class

Select exactly one:

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `2fd1d5a087bcefb809de83a49d56eb5b27c4096d` (tree `61aeac86db6af40fa04e57a03271cf1ad0ec5bc7`). Required checks are `Web base policy (trusted base)` and `PR / gate`; protected selective CI owns broad regression.
- Repair the publication failure `Gallery publication request differs at $.records[0].cardinality` without weakening canonical equivalence or updating generated output.

## User-visible impact

Publishing a materialized schema-5 Gallery session can complete its canonical request round trip instead of stopping at the first record's cardinality. The selected records, source resources, diagram output, and scientific comparison behavior are unchanged.

## Changes

- Promote schema-5 Gallery publication requests with their canonical `exactly_one` materialized-record default before rebuilding the current request.
- Carry that explicit cardinality through the existing publication projection and request builder instead of re-deriving it from the absence of a selector or region.
- Keep the ordinary Web schema-5 source-card migration, Python replay materialization, strict equivalence checker, and compatibility readers unchanged.
- Add a Lambda publication regression that executes the real `prepare -> CLI replay -> finalize` path and a focused prepared-request cardinality assertion.

## Verification

- Pre-fix proof: `node tests/web/gallery-session-publication.test.mjs` failed with prepared `all` versus expected `exactly_one`.
- Pre-fix proof: `python -m pytest tests/test_refresh_gallery_sessions.py::test_linear_schema5_publication_preserves_materialized_cardinality_round_trip -q` failed during finalize at `$.records[0].cardinality`.
- `node tests/web/gallery-session-publication.test.mjs`
- `node tests/web/gallery-session-migration.test.mjs`
- `node tests/web/session-request.test.mjs`
- `python -m pytest tests/test_refresh_gallery_sessions.py::test_linear_schema5_publication_preserves_materialized_cardinality_round_trip tests/test_refresh_gallery_sessions.py::test_refresh_records_resolved_track_geometry -q`: 2 passed.
- `node tests/web/architecture-contracts.test.mjs`: 133 passed.
- `WEB_ARCHITECTURE_CHANGE=true node tools/check-web-change-budget.mjs --base 2fd1d5a087bcefb809de83a49d56eb5b27c4096d`: Gate `PASS`, Review `REQUIRED`, no architecture differential, privileged expansion, dependency cycle, or guard change.
- `python -m ruff check tests/test_refresh_gallery_sessions.py`
- `git diff --check`
- Diff guards confirm no changes under `gbdraw/web/gallery/`, `tests/reference_outputs/`, Product authority, Architecture/Product/Web policy, CI, or admission files.

## Risk and review notes

- Gate result and any blocker: local Gate `PASS`; no blocker. Protected selective CI remains required on the exact PR head.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because `gbdraw/web/js/services/session-request.js` is a registered Session/compatibility path.
- Architecture impact: **This is architecture-bearing**. `gbdraw/web/js/services/gallery-session-publication.js` remains the publication alignment owner, and `gbdraw/web/js/services/session-request.js` remains the canonical request owner; the change makes the publication projection carry the canonical value instead of invoking the fresh-input fallback.
- Architecture baseline and changed-scope conclusion: semantic owners remain unchanged (`OE 0 -> 0`); the canonical production path remains `prepare -> CLI replay -> finalize` (`PE 0 -> 0`); request schema-5 compatibility remains the same bounded reader path and no branch is added (`CB 1 -> 1`). The selector/region fallback remains only because fresh Web inputs still require cardinality derivation. Therefore `delta(OE) = 0`, `delta(PE) = 0`, and `delta(CB) = 0`.
- `architecture-change` label, if relevant: required and applied at PR creation.
- Scientific and generated-output risk: none in the diff. The repair does not touch LOSAT, comparison projection, cache identity, clustering, rendering, Gallery sessions, SVGs, thumbnails, manifests, or reference output.

## Rollback

Revert this commit. That restores the publication mismatch without requiring an asset rollback or compatibility migration.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Affected concern(s), if known: `product.canonical-render-request-boundary`
- Affected journey/checkpoint effects: regeneration after a Session round trip preserves the same canonical request semantics and resource bindings.
- Authority and decision references: `gbdraw/web/CLAUDE.md` request/session boundary; `docs/SESSION_COMPATIBILITY.md` schema-5 `exactly_one` decoding and current-writer ownership; no new Product Decision.
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: the focused Node assertion checks the prepared value, and the Python regression executes strict full-request equivalence through the real publication path. Alternate supported Session/request paths remain covered by the focused migration/request tests and protected selective CI.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

N/A for a `STANDARD` change.
