### PR TITLE
Restore Linear comparison controls and appearance settings

### DIFF
--- a/docs/capture/flows/tutorials/gui_losatn.py
+++ b/docs/capture/flows/tutorials/gui_losatn.py
@@ -173,7 +173,7 @@ def capture_gui_losatn(
         task.select_option("megablast")
         expect(task).to_have_value("megablast")
         pairwise_match_height = settings.get_by_label(
-            "Pairwise Match Height", exact=True
+            "Comparison match height", exact=True
         )
         pairwise_match_height.fill("120")
         pairwise_match_height.press("Tab")

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1688,13 +1688,13 @@
                                     </div>
 
                                     <div v-if="linearComparisonUi.sectionKeys.settings.includes('blastp-max-hits')">
-                                        <label class="linear-primary-label mb-1">Max hits per protein <help-tip text="Maximum distinct subject proteins drawn for each query protein in Pairwise mode."></help-tip></label>
-                                        <input type="number" min="1" v-model.number="losat.blastp.maxHits" aria-label="LOSATP max hits per protein" class="form-input px-2 py-1.5 text-xs">
+                                        <label class="linear-primary-label mb-1">Pairwise display max hits <help-tip text="Maximum filtered matches displayed per query protein in Pairwise mode. This does not limit LOSATP candidates or Similarity/Collinear member evidence."></help-tip></label>
+                                        <input type="number" min="1" step="1" v-model.number="losat.blastp.maxHits" aria-label="Pairwise display max hits per protein" class="form-input px-2 py-1.5 text-xs">
                                     </div>
 
-                                    <div v-if="linearComparisonUi.sectionKeys.settings.includes('similarity-grouping')">
-                                        <label class="linear-primary-label mb-1">Member hits per protein <help-tip text="Maximum subject hits considered when assigning proteins to a similarity group."></help-tip></label>
-                                        <input type="number" min="1" step="1" v-model.number="losat.blastp.orthogroupMemberMaxHits" aria-label="Similarity group member hits per protein" class="form-input px-2 py-1.5 text-xs">
+                                    <div v-if="linearComparisonUi.sectionKeys.settings.includes('member-hits')">
+                                        <label class="linear-primary-label mb-1">Member hits per protein <help-tip text="Maximum directional subject hits used to construct Similarity groups and Collinear blocks. This does not limit raw LOSATP candidates or Pairwise display matches."></help-tip></label>
+                                        <input type="number" min="1" step="1" v-model.number="losat.blastp.orthogroupMemberMaxHits" aria-label="Member hits per protein" class="form-input px-2 py-1.5 text-xs">
                                     </div>
 
                                     <div v-if="linearComparisonUi.sectionKeys.settings.includes('collinear-primary')" class="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
@@ -1754,7 +1754,7 @@
                                         <div class="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
                                             <div>
                                                 <label class="linear-primary-label mb-1">Match style</label>
-                                                <select v-model="adv.pairwise_match_style" aria-label="Pairwise Match Style" class="form-input px-2 py-1.5 text-xs">
+                                                <select v-model="adv.pairwise_match_style" aria-label="Comparison match style" class="form-input px-2 py-1.5 text-xs">
                                                     <option value="ribbon">Ribbon</option>
                                                     <option value="curve">Curve</option>
                                                 </select>
@@ -1762,7 +1762,7 @@
                                             <div>
                                                 <label class="linear-primary-label mb-1">Match height</label>
                                                 <auto-value-field :visible="autoValueVisible(adv.comparison_height, 'pairwiseMatchHeight')" :text="autoValueText('pairwiseMatchHeight')">
-                                                    <input type="number" min="0.01" step="0.01" v-model.number="adv.comparison_height" aria-label="Pairwise Match Height" :aria-invalid="comparisonHeightValidationError ? 'true' : 'false'" :class="comparisonHeightValidationError ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : ''" class="form-input px-2 py-1.5 text-xs auto-value-input">
+                                                    <input type="number" min="0.01" step="0.01" v-model.number="adv.comparison_height" aria-label="Comparison match height" :aria-invalid="comparisonHeightValidationError ? 'true' : 'false'" :class="comparisonHeightValidationError ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : ''" class="form-input px-2 py-1.5 text-xs auto-value-input">
                                                 </auto-value-field>
                                                 <p v-if="comparisonHeightValidationError" class="mt-1 text-[10px] text-red-600">{{ comparisonHeightValidationError }}</p>
                                             </div>
@@ -1971,6 +1971,15 @@
                                 <div class="flex min-w-0 items-start gap-1 text-[10px] leading-snug text-slate-500"><i class="ph ph-cpu mt-0.5"></i><span>{{ losatThreadingPlanSummary }}</span></div>
                             </section>
 
+                            <section v-if="linearComparisonUi.sectionKeys.advanced.includes('losatp-candidate')" class="min-w-0 space-y-2 border-t border-slate-200 pt-3">
+                                <div class="linear-primary-label">LOSATP Advanced</div>
+                                <div>
+                                    <label class="linear-primary-label mb-1">Candidate limit <help-tip text="Maximum raw LOSATP candidate hits retained per query protein before Pairwise display or Similarity/Collinear construction. Leave blank for an unbounded search."></help-tip></label>
+                                    <input type="number" min="1" step="1" placeholder="Unbounded" v-model.number="losat.blastp.candidateLimit" aria-label="LOSATP Candidate limit" class="form-input px-2 py-1.5 text-xs">
+                                    <p class="mt-1 text-[10px] leading-snug text-slate-500">Shared by Pairwise, Similarity groups, and Collinear blocks. Blank keeps the candidate search unbounded.</p>
+                                </div>
+                            </section>
+
                             <section v-if="linearComparisonUi.sectionKeys.advanced.includes('losat-cache')" class="min-w-0 space-y-2 border-t border-slate-200 pt-3">
                                 <div class="linear-primary-label">LOSAT cache</div>
                                 <p class="text-[10px] leading-snug text-slate-500">{{ losatCacheInfo.length }} cached raw result{{ losatCacheInfo.length === 1 ? '' : 's' }}. Matching canonical inputs and settings reuse cached TSV data.</p>
@@ -2042,6 +2051,30 @@
                                 <div class="linear-primary-label">Advanced collinear search</div>
                                 <div class="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
                                     <div>
+                                        <label class="linear-primary-label mb-1">Unit mode <help-tip text="Auto resolves the current Collinear unit type; CDS and locus require that exact unit type."></help-tip></label>
+                                        <select v-model="losat.blastp.collinearUnitMode" aria-label="Collinear unit mode" class="form-input px-2 py-1.5 text-xs">
+                                            <option value="auto">Auto</option>
+                                            <option value="cds">CDS</option>
+                                            <option value="locus">Locus</option>
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="linear-primary-label mb-1">Anchor mode <help-tip text="Choose all directional hits, one-to-one hits, or reciprocal best hits as Collinear anchors."></help-tip></label>
+                                        <select v-model="losat.blastp.collinearAnchorMode" aria-label="Collinear anchor mode" class="form-input px-2 py-1.5 text-xs">
+                                            <option value="all">All hits</option>
+                                            <option value="one_to_one">One-to-one</option>
+                                            <option value="rbh">Reciprocal best hits</option>
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="linear-primary-label mb-1">Merge orientation <help-tip text="Require compatible strand, gene order, or either orientation when merging Collinear anchors."></help-tip></label>
+                                        <select v-model="losat.blastp.collinearMergeOrientation" aria-label="Collinear merge orientation" class="form-input px-2 py-1.5 text-xs">
+                                            <option value="strand">Strand</option>
+                                            <option value="order">Gene order</option>
+                                            <option value="either">Either</option>
+                                        </select>
+                                    </div>
+                                    <div>
                                         <label class="linear-primary-label mb-1">Diagonal drift</label>
                                         <input type="number" min="0" step="1" v-model.number="losat.blastp.collinearMaxDiagonalDrift" aria-label="Collinear diagonal drift" class="form-input px-2 py-1.5 text-xs">
                                     </div>
@@ -2049,7 +2082,7 @@
                                         <label class="linear-primary-label mb-1">Merge conflicts</label>
                                         <input type="number" min="0" step="1" v-model.number="losat.blastp.collinearMaxConflictsInMergeGap" aria-label="Collinear merge conflicts" class="form-input px-2 py-1.5 text-xs">
                                     </div>
-                                    <div class="sm:col-span-2">
+                                    <div>
                                         <label class="linear-primary-label mb-1">Paralog links per group</label>
                                         <input type="number" min="1" step="1" v-model.number="losat.blastp.collinearMaxParalogLinksPerOrthogroup" aria-label="Collinear paralog links per group" class="form-input px-2 py-1.5 text-xs">
                                     </div>

--- a/gbdraw/web/js/app/comparison-ui.js
+++ b/gbdraw/web/js/app/comparison-ui.js
@@ -36,7 +36,7 @@ const LINEAR_COMPARISON_SECTION_KEYS = Object.freeze({
     BLASTN_TASK: 'blastn-task',
     RECORD_GENETIC_CODES: 'record-genetic-codes',
     BLASTP_MAX_HITS: 'blastp-max-hits',
-    SIMILARITY_GROUPING: 'similarity-grouping',
+    MEMBER_HITS: 'member-hits',
     COLLINEAR_PRIMARY: 'collinear-primary',
     UPLOAD_READINESS: 'upload-readiness',
     RESULT_FILTERS: 'result-filters',
@@ -49,6 +49,7 @@ const LINEAR_COMPARISON_SECTION_KEYS = Object.freeze({
   ADVANCED: Object.freeze({
     RECORD_LAYOUT: 'record-layout',
     LOSAT_RUNTIME: 'losat-runtime',
+    LOSATP_CANDIDATE: 'losatp-candidate',
     LOSAT_CACHE: 'losat-cache',
     RAW_RESULTS: 'raw-results',
     COLLINEAR_DETAILS: 'collinear-details'
@@ -311,24 +312,23 @@ const projectSettingsSectionKeys = ({
       keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.RECORD_GENETIC_CODES);
     } else if (losatpModeKey === LINEAR_COMPARISON_LOSATP_MODE_KEYS.PAIRWISE) {
       keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.BLASTP_MAX_HITS);
-    } else if (!selectedTopology && losatpModeKey === LINEAR_COMPARISON_LOSATP_MODE_KEYS.SIMILARITY_GROUPS) {
-      keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.SIMILARITY_GROUPING);
+    } else if (
+      !selectedTopology &&
+      losatpModeKey === LINEAR_COMPARISON_LOSATP_MODE_KEYS.SIMILARITY_GROUPS
+    ) {
+      keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.MEMBER_HITS);
     } else if (!selectedTopology && losatpModeKey === LINEAR_COMPARISON_LOSATP_MODE_KEYS.COLLINEAR_BLOCKS) {
-      keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.COLLINEAR_PRIMARY);
+      keys.push(
+        LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.MEMBER_HITS,
+        LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.COLLINEAR_PRIMARY
+      );
     }
   }
   if (planned.hasUpload) {
     keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.UPLOAD_READINESS);
   }
   keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.RESULT_FILTERS);
