### PR TITLE
Make protein search options control LOSATP jobs and caches

### DIFF
--- a/gbdraw/web/js/app/current-option-values.js
+++ b/gbdraw/web/js/app/current-option-values.js
@@ -56,6 +56,33 @@ export const requireCurrentLinearLabelPlacement = (value) => (
   )
 );
 
+export const requireCurrentProteinBlastpMode = (value) => (
+  requireCurrentValue(
+    value,
+    'orthogroup',
+    ['pairwise', 'orthogroup', 'collinear'],
+    'Protein BLASTP mode'
+  )
+);
+
+export const requireCurrentCollinearSearchScope = (value) => (
+  requireCurrentValue(
+    value,
+    'adjacent',
+    ['adjacent', 'all'],
+    'Collinear search scope'
+  )
+);
+
+export const requireCurrentProteinBlastpCandidateLimit = (value) => {
+  if (value === null || value === undefined || value === '') return null;
+  const numeric = Number(value);
+  if (!Number.isInteger(numeric) || numeric <= 0) {
+    throw new Error('Protein BLASTP Candidate limit must be a positive integer or None.');
+  }
+  return numeric;
+};
+
 export const migratePersistedCircularMultiRecordSizeMode = (value) => {
   const normalized = normalizedValue(value, 'auto');
   return requireCurrentCircularMultiRecordSizeMode(

--- a/gbdraw/web/js/app/python-helpers.js
+++ b/gbdraw/web/js/app/python-helpers.js
@@ -955,6 +955,7 @@ def _dataframe_json_rows(df):
 
 def convert_losatp_blastp_pairs_to_genomic_payload(
     pairs_path,
+    raw_tsv_path,
     mode="pairwise",
     max_hits=5,
     bitscore=50,
@@ -1003,7 +1004,7 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
             raise ValueError("LOSATP blastp conversion payload must contain 'records' and 'pairs' lists.")
         normalized_mode = str(mode or "pairwise").strip().lower()
         if normalized_mode not in {"pairwise", "orthogroup", "collinear"}:
-            normalized_mode = "pairwise"
+            raise ValueError(f"Unsupported LOSATP blastp mode: {mode!r}")
         normalized_membership_mode = normalize_orthogroup_membership_mode(str(orthogroup_membership_mode or "anchor_core_v1"))
         try:
             normalized_member_max_hits = int(orthogroup_member_max_hits or 5)
@@ -1018,11 +1019,11 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
         if normalized_max_paralog_links <= 0:
             normalized_max_paralog_links = 2
         normalized_collinear_anchor_mode = "rbh"
-        normalized_collinear_search_scope = str(collinear_search_scope or "adjacent").strip().lower().replace("-", "_")
-        if normalized_collinear_search_scope in {"all_records", "all_pairs", "all_record_pairs", "global"}:
-            normalized_collinear_search_scope = "all"
-        elif normalized_collinear_search_scope not in {"adjacent", "all"}:
-            normalized_collinear_search_scope = "adjacent"
+        normalized_collinear_search_scope = str(collinear_search_scope or "adjacent").strip().lower()
+        if normalized_collinear_search_scope not in {"adjacent", "all"}:
+            raise ValueError(
+                f"Unsupported Collinear search scope: {collinear_search_scope!r}"
+            )
 
         record_payloads = []
         for idx, record in enumerate(raw_records):
@@ -1043,6 +1044,9 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
             )
 
         pair_payloads = []
+        with open(str(raw_tsv_path), "rb") as raw_tsv_handle:
+            raw_tsv_handle.seek(0, 2)
+            raw_tsv_size = raw_tsv_handle.tell()
         for idx, item in enumerate(raw_pairs):
             if not isinstance(item, dict):
                 raise ValueError(f"LOSATP pair payload #{idx + 1} must be an object.")
@@ -1054,6 +1058,13 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
                 subject_index = int(item["subjectIndex"])
             except Exception as exc:
                 raise ValueError(f"LOSATP pair payload #{idx + 1} is missing a valid subjectIndex.") from exc
+            try:
+                raw_offset = int(item["rawTsvOffset"])
+                raw_bytes = int(item["rawTsvBytes"])
+            except Exception as exc:
+                raise ValueError(f"LOSATP pair payload #{idx + 1} is missing a valid raw TSV range.") from exc
+            if raw_offset < 0 or raw_bytes < 0 or raw_offset + raw_bytes > raw_tsv_size:
+                raise ValueError(f"LOSATP pair payload #{idx + 1} has an invalid raw TSV range.")
             pair_index = int(item.get("pairIndex", min(query_index, subject_index)))
             cache_key = str(item.get("cacheKey") or "").strip()
             if not cache_key:
@@ -1065,9 +1076,19 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
                     "subject_index": subject_index,
                     "display_pair": item.get("displayPair") is True,
                     "cache_key": cache_key,
-                    "blast_text": str(item.get("blastText") or ""),
+                    "raw_tsv_offset": raw_offset,
+                    "raw_tsv_bytes": raw_bytes,
                 }
             )
+
+        raw_tsv_stats = {
+            "rawTsvEntryCount": len(pair_payloads),
+            "rawTsvBytes": raw_tsv_size,
+            "rawTsvLargestEntryBytes": max(
+                (item["raw_tsv_bytes"] for item in pair_payloads),
+                default=0,
+            ),
+        }
 
         conversion_cache_key = (
             normalized_mode,
@@ -1114,6 +1135,8 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
                 convertedPayloadHit=True,
                 filteredHitCacheHits=0,
                 filteredHitCacheMisses=0,
+                simultaneousParsedTables=0,
+                **raw_tsv_stats,
             )
 
         protein_maps_by_record = {}
@@ -1149,7 +1172,10 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
             )
             filtered = _web_losatp_cache_get("filtered", filter_cache_key)
             if filtered is None:
-                hits = parse_losatp_outfmt6(item["blast_text"])
+                with open(str(raw_tsv_path), "rb") as raw_tsv_handle:
+                    raw_tsv_handle.seek(item["raw_tsv_offset"])
+                    blast_text = raw_tsv_handle.read(item["raw_tsv_bytes"]).decode("utf-8")
+                hits = parse_losatp_outfmt6(blast_text)
                 filtered = filter_protein_hits_by_thresholds(
                     hits,
                     evalue=evalue,
@@ -1177,6 +1203,8 @@ def convert_losatp_blastp_pairs_to_genomic_payload(
             "convertedPayloadHit": False,
             "filteredHitCacheHits": filtered_cache_hits,
             "filteredHitCacheMisses": filtered_cache_misses,
+            "simultaneousParsedTables": len(pair_items),
+            **raw_tsv_stats,
         }
 
         def _finalize_losatp_payload(payload):

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -70,8 +70,11 @@ import {
 } from './plot-title-position.js';
 import {
   requireCurrentCircularMultiRecordSizeMode,
+  requireCurrentCollinearSearchScope,
   requireCurrentLinearLabelPlacement,
-  requireCurrentLinearTrackLayout
+  requireCurrentLinearTrackLayout,
+  requireCurrentProteinBlastpCandidateLimit,
+  requireCurrentProteinBlastpMode
 } from './current-option-values.js';
 import {
   discoverGffFastaRecords,
@@ -377,11 +380,9 @@ export const hasRequiredCanonicalAnalysisResource = (mode, payload) => {
   );
 };
 
-export const resolveProteinBlastpCandidateLimit = (mode, candidateLimit, maxHits = 5) => {
-  const source = ['orthogroup', 'collinear'].includes(normalizeBlastpMode(mode)) ? candidateLimit : maxHits;
-  if (source === null || source === undefined || source === '') return null;
-  return normalizePositiveInteger(source, null);
-};
+export const resolveProteinBlastpCandidateLimit = (candidateLimit) => (
+  requireCurrentProteinBlastpCandidateLimit(candidateLimit)
+);
 
 const stripRuntimeCacheStats = (payload) => {
   const cloned = cloneJsonData(payload);
@@ -1693,6 +1694,7 @@ export const createRunAnalysis = ({
     const legacyPromotionTransaction = [];
     let legacyPromotionCommitted = false;
     let commitProteinMigration = null;
+    let pendingLosatCacheCommit = null;
 
     if (isReflow) {
       labelReflowProcessing.value = true;
@@ -2323,7 +2325,7 @@ export const createRunAnalysis = ({
             const subjectHash = await hashText(subjectEntry.fasta);
             const subjectSequenceKey = `circular-subject:${subjectHash}`;
             const sequenceEntriesByKey = new Map([[subjectSequenceKey, subjectEntry.fasta]]);
-            const cacheMap = losatCache.value || new Map();
+            const cacheMap = new Map(losatCache.value || []);
             const cacheInfo = [];
             const losatPairs = [];
             const losatJobs = [];
@@ -2443,8 +2445,7 @@ export const createRunAnalysis = ({
                 text: blastText
               });
             }
-            losatCacheInfo.value = cacheInfo;
-            losatCache.value = cacheMap;
+            pendingLosatCacheCommit = { cacheInfo, cacheMap, derivedCacheMap: null };
             return resolved;
           };
 
@@ -2550,7 +2551,7 @@ export const createRunAnalysis = ({
         const useLosat = hasLosatIntent && !reuseResolvedProteinArtifacts;
         if (useLosat) recordSessionLifecycleEvent('losat-cache-preparation-start');
         const blastpMode = useProteinBlastp
-          ? normalizeBlastpMode(losat.blastp?.mode)
+          ? requireCurrentProteinBlastpMode(losat.blastp?.mode)
           : String(losat.blastp?.mode ?? '');
         const usePairwiseBlastp = useProteinBlastp && blastpMode === 'pairwise';
         const useOrthogroupBlastp = useProteinBlastp && blastpMode === 'orthogroup';
@@ -2577,11 +2578,7 @@ export const createRunAnalysis = ({
           ? Math.max(1, normalizeBlastThresholdNumber(losat.blastp?.maxHits, 5, { integer: true }))
           : 5;
         const blastpCandidateLimit = useProteinBlastp
-          ? resolveProteinBlastpCandidateLimit(
-              blastpMode,
-              losat.blastp?.candidateLimit,
-              blastpMaxHits
-            )
+          ? resolveProteinBlastpCandidateLimit(losat.blastp?.candidateLimit)
           : null;
         const orthogroupMembershipMode = useOrthogroupBlastp
           ? normalizeOrthogroupMembershipMode(losat.blastp?.orthogroupMembershipMode)
@@ -2648,19 +2645,19 @@ export const createRunAnalysis = ({
           ? normalizeCollinearAnchorMode(losat.blastp?.collinearAnchorMode)
           : 'rbh';
         const collinearSearchScope = useCollinearBlastp
-          ? normalizeCollinearSearchScope(losat.blastp?.collinearSearchScope)
+          ? requireCurrentCollinearSearchScope(losat.blastp?.collinearSearchScope)
           : 'adjacent';
 
-        if (useProteinBlastp) losat.blastp.mode = blastpMode;
+        if (useProteinBlastp) {
+          losat.blastp.mode = blastpMode;
+          losat.blastp.candidateLimit = blastpCandidateLimit;
+        }
         if (usePairwiseBlastp) {
           losat.blastp.maxHits = blastpMaxHits;
-          losat.blastp.candidateLimit = null;
         } else if (useOrthogroupBlastp) {
-          losat.blastp.candidateLimit = blastpCandidateLimit;
           losat.blastp.orthogroupMembershipMode = orthogroupMembershipMode;
           losat.blastp.orthogroupMemberMaxHits = orthogroupMemberMaxHits;
         } else if (useCollinearBlastp) {
-          losat.blastp.candidateLimit = blastpCandidateLimit;
           losat.blastp.collinearMinAnchors = collinearMinAnchors;
           losat.blastp.collinearMaxUnitGap = collinearMaxUnitGap;
           losat.blastp.collinearMaxDiagonalDrift = collinearMaxDiagonalDrift;
@@ -2764,7 +2761,10 @@ export const createRunAnalysis = ({
           }
         }
         let cacheInfo = [];
-        const cacheMap = losatCache.value || new Map();
+        const cacheMap = new Map(losatCache.value || []);
+        const derivedCacheMap = useProteinBlastp
+          ? new Map(losatDerivedCache.value || [])
+          : null;
         const losatTiming = useLosat
           ? {
               inputWriteMs: 0,
@@ -2785,6 +2785,14 @@ export const createRunAnalysis = ({
               proteinConversionCacheHits: 0,
               proteinFilteredHitCacheHits: 0,
               proteinFilteredHitCacheMisses: 0,
+              rawTsvEntryCount: 0,
+              rawTsvBytes: 0,
+              rawTsvLargestEntryBytes: 0,
+              simultaneousParsedTables: 0,
+              helperRequestMetadataBytes: 0,
+              helperRequestRawTransferBytes: 0,
+              helperRequestFileCount: 0,
+              rawJobs: [],
               cacheHashHits: 0,
               cacheHits: 0,
               cacheMisses: 0,
@@ -3444,6 +3452,12 @@ export const createRunAnalysis = ({
               displayPair: isResolvedDisplayPair
             };
             losatPairs.push(pair);
+            losatTiming.rawJobs.push({
+              queryRecordIndex: spec.queryIndex,
+              subjectRecordIndex: spec.subjectIndex,
+              cacheKey,
+              args: [...losatArgs]
+            });
             if (
               isResolvedDisplayPair &&
               !cacheInfo.some((entry) => entry.edgeKey === spec.edgeKey)
@@ -3574,10 +3588,14 @@ export const createRunAnalysis = ({
               });
             }
             const pairPayloads = [];
+            const rawTsvParts = [];
+            let rawTsvOffset = 0;
+            let rawTsvLargestEntryBytes = 0;
             for (const pair of losatPairs) {
               throwIfGenerationCanceled();
               const cached = cacheMap.get(pair.cacheKey);
               const losatText = isCurrentRawLosatCacheEntry(cached) ? cached.text : '';
+              const rawTsvBytes = new Blob([losatText]).size;
               pairPayloads.push({
                 pairIndex: pair.pairIndex,
                 ordinal: pair.ordinal,
@@ -3586,16 +3604,22 @@ export const createRunAnalysis = ({
                 subjectIndex: pair.subjectIndex,
                 displayPair: pair.displayPair,
                 cacheKey: pair.cacheKey,
-                blastText: losatText
+                rawTsvOffset,
+                rawTsvBytes
               });
+              rawTsvParts.push(losatText);
+              rawTsvOffset += rawTsvBytes;
+              rawTsvLargestEntryBytes = Math.max(rawTsvLargestEntryBytes, rawTsvBytes);
             }
+            losatTiming.rawTsvEntryCount = pairPayloads.length;
+            losatTiming.rawTsvBytes = rawTsvOffset;
+            losatTiming.rawTsvLargestEntryBytes = rawTsvLargestEntryBytes;
             setProcessingStatus(
               useCollinearBlastp
                 ? 'Converting LOSAT protein links to collinear ribbons...'
                 : 'Converting LOSAT protein hits...'
             );
             const useDerivedProteinPayloadCache = useOrthogroupBlastp || useCollinearBlastp;
-            const derivedCacheMap = losatDerivedCache.value || new Map();
             let derivedCacheKey = '';
             let convertedPayload = null;
             if (useDerivedProteinPayloadCache) {
@@ -3640,10 +3664,23 @@ export const createRunAnalysis = ({
               }
             }
             if (!convertedPayload) {
+              const pairManifestBytes = textEncoder.encode(JSON.stringify({
+                records: recordPayloads,
+                pairs: pairPayloads
+              }));
+              const rawTsvBuffer = await new Blob(rawTsvParts, {
+                type: 'text/tab-separated-values'
+              }).arrayBuffer();
+              losatTiming.helperRequestMetadataBytes = pairManifestBytes.byteLength;
+              losatTiming.helperRequestRawTransferBytes = rawTsvBuffer.byteLength;
+              losatTiming.helperRequestFileCount = 2;
               const response = await runDiagramHelperOperation(
                 DIAGRAM_HELPER_OPERATIONS.CONVERT_LOSATP_PAIRS_TO_GENOMIC_PAYLOAD,
                 {
-                  files: [{ role: 'pairs', bytes: textEncoder.encode(JSON.stringify({ records: recordPayloads, pairs: pairPayloads })).buffer }],
+                  files: [
+                    { role: 'pairs', bytes: pairManifestBytes.buffer },
+                    { role: 'rawTsv', bytes: rawTsvBuffer }
+                  ],
                   mode: blastpMode,
                   maxHits: blastpMaxHits,
                   bitscore: adv.min_bitscore,
@@ -3665,14 +3702,13 @@ export const createRunAnalysis = ({
               );
               convertedPayload = response.result;
               if (useDerivedProteinPayloadCache && !convertedPayload?.error) {
-                convertedPayload = setLosatDerivedCacheEntry(derivedCacheMap, derivedCacheKey, {
+                setLosatDerivedCacheEntry(derivedCacheMap, derivedCacheKey, {
                   mode: blastpMode,
                   payload: convertedPayload,
                   manifest: proteinIdentityManifest.value
-                }) || convertedPayload;
+                });
               }
             }
-            losatDerivedCache.value = derivedCacheMap;
             if (convertedPayload.error) throw new Error(convertedPayload.error);
             if (!hasRequiredCanonicalAnalysisResource(blastpMode, convertedPayload)) {
               throw new Error(
@@ -3683,6 +3719,9 @@ export const createRunAnalysis = ({
             if (conversionCache.convertedPayloadHit) losatTiming.proteinConversionCacheHits += 1;
             losatTiming.proteinFilteredHitCacheHits += Number(conversionCache.filteredHitCacheHits || 0);
             losatTiming.proteinFilteredHitCacheMisses += Number(conversionCache.filteredHitCacheMisses || 0);
+            losatTiming.simultaneousParsedTables = Number(
+              conversionCache.simultaneousParsedTables || 0
+            );
             if (useCollinearBlastp) {
               resolvedComparisons.push({
                 kind: 'collinearityResult',
@@ -3818,9 +3857,25 @@ export const createRunAnalysis = ({
             uniqueJobs: losatTiming.uniqueJobs,
             workerCalls: losatTiming.uniqueJobs,
             proteinDerivedPayloadCacheHits: losatTiming.proteinDerivedPayloadCacheHits,
-            proteinDerivedPayloadCacheMisses: losatTiming.proteinDerivedPayloadCacheMisses
+            proteinDerivedPayloadCacheMisses: losatTiming.proteinDerivedPayloadCacheMisses,
+            mode: useProteinBlastp ? blastpMode : null,
+            candidateLimitRequested: useProteinBlastp ? blastpCandidateLimit : null,
+            candidateLimitEffective: useProteinBlastp ? blastpCandidateLimit : null,
+            collinearSearchScope: useCollinearBlastp ? collinearSearchScope : null,
+            program: useProteinBlastp ? 'blastp' : losatProgram.value,
+            outfmt: String(losat.outfmt || '6'),
+            rawTsvEntryCount: losatTiming.rawTsvEntryCount,
+            rawTsvBytes: losatTiming.rawTsvBytes,
+            rawTsvLargestEntryBytes: losatTiming.rawTsvLargestEntryBytes,
+            simultaneousParsedTables: losatTiming.simultaneousParsedTables,
+            helperRequestMetadataBytes: losatTiming.helperRequestMetadataBytes,
+            helperRequestRawTransferBytes: losatTiming.helperRequestRawTransferBytes,
+            helperRequestFileCount: losatTiming.helperRequestFileCount,
+            rawIdentitySchema: useProteinBlastp
+              ? PROTEIN_LOSAT_CACHE_SCHEMA
+              : NUCLEOTIDE_LOSAT_CACHE_SCHEMA,
+            rawJobs: cloneJsonData(losatTiming.rawJobs)
           };
-          globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__ = cloneJsonData(structuredLosatTelemetry);
           console.info(
             [
               `LOSAT timing: pairs=${losatTiming.totalPairs}`,
@@ -3850,10 +3905,13 @@ export const createRunAnalysis = ({
           );
         }
         if (useLosat) {
-          losatCacheInfo.value = cacheInfo.sort(
-            (left, right) => Number(left?.ordinal) - Number(right?.ordinal)
-          );
-          losatCache.value = cacheMap;
+          pendingLosatCacheCommit = {
+            cacheInfo: cacheInfo.sort(
+              (left, right) => Number(left?.ordinal) - Number(right?.ordinal)
+            ),
+            cacheMap,
+            derivedCacheMap
+          };
           recordSessionLifecycleEvent('losat-cache-preparation-end', {
             cacheHits: Number(losatTiming?.cacheHits || 0),
             cacheMisses: Number(losatTiming?.cacheMisses || 0),
@@ -4197,6 +4255,18 @@ export const createRunAnalysis = ({
         setGeneratedArtifactIdentity(generationResponse.artifactIdentity, {
           results: candidateCommit.results
         });
+      }
+      if (!isReflow && pendingLosatCacheCommit) {
+        losatCacheInfo.value = pendingLosatCacheCommit.cacheInfo;
+        losatCache.value = pendingLosatCacheCommit.cacheMap;
+        if (pendingLosatCacheCommit.derivedCacheMap) {
+          losatDerivedCache.value = pendingLosatCacheCommit.derivedCacheMap;
+        }
+      }
+      if (!isReflow) {
+        globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__ = cloneJsonData(
+          structuredLosatTelemetry
+        );
       }
       return { status: 'ok' };
     } catch (e) {

--- a/gbdraw/web/js/services/session-active-config-contract.js
+++ b/gbdraw/web/js/services/session-active-config-contract.js
@@ -1,6 +1,6 @@
 import { createDefaultLinearDefinitionLineStyles } from '../app/definition-line-style-state.js'; import { CIRCULAR_TRACK_RENDERERS, createDefaultCircularTrackSlots } from '../app/circular-track-slots.js';
 import { LEGACY_LINEAR_TRACK_SLOT_SCHEMA_VERSION, LINEAR_TRACK_RENDERERS, LINEAR_TRACK_SLOT_SCHEMA_VERSION, createDefaultLinearTrackSlots } from '../app/linear-track-slots.js'; import { validateTrackSlotBindingInvariants } from '../app/track-slot-validation.js';
-import { requireCurrentCircularMultiRecordSizeMode, requireCurrentLinearLabelPlacement, requireCurrentLinearTrackLayout, requireCurrentWebStateFieldNames } from '../app/current-option-values.js'; import { DEFAULT_ARROW_SHAFT_WIDTH_RATIO, createDefaultFeatureRenderings } from '../utils/feature-rendering.js';
+import { requireCurrentCircularMultiRecordSizeMode, requireCurrentCollinearSearchScope, requireCurrentLinearLabelPlacement, requireCurrentLinearTrackLayout, requireCurrentProteinBlastpCandidateLimit, requireCurrentProteinBlastpMode, requireCurrentWebStateFieldNames } from '../app/current-option-values.js'; import { DEFAULT_ARROW_SHAFT_WIDTH_RATIO, createDefaultFeatureRenderings } from '../utils/feature-rendering.js';
 import { MODE_DEFAULT_FEATURE_TYPES, comparisonStateForMode, managedAdvStateForMode, trackDefaultsForMode } from '../mode-profiles.js'; import { WEB_UX_PROFILE } from '../web-ux-profile.js';
 const circularTracks = trackDefaultsForMode('circular'), linearTracks = trackDefaultsForMode('linear');
 export const CIRCULAR_TRACK_SLOT_SCHEMA_VERSION = 4, LEGACY_CIRCULAR_TRACK_SLOT_SCHEMA_VERSION = 3;
@@ -38,7 +38,7 @@ export const createDefaultLosat = () => ({
   blastn: { task: 'megablast' }, blastp: { mode: 'orthogroup', maxHits: 5, candidateLimit: null, orthogroupMembershipMode: 'anchor_core_v1',
     orthogroupMemberMaxHits: 5, collinearMinAnchors: 1, collinearMaxUnitGap: 0, collinearMaxDiagonalDrift: 0,
     collinearMaxConflictsInMergeGap: 1, collinearMaxParalogLinksPerOrthogroup: 2, collinearColorMode: 'orientation',
-    collinearUnitMode: 'auto', collinearAnchorMode: 'rbh', collinearSearchScope: 'all' }
+    collinearUnitMode: 'auto', collinearAnchorMode: 'rbh', collinearSearchScope: 'adjacent' }
 });
 export const createDefaultCircularConservation = () => ({ enabled: false, source: 'losat', losat_program: 'blastn',
   subject_gencode: 1, reference: 'auto', labels: '', series: [], ring_width: null, ring_gap: null });
@@ -144,6 +144,16 @@ export const validateCurrentWriterActiveConfig = ({ mode, storedConfig: config }
   for (const [path, value] of [['config.adv.losatProgram', config.adv.losatProgram], ['config.losatProgram', config.losatProgram]]) {
     if (value !== undefined && !['blastn', 'tblastx', 'blastp'].includes(value))
       throw new Error(`Current session active configuration ${path} is invalid.`);
+  }
+  if (isObject(config.losat?.blastp)) {
+    const blastp = config.losat.blastp;
+    if (has(blastp, 'mode')) requireCurrentProteinBlastpMode(blastp.mode);
+    if (has(blastp, 'candidateLimit')) {
+      requireCurrentProteinBlastpCandidateLimit(blastp.candidateLimit);
+    }
+    if (has(blastp, 'collinearSearchScope')) {
+      requireCurrentCollinearSearchScope(blastp.collinearSearchScope);
+    }
   }
   if (has(config, 'filterMode') && !['None', 'Whitelist', 'Blacklist'].includes(config.filterMode)) throw new Error('Current session active configuration config.filterMode is invalid.');
   if (has(config, 'palette') && !config.palette.trim()) throw new Error('Current session active configuration config.palette cannot be empty.');

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -72,8 +72,11 @@ import {
   migratePersistedLinearLabelPlacement,
   migratePersistedLinearTrackLayout,
   requireCurrentCircularMultiRecordSizeMode,
+  requireCurrentCollinearSearchScope,
   requireCurrentLinearLabelPlacement,
   requireCurrentLinearTrackLayout,
+  requireCurrentProteinBlastpCandidateLimit,
+  requireCurrentProteinBlastpMode,
   requireCurrentWebStateFieldNames
 } from '../app/current-option-values.js';
 import {
@@ -1207,6 +1210,7 @@ const buildTrackPlan = ({
 
 const generatedProteinSettings = (state, baseline = {}) => {
   const blastp = state.losat.blastp || {};
+  const blastpMode = requireCurrentProteinBlastpMode(blastp.mode);
   const positiveInteger = (value, fallback) => optionalPositiveInteger(value) ?? fallback;
   const nonNegativeInteger = (value, fallback) => {
     const numeric = optionalNumber(value);
@@ -1255,14 +1259,17 @@ const generatedProteinSettings = (state, baseline = {}) => {
     },
     collinearityUnitMode,
     collinearityAnchorMode: normalizeCollinearAnchorMode(blastp.collinearAnchorMode),
-    collinearitySearchScope: normalizeCollinearSearchScope(blastp.collinearSearchScope),
+    collinearitySearchScope: blastpMode === 'collinear'
+      ? requireCurrentCollinearSearchScope(blastp.collinearSearchScope)
+      : normalizeCollinearSearchScope(blastp.collinearSearchScope),
     collinearityColorMode,
     losatpBin: baseline.losatpBin || 'losat',
     ncbiBlastpBin: baseline.ncbiBlastpBin ?? null,
     losatpThreads: optionalPositiveInteger(state.losat.threadsPerJob),
     proteinBlastpMaxHits: positiveInteger(blastp.maxHits, 5),
-    proteinBlastpCandidateLimit:
-      baseline.proteinBlastpCandidateLimit ?? optionalPositiveInteger(blastp.candidateLimit),
+    proteinBlastpCandidateLimit: requireCurrentProteinBlastpCandidateLimit(
+      blastp.candidateLimit
+    ),
     orthogroupMembershipMode: normalizeOrthogroupMembershipMode(
       blastp.orthogroupMembershipMode
     ),

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -272,7 +272,8 @@ const HELPER_FILE_NAMES = Object.freeze({
   gff: 'source.gff',
   fasta: 'source.fasta',
   pairs: 'pairs.json',
-  visibility: 'feature-visibility.tsv'
+  visibility: 'feature-visibility.tsv',
+  rawTsv: 'raw-losatp.tsv'
 });
 
 const requirePayloadObject = (payload, operation) => {
@@ -614,12 +615,13 @@ const HELPER_OPERATION_SPECS = Object.freeze({
       'orthogroupMembershipMode',
       'orthogroupMemberMaxHits'
     ],
-    fileRoles: ['pairs'],
+    fileRoles: ['pairs', 'rawTsv'],
     run: (pyodide, payload, paths, operation) => callJsonHelper(
       pyodide,
       'convert_losatp_blastp_pairs_to_genomic_payload',
       [
         requireHelperFile(paths, 'pairs', operation),
+        requireHelperFile(paths, 'rawTsv', operation),
         payload.mode ?? 'pairwise',
         payload.maxHits ?? 5,
         payload.bitscore ?? 50,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from collections.abc import Callable
@@ -23,6 +24,34 @@ INPUT_SEARCH_DIRS = (
     Path("/home/kawato/study/2025-09-17_gbdraw_test"),
     Path("/home/kawato/study/2025-05-15_gbdraw"),
 )
+
+
+@pytest.fixture
+def stage_web_losatp_transport() -> Callable[
+    [Path, dict[str, object], str], tuple[Path, Path]
+]:
+    """Stage Web LOSATP pair metadata beside one binary raw-TSV bundle."""
+
+    def stage(
+        directory: Path,
+        payload: dict[str, object],
+        stem: str = "losatp-pairs",
+    ) -> tuple[Path, Path]:
+        manifest = json.loads(json.dumps(payload))
+        raw_tsv = bytearray()
+        for pair in manifest.get("pairs", []):
+            blast_text = str(pair.pop("blastText"))
+            encoded = blast_text.encode("utf-8")
+            pair["rawTsvOffset"] = len(raw_tsv)
+            pair["rawTsvBytes"] = len(encoded)
+            raw_tsv.extend(encoded)
+        pairs_path = directory / f"{stem}.json"
+        raw_tsv_path = directory / f"{stem}.tsv"
+        pairs_path.write_text(json.dumps(manifest), encoding="utf-8")
+        raw_tsv_path.write_bytes(raw_tsv)
+        return pairs_path, raw_tsv_path
+
+    return stage
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_collinearity.py
+++ b/tests/test_collinearity.py
@@ -2175,7 +2175,10 @@ def test_linear_cli_rejects_nonpositive_collinear_min_anchors() -> None:
 
 
 @pytest.mark.linear
-def test_web_losatp_blastp_payload_helper_returns_collinear_rows(tmp_path: Path) -> None:
+def test_web_losatp_blastp_payload_helper_returns_collinear_rows(
+    tmp_path: Path,
+    stage_web_losatp_transport,
+) -> None:
     class JsNull:
         def __str__(self) -> str:
             return "null"
@@ -2248,10 +2251,10 @@ def test_web_losatp_blastp_payload_helper_returns_collinear_rows(tmp_path: Path)
         ],
     }
 
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(payload), encoding="utf-8")
+    pairs_path, raw_tsv_path = stage_web_losatp_transport(tmp_path, payload)
     raw_result = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "collinear",
         5,
         50,
@@ -2302,6 +2305,7 @@ def test_web_losatp_blastp_payload_helper_returns_collinear_rows(tmp_path: Path)
 @pytest.mark.linear
 def test_web_losatp_blastp_payload_helper_uses_rbh_collinear_anchor_mode(
     tmp_path: Path,
+    stage_web_losatp_transport,
 ) -> None:
     class JsNull:
         def __str__(self) -> str:
@@ -2375,10 +2379,10 @@ def test_web_losatp_blastp_payload_helper_uses_rbh_collinear_anchor_mode(
         ],
     }
 
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(payload), encoding="utf-8")
+    pairs_path, raw_tsv_path = stage_web_losatp_transport(tmp_path, payload)
     raw_result = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "collinear",
         5,
         50,
@@ -2406,6 +2410,7 @@ def test_web_losatp_blastp_payload_helper_uses_rbh_collinear_anchor_mode(
 
     raw_min_two = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "collinear",
         5,
         50,
@@ -2430,6 +2435,7 @@ def test_web_losatp_blastp_payload_helper_uses_rbh_collinear_anchor_mode(
 @pytest.mark.linear
 def test_web_losatp_blastp_payload_helper_applies_collinear_search_scope(
     tmp_path: Path,
+    stage_web_losatp_transport,
 ) -> None:
     helpers_js = Path("gbdraw/web/js/app/python-helpers.js").read_text(encoding="utf-8")
     helper_source = helpers_js.split("`", 1)[1].rsplit("`", 1)[0]
@@ -2523,12 +2529,16 @@ def test_web_losatp_blastp_payload_helper_applies_collinear_search_scope(
         ],
     }
 
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(payload), encoding="utf-8")
+    pairs_path, raw_tsv_path = stage_web_losatp_transport(tmp_path, payload)
 
-    def convert(scope: str, input_payload: Path = pairs_path) -> dict[str, object]:
+    def convert(
+        scope: str,
+        input_payload: Path = pairs_path,
+        input_raw_tsv: Path = raw_tsv_path,
+    ) -> dict[str, object]:
         raw_result = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
             str(input_payload),
+            str(input_raw_tsv),
             "collinear",
             5,
             50,
@@ -2550,18 +2560,38 @@ def test_web_losatp_blastp_payload_helper_applies_collinear_search_scope(
 
     adjacent = convert("adjacent")
     all_records = convert("all")
+    invalid_scope = convert("global")
+    invalid_mode = json.loads(
+        str(
+            namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
+                str(pairs_path),
+                str(raw_tsv_path),
+                "similarity",
+            )
+        )
+    )
     multi_row_payload = json.loads(json.dumps(payload))
     for pair in multi_row_payload["pairs"]:
         pair["displayPair"] = (
             pair["queryIndex"] == 0 and pair["subjectIndex"] == 2
         )
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(multi_row_payload), encoding="utf-8")
-    multi_row_adjacent = convert("adjacent", pairs_path)
+    multi_row_pairs_path, multi_row_raw_tsv_path = stage_web_losatp_transport(
+        tmp_path,
+        multi_row_payload,
+        "losatp-multi-row-pairs",
+    )
+    multi_row_adjacent = convert(
+        "adjacent",
+        multi_row_pairs_path,
+        multi_row_raw_tsv_path,
+    )
 
     assert "error" not in adjacent
     assert "error" not in all_records
     assert "error" not in multi_row_adjacent
+    assert "Unsupported Collinear search scope" in invalid_scope["error"]
+    assert "Unsupported LOSATP blastp mode" in invalid_mode["error"]
+
     def member_sets(result: dict[str, object]) -> list[set[str]]:
         groups = result["collinearityResult"]["value"]["fields"][
             "orthogroups"

--- a/tests/test_protein_colinearity.py
+++ b/tests/test_protein_colinearity.py
@@ -545,6 +545,36 @@ def test_identical_record_instances_share_content_but_not_runtime_bindings() -> 
 
 
 @pytest.mark.linear
+def test_protein_raw_identity_tracks_candidate_limit_args_exactly() -> None:
+    extraction = extract_protein_identity_manifest(
+        [
+            _record("query", features=[_cds(0, 9)]),
+            _record("subject", features=[_cds(3, 12)]),
+        ],
+        record_instance_keys=("query-row", "subject-row"),
+    )
+    identity = build_protein_losat_pair_identity(
+        extraction.identity_manifest,
+        query_record_instance_key="query-row",
+        subject_record_instance_key="subject-row",
+    )
+
+    omitted = build_protein_losat_cache_key(identity, args=[])
+    explicit_none = build_protein_losat_cache_key(identity, args=[])
+    finite = build_protein_losat_cache_key(
+        identity,
+        args=["--max-target-seqs", "7"],
+    )
+
+    assert explicit_none == omitted
+    assert finite != omitted
+    assert finite == build_protein_losat_cache_key(
+        identity,
+        args=["--max-target-seqs", "7"],
+    )
+
+
+@pytest.mark.linear
 def test_legacy_protein_artifact_references_resolve_to_runtime_handles() -> None:
     extraction = extract_protein_identity_manifest(
         [
@@ -3079,7 +3109,10 @@ def test_web_extract_cds_protein_fasta_uses_coordinate_stable_ids(tmp_path: Path
 
 
 @pytest.mark.linear
-def test_web_losatp_pairwise_payload_uses_display_view_transform(tmp_path: Path) -> None:
+def test_web_losatp_pairwise_payload_uses_display_view_transform(
+    tmp_path: Path,
+    stage_web_losatp_transport,
+) -> None:
     namespace = _load_web_helper_namespace()
     hits = pd.DataFrame.from_records(
         [_hit_row("qa", "sb")],
@@ -3131,10 +3164,10 @@ def test_web_losatp_pairwise_payload_uses_display_view_transform(tmp_path: Path)
         ],
     }
 
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(payload), encoding="utf-8")
+    pairs_path, raw_tsv_path = stage_web_losatp_transport(tmp_path, payload)
     raw_result = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "pairwise",
         1,
         50,
@@ -3156,6 +3189,7 @@ def test_web_losatp_pairwise_payload_uses_display_view_transform(tmp_path: Path)
 @pytest.mark.linear
 def test_web_losatp_blastp_payload_helper_uses_rbh_edges_for_orthogroups(
     tmp_path: Path,
+    stage_web_losatp_transport,
 ) -> None:
     helpers_js = Path("gbdraw/web/js/app/python-helpers.js").read_text(encoding="utf-8")
     helper_source = helpers_js.split("`", 1)[1].rsplit("`", 1)[0]
@@ -3245,10 +3279,10 @@ def test_web_losatp_blastp_payload_helper_uses_rbh_edges_for_orthogroups(
         ],
     }
 
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(payload), encoding="utf-8")
+    pairs_path, raw_tsv_path = stage_web_losatp_transport(tmp_path, payload)
     raw_result = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "orthogroup",
         2,
         50,
@@ -3308,9 +3342,14 @@ def test_web_losatp_blastp_payload_helper_uses_rbh_edges_for_orthogroups(
     assert len(rows) == 2
     assert result["cache"]["convertedPayloadHit"] is False
     assert result["cache"]["filteredHitCacheMisses"] == 2
+    assert result["cache"]["rawTsvEntryCount"] == 2
+    assert result["cache"]["rawTsvBytes"] == raw_tsv_path.stat().st_size
+    assert 0 < result["cache"]["rawTsvLargestEntryBytes"] <= raw_tsv_path.stat().st_size
+    assert result["cache"]["simultaneousParsedTables"] == 2
 
     repeated_result = json.loads(str(namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "orthogroup",
         2,
         50,
@@ -3320,10 +3359,12 @@ def test_web_losatp_blastp_payload_helper_uses_rbh_edges_for_orthogroups(
         orthogroup_membership_mode="rbh",
     )))
     assert repeated_result["cache"]["convertedPayloadHit"] is True
+    assert repeated_result["cache"]["simultaneousParsedTables"] == 0
     assert repeated_result["pairs"] == result["pairs"]
 
     filter_cached_result = json.loads(str(namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "orthogroup",
         3,
         50,
@@ -3346,9 +3387,12 @@ def test_web_losatp_blastp_payload_helper_rejects_legacy_list_payload(
     exec(helper_source, namespace)
 
     pairs_path = tmp_path / "losatp-pairs.json"
+    raw_tsv_path = tmp_path / "losatp-pairs.tsv"
     pairs_path.write_text(json.dumps([]), encoding="utf-8")
+    raw_tsv_path.write_bytes(b"")
     raw_result = namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
         str(pairs_path),
+        str(raw_tsv_path),
         "pairwise",
         2,
         50,

--- a/tests/test_reverse_complement_feature_identity.py
+++ b/tests/test_reverse_complement_feature_identity.py
@@ -151,6 +151,7 @@ def test_reverse_complement_protein_extraction_uses_biological_hash_parts() -> N
 
 def test_web_losatp_typed_result_separates_stable_view_and_dom_ids(
     tmp_path: Path,
+    stage_web_losatp_transport,
 ) -> None:
     helpers_js = (
         Path(__file__).parents[1] / "gbdraw" / "web" / "js" / "app" / "python-helpers.js"
@@ -241,12 +242,12 @@ def test_web_losatp_typed_result_separates_stable_view_and_dom_ids(
             },
         ],
     }
-    pairs_path = tmp_path / "losatp-pairs.json"
-    pairs_path.write_text(json.dumps(payload), encoding="utf-8")
+    pairs_path, raw_tsv_path = stage_web_losatp_transport(tmp_path, payload)
     result = json.loads(
         str(
             namespace["convert_losatp_blastp_pairs_to_genomic_payload"](
                 str(pairs_path),
+                str(raw_tsv_path),
                 "orthogroup",
                 5,
                 50,

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -127,6 +127,7 @@ const recordPlacementSummary = (page) => page.evaluate(() => {
 const installCanonicalRequestCapture = (page) => page.evaluate(() => {
   const previousPostMessage = Worker.prototype.postMessage;
   window.__GBDRAW_VIBRIO_CANONICAL_REQUESTS__ = [];
+  window.__GBDRAW_VIBRIO_RAW_HELPER_TRANSPORTS__ = [];
   Worker.prototype.postMessage = function captureCanonicalRequest(message, transfer) {
     if (message?.type === 'run' && message.payload?.request) {
       window.__GBDRAW_VIBRIO_CANONICAL_REQUESTS__.push(
@@ -135,6 +136,23 @@ const installCanonicalRequestCapture = (page) => page.evaluate(() => {
           resourceManifest: structuredClone(message.payload.resourceManifest || [])
         }
       );
+    }
+    if (
+      message?.type === 'helper'
+      && message.operation === 'convertLosatpPairsToGenomicPayload'
+    ) {
+      const files = Array.isArray(message.payload?.files) ? message.payload.files : [];
+      const pairs = files.find(({ role }) => role === 'pairs');
+      const rawTsv = files.find(({ role }) => role === 'rawTsv');
+      const manifestText = pairs?.bytes instanceof ArrayBuffer
+        ? new TextDecoder().decode(pairs.bytes)
+        : '';
+      window.__GBDRAW_VIBRIO_RAW_HELPER_TRANSPORTS__.push({
+        roles: files.map(({ role }) => String(role || '')),
+        metadataBytes: Number(pairs?.bytes?.byteLength || 0),
+        rawTsvBytes: Number(rawTsv?.bytes?.byteLength || 0),
+        manifestContainsBlastText: manifestText.includes('"blastText"')
+      });
     }
     if (transfer === undefined) return previousPostMessage.call(this, message);
     return previousPostMessage.call(this, message, transfer);
@@ -175,6 +193,15 @@ const canonicalRequestEvidence = async (page) => {
           : [],
         recordRows: Array.isArray(request.records)
           ? request.records.map(({ presentation }) => Number(presentation?.gridRow || 0))
+          : [],
+        proteinSearchSettings: Array.isArray(request.comparisons)
+          ? request.comparisons
+            .filter(({ kind }) => kind === 'generatedProteinComparison')
+            .map(({ mode, settings }) => ({
+              mode: String(mode || ''),
+              candidateLimit: settings?.proteinBlastpCandidateLimit ?? null,
+              searchScope: String(settings?.collinearitySearchScope || '')
+            }))
           : [],
         layout: request.layout || null,
         colors: request.diagramOptions?.colors || null,
@@ -265,6 +292,11 @@ const activeIntentSummary = (page) => page.evaluate(async () => {
       }))
     },
     linearComparisonPlan: plain(state.linearComparisonPlan),
+    proteinSearch: {
+      mode: state.losat.blastp.mode,
+      candidateLimit: state.losat.blastp.candidateLimit,
+      searchScope: state.losat.blastp.collinearSearchScope
+    },
     linearRecordLayout: {
       enabled: state.linearRecordLayoutEnabled.value,
       recordGap: state.linearRecordGap.value,
@@ -677,7 +709,12 @@ const invokeGeneration = async (page, terminal, runnerEvidence, terminalSignal) 
           historyStructural: Object.fromEntries(diagnosticFields.map((name) => [
             name,
             Number(historyAfter[name] || 0) - Number(historyBefore[name] || 0)
-          ]))
+          ])),
+          rawSearchTelemetry: JSON.parse(JSON.stringify(
+            app.lastRunInfo?.losatTelemetry
+              || window.__GBDRAW_LAST_LOSAT_TELEMETRY__
+              || null
+          ))
         };
       } catch (error) {
         return {
@@ -844,6 +881,11 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     defaultSource: 'losat',
     edges: []
   });
+  expect(preFirstGenerateActiveIntent.proteinSearch).toEqual({
+    mode: 'collinear',
+    candidateLimit: 5,
+    searchScope: 'adjacent'
+  });
   expect(preFirstGenerateActiveIntent.linearRecordLayout).toMatchObject({
     enabled: true,
     recordGap: 48
@@ -889,6 +931,9 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
   const secondRecordPlacements = await recordPlacementSummary(page);
   const postSecondGenerateActiveIntent = await activeIntentSummary(page);
   const canonicalRequestCapture = await canonicalRequestEvidence(page);
+  const rawHelperTransports = await page.evaluate(() => (
+    structuredClone(window.__GBDRAW_VIBRIO_RAW_HELPER_TRANSPORTS__ || [])
+  ));
   const capturedCanonicalRequests = canonicalRequestCapture.requests;
   expect(capturedCanonicalRequests).toHaveLength(2);
   expect(capturedCanonicalRequests[0]).toMatchObject({
@@ -901,11 +946,55 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     recordRows: [1, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5],
     layout: {
       recordGapPx: 48
-    }
+    },
+    proteinSearchSettings: [{
+      mode: 'none',
+      candidateLimit: 5,
+      searchScope: 'adjacent'
+    }]
   });
   expect(capturedCanonicalRequests[0].layout).not.toHaveProperty('multiRecordPositions');
   expect(canonicalRequestCapture.repeatComparison).toMatchObject({ equivalent: true });
   expect(postSecondGenerateActiveIntent.sha256).toBe(preFirstGenerateActiveIntent.sha256);
+  expect(first.outcome.rawSearchTelemetry).toMatchObject({
+    mode: 'collinear',
+    candidateLimitRequested: 5,
+    candidateLimitEffective: 5,
+    collinearSearchScope: 'adjacent',
+    program: 'blastp',
+    outfmt: '6',
+    cacheMisses: 0,
+    helperRequestFileCount: 2
+  });
+  expect(first.outcome.rawSearchTelemetry.totalPairs).toBeGreaterThan(0);
+  expect(first.outcome.rawSearchTelemetry.cacheHits).toBe(
+    first.outcome.rawSearchTelemetry.totalPairs
+  );
+  expect(first.outcome.rawSearchTelemetry.rawTsvEntryCount).toBe(
+    first.outcome.rawSearchTelemetry.totalPairs
+  );
+  expect(first.outcome.rawSearchTelemetry.rawJobs).toHaveLength(
+    first.outcome.rawSearchTelemetry.totalPairs
+  );
+  expect(first.outcome.rawSearchTelemetry.rawJobs.every(({ cacheKey, args }) => (
+    /^[0-9a-f]{64}$/.test(cacheKey)
+      && args.includes('--max-target-seqs')
+      && args[args.indexOf('--max-target-seqs') + 1] === '5'
+  ))).toBe(true);
+  expect(first.outcome.rawSearchTelemetry.rawTsvBytes).toBeGreaterThan(0);
+  expect(first.outcome.rawSearchTelemetry.rawTsvLargestEntryBytes).toBeGreaterThan(0);
+  expect(first.outcome.rawSearchTelemetry.helperRequestMetadataBytes).toBeGreaterThan(0);
+  expect(first.outcome.rawSearchTelemetry.helperRequestRawTransferBytes).toBe(
+    first.outcome.rawSearchTelemetry.rawTsvBytes
+  );
+  expect(first.outcome.rawSearchTelemetry.simultaneousParsedTables).toBeGreaterThan(0);
+  expect(second.outcome.rawSearchTelemetry).toBeNull();
+  expect(rawHelperTransports).toEqual([{
+    roles: ['pairs', 'rawTsv'],
+    metadataBytes: first.outcome.rawSearchTelemetry.helperRequestMetadataBytes,
+    rawTsvBytes: first.outcome.rawSearchTelemetry.helperRequestRawTransferBytes,
+    manifestContainsBlastText: false
+  }]);
   const expectedRecordPlacements = [
     [0, 0], [0, 1], [0, 2],
     [1, 0], [1, 1],
@@ -1326,6 +1415,7 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
       generatedSvgCharacters: resultSvgCharacters,
       firstElapsedMs: first.outcome.elapsedMs,
       secondElapsedMs: second.outcome.elapsedMs,
+      rawHelperTransports,
       firstPhaseAttribution,
       secondPhaseAttribution
     },
@@ -1367,6 +1457,8 @@ test('real Vibrio preview regenerates twice through staged binary resources', as
     preFirstGenerateActiveIntent: report.load.preFirstGenerateActiveIntent,
     firstGenerateMs: report.generations.firstElapsedMs,
     secondGenerateMs: report.generations.secondElapsedMs,
+    firstRawSearchTelemetry: report.generations.first.outcome.rawSearchTelemetry,
+    secondRawSearchTelemetry: report.generations.second.outcome.rawSearchTelemetry,
     referencedResourceCount: report.generations.referencedResourceCount,
     referencedDeclaredBytes: report.generations.referencedDeclaredBytes,
     firstTransferredBytes: report.generations.firstTransferredBytes,

--- a/tests/web/current-option-values.test.mjs
+++ b/tests/web/current-option-values.test.mjs
@@ -6,8 +6,11 @@ import {
   migratePersistedLinearTrackLayout,
   migratePersistedWebStateFieldNames,
   requireCurrentCircularMultiRecordSizeMode,
+  requireCurrentCollinearSearchScope,
   requireCurrentLinearLabelPlacement,
   requireCurrentLinearTrackLayout,
+  requireCurrentProteinBlastpCandidateLimit,
+  requireCurrentProteinBlastpMode,
   requireCurrentWebStateFieldNames
 } from '../../gbdraw/web/js/app/current-option-values.js';
 
@@ -35,6 +38,29 @@ assert.throws(
   () => requireCurrentLinearLabelPlacement('on_feature'),
   /Linear label placement/
 );
+
+assert.equal(requireCurrentProteinBlastpMode(), 'orthogroup');
+for (const mode of ['pairwise', 'orthogroup', 'collinear']) {
+  assert.equal(requireCurrentProteinBlastpMode(mode), mode);
+}
+assert.throws(() => requireCurrentProteinBlastpMode('similarity'), /Protein BLASTP mode/);
+
+assert.equal(requireCurrentCollinearSearchScope(), 'adjacent');
+assert.equal(requireCurrentCollinearSearchScope('adjacent'), 'adjacent');
+assert.equal(requireCurrentCollinearSearchScope('all'), 'all');
+assert.throws(() => requireCurrentCollinearSearchScope('all-records'), /search scope/i);
+
+for (const omitted of [undefined, null, '']) {
+  assert.equal(requireCurrentProteinBlastpCandidateLimit(omitted), null);
+}
+assert.equal(requireCurrentProteinBlastpCandidateLimit(7), 7);
+assert.equal(requireCurrentProteinBlastpCandidateLimit('7'), 7);
+for (const invalid of [0, -1, 1.5, 'unbounded']) {
+  assert.throws(
+    () => requireCurrentProteinBlastpCandidateLimit(invalid),
+    /Candidate limit/
+  );
+}
 
 assert.equal(migratePersistedCircularMultiRecordSizeMode('sqrt'), 'auto');
 assert.equal(migratePersistedLinearTrackLayout('spreadout'), 'above');

--- a/tests/web/mode-profiles.test.mjs
+++ b/tests/web/mode-profiles.test.mjs
@@ -257,8 +257,8 @@ const { createDefaultAdv, createDefaultForm, createDefaultLosat, state } = await
 );
 assert.equal(
   createDefaultLosat().blastp.collinearSearchScope,
-  'all',
-  'fresh Collinear LOSATP must search all record pairs by default'
+  'adjacent',
+  'fresh Collinear LOSATP must search adjacent record pairs by default'
 );
 assert.equal(Object.keys(state.form).includes('legend'), false);
 assert.equal(Object.keys(state.adv).includes('plot_title_position'), false);
@@ -429,8 +429,8 @@ assert.deepEqual(
   assert.equal(state.form.show_scale, true);
   assert.equal(
     state.losat.blastp.collinearSearchScope,
-    'all',
-    'Reset must restore the fresh all-vs-all Collinear default'
+    'adjacent',
+    'Reset must restore the fresh adjacent Collinear default'
   );
   assert.deepEqual(
     state.adv.circular_track_slots,
@@ -670,6 +670,6 @@ const defaultCollinearComparison = defaultCollinearRequest.comparisons.find(
 assert.equal(defaultCollinearComparison.mode, 'collinear');
 assert.equal(
   defaultCollinearComparison.settings.collinearitySearchScope,
-  'all',
-  'the fresh all-vs-all scope must reach the canonical Collinear request'
+  'adjacent',
+  'the fresh adjacent scope must reach the canonical Collinear request'
 );

--- a/tests/web/run-analysis-derived-cache.test.mjs
+++ b/tests/web/run-analysis-derived-cache.test.mjs
@@ -7,10 +7,12 @@ import {
   resolveProteinBlastpCandidateLimit
 } from '../../gbdraw/web/js/app/run-analysis.js';
 
-assert.equal(resolveProteinBlastpCandidateLimit('collinear', 5), 5);
-assert.equal(resolveProteinBlastpCandidateLimit('orthogroup', '7'), 7);
-assert.equal(resolveProteinBlastpCandidateLimit('pairwise', null, 3), 3);
-assert.equal(resolveProteinBlastpCandidateLimit('collinear', null), null);
+assert.equal(resolveProteinBlastpCandidateLimit(5), 5);
+assert.equal(resolveProteinBlastpCandidateLimit('7'), 7);
+assert.equal(resolveProteinBlastpCandidateLimit(null), null);
+assert.equal(resolveProteinBlastpCandidateLimit(undefined), null);
+assert.throws(() => resolveProteinBlastpCandidateLimit(0), /Candidate limit/);
+assert.throws(() => resolveProteinBlastpCandidateLimit('invalid'), /Candidate limit/);
 
 const baselineInput = {
   mode: 'collinear',

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -822,12 +822,17 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
   state.losatCache.value = new Map(cacheEntries);
   state.losatDerivedCache.value = new Map();
 
+  let failLateArtifactAdoption = false;
   const runner = wireGeneratedArtifactRuntimeOwner(createRunAnalysis({
     ...generatedArtifactHandleOptions,
     state,
     serializeCanonicalFiles: () => serializeActiveRenderFiles(state.mode.value, state),
     canonicalSessionVersion: SESSION_VERSION,
-    adoptCanonicalRenderArtifacts: () => {},
+    adoptCanonicalRenderArtifacts: () => {
+      if (failLateArtifactAdoption) {
+        throw new Error('injected LOSAT late artifact adoption failure');
+      }
+    },
     prepareLinearRecordCatalog: async () => ({
       catalog: { mode: 'linear', status: 'ready', records: [] },
       error: ''
@@ -1029,6 +1034,46 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
       'the explicit staged text fast path must not materialize file text again'
     );
 
+    const committedLosatCache = state.losatCache.value;
+    const committedLosatCacheEntries = Array.from(committedLosatCache.entries());
+    const committedLosatCacheInfo = structuredClone(state.losatCacheInfo.value);
+    const committedLosatTelemetry = structuredClone(
+      globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__
+    );
+    state.losat.blastn.task = 'blastn';
+    failLateArtifactAdoption = true;
+    workerHelperResponses.push({
+      ok: true,
+      result: {
+        tsv: 'SECOND\tTHIRD\t100\t4\t0\t0\t1\t4\t1\t4\t1e-10\t20\n'
+      }
+    });
+    const failedLinearResult = result('lazy-linear-failed.svg', 'lazy-linear-failed');
+    workerResponses.push(response(
+      failedLinearResult,
+      validCatalog(failedLinearResult.name)
+    ));
+    assert.deepEqual(await runner.runAnalysis(comparisonPlanSnapshot), { status: 'error' });
+    failLateArtifactAdoption = false;
+    state.losat.blastn.task = 'megablast';
+    assert.match(
+      state.errorLog.value?.summary || '',
+      /injected LOSAT late artifact adoption failure/
+    );
+    assert.notEqual(state.losatCache.value, committedLosatCache);
+    assert.deepEqual(
+      Array.from(state.losatCache.value.entries()),
+      committedLosatCacheEntries,
+      'artifact rollback may restore a snapshot map but must not publish candidate entries'
+    );
+    assert.deepEqual(state.losatCacheInfo.value, committedLosatCacheInfo);
+    assert.deepEqual(
+      globalThis.__GBDRAW_LAST_LOSAT_TELEMETRY__,
+      committedLosatTelemetry,
+      'failed candidate provenance must roll back with the committed artifact'
+    );
+    assert.equal(losatCalls, 2, 'the failed candidate must execute without becoming committed evidence');
+
     const warmCacheInfo = [{
       key: 'warm-cache', edgeKey: 'multi->third', queryUid: 'multi', subjectUid: 'third',
       queryIndex: 0, subjectIndex: 1, ordinal: 0, display: true
@@ -1053,7 +1098,7 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
       { status: 'ok' },
       JSON.stringify(state.errorLog.value)
     );
-    assert.equal(losatCalls, 1, 'resolved protein artifacts must bypass LOSAT execution');
+    assert.equal(losatCalls, 2, 'resolved protein artifacts must bypass further LOSAT execution');
     assert.deepEqual(state.losatCacheInfo.value, warmCacheInfo);
   } finally {
     if (previousTestHooks === undefined) {

--- a/tests/web/session-active-config-contract.test.mjs
+++ b/tests/web/session-active-config-contract.test.mjs
@@ -8,6 +8,7 @@ const {
   CURRENT_WRITER_FORM_FIELDS,
   createDefaultAdv,
   createDefaultForm,
+  createDefaultLosat,
   validateCurrentWriterActiveConfig
 } = await import('../../gbdraw/web/js/services/session-active-config-contract.js');
 
@@ -29,6 +30,39 @@ assert.deepEqual(CURRENT_WRITER_ADV_FIELDS, [
   'plot_title_position',
   'losatProgram'
 ]);
+assert.equal(createDefaultLosat().blastp.candidateLimit, null);
+assert.equal(createDefaultLosat().blastp.collinearSearchScope, 'adjacent');
+
+for (const [candidateLimit, collinearSearchScope] of [[null, 'adjacent'], [9, 'all']]) {
+  assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
+    mode: 'linear',
+    storedConfig: {
+      ...storedConfig,
+      losat: {
+        ...createDefaultLosat(),
+        blastp: {
+          ...createDefaultLosat().blastp,
+          mode: 'collinear',
+          candidateLimit,
+          collinearSearchScope
+        }
+      }
+    }
+  }));
+}
+for (const blastp of [
+  { mode: 'unsupported' },
+  { candidateLimit: 0 },
+  { collinearSearchScope: 'global' }
+]) {
+  assert.throws(() => validateCurrentWriterActiveConfig({
+    mode: 'linear',
+    storedConfig: {
+      ...storedConfig,
+      losat: { blastp }
+    }
+  }));
+}
 
 const retiredTrackOrder = structuredClone(storedConfig);
 retiredTrackOrder.adv.cli_circular_track_order = ['features'];

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -3873,6 +3873,7 @@ const activeProteinFiles = {
 };
 const inactiveProteinDefaults = {
   proteinBlastpMaxHits: 5,
+  proteinBlastpCandidateLimit: null,
   orthogroupMembershipMode: 'anchor_core_v1',
   orthogroupMemberMaxHits: 5,
   collinearMinAnchors: 1,
@@ -3900,18 +3901,24 @@ const invalidDormantProteinSettings = {
 for (const { mode, activeSettings, expected } of [
   {
     mode: 'pairwise',
-    activeSettings: { maxHits: 13 },
-    expected: { ...inactiveProteinDefaults, proteinBlastpMaxHits: 13 }
+    activeSettings: { maxHits: 13, candidateLimit: 11 },
+    expected: {
+      ...inactiveProteinDefaults,
+      proteinBlastpMaxHits: 13,
+      proteinBlastpCandidateLimit: 11
+    }
   },
   {
     mode: 'orthogroup',
     activeSettings: {
       orthogroupMembershipMode: 'anchor_core_v1',
-      orthogroupMemberMaxHits: 9
+      orthogroupMemberMaxHits: 9,
+      candidateLimit: 11
     },
     expected: {
       ...inactiveProteinDefaults,
-      orthogroupMemberMaxHits: 9
+      orthogroupMemberMaxHits: 9,
+      proteinBlastpCandidateLimit: 11
     }
   },
   {
@@ -3924,7 +3931,8 @@ for (const { mode, activeSettings, expected } of [
       collinearUnitMode: 'locus',
       collinearAnchorMode: 'rbh',
       collinearSearchScope: 'all',
-      collinearColorMode: 'orientation_identity'
+      collinearColorMode: 'orientation_identity',
+      candidateLimit: 11
     },
     expected: {
       ...inactiveProteinDefaults,
@@ -3934,7 +3942,8 @@ for (const { mode, activeSettings, expected } of [
       collinearMaxConflicts: 0,
       collinearityUnitMode: 'locus',
       collinearitySearchScope: 'all',
-      collinearityColorMode: 'orientation_identity'
+      collinearityColorMode: 'orientation_identity',
+      proteinBlastpCandidateLimit: 11
     }
   }
 ]) {
@@ -3967,6 +3976,7 @@ for (const { mode, activeSettings, expected } of [
   assert.deepEqual(activeProteinState.losat, activeProteinStateBefore);
   assert.deepEqual({
     proteinBlastpMaxHits: generated.settings.proteinBlastpMaxHits,
+    proteinBlastpCandidateLimit: generated.settings.proteinBlastpCandidateLimit,
     orthogroupMembershipMode: generated.settings.orthogroupMembershipMode,
     orthogroupMemberMaxHits: generated.settings.orthogroupMemberMaxHits,
     collinearMinAnchors: generated.settings.collinearityParams.parameters.minAnchors,
@@ -3979,6 +3989,69 @@ for (const { mode, activeSettings, expected } of [
     collinearitySearchScope: generated.settings.collinearitySearchScope,
     collinearityColorMode: generated.settings.collinearityColorMode
   }, expected, `${mode} must canonicalize only the request copy of dormant settings`);
+}
+
+const canonicalCandidateLimit = (candidateLimit, { omitted = false } = {}) => {
+  const blastp = {
+    ...structuredClone(comparisonContractState.losat.blastp),
+    mode: 'pairwise',
+    candidateLimit
+  };
+  if (omitted) delete blastp.candidateLimit;
+  const candidateState = {
+    ...comparisonContractState,
+    losatProgram: ref('blastp'),
+    losat: {
+      ...structuredClone(comparisonContractState.losat),
+      blastp
+    },
+    linearComparisonPlan: structuredClone(activeProteinPlan)
+  };
+  const request = buildCanonicalRenderRequestRaw({
+    state: candidateState,
+    filesData: activeProteinFiles,
+    comparisonPlanSnapshot: resolveLinearComparisonPlan({
+      plan: activeProteinPlan,
+      sequences: comparisonContractSequences,
+      losatProgram: 'blastp',
+      blastpMode: 'pairwise'
+    })
+  });
+  return request.renderRequest.comparisons.find(
+    (comparison) => comparison.kind === 'generatedProteinComparison'
+  ).settings.proteinBlastpCandidateLimit;
+};
+assert.equal(canonicalCandidateLimit(undefined, { omitted: true }), null);
+assert.equal(canonicalCandidateLimit(null), null);
+assert.equal(canonicalCandidateLimit(17), 17);
+
+for (const blastpOverride of [
+  { mode: 'pairwise', candidateLimit: 0 },
+  { mode: 'unsupported', candidateLimit: null },
+  { mode: 'collinear', candidateLimit: null, collinearSearchScope: 'global' }
+]) {
+  const invalidProteinState = {
+    ...comparisonContractState,
+    losatProgram: ref('blastp'),
+    losat: {
+      ...structuredClone(comparisonContractState.losat),
+      blastp: {
+        ...structuredClone(comparisonContractState.losat.blastp),
+        ...blastpOverride
+      }
+    },
+    linearComparisonPlan: structuredClone(activeProteinPlan)
+  };
+  assert.throws(() => buildCanonicalRenderRequestRaw({
+    state: invalidProteinState,
+    filesData: activeProteinFiles,
+    comparisonPlanSnapshot: resolveLinearComparisonPlan({
+      plan: activeProteinPlan,
+      sequences: comparisonContractSequences,
+      losatProgram: 'blastp',
+      blastpMode: blastpOverride.mode
+    })
+  }));
 }
 
 const emptySelectedSnapshot = resolveLinearComparisonPlan({


### PR DESCRIPTION
## Plain-language summary

This PR makes the Web protein-search candidate limit, mode, and Collinear search scope reach the LOSATP jobs they describe. A fresh or omitted candidate limit now stays unbounded (`None`), finite limits reach every raw `blastp` invocation exactly, and fresh Collinear search uses `adjacent` while explicit `all` remains supported. The same values now govern current Session writes, canonical requests, raw cache keys, and provenance; failed, canceled, or stale results cannot publish candidate raw state.

## Objective and Product Decisions

This implements existing authority without adding a Product choice. `PD-OI-001`, `PD-OI-002`, `PD-OI-005`, `PD-OI-006`, `PD-OI-014`, and `PD-OI-016` require one common Candidate setting, unbounded fresh and omitted Candidate semantics, consume-or-reject handling for current mode and scope values, fresh `adjacent` Collinear scope, preserved Similarity all-vs-all evidence, and transactional publication. The applicable conformance clauses are `OIPC-C01`, `OIPC-C02`, `OIPC-C03`, `OIPC-C04`, `OIPC-C07`, and `OIPC-C08`.

## Behavior and owners

Before this change, pairwise search replaced Candidate with a hidden finite value, the fresh Collinear scope was `all`, active fields could fall back after invalid values, and raw cache/telemetry state could publish before final result admission. The helper request also repeated every raw TSV string inside JSON.

After this change:

- `gbdraw/web/js/app/current-option-values.js` owns current-value validation for protein mode, Candidate, and Collinear scope. Invalid active values reject at the boundary.
- `gbdraw/web/js/services/session-active-config-contract.js` writes current validated fields and uses fresh `adjacent`; `gbdraw/web/js/services/session-request.js` carries omission, explicit `None`, and exact finite Candidate values into the canonical request.
- `gbdraw/web/js/app/run-analysis.js` uses the same Candidate value for pairwise, orthogroup, and collinear raw jobs; raw identity includes the exact invocation semantics; cache and telemetry publication waits for final result admission.
- `gbdraw/web/js/workers/diagram-generation-worker.js` and `gbdraw/web/js/app/python-helpers.js` stage pair metadata and one binary raw TSV file. The helper reads declared ranges, reports transport and parse counts, and keeps the existing worker phase.
- Focused coverage changed in `tests/conftest.py`, three Python test modules, and seven DOM-free Node or Playwright contract modules.

## Verification

Focused Python selections passed for typed defaults and validation, pair inventory, Candidate invocation with `None` and `7`, raw-key Candidate sensitivity, helper transport and telemetry, Python API forwarding, CLI forwarding, uploaded evidence, and reverse-complement identity. Focused DOM-free tests passed for current option validation, active Session writes, canonical requests, mode profiles, draft authority, cache validation, derived-cache reuse, and late result-admission failure without cache or telemetry publication.

Changed-file syntax/lint checks, `git diff --check`, and 133 Web architecture contract assertions passed. `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD` passes the gate. With the `architecture-change` profile, authority remains unchanged, the canonical request path and semantic owner remain conforming, and the 140-module/420-edge graph remains at zero cycles; maintainer review is required for the shared validator exports and Session contract change.

The official maximum lane `npx playwright test --config=playwright.vibrio.config.js` passed once on the final commit in 8.9 minutes. Both Generate operations completed with identical canonical requests and SVG output. The first run reported 47 raw jobs, 47 cache hits, no misses or worker calls, and `--max-target-seqs 5` on every job. The helper received two files, transferred 51,883,784 raw TSV bytes without embedding `blastText` in metadata, and reported 47 parsed tables; the second run transferred zero resource bytes and did not rerun raw search. The accepted 16 comparison groups, 579 pairwise matches, and two comparison legends were unchanged.

## Ratchet and compatibility

Production changes are six files with 192 additions and 48 deletions. No new phase, Worker, schema, global carrier, compatibility reader, or migration was added. Existing current Session fixtures all contain an explicit Collinear scope, and older raw caches safely miss when invocation arguments differ. Similarity all-vs-all evidence and uploaded BLAST TSV assignment remain supported. Derived Collinear controls remain outside this PR.

The protected required checks `Web base policy (trusted base)` and `PR / gate` must pass on the exact PR head before merge. Their final run identities will be recorded in an evidence comment without changing this body after CI starts.

## Residual risk

Leaving Candidate blank now permits an unbounded raw `blastp` result set, so datasets with many similar proteins may take more browser memory and time than the previous hidden finite behavior. This is the accepted `PD-OI-001` outcome; finite values remain available and exact. No other residual compatibility or scientific-output difference is known.