-  if (
-    planned.hasUpload ||
-    losatModeKey === LINEAR_COMPARISON_LOSAT_MODE_KEYS.LOSATN ||
-    losatModeKey === LINEAR_COMPARISON_LOSAT_MODE_KEYS.TLOSATX ||
-    losatpModeKey === LINEAR_COMPARISON_LOSATP_MODE_KEYS.PAIRWISE
-  ) {
-    keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.COMPARISON_APPEARANCE);
-  }
+  keys.push(LINEAR_COMPARISON_SECTION_KEYS.SETTINGS.COMPARISON_APPEARANCE);
   return Object.freeze(keys);
 };
 
@@ -358,10 +358,11 @@ const projectSectionKeys = ({
 
   const advanced = [LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.RECORD_LAYOUT];
   if (planned.hasLosat) {
-    advanced.push(
-      LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.LOSAT_RUNTIME,
-      LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.LOSAT_CACHE
-    );
+    advanced.push(LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.LOSAT_RUNTIME);
+    if (losatModeKey === LINEAR_COMPARISON_LOSAT_MODE_KEYS.LOSATP) {
+      advanced.push(LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.LOSATP_CANDIDATE);
+    }
+    advanced.push(LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.LOSAT_CACHE);
   }
   if (planned.hasLosat || dormantRawResultDraftCount > 0) {
     advanced.push(LINEAR_COMPARISON_SECTION_KEYS.ADVANCED.RAW_RESULTS);

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -812,14 +812,6 @@ const cloneCanonicalSession = (canonical) => {
   };
 };
 
-const cloneLosatForConfig = () => {
-  const cloned = cloneJsonData(state.losat || {});
-  if (cloned.blastp && typeof cloned.blastp === 'object' && !Array.isArray(cloned.blastp)) {
-    delete cloned.blastp.collinearAnchorMode;
-  }
-  return cloned;
-};
-
 const normalizedArrowGeometryState = (adv = {}) => ({
   arrow_head_length_ratio: arrowHeadLengthRatioForState(
     adv?.arrow_head_length_ratio
@@ -880,7 +872,7 @@ export const buildConfigData = () => ({
       ...normalizeFeatureRenderingMap(state.adv.feature_shapes || {})
     }
   },
-  losat: cloneLosatForConfig(),
+  losat: cloneJsonData(state.losat || {}),
   cliOptions: preservedCliOptions ? cloneJsonData(preservedCliOptions) : undefined,
   colors: state.currentColors.value,
   palette: state.selectedPalette.value,
@@ -1359,9 +1351,9 @@ export const restoreCurrentWriterActiveConfig = ({
   }
   if (isPlainObject(restored.adv)) delete restored.adv.losatProgram;
 
-  // The current writer deliberately omits this generated-pipeline authority
-  // from config.losat. Preserve the committed projection only when the active
-  // config has no value of its own.
+  // Current sessions written before the anchor control became editable omitted
+  // this value. Preserve their committed projection only when active config has
+  // no value of its own; new sessions store the explicit editor value above.
   const projectedAnchorMode = projectedConfig?.losat?.blastp?.collinearAnchorMode;
   if (
     projectedAnchorMode !== undefined &&

--- a/tests/test_documentation_capture_contracts.py
+++ b/tests/test_documentation_capture_contracts.py
@@ -605,7 +605,7 @@ def test_gui_losatn_flow_runs_the_real_serial_one_thread_journey() -> None:
     shared_source = WEB_CAPTURE_PATH.read_text(encoding="utf-8")
     index_source = WEB_INDEX_PATH.read_text(encoding="utf-8")
 
-    assert 'aria-label="Pairwise Match Height"' in index_source
+    assert 'aria-label="Comparison match height"' in index_source
 
     for required in (
         'get_by_role("button", name="Linear", exact=True)',
@@ -629,7 +629,7 @@ def test_gui_losatn_flow_runs_the_real_serial_one_thread_journey() -> None:
         'name="LOSAT threads per run", exact=True',
         'name="LOSATN task", exact=True',
         'name="Raw LOSAT filename for #1 to #2", exact=True',
-        '"Pairwise Match Height", exact=True',
+        '"Comparison match height", exact=True',
         'pairwise_match_height.fill("120")',
         'select_option("serial")',
         'select_option("1")',

--- a/tests/web/comparison-ui.playwright.spec.js
+++ b/tests/web/comparison-ui.playwright.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { gunzipSync } = require('node:zlib');
 
 const makeGenbank = (recordId, base = 'atg') => {
   const sequence = base.repeat(100);
@@ -348,19 +350,26 @@ test('LOSAT and LOSATP modes own their controls and mixed plans require explicit
       'input[aria-label^="TLOSATX gencode for sequence"]'
     ).count(),
     pairwiseHits: await page.getByRole('spinbutton', {
-      name: 'LOSATP max hits per protein'
+      name: 'Pairwise display max hits per protein'
     }).count(),
     groupHits: await page.getByRole('spinbutton', {
-      name: 'Similarity group member hits per protein'
+      name: 'Member hits per protein'
     }).count(),
     collinearGap: await page.getByRole('spinbutton', {
       name: 'Collinear max unit gap'
+    }).count(),
+    matchStyle: await page.getByRole('combobox', {
+      name: 'Comparison match style'
+    }).count(),
+    matchHeight: await page.getByRole('spinbutton', {
+      name: 'Comparison match height'
     }).count()
   });
   await chooseLosatMode('LOSATN');
   await expect(losatpMode).toHaveCount(0);
   expect(await controlCounts()).toEqual({
-    blastnTask: 1, gencode: 0, pairwiseHits: 0, groupHits: 0, collinearGap: 0
+    blastnTask: 1, gencode: 0, pairwiseHits: 0, groupHits: 0, collinearGap: 0,
+    matchStyle: 1, matchHeight: 1
   });
   await expect(page.getByRole('combobox', {
     name: 'LOSATN task'
@@ -369,7 +378,8 @@ test('LOSAT and LOSATP modes own their controls and mixed plans require explicit
   await chooseLosatMode('TLOSATX');
   await expect(losatpMode).toHaveCount(0);
   expect(await controlCounts()).toEqual({
-    blastnTask: 0, gencode: 3, pairwiseHits: 0, groupHits: 0, collinearGap: 0
+    blastnTask: 0, gencode: 3, pairwiseHits: 0, groupHits: 0, collinearGap: 0,
+    matchStyle: 1, matchHeight: 1
   });
   const recordOptions = page.locator('details[data-linear-record-options]').first();
   const recordSummary = recordOptions.locator(':scope > summary');
@@ -391,9 +401,18 @@ test('LOSAT and LOSATP modes own their controls and mixed plans require explicit
     'Similarity groups', 'Collinear blocks', 'Pairwise matches'
   ]);
   const proteinCases = [
-    ['orthogroup', { blastnTask: 0, gencode: 0, pairwiseHits: 0, groupHits: 1, collinearGap: 0 }],
-    ['collinear', { blastnTask: 0, gencode: 0, pairwiseHits: 0, groupHits: 0, collinearGap: 1 }],
-    ['pairwise', { blastnTask: 0, gencode: 0, pairwiseHits: 1, groupHits: 0, collinearGap: 0 }]
+    ['orthogroup', {
+      blastnTask: 0, gencode: 0, pairwiseHits: 0, groupHits: 1, collinearGap: 0,
+      matchStyle: 1, matchHeight: 1
+    }],
+    ['collinear', {
+      blastnTask: 0, gencode: 0, pairwiseHits: 0, groupHits: 1, collinearGap: 1,
+      matchStyle: 1, matchHeight: 1
+    }],
+    ['pairwise', {
+      blastnTask: 0, gencode: 0, pairwiseHits: 1, groupHits: 0, collinearGap: 0,
+      matchStyle: 1, matchHeight: 1
+    }]
   ];
   for (const [value, expected] of proteinCases) {
     await losatpMode.selectOption(value);
@@ -410,8 +429,8 @@ test('LOSAT and LOSATP modes own their controls and mixed plans require explicit
       const scope = page.getByRole('combobox', {
         name: 'Collinear evidence scope'
       });
-      await expect(scope).toHaveValue('all');
-      await expect(scope.locator('option:checked')).toHaveText('All records');
+      await expect(scope).toHaveValue('adjacent');
+      await expect(scope.locator('option:checked')).toHaveText('Adjacent pairs');
     }
   }
 
@@ -473,10 +492,14 @@ test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and fi
     app.setLinearComparisonLosatMode('blastn');
     app.losat.blastn.task = 'dc-megablast';
     Object.assign(app.losat.blastp, {
+      candidateLimit: 37,
       maxHits: 41,
       orthogroupMemberMaxHits: 43,
       collinearMinAnchors: 7,
       collinearMaxUnitGap: 11,
+      collinearUnitMode: 'locus',
+      collinearAnchorMode: 'all',
+      collinearMergeOrientation: 'strand',
       collinearSearchScope: 'adjacent',
       collinearColorMode: 'orientation_identity'
     });
@@ -485,7 +508,8 @@ test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and fi
       evalue: '1e-45',
       identity: 76,
       alignment_length: 321,
-      pairwise_match_style: 'ribbon'
+      pairwise_match_style: 'ribbon',
+      comparison_height: 73
     });
     const snapshot = () => JSON.parse(JSON.stringify({
       program: app.losatProgram,
@@ -494,10 +518,14 @@ test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and fi
       blastnTask: app.losat.blastn.task,
       blastpMode: app.losat.blastp.mode,
       blastpDraft: {
+        candidateLimit: app.losat.blastp.candidateLimit,
         maxHits: app.losat.blastp.maxHits,
         orthogroupMemberMaxHits: app.losat.blastp.orthogroupMemberMaxHits,
         collinearMinAnchors: app.losat.blastp.collinearMinAnchors,
         collinearMaxUnitGap: app.losat.blastp.collinearMaxUnitGap,
+        collinearUnitMode: app.losat.blastp.collinearUnitMode,
+        collinearAnchorMode: app.losat.blastp.collinearAnchorMode,
+        collinearMergeOrientation: app.losat.blastp.collinearMergeOrientation,
         collinearSearchScope: app.losat.blastp.collinearSearchScope,
         collinearColorMode: app.losat.blastp.collinearColorMode
       },
@@ -507,7 +535,10 @@ test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and fi
         identity: app.adv.identity,
         length: app.adv.alignment_length
       },
-      style: app.adv.pairwise_match_style
+      appearance: {
+        style: app.adv.pairwise_match_style,
+        height: app.adv.comparison_height
+      }
     }));
     const losatn = snapshot();
     const selectedLosatp = app.setLinearComparisonLosatMode('blastp');
@@ -551,11 +582,220 @@ test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and fi
     activeLosatpMode: 'collinear',
     blastpMode: 'collinear'
   });
-  for (const key of ['blastnTask', 'blastpDraft', 'filters', 'style']) {
+  for (const key of ['blastnTask', 'blastpDraft', 'filters', 'appearance']) {
     expect(transitions.collinear[key]).toEqual(transitions.losatn[key]);
     expect(transitions.restoredLosatn[key]).toEqual(transitions.losatn[key]);
     expect(transitions.restoredCollinear[key]).toEqual(transitions.losatn[key]);
   }
+});
+
+test('comparison controls drive appearance and current Session round trips', async ({ page }) => {
+  test.setTimeout(600000);
+  await openLinear(page);
+  await page.evaluate((records) => {
+    const app = window.__GBDRAW_APP__;
+    if (app.linearSeqs.length < 2) app.addLinearSeq();
+    records.forEach((content, index) => app.setLinearSeqPrimaryFile(
+      index,
+      'gb',
+      new File([content], `ui04-record-${index + 1}.gbk`, {
+        type: 'text/plain',
+        lastModified: index + 1
+      })
+    ));
+    Object.assign(app.form, {
+      legend: 'none',
+      show_gc: false,
+      show_skew: false,
+      show_depth: false,
+      show_labels_linear: 'none'
+    });
+    app.setLinearComparisonGlobalAction('losat');
+    app.setLinearComparisonLosatMode('blastp');
+    app.setLinearComparisonLosatpMode('pairwise');
+  }, [makeGenbank('Ui04A', 'atg'), makeGenbank('Ui04B', 'gct')]);
+
+  await comparisonSettings(page).locator('summary').click();
+  const advanced = page.locator(
+    'details[data-linear-comparison-disclosure="advanced"]'
+  );
+  await advanced.locator('summary').click();
+
+  const candidate = page.getByRole('spinbutton', { name: 'LOSATP Candidate limit' });
+  const pairwiseMax = page.getByRole('spinbutton', {
+    name: 'Pairwise display max hits per protein'
+  });
+  const memberHits = page.getByRole('spinbutton', { name: 'Member hits per protein' });
+  const losatpMode = page.getByRole('combobox', { name: 'LOSATP mode' });
+  const matchStyle = page.getByRole('combobox', { name: 'Comparison match style' });
+  const matchHeight = page.getByRole('spinbutton', { name: 'Comparison match height' });
+
+  await expect(candidate).toBeVisible();
+  await expect(candidate).toHaveAttribute('placeholder', 'Unbounded');
+  await candidate.fill('17');
+  await candidate.focus();
+  await expectKeyboardFocusIndicator(candidate);
+  await pairwiseMax.fill('3');
+  await matchHeight.fill('45');
+  await matchStyle.focus();
+  await page.keyboard.press('Home');
+  await expect(matchStyle).toHaveValue('ribbon');
+  await page.keyboard.press('ArrowDown');
+  await expect(matchStyle).toHaveValue('curve');
+
+  await losatpMode.selectOption('orthogroup');
+  await expect(candidate).toBeVisible();
+  await expect(memberHits).toBeVisible();
+  await memberHits.fill('7');
+  await expect(matchStyle).toHaveValue('curve');
+  await expect(matchHeight).toHaveValue('45');
+
+  await losatpMode.selectOption('collinear');
+  await expect(candidate).toBeVisible();
+  await expect(memberHits).toHaveValue('7');
+  await page.getByRole('combobox', { name: 'Collinear evidence scope' }).selectOption('all');
+  await page.getByRole('combobox', { name: 'Collinear color mode' })
+    .selectOption('orientation_identity');
+  await page.getByRole('combobox', { name: 'Collinear unit mode' }).selectOption('locus');
+  await page.getByRole('combobox', { name: 'Collinear anchor mode' }).selectOption('all');
+  await page.getByRole('combobox', { name: 'Collinear merge orientation' })
+    .selectOption('strand');
+
+  await losatpMode.selectOption('pairwise');
+  await expect(pairwiseMax).toHaveValue('3');
+  await expect(candidate).toHaveValue('17');
+  await losatpMode.selectOption('collinear');
+  await expect(memberHits).toHaveValue('7');
+  await expect(page.getByRole('combobox', { name: 'Collinear unit mode' })).toHaveValue('locus');
+  await expect(page.getByRole('combobox', { name: 'Collinear anchor mode' })).toHaveValue('all');
+  await expect(page.getByRole('combobox', {
+    name: 'Collinear merge orientation'
+  })).toHaveValue('strand');
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const edge = app.linearComparisonResolution.edges[0];
+    app.setLinearComparisonCardFile(edge.edgeKey, new File([
+      'Ui04A\tUi04B\t95\t80\t4\t0\t1\t80\t5\t84\t1e-40\t160\n'
+    ], 'ui04-comparison.tsv', {
+      type: 'text/tab-separated-values',
+      lastModified: 80
+    }));
+  });
+  await expect(candidate).toHaveCount(0);
+  await expect(matchStyle).toBeVisible();
+
+  const renderAppearance = async (style, height) => page.evaluate(async ({ style_, height_ }) => {
+    const app = window.__GBDRAW_APP__;
+    app.adv.pairwise_match_style = style_;
+    app.adv.comparison_height = height_;
+    const result = await app.runAnalysis();
+    const content = String(app.results?.[app.selectedResultIndex]?.content || '');
+    const svg = new DOMParser().parseFromString(content, 'image/svg+xml');
+    const match = svg.querySelector('[data-gbdraw-pairwise-match-id]');
+    return {
+      result,
+      error: app.errorLog,
+      style: match?.getAttribute('data-pairwise-match-style') || '',
+      path: match?.getAttribute('d') || '',
+      matchCount: svg.querySelectorAll('[data-gbdraw-pairwise-match-id]').length
+    };
+  }, { style_: style, height_: height });
+
+  const ribbon = await renderAppearance('ribbon', 35);
+  expect(ribbon.result, JSON.stringify(ribbon.error, null, 2)).toEqual({ status: 'ok' });
+  expect(ribbon.style).toBe('ribbon');
+  expect(ribbon.matchCount).toBeGreaterThan(0);
+
+  const curve = await renderAppearance('curve', 35);
+  expect(curve.result, JSON.stringify(curve.error, null, 2)).toEqual({ status: 'ok' });
+  expect(curve.style).toBe('curve');
+  expect(curve.path).not.toBe(ribbon.path);
+  expect(curve.path).toContain('C');
+
+  const taller = await renderAppearance('curve', 85);
+  expect(taller.result, JSON.stringify(taller.error, null, 2)).toEqual({ status: 'ok' });
+  expect(taller.style).toBe('curve');
+  expect(taller.path).not.toBe(curve.path);
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    app.setLinearComparisonGlobalAction('losat');
+    app.setLinearComparisonLosatMode('blastp');
+    app.setLinearComparisonLosatpMode('collinear');
+    app.sessionTitle = 'ui04-comparison-controls';
+  });
+  const sessionDownloadPromise = page.waitForEvent('download', { timeout: 180000 });
+  const saveResult = await page.evaluate(() => (
+    window.__GBDRAW_APP__.saveSessionWithTitle()
+  ));
+  expect(saveResult).toMatchObject({ status: 'saved' });
+  const sessionDownload = await sessionDownloadPromise;
+  const sessionPath = await sessionDownload.path();
+  const sessionBuffer = readFileSync(sessionPath);
+  const session = JSON.parse(gunzipSync(sessionBuffer).toString('utf8'));
+  expect(session.config.losat.blastp).toMatchObject({
+    mode: 'collinear',
+    candidateLimit: 17,
+    maxHits: 3,
+    orthogroupMemberMaxHits: 7,
+    collinearUnitMode: 'locus',
+    collinearAnchorMode: 'all',
+    collinearMergeOrientation: 'strand',
+    collinearSearchScope: 'all',
+    collinearColorMode: 'orientation_identity'
+  });
+  expect(session.config.adv).toMatchObject({
+    pairwise_match_style: 'curve',
+    comparison_height: 85
+  });
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 180000 });
+  await page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  ).setInputFiles({
+    name: sessionDownload.suggestedFilename(),
+    mimeType: 'application/gzip',
+    buffer: sessionBuffer
+  });
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+  await page.waitForFunction(() => {
+    const app = window.__GBDRAW_APP__;
+    return app?.mode === 'linear'
+      && app?.losatProgram === 'blastp'
+      && app?.losat?.blastp?.mode === 'collinear'
+      && app?.losat?.blastp?.collinearAnchorMode === 'all';
+  }, null, { timeout: 180000 });
+  expect(await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    return {
+      candidate: app.losat.blastp.candidateLimit,
+      pairwise: app.losat.blastp.maxHits,
+      member: app.losat.blastp.orthogroupMemberMaxHits,
+      unit: app.losat.blastp.collinearUnitMode,
+      anchor: app.losat.blastp.collinearAnchorMode,
+      merge: app.losat.blastp.collinearMergeOrientation,
+      scope: app.losat.blastp.collinearSearchScope,
+      color: app.losat.blastp.collinearColorMode,
+      style: app.adv.pairwise_match_style,
+      height: app.adv.comparison_height
+    };
+  })).toEqual({
+    candidate: 17,
+    pairwise: 3,
+    member: 7,
+    unit: 'locus',
+    anchor: 'all',
+    merge: 'strand',
+    scope: 'all',
+    color: 'orientation_identity',
+    style: 'curve',
+    height: 85
+  });
 });
 
 test('structured comparison errors open and focus their owning disclosure', async ({ page }) => {

--- a/tests/web/comparison-ui.test.mjs
+++ b/tests/web/comparison-ui.test.mjs
@@ -206,7 +206,7 @@ test('LOSAT and LOSATP modes project only their active Settings and Advanced con
       settings: ['losat-mode', 'blastn-task', 'result-filters', 'comparison-appearance'],
       absent: [
         'losatp-mode', 'record-genetic-codes', 'blastp-max-hits',
-        'similarity-grouping', 'collinear-primary'
+        'member-hits', 'collinear-primary'
       ]
     },
     {
@@ -217,7 +217,7 @@ test('LOSAT and LOSATP modes project only their active Settings and Advanced con
       settings: ['losat-mode', 'record-genetic-codes', 'result-filters', 'comparison-appearance'],
       absent: [
         'losatp-mode', 'blastn-task', 'blastp-max-hits',
-        'similarity-grouping', 'collinear-primary'
+        'member-hits', 'collinear-primary'
       ]
     },
     {
@@ -229,25 +229,30 @@ test('LOSAT and LOSATP modes project only their active Settings and Advanced con
         'losat-mode', 'losatp-mode', 'blastp-max-hits',
         'result-filters', 'comparison-appearance'
       ],
-      absent: ['blastn-task', 'record-genetic-codes', 'similarity-grouping', 'collinear-primary']
+      absent: ['blastn-task', 'record-genetic-codes', 'member-hits', 'collinear-primary']
     },
     {
       program: 'blastp',
       blastpMode: 'orthogroup',
       losatKey: 'blastp',
       losatpKey: 'orthogroup',
-      settings: ['losat-mode', 'losatp-mode', 'similarity-grouping', 'result-filters'],
-      absent: ['blastn-task', 'record-genetic-codes', 'blastp-max-hits', 'collinear-primary', 'comparison-appearance']
+      settings: [
+        'losat-mode', 'losatp-mode', 'member-hits',
+        'result-filters', 'comparison-appearance'
+      ],
+      absent: ['blastn-task', 'record-genetic-codes', 'blastp-max-hits', 'collinear-primary']
     },
     {
       program: 'blastp',
       blastpMode: 'collinear',
       losatKey: 'blastp',
       losatpKey: 'collinear',
-      settings: ['losat-mode', 'losatp-mode', 'collinear-primary', 'result-filters'],
+      settings: [
+        'losat-mode', 'losatp-mode', 'member-hits', 'collinear-primary',
+        'result-filters', 'comparison-appearance'
+      ],
       absent: [
-        'blastn-task', 'record-genetic-codes', 'blastp-max-hits',
-        'similarity-grouping', 'comparison-appearance'
+        'blastn-task', 'record-genetic-codes', 'blastp-max-hits'
       ],
       advanced: 'collinear-details'
     }
@@ -266,6 +271,10 @@ test('LOSAT and LOSATP modes project only their active Settings and Advanced con
     assert.equal(
       projection.sectionKeys.advanced.includes('collinear-details'),
       advanced === 'collinear-details'
+    );
+    assert.equal(
+      projection.sectionKeys.advanced.includes('losatp-candidate'),
+      program === 'blastp'
     );
   });
 
@@ -328,7 +337,9 @@ test('selected topology blocks only grouping and collinear LOSATP modes without 
   assert.equal(modeOption(grouping.losatpModes, 'collinear').selectable, false);
   assert.equal(modeOption(grouping.losatpModes, 'pairwise').selectable, true);
   assert(grouping.sectionKeys.settings.includes('losatp-mode'));
-  assert(!grouping.sectionKeys.settings.includes('similarity-grouping'));
+  assert(!grouping.sectionKeys.settings.includes('member-hits'));
+  assert(grouping.sectionKeys.settings.includes('comparison-appearance'));
+  assert(grouping.sectionKeys.advanced.includes('losatp-candidate'));
   assert.equal(grouping.errorDisclosureKey, 'settings');
 
   for (const modeKey of ['orthogroup', 'collinear']) {

--- a/tests/web/run-analysis-derived-cache.test.mjs
+++ b/tests/web/run-analysis-derived-cache.test.mjs
@@ -1,5 +1,9 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   buildLosatDerivedPayloadCachePayload,
@@ -13,6 +17,46 @@ assert.equal(resolveProteinBlastpCandidateLimit(null), null);
 assert.equal(resolveProteinBlastpCandidateLimit(undefined), null);
 assert.throws(() => resolveProteinBlastpCandidateLimit(0), /Candidate limit/);
 assert.throws(() => resolveProteinBlastpCandidateLimit('invalid'), /Candidate limit/);
+
+const runAnalysisPath = resolve('gbdraw/web/js/app/run-analysis.js');
+const runAnalysisUrl = pathToFileURL(runAnalysisPath);
+const identityProbeDir = await mkdtemp(join(tmpdir(), 'gbdraw-raw-identity-'));
+const identityProbePath = join(identityProbeDir, 'run-analysis-identity-probe.mjs');
+const identityProbeSource = (await readFile(runAnalysisPath, 'utf8'))
+  .replace(
+    'const buildLosatCachePayload = ({',
+    'export const buildLosatCachePayload = ({'
+  )
+  .replace(/from '(\.\.?(?:\/[^']+)+)'/g, (_match, specifier) => (
+    `from '${new URL(specifier, runAnalysisUrl).href}'`
+  ));
+await writeFile(identityProbePath, identityProbeSource, 'utf8');
+const { buildLosatCachePayload } = await import(pathToFileURL(identityProbePath));
+
+const rawIdentityInput = {
+  identityKind: 'protein',
+  program: 'blastp',
+  outfmt: '6',
+  args: ['--max-target-seqs', '9'],
+  queryProteinSetHash: 'query-proteins',
+  subjectProteinSetHash: 'subject-proteins',
+  queryRuntimeBindingHash: 'query-runtime',
+  subjectRuntimeBindingHash: 'subject-runtime',
+  queryRecordInstanceKey: 'query-record',
+  subjectRecordInstanceKey: 'subject-record'
+};
+const rawIdentity = buildLosatCachePayload(rawIdentityInput);
+for (const appearanceOnly of [
+  { pairwiseMatchStyle: 'curve' },
+  { comparisonHeight: 90 },
+  { comparisonDisclosureOpen: true }
+]) {
+  assert.deepEqual(
+    buildLosatCachePayload({ ...rawIdentityInput, ...appearanceOnly }),
+    rawIdentity,
+    'render appearance and disclosure state must not change raw scientific identity'
+  );
+}
 
 const baselineInput = {
   mode: 'collinear',
@@ -142,10 +186,21 @@ for (const [inputName, identityName, changedValue, section = 'collinear'] of inv
 }
 
 assert.deepEqual(
-  buildIdentity({ maxHits: 99, renderOnlyPresentation: 'changed' }),
+  buildIdentity({ maxHits: 99, pairwiseMatchStyle: 'curve' }),
   baselineIdentity,
-  'Collinear derived identity must ignore Pairwise-only and render-only settings'
+  'Collinear derived identity must ignore Pairwise-only and match-style settings'
 );
+for (const appearanceOnly of [
+  { pairwiseMatchStyle: 'curve' },
+  { comparisonHeight: 90 },
+  { comparisonDisclosureOpen: true }
+]) {
+  assert.deepEqual(
+    buildIdentity(appearanceOnly),
+    baselineIdentity,
+    'render appearance and disclosure state must not change derived scientific identity'
+  );
+}
 
 const orthogroupIdentity = buildIdentity({ mode: 'orthogroup' });
 assert.equal(Object.hasOwn(orthogroupIdentity, 'pairwise'), false);

--- a/tests/web/session-draft-authority.test.mjs
+++ b/tests/web/session-draft-authority.test.mjs
@@ -336,8 +336,12 @@ Object.assign(divergentSession.config.losat.blastp, {
   mode: 'collinear',
   maxHits: 17,
   candidateLimit: 11,
+  orthogroupMemberMaxHits: 19,
   collinearMinAnchors: 4,
   collinearMaxUnitGap: 9,
+  collinearUnitMode: 'locus',
+  collinearAnchorMode: 'all',
+  collinearMergeOrientation: 'strand',
   collinearSearchScope: 'adjacent',
   collinearColorMode: 'orientation_identity'
 });
@@ -355,10 +359,18 @@ const dormantComparisonDraft = structuredClone({
     mode: divergentSession.config.losat.blastp.mode,
     maxHits: divergentSession.config.losat.blastp.maxHits,
     candidateLimit: divergentSession.config.losat.blastp.candidateLimit,
+    orthogroupMemberMaxHits:
+      divergentSession.config.losat.blastp.orthogroupMemberMaxHits,
     collinearMinAnchors:
       divergentSession.config.losat.blastp.collinearMinAnchors,
     collinearMaxUnitGap:
       divergentSession.config.losat.blastp.collinearMaxUnitGap,
+    collinearUnitMode:
+      divergentSession.config.losat.blastp.collinearUnitMode,
+    collinearAnchorMode:
+      divergentSession.config.losat.blastp.collinearAnchorMode,
+    collinearMergeOrientation:
+      divergentSession.config.losat.blastp.collinearMergeOrientation,
     collinearSearchScope:
       divergentSession.config.losat.blastp.collinearSearchScope,
     collinearColorMode:
@@ -406,12 +418,21 @@ assert.deepEqual({
     mode: state.losat.blastp.mode,
     maxHits: state.losat.blastp.maxHits,
     candidateLimit: state.losat.blastp.candidateLimit,
+    orthogroupMemberMaxHits: state.losat.blastp.orthogroupMemberMaxHits,
     collinearMinAnchors: state.losat.blastp.collinearMinAnchors,
     collinearMaxUnitGap: state.losat.blastp.collinearMaxUnitGap,
+    collinearUnitMode: state.losat.blastp.collinearUnitMode,
+    collinearAnchorMode: state.losat.blastp.collinearAnchorMode,
+    collinearMergeOrientation: state.losat.blastp.collinearMergeOrientation,
     collinearSearchScope: state.losat.blastp.collinearSearchScope,
     collinearColorMode: state.losat.blastp.collinearColorMode
   }
 }, dormantComparisonDraft);
+assert.deepEqual(
+  JSON.parse(JSON.stringify(buildConfigData().losat.blastp)),
+  JSON.parse(JSON.stringify(state.losat.blastp)),
+  'the current Session writer must retain every editable LOSATP value'
+);
 assert.equal(
   state.form.legend,
   'bottom',


### PR DESCRIPTION
## Plain-language summary

This PR restores the existing Linear comparison controls to the journeys where they take effect. Candidate retrieval, Pairwise display limits, Similarity/Collinear member limits, and Collinear unit, anchor, and merge-orientation settings are now separately named and reachable. Ribbon/curve style and match height are also available for every active Linear comparison, and current Sessions retain the exact editable values.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Behavior and scope

- Expose the LOSATP Candidate limit only when LOSATP `blastp` is active, preserving blank as the existing unbounded value.
- Keep Pairwise display max hits separate from the member-hit limit shared by Similarity and Collinear.
- Expose the supported Collinear unit (`auto`, `cds`, `locus`), anchor (`all`, `one_to_one`, `rbh`), and merge-orientation (`strand`, `order`, `either`) values.
- Show comparison style and height for uploaded, nucleotide, Pairwise, Similarity, and Collinear Linear comparisons.
- Preserve independent analysis and appearance values across mode switches without adding refs, watchers, resets, state stores, protocols, or scientific semantics.
- Keep `losat.collinearAnchorMode` in fresh current Session writes; the existing missing-value fallback remains limited to older current Sessions.

This implements existing Product authority: `OIPC-C01`, `OIPC-C03`, `OIPC-C04`, `OIPC-C05`, and `OIPC-C08`, together with `PD-OI-001` through `PD-OI-007`, `PD-OI-015`, and `PD-OI-017`. The Product preflight classification is `IMPLEMENT_EXISTING_AUTHORITY`; no Product decision or authority change is included.

## Verification

- Focused DOM-free comparison, raw/derived identity, Session authority, canonical Session, and changed-scope ratchet fixtures: 7 test files passed.
- `npx playwright test tests/web/comparison-ui.playwright.spec.js --project=chromium`: 7 passed, covering control availability, keyboard access, mode preservation, real ribbon/curve and height rendering, and exact Session save/reload values.
- `node tests/web/architecture-contracts.test.mjs`: 133 passed.
- `node tools/check-web-change-budget.mjs`: Gate `PASS`, Review `REQUIRED`, with no blocking violation; production modules 140, exports 807, create sites 79, reactive state sites 313, watchers 53, and import cycles 0, all unchanged.
- Changed JavaScript syntax checks and `git diff --check`: passed.
- The affected LOSATN capture contract for the shared comparison-height accessible name: 1 passed; the official capture flow now uses that same name.
- Official maximum lane `npx playwright test --config=playwright.vibrio.config.js --project=chromium`: 1 passed in 16.1 minutes. Both Generate operations completed; the derived-only member-limit mutation reused all 47 raw jobs and produced exactly equal first/second SVG output.

## Architecture Ratchet report

- Control/state semantic owners before and after: the existing state refs remain the single semantic owners, and `gbdraw/web/js/app/comparison-ui.js` remains their availability/presentation projection.
- Canonical projection path before and after: unchanged through `gbdraw/web/js/services/session-request.js`; no second request path was added.
- Duplicate refs/watchers/resets removed: none existed in this slice; none were added. Mode changes continue to preserve independent values.
- New module classification: none.
- Session/schema/Worker effect: one bounded current Session writer correction retains the existing editable Collinear anchor value. Session schema and Worker protocol are unchanged.
- Raw/derived key invariance: focused identity tests show ribbon/curve style, comparison height, and disclosure state change neither raw nor derived scientific identities; the production-size derived mutation reused the raw jobs.
- Changed-scope conclusion: `delta(OE) = 0`, `delta(PE) = 0`, and `delta(CB) = 0`. The writer's exceptional omission of an existing editable value is removed without adding an owner or compatibility path; this PR does not claim convergence.
- User journey/accessibility: the focused browser journey verifies distinct accessible names, native keyboard operation, contextual visibility, mode-switch preservation, rendering, and Session round-trip behavior.
- `architecture-change` label: required because the bounded current Session writer path is architecture-bearing and received the high-risk production-size check.

Production scope is three files with 62 additions and 36 deletions. Test scope is five focused files, plus one capture-flow locator update required by the new accessible name. Protected required PR checks must pass on the final PR head before merge.

## Rollback and residual risk

Rollback is a single revert of this commit. Older current Sessions that omitted `collinearAnchorMode` continue to use the existing fallback, while newly saved Sessions retain the explicit editor value; no other compatibility or scientific-output risk is known.
