### PR TITLE
Preserve imported Linear comparison intent across Generate failures

### DIFF
--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1604,6 +1604,45 @@
                                 <i class="ph ph-arrows-left-right text-lg text-blue-600"></i>
                                 <span class="min-w-0 flex-1">Comparison</span>
                             </div>
+                            <div
+                                v-if="importedComparisonNeedsResolution"
+                                data-imported-comparison-resolution
+                                role="status"
+                                class="rounded-lg border border-amber-300 bg-amber-50 p-2.5 text-[10px] leading-snug text-amber-950 space-y-2"
+                            >
+                                <div class="font-bold text-xs">
+                                    {{ importedComparisonIntent.disposition === 'PRESERVED_READ_ONLY'
+                                        ? 'Saved comparison preserved as read-only'
+                                        : 'Saved comparison needs a decision' }}
+                                </div>
+                                <p>{{ importedComparisonIntent.message }}</p>
+                                <p>The controls below are a replacement draft. The saved comparison and last successful Result remain unchanged until Generate succeeds.</p>
+                                <p v-if="importedComparisonIntent.action" class="font-semibold">
+                                    Selected action: {{ importedComparisonIntent.action }}
+                                </p>
+                                <div class="flex flex-wrap gap-1.5" role="group" aria-label="Resolve saved comparison">
+                                    <button
+                                        v-if="importedComparisonCanInherit"
+                                        type="button"
+                                        data-history-ignore
+                                        @click="inheritImportedComparison"
+                                        class="btn btn-secondary text-[10px]"
+                                    >Inherit saved comparison</button>
+                                    <button
+                                        type="button"
+                                        data-history-ignore
+                                        :disabled="!importedComparisonCanReplace"
+                                        @click="replaceImportedComparison"
+                                        class="btn btn-secondary text-[10px] disabled:opacity-40 disabled:cursor-not-allowed"
+                                    >Replace with current controls</button>
+                                    <button
+                                        type="button"
+                                        data-history-ignore
+                                        @click="clearImportedComparison"
+                                        class="btn btn-secondary text-[10px]"
+                                    >Clear comparison</button>
+                                </div>
+                            </div>
                             <div role="group" aria-label="Set all adjacent comparisons" data-capture="linear-blast-source" class="linear-comparison-actions">
                                 <button type="button" aria-label="Set no comparison" @click="setLinearComparisonGlobalAction('none')" :class="linearComparisonGlobalAction === 'none' ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'" class="btn rounded-lg border text-xs font-bold shadow-sm">No comparison</button>
                                 <button type="button" aria-label="Run LOSAT for all adjacent pairs" @click="setLinearComparisonGlobalAction('losat')" :class="linearComparisonGlobalAction === 'losat' ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'" class="btn rounded-lg border text-xs font-bold shadow-sm">Run LOSAT</button>

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -15,6 +15,7 @@ import {
   buildRunStateData,
   buildUiStateData,
   exportSession,
+  getCommittedCanonicalSession,
   getCommittedCanonicalRenderRequest,
   importSession as importSessionFromFile,
   SESSION_VERSION,
@@ -116,6 +117,12 @@ import {
 } from './depth-tracks.js';
 import { comparisonProfileDefault } from '../mode-profiles.js';
 import {
+  IMPORTED_COMPARISON_ACTIONS,
+  IMPORTED_COMPARISON_DISPOSITIONS,
+  importedComparisonExecution,
+  resolveImportedComparisonAction
+} from '../services/imported-comparison-intent.js';
+import {
   activeDepthTrackIndices,
   clearDepthTrackSourceAt,
   compactDepthFileSlots,
@@ -183,6 +190,7 @@ export const createAppSetup = () => {
     generationCancelRequested,
     errorLog,
     sessionTitle,
+    importedComparisonIntent,
     results,
     selectedResultIndex,
     failedGeneratePreservedResult,
@@ -1849,6 +1857,7 @@ export const createAppSetup = () => {
     canonicalSessionVersion: SESSION_VERSION,
     adoptCanonicalRenderArtifacts,
     getCommittedCanonicalRenderRequest,
+    getCommittedCanonicalSession,
     captureGeneratedArtifactHandle: historySnapshots.captureGeneratedArtifactHandle,
     restoreGeneratedArtifactHandle: historySnapshots.restoreGeneratedArtifactHandle,
     setGeneratedArtifactIdentity: historySnapshots.setGeneratedArtifactIdentity,
@@ -2220,30 +2229,82 @@ export const createAppSetup = () => {
         : {}
     });
   };
-  const runAnalysis = async () => history.runUndoableArtifactReplacement(
-    'Generate diagram',
-    async (generatedArtifactHandle) => {
-      cancelDefinitionUpdate();
-      const comparisonPlanSnapshot = mode.value === 'linear'
-        ? linearComparisonResolution.value
-        : null;
+  const runAnalysis = async () => {
+    const comparisonPlanSnapshot = mode.value === 'linear'
+      ? linearComparisonResolution.value
+      : null;
+    const comparisonExecution = importedComparisonExecution({
+      intent: importedComparisonIntent,
+      draftResolution: comparisonPlanSnapshot
+    });
+    if (!comparisonExecution.ok) {
+      errorLog.value = new Error(comparisonExecution.message);
+      failedGeneratePreservedResult.value = results.value.length > 0;
+      if (mode.value === 'linear') await focusLinearComparisonIssue();
+      return { status: 'error' };
+    }
+    return history.runUndoableArtifactReplacement(
+      'Generate diagram',
+      async (generatedArtifactHandle) => {
+        cancelDefinitionUpdate();
+        const result = await runGeneratedDiagramAnalysis(
+          comparisonPlanSnapshot,
+          generatedArtifactHandle,
+          comparisonExecution
+        );
+        if (result?.status === 'error' && mode.value === 'linear') {
+          await focusLinearComparisonIssue();
+        }
+        if (result?.status === 'ok') {
+          featureSelection.clearFeatureSelection({ clearStatus: true });
+        }
+        return result;
+      }, {
+        shouldCommit: (result) => result?.status === 'ok',
+        onCheckpointCapture: recordGenerateHistoryCapture
+      }
+    );
+  };
 
-      const result = await runGeneratedDiagramAnalysis(
-        comparisonPlanSnapshot,
-        generatedArtifactHandle
-      );
-      if (result?.status === 'error' && mode.value === 'linear') {
-        await focusLinearComparisonIssue();
+  const chooseImportedComparisonAction = (action) => history.runUndoable(
+    `${String(action || '').toLowerCase()} imported comparison`,
+    () => {
+      const outcome = resolveImportedComparisonAction({
+        intent: importedComparisonIntent,
+        action,
+        draftResolution: linearComparisonResolution.value
+      });
+      if (!outcome.ok) {
+        errorLog.value = new Error(outcome.message);
+        return false;
       }
-      if (result?.status === 'ok') {
-        featureSelection.clearFeatureSelection({ clearStatus: true });
+      if (outcome.action === IMPORTED_COMPARISON_ACTIONS.CLEAR) {
+        replaceLinearComparisonPlan({ mode: 'none', defaultSource: 'losat', edges: [] });
       }
-      return result;
-    }, {
-      shouldCommit: (result) => result?.status === 'ok',
-      onCheckpointCapture: recordGenerateHistoryCapture
+      errorLog.value = null;
+      return true;
     }
   );
+  const inheritImportedComparison = () => chooseImportedComparisonAction(
+    IMPORTED_COMPARISON_ACTIONS.INHERIT
+  );
+  const replaceImportedComparison = () => chooseImportedComparisonAction(
+    IMPORTED_COMPARISON_ACTIONS.REPLACE
+  );
+  const clearImportedComparison = () => chooseImportedComparisonAction(
+    IMPORTED_COMPARISON_ACTIONS.CLEAR
+  );
+  const importedComparisonNeedsResolution = computed(() => (
+    importedComparisonIntent.disposition !== IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE
+  ));
+  const importedComparisonCanInherit = computed(() => (
+    importedComparisonIntent.disposition
+      === IMPORTED_COMPARISON_DISPOSITIONS.PRESERVED_READ_ONLY
+  ));
+  const importedComparisonCanReplace = computed(() => (
+    linearComparisonResolution.value.valid
+    && linearComparisonResolution.value.hasComparisonIntent
+  ));
 
   const cancelGeneration = () => {
     cancelRunAnalysis();
@@ -3022,6 +3083,13 @@ export const createAppSetup = () => {
     results,
     selectedResultIndex,
     failedGeneratePreservedResult,
+    importedComparisonIntent,
+    importedComparisonNeedsResolution,
+    importedComparisonCanInherit,
+    importedComparisonCanReplace,
+    inheritImportedComparison,
+    replaceImportedComparison,
+    clearImportedComparison,
     selectResult,
     resultPanelTab,
     lastRunInfo,

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -128,6 +128,11 @@ import {
   recordSessionLifecycleEvent,
   recordStructuralMetric
 } from '../services/runtime-test-hooks.js';
+import {
+  IMPORTED_COMPARISON_DISPOSITIONS,
+  createImportedComparisonIntentState,
+  inheritCommittedComparisonIntent
+} from '../services/imported-comparison-intent.js';
 
 const DEFAULT_CIRCULAR_CONSERVATION_BLAST_FILTERS = Object.freeze(
   comparisonFiltersForMode('circular')
@@ -915,6 +920,7 @@ export const createRunAnalysis = ({
   canonicalSessionVersion,
   adoptCanonicalRenderArtifacts,
   getCommittedCanonicalRenderRequest = null,
+  getCommittedCanonicalSession = null,
   captureGeneratedArtifactHandle,
   restoreGeneratedArtifactHandle,
   setGeneratedArtifactIdentity = null,
@@ -991,6 +997,7 @@ export const createRunAnalysis = ({
     linearRecordRows,
     linearComparisonPlan,
     linearComparisonResolution,
+    importedComparisonIntent,
     generatedLegendPosition,
     generatedMode,
     generatedMultiRecordCanvas,
@@ -1625,28 +1632,40 @@ export const createRunAnalysis = ({
     runMode = 'manual',
     requestId = 0,
     comparisonPlanSnapshot = null,
-    generatedArtifactHandle = null
+    generatedArtifactHandle = null,
+    comparisonExecution = null
   } = {}) => {
     const isReflow = runMode === 'reflow';
     if (!isReflow) {
       recordSessionLifecycleEvent('generate-start');
       recordSessionLifecycleEvent('generation-input-resolution-start');
     }
+    const useCommittedComparison = comparisonExecution?.mode === 'inherit';
+    const forceEmptyComparison = useCommittedComparison || comparisonExecution?.mode === 'clear';
     const activeComparisonPlanSnapshot = mode.value === 'linear'
       ? (
-          comparisonPlanSnapshot || resolveLinearComparisonPlan({
-            plan: linearComparisonPlan,
-            sequences: linearSeqs,
-            layout: linearRecordLayoutEnabled.value ? linearRecordRows : [],
-            losatProgram: losatProgram.value,
-            blastpMode: normalizeBlastpMode(losat.blastp?.mode)
-          })
+          forceEmptyComparison
+            ? resolveLinearComparisonPlan({
+                plan: { mode: 'none', defaultSource: 'losat', edges: [] },
+                sequences: linearSeqs,
+                layout: linearRecordLayoutEnabled.value ? linearRecordRows : [],
+                losatProgram: losatProgram.value,
+                blastpMode: normalizeBlastpMode(losat.blastp?.mode)
+              })
+            : comparisonPlanSnapshot || resolveLinearComparisonPlan({
+                plan: linearComparisonPlan,
+                sequences: linearSeqs,
+                layout: linearRecordLayoutEnabled.value ? linearRecordRows : [],
+                losatProgram: losatProgram.value,
+                blastpMode: normalizeBlastpMode(losat.blastp?.mode)
+              })
         )
       : null;
     let linearRecordCatalog = null;
 
     const generationToken = ++latestGenerationToken;
     let keepProcessingStatus = false;
+    let canceledAttemptOwnsPresentation = false;
     let generationAbortController = null;
     let generationAbortSignal = null;
     const committedArtifactHandle = isReflow
@@ -1657,14 +1676,22 @@ export const createRunAnalysis = ({
       await restoreGeneratedArtifactHandle(committedArtifactHandle);
     };
     const finishCanceledManualRun = async () => {
+      if (latestGenerationToken !== generationToken + 1) {
+        return { status: 'stale' };
+      }
+      canceledAttemptOwnsPresentation = true;
       await restoreCommittedArtifact();
       errorLog.value = null;
       processingStatus.value = 'Canceled.';
+      generationCancelRequested.value = false;
+      processing.value = false;
       keepProcessingStatus = true;
       return { status: 'canceled' };
     };
     const setProcessingStatus = (message) => {
-      if (!isReflow) processingStatus.value = String(message || '');
+      if (!isReflow && generationToken === latestGenerationToken) {
+        processingStatus.value = String(message || '');
+      }
     };
     const throwIfGenerationCanceled = () => {
       if (!isReflow && generationCancelRequested.value) {
@@ -1694,23 +1721,18 @@ export const createRunAnalysis = ({
           error: error?.message || 'Could not read records from the Linear input file(s).'
         };
       } finally {
-        if (!isReflow) {
+        if (!isReflow && generationToken === latestGenerationToken) {
           processing.value = false;
           processingStatus.value = '';
         }
       }
-      if (
-        !isReflow && (
-          generationAbortSignal?.aborted ||
-          generationCancelRequested.value ||
-          generationToken !== latestGenerationToken
-        )
-      ) {
+      if (!isReflow && generationToken !== latestGenerationToken) {
         if (activeLosatAbortController === generationAbortController) {
           activeLosatAbortController = null;
         }
-        generationCancelRequested.value = false;
-        return finishCanceledManualRun();
+        return generationAbortSignal?.aborted
+          ? finishCanceledManualRun()
+          : { status: 'stale' };
       }
       if (prepared?.error) {
         const message = String(prepared.error);
@@ -1740,19 +1762,18 @@ export const createRunAnalysis = ({
         try {
           await refreshCircularRecordOrder();
         } finally {
-          processing.value = false;
-          processingStatus.value = '';
+          if (generationToken === latestGenerationToken) {
+            processing.value = false;
+            processingStatus.value = '';
+          }
         }
-        if (
-          generationAbortSignal?.aborted ||
-          generationCancelRequested.value ||
-          generationToken !== latestGenerationToken
-        ) {
+        if (generationToken !== latestGenerationToken) {
           if (activeLosatAbortController === generationAbortController) {
             activeLosatAbortController = null;
           }
-          generationCancelRequested.value = false;
-          return finishCanceledManualRun();
+          return generationAbortSignal?.aborted
+            ? finishCanceledManualRun()
+            : { status: 'stale' };
         }
         if (!circularDiscoveryMatchesCurrentInput()) {
           const message = circularRecordDiscovery.error || 'Could not read records from the circular input file(s).';
@@ -4083,18 +4104,30 @@ export const createRunAnalysis = ({
       );
       recordSessionLifecycleEvent('serialize-canonical-files-end');
       throwIfGenerationCanceled();
+      const candidateFiles = forceEmptyComparison
+        ? { ...serializedFiles, linearCanonicalComparisons: [] }
+        : serializedFiles;
       const canonicalCircularConservation = resolvedCircularConservation.map((entry) => ({
         ...entry,
-        fasta: serializedFiles.c_conservation_fastas?.[entry.sourceIndex] || null
+        fasta: candidateFiles.c_conservation_fastas?.[entry.sourceIndex] || null
       }));
       recordSessionLifecycleEvent('canonical-request-construction-start');
       const canonical = buildCanonicalRenderRequest({
         state,
-        filesData: serializedFiles,
+        filesData: candidateFiles,
         comparisonPlanSnapshot: activeComparisonPlanSnapshot,
         resolvedComparisons,
         resolvedCircularConservation: canonicalCircularConservation
       });
+      if (useCommittedComparison) {
+        if (typeof getCommittedCanonicalSession !== 'function') {
+          throw new Error('The preserved comparison owner is unavailable.');
+        }
+        inheritCommittedComparisonIntent({
+          candidate: canonical,
+          committed: getCommittedCanonicalSession()
+        });
+      }
       recordSessionLifecycleEvent('canonical-request-construction-end');
       const canonicalResourceEntries = Object.values(canonical.resources || {});
       const canonicalResourceCount = canonicalResourceEntries.length;
@@ -4180,6 +4213,12 @@ export const createRunAnalysis = ({
       )
         ? generationResponse.metadata
         : {};
+      if (generationToken !== latestGenerationToken) {
+        if (!isReflow && generationAbortSignal?.aborted) {
+          return finishCanceledManualRun();
+        }
+        return { status: 'stale' };
+      }
       if (res?.error) {
         logPostGbdrawTimings(postGbdrawTimingEntries);
         if (isReflow) {
@@ -4192,14 +4231,6 @@ export const createRunAnalysis = ({
       }
       if (!Array.isArray(res)) {
         throw new Error('The diagram engine returned an invalid Result list.');
-      }
-
-      if (generationToken !== latestGenerationToken) {
-        if (!isReflow && generationCancelRequested.value) {
-          return finishCanceledManualRun();
-        }
-        if (!isReflow) await restoreCommittedArtifact();
-        return { status: 'stale' };
       }
 
       if (isReflow && requestId !== pendingReflowRequestId) {
@@ -4252,13 +4283,9 @@ export const createRunAnalysis = ({
       recordSessionLifecycleEvent('result-admission-end');
 
       if (generationToken !== latestGenerationToken) {
-        if (
-          !isReflow
-          && (generationCancelRequested.value || generationAbortSignal?.aborted)
-        ) {
+        if (!isReflow && generationAbortSignal?.aborted) {
           return finishCanceledManualRun();
         }
-        if (!isReflow) await restoreCommittedArtifact();
         return { status: 'stale' };
       }
 
@@ -4367,9 +4394,6 @@ export const createRunAnalysis = ({
         pendingPaletteColors.value = {};
       }
       commitProteinMigration?.();
-      if (!isReflow && typeof adoptCanonicalRenderArtifacts === 'function') {
-        adoptCanonicalRenderArtifacts(canonical, { adoptOwnedRequest: true });
-      }
       if (!isReflow && typeof setGeneratedArtifactIdentity === 'function') {
         setGeneratedArtifactIdentity(generationResponse.artifactIdentity, {
           results: candidateCommit.results
@@ -4387,6 +4411,16 @@ export const createRunAnalysis = ({
           structuredLosatTelemetry
         );
       }
+      if (!isReflow && typeof adoptCanonicalRenderArtifacts === 'function') {
+        adoptCanonicalRenderArtifacts(canonical, { adoptOwnedRequest: true });
+      }
+      if (!isReflow && !useCommittedComparison && importedComparisonIntent) {
+        Object.assign(
+          importedComparisonIntent,
+          createImportedComparisonIntentState(),
+          { disposition: IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE }
+        );
+      }
       return { status: 'ok' };
     } catch (e) {
       if (!legacyPromotionCommitted) {
@@ -4402,6 +4436,9 @@ export const createRunAnalysis = ({
         }
         return { status: 'canceled' };
       }
+      if (!isReflow && generationToken !== latestGenerationToken) {
+        return { status: 'stale' };
+      }
       if (isReflow) {
         labelReflowLastError.value = formatJsError(e)?.summary || 'Auto reflow failed';
         return { status: 'error' };
@@ -4416,23 +4453,27 @@ export const createRunAnalysis = ({
         if (activeLosatAbortController === generationAbortController) {
           activeLosatAbortController = null;
         }
-        if (!keepProcessingStatus) processingStatus.value = '';
-        generationCancelRequested.value = false;
-        processing.value = false;
+        if (generationToken === latestGenerationToken || canceledAttemptOwnsPresentation) {
+          if (!keepProcessingStatus) processingStatus.value = '';
+          generationCancelRequested.value = false;
+          processing.value = false;
+        }
       }
     }
   };
 
   const runAnalysis = async (
     comparisonPlanSnapshot = null,
-    generatedArtifactHandle = null
+    generatedArtifactHandle = null,
+    comparisonExecution = null
   ) => {
     const outcome = await runAnalysisInternal({
       runMode: 'manual',
       comparisonPlanSnapshot,
-      generatedArtifactHandle
+      generatedArtifactHandle,
+      comparisonExecution
     });
-    if (outcome?.status === 'error') {
+    if (['error', 'canceled'].includes(outcome?.status)) {
       failedGeneratePreservedResult.value = results.value.length > 0;
     } else if (outcome?.status === 'ok') {
       failedGeneratePreservedResult.value = false;

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -187,6 +187,14 @@ import {
   validateImportedCircularTrackSlots,
   validateImportedLinearTrackSlots
 } from './session-active-config-contract.js';
+import {
+  IMPORTED_COMPARISON_ACTIONS,
+  IMPORTED_COMPARISON_DISPOSITIONS,
+  classifyImportedComparisonIntent,
+  createImportedComparisonIntentState,
+  restoreImportedComparisonIntent,
+  serializeImportedComparisonResolution
+} from './imported-comparison-intent.js';
 
 const { nextTick } = window.Vue;
 
@@ -895,6 +903,9 @@ export const buildConfigData = () => ({
     }))
   },
   linearComparisonPlan: serializeLinearComparisonPlan(state.linearComparisonPlan),
+  importedComparisonResolution: serializeImportedComparisonResolution(
+    state.importedComparisonIntent
+  ),
   webEdits: {
     orthogroupNameOverrides: cloneStringMap(state.orthogroupNameOverrides),
     orthogroupDescriptionOverrides: cloneStringMap(state.orthogroupDescriptionOverrides)
@@ -1433,6 +1444,17 @@ const preflightSessionImport = (rawData) => {
   const data = currentSession
     ? promotedData
     : migrateSessionDataToCurrent(promotedData, sourceSessionVersion);
+  const comparisonClassification = classifyImportedComparisonIntent({
+    renderRequest: data.renderRequest,
+    resources: data.resources
+  });
+  const projectionRenderRequest = (
+    data.renderRequest?.mode === 'linear'
+    && comparisonClassification.disposition
+      !== IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE
+  )
+    ? { ...data.renderRequest, comparisons: [] }
+    : data.renderRequest;
   const runtimeStoredConfig = currentSession
     ? migrateImportedLinearTrackSlots(
         migrateImportedCircularTrackSlots(data.config),
@@ -1442,7 +1464,7 @@ const preflightSessionImport = (rawData) => {
   if (currentSession) recordSessionLifecycleEvent('canonical-request-projection-start');
   const canonicalProjection = sourceSessionVersion >= 31
     ? projectCanonicalSessionRequest({
-        renderRequest: data.renderRequest,
+        renderRequest: projectionRenderRequest,
         resources: data.resources,
         webFiles: data.webFiles,
         legacyFiles: data.files,
@@ -1562,7 +1584,8 @@ const preflightSessionImport = (rawData) => {
     restoredConfig,
     projectionResult,
     adoptedCanonicalSession: adoptedSession?.canonical || null,
-    currentResourceTable
+    currentResourceTable,
+    comparisonClassification
   };
 };
 
@@ -1668,6 +1691,10 @@ export const applyConfigData = (data) => {
     state.linearComparisonPlan,
     data.linearComparisonPlan || createDefaultLinearComparisonPlan()
   );
+  state.importedComparisonIntent.action = Object.values(IMPORTED_COMPARISON_ACTIONS)
+    .includes(data.importedComparisonResolution?.action)
+    ? data.importedComparisonResolution.action
+    : null;
   state.adv.rich_feature_popup = data?.adv?.rich_feature_popup !== false;
   state.adv.label_placement = requireCurrentLinearLabelPlacement(
     state.adv.label_placement
@@ -2668,66 +2695,75 @@ export const adoptCanonicalRenderArtifacts = (
   const nextCommittedCanonicalSession = preserveAdoptedResources
     ? adoptRuntimeCanonicalSession(ownedCanonical)
     : cloneCanonicalSession(ownedCanonical);
-  activeSessionResourceTable = sessionResourceTable;
+  let nextLinearComparisons = null;
+  let nextCircularState = null;
   if (projection.mode === 'linear') {
-    const nextComparisons = deserializeCanonicalComparisons(
+    nextLinearComparisons = deserializeCanonicalComparisons(
       projection.files.linearCanonicalComparisons,
       { adoptCanonicalPayloads: preserveAdoptedResources }
     );
-    state.files.linearCanonicalComparisons = nextComparisons;
-    committedCanonicalSession = nextCommittedCanonicalSession;
-    return;
-  }
-  if (projection.files.c_conservation_blasts_source !== 'losat-cache') {
-    committedCanonicalSession = nextCommittedCanonicalSession;
-    return;
+  } else if (projection.files.c_conservation_blasts_source === 'losat-cache') {
+    const projectedConservation = projection.config.circularConservation;
+    const currentSeries = Array.isArray(state.circularConservation.series)
+      ? state.circularConservation.series.map((entry) => cloneJsonData(entry))
+      : [];
+    const nextSeries = Array.isArray(projectedConservation?.series)
+      ? projectedConservation.series.map((entry, index) => ({
+          ...entry,
+          ...(currentSeries[index] || {}),
+          sourceIndex: index,
+          fileName: entry.fileName,
+          label: entry.label,
+          color: entry.color
+        }))
+      : [];
+    nextCircularState = {
+      blasts: (projection.files.c_conservation_blasts || [])
+        .map((entry) => deserializeFile(entry))
+        .filter(Boolean),
+      fastas: (projection.files.c_conservation_fastas || [])
+        .map((entry) => deserializeFile(entry)),
+      sequenceSources: (projection.files.c_conservation_sequence_sources || [])
+        .map((entry) => deserializeFile(entry)),
+      projectedConservation,
+      series: nextSeries
+    };
   }
 
-  const nextBlastFiles = (projection.files.c_conservation_blasts || [])
-    .map((entry) => deserializeFile(entry))
-    .filter(Boolean);
-  const nextFastaFiles = (projection.files.c_conservation_fastas || [])
-    .map((entry) => deserializeFile(entry));
-  const nextSequenceSources = (projection.files.c_conservation_sequence_sources || [])
-    .map((entry) => deserializeFile(entry));
-  const projectedConservation = projection.config.circularConservation;
-  const currentSeries = Array.isArray(state.circularConservation.series)
-    ? state.circularConservation.series.map((entry) => cloneJsonData(entry))
-    : [];
-  const nextSeries = Array.isArray(projectedConservation?.series)
-    ? projectedConservation.series.map((entry, index) => ({
-        ...entry,
-        ...(currentSeries[index] || {}),
-        sourceIndex: index,
-        fileName: entry.fileName,
-        label: entry.label,
-        color: entry.color
-      }))
-    : [];
-
-  state.files.c_conservation_blasts = nextBlastFiles;
-  state.files.c_conservation_blasts_source = 'losat-cache';
-  state.files.c_conservation_fastas = nextFastaFiles;
-  state.files.c_conservation_sequence_sources = nextSequenceSources;
-  if (projectedConservation) {
-    state.circularConservation.enabled = true;
-    state.circularConservation.source = 'losat';
-    state.circularConservation.reference = projectedConservation.reference;
-    state.circularConservation.labels = nextSeries.map((entry) => entry.label).join(',');
-    state.circularConservation.ring_width = projectedConservation.ring_width;
-    state.circularConservation.ring_gap = projectedConservation.ring_gap;
-    state.circularConservation.series.splice(
-      0,
-      state.circularConservation.series.length,
-      ...nextSeries
-    );
-  }
+  // Everything that can validate, project, or deserialize finishes before the
+  // committed request and its comparison-backed draft resources are replaced.
+  activeSessionResourceTable = sessionResourceTable;
   committedCanonicalSession = nextCommittedCanonicalSession;
+  if (nextLinearComparisons) {
+    state.files.linearCanonicalComparisons = nextLinearComparisons;
+  }
+  if (nextCircularState) {
+    state.files.c_conservation_blasts = nextCircularState.blasts;
+    state.files.c_conservation_blasts_source = 'losat-cache';
+    state.files.c_conservation_fastas = nextCircularState.fastas;
+    state.files.c_conservation_sequence_sources = nextCircularState.sequenceSources;
+    if (nextCircularState.projectedConservation) {
+      state.circularConservation.enabled = true;
+      state.circularConservation.source = 'losat';
+      state.circularConservation.reference = nextCircularState.projectedConservation.reference;
+      state.circularConservation.labels = nextCircularState.series
+        .map((entry) => entry.label).join(',');
+      state.circularConservation.ring_width = nextCircularState.projectedConservation.ring_width;
+      state.circularConservation.ring_gap = nextCircularState.projectedConservation.ring_gap;
+      state.circularConservation.series.splice(
+        0,
+        state.circularConservation.series.length,
+        ...nextCircularState.series
+      );
+    }
+  }
 };
 
 export const getCommittedCanonicalRenderRequest = () => (
   committedCanonicalSession?.renderRequest || null
 );
+
+export const getCommittedCanonicalSession = () => committedCanonicalSession;
 
 const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
   state.matchSequenceRegistry?.reset?.();
@@ -3131,6 +3167,7 @@ const captureSessionImportSnapshot = () => ({
     ? committedCanonicalSession
     : cloneCanonicalSession(committedCanonicalSession),
   activeSessionResourceTable,
+  importedComparisonIntent: cloneJsonData(state.importedComparisonIntent),
   errorLog: state.errorLog.value,
   resultPanelTab: state.resultPanelTab.value,
   transients: captureSessionImportTransientState()
@@ -3159,6 +3196,11 @@ const restoreSessionImportSnapshot = async (snapshot) => {
       ? snapshot.committedCanonicalSession
       : cloneCanonicalSession(snapshot.committedCanonicalSession);
     activeSessionResourceTable = snapshot.activeSessionResourceTable;
+    Object.assign(
+      state.importedComparisonIntent,
+      createImportedComparisonIntentState(),
+      cloneJsonData(snapshot.importedComparisonIntent)
+    );
     state.skipCaptureBaseConfig.value = true;
     state.skipPositionReapply.value = true;
     applyResultsData(snapshot.results, snapshot.ui);
@@ -3187,6 +3229,10 @@ const resetSessionBaseline = () => {
   preservedCliOptions = null;
   committedCanonicalSession = null;
   activeSessionResourceTable = null;
+  Object.assign(
+    state.importedComparisonIntent,
+    createImportedComparisonIntentState()
+  );
   adoptedProteinIdentityManifest = null;
   state.sessionResourceDiscoveryDeferred.value = false;
   resetSettingsState(state);
@@ -3793,7 +3839,8 @@ export const importSession = async (e, options = {}) => {
       restoredConfig,
       projectionResult,
       adoptedCanonicalSession,
-      currentResourceTable
+      currentResourceTable,
+      comparisonClassification
     } = preflight;
     const canonicalSession = Boolean(projectionResult);
     const currentSchemaSession = sourceSessionVersion === SESSION_VERSION;
@@ -3867,6 +3914,11 @@ export const importSession = async (e, options = {}) => {
     const { collapsedLinearSeqs } = applyFiles(
       canonicalSession ? projectionResult.restoredFiles : data.files,
       { adoptCanonicalPayloads: currentSchemaSession }
+    );
+    restoreImportedComparisonIntent(
+      state.importedComparisonIntent,
+      comparisonClassification,
+      restoredConfig?.importedComparisonResolution
     );
     reconcileDepthTrackStateAfterSessionFiles();
     if (canonicalSession) {
@@ -4158,7 +4210,8 @@ export const importSession = async (e, options = {}) => {
       status: 'ok',
       data,
       decompressedCharacters: text.length,
-      degradedRecovery: Boolean(currentRecoveryError)
+      degradedRecovery: Boolean(currentRecoveryError),
+      comparisonDisposition: state.importedComparisonIntent.disposition
     };
   } catch (err) {
     console.error(err);

--- a/gbdraw/web/js/services/imported-comparison-intent.js
+++ b/gbdraw/web/js/services/imported-comparison-intent.js
@@ -1,0 +1,481 @@
+export const IMPORTED_COMPARISON_DISPOSITIONS = Object.freeze({
+  EDITABLE: 'EDITABLE',
+  PRESERVED_READ_ONLY: 'PRESERVED_READ_ONLY',
+  DECISION_REQUIRED: 'DECISION_REQUIRED'
+});
+
+export const IMPORTED_COMPARISON_ACTIONS = Object.freeze({
+  INHERIT: 'INHERIT',
+  REPLACE: 'REPLACE',
+  CLEAR: 'CLEAR'
+});
+
+const VALID_ACTIONS = new Set(Object.values(IMPORTED_COMPARISON_ACTIONS));
+const RESOURCE_BACKED_KINDS = new Set([
+  'nucleotideBlast',
+  'precomputedProteinComparison',
+  'orthogroupResult',
+  'collinearityResult'
+]);
+const ENDPOINT_KINDS = new Set([
+  'nucleotideBlast',
+  'precomputedProteinComparison'
+]);
+const PIPELINE_SETTING_FIELDS = new Set([
+  'collinearityParams',
+  'collinearityUnitMode',
+  'collinearityAnchorMode',
+  'collinearitySearchScope',
+  'collinearityColorMode',
+  'losatpBin',
+  'ncbiBlastpBin',
+  'losatpThreads',
+  'proteinBlastpMaxHits',
+  'proteinBlastpCandidateLimit',
+  'orthogroupMembershipMode',
+  'orthogroupMemberMaxHits',
+  'collinearMaxParalogLinksPerOrthogroup',
+  'alignOrthogroupFeature'
+]);
+const RESOURCE_KIND_BY_COMPARISON_KIND = Object.freeze({
+  nucleotideBlast: 'nucleotide-blast',
+  precomputedProteinComparison: 'canonical-tsv',
+  orthogroupResult: 'orthogroup-result',
+  collinearityResult: 'collinearity-result'
+});
+
+const isObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+const positiveRow = (value, fallback) => {
+  const row = Number(value);
+  return Number.isInteger(row) && row > 0 ? row : fallback;
+};
+const recordKey = (record, index) => String(record?.recordKey || `record-${index + 1}`);
+const endpointKey = (queryKey, subjectKey) => `${queryKey}->${subjectKey}`;
+
+export const createImportedComparisonIntentState = () => ({
+  disposition: IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE,
+  action: null,
+  message: '',
+  hasCommittedComparison: false
+});
+
+export const serializeImportedComparisonResolution = (intent) => ({
+  action: VALID_ACTIONS.has(intent?.action) ? intent.action : null
+});
+
+const comparisonResourceIssue = (comparison, resources) => {
+  const resourceId = String(comparison?.resourceId || '').trim();
+  if (!resourceId || !isObject(resources?.[resourceId])) {
+    return 'The saved comparison is missing a required resource.';
+  }
+  if (resources[resourceId].kind !== RESOURCE_KIND_BY_COMPARISON_KIND[comparison.kind]) {
+    return 'The saved comparison resource has an incompatible kind.';
+  }
+  if (
+    comparison.kind === 'precomputedProteinComparison'
+    && comparison.encoding !== 'canonicalTsv'
+  ) {
+    return 'The saved protein comparison uses an unsupported encoding.';
+  }
+  if (
+    comparison.kind === 'orthogroupResult'
+    && comparison.encoding !== 'canonicalJson'
+  ) {
+    return 'The saved Similarity Group result uses an unsupported encoding.';
+  }
+  if (
+    comparison.kind === 'collinearityResult'
+    && (
+      comparison.encoding !== 'canonicalJson'
+      || !['result', 'blocks'].includes(comparison.valueKind)
+    )
+  ) {
+    return 'The saved Collinear result uses an unsupported representation.';
+  }
+  return '';
+};
+
+const endpointIssue = (comparison, recordCount) => {
+  const query = Number(comparison?.queryRecordIndex);
+  const subject = Number(comparison?.subjectRecordIndex);
+  if (
+    !Number.isInteger(query)
+    || !Number.isInteger(subject)
+    || query < 0
+    || subject < 0
+    || query >= recordCount
+    || subject >= recordCount
+    || query === subject
+  ) {
+    return 'The saved comparison does not identify two available records.';
+  }
+  return '';
+};
+
+const pipelineIssue = (comparison, recordCount) => {
+  if (
+    !['none', 'pairwise', 'orthogroup', 'collinear'].includes(comparison?.mode)
+    || !isObject(comparison?.settings)
+    || !Array.isArray(comparison?.pairs)
+  ) {
+    return 'The saved protein comparison pipeline is incomplete or unsupported.';
+  }
+  const settingKeys = Object.keys(comparison.settings);
+  if (
+    settingKeys.length !== PIPELINE_SETTING_FIELDS.size
+    || settingKeys.some((key) => !PIPELINE_SETTING_FIELDS.has(key))
+  ) {
+    return 'The saved protein comparison pipeline is incomplete or unsupported.';
+  }
+  const collinearity = comparison.settings.collinearityParams;
+  if (collinearity !== null) {
+    const parameters = collinearity?.parameters;
+    const parameterKeys = isObject(parameters) ? Object.keys(parameters) : [];
+    if (
+      !isObject(collinearity)
+      || !['lossless', 'standard'].includes(collinearity.kind)
+      || parameterKeys.length === 0
+    ) {
+      return 'The saved Collinear parameters are incomplete or unsupported.';
+    }
+  }
+  for (const pair of comparison.pairs) {
+    const issue = endpointIssue(pair, recordCount);
+    if (issue) return issue;
+  }
+  return '';
+};
+
+const rowsAreEditable = (records, comparisons) => {
+  const rows = records.map((record, index) => (
+    positiveRow(record?.presentation?.gridRow, index + 1)
+  ));
+  const orderedRows = [...new Set(rows)].sort((left, right) => left - right);
+  const rowPosition = new Map(orderedRows.map((row, index) => [row, index]));
+  return comparisons.every((comparison) => {
+    const query = Number(comparison.queryRecordIndex);
+    const subject = Number(comparison.subjectRecordIndex);
+    return Math.abs(rowPosition.get(rows[query]) - rowPosition.get(rows[subject])) === 1;
+  });
+};
+
+const endpointKeys = (records, comparisons) => comparisons.map((comparison) => (
+  endpointKey(
+    recordKey(records[Number(comparison.queryRecordIndex)], Number(comparison.queryRecordIndex)),
+    recordKey(records[Number(comparison.subjectRecordIndex)], Number(comparison.subjectRecordIndex))
+  )
+));
+
+const generatedPipelineIsProjectable = ({ records, comparisons, pipeline }) => {
+  const endpoints = comparisons.filter((comparison) => ENDPOINT_KINDS.has(comparison.kind));
+  if (!rowsAreEditable(records, [...endpoints, ...pipeline.pairs])) return false;
+  if (pipeline.mode === 'pairwise' && pipeline.pairs.length === 0 && endpoints.length === 0) {
+    return false;
+  }
+  if (pipeline.mode === 'none') {
+    const inferredMode = comparisons.some((comparison) => comparison.kind === 'collinearityResult')
+      ? 'collinear'
+      : comparisons.some((comparison) => comparison.kind === 'orthogroupResult')
+        ? 'orthogroup'
+        : endpoints.some((comparison) => comparison.kind === 'precomputedProteinComparison')
+          ? 'pairwise'
+          : '';
+    if (!inferredMode) return false;
+  }
+  const collinearity = pipeline.settings?.collinearityParams;
+  if (!isObject(collinearity) || collinearity.kind !== 'lossless') return false;
+  const parameters = collinearity.parameters;
+  if (
+    !isObject(parameters)
+    || !['minAnchors', 'maxUnitGap', 'maxDiagonalDrift', 'maxConflicts', 'mergeOrientation']
+      .every((key) => Object.prototype.hasOwnProperty.call(parameters, key))
+  ) return false;
+  return true;
+};
+
+export const classifyImportedComparisonIntent = ({
+  renderRequest,
+  resources = {}
+} = {}) => {
+  const mode = String(renderRequest?.mode || '');
+  const comparisons = Array.isArray(renderRequest?.comparisons)
+    ? renderRequest.comparisons
+    : [];
+  const conservation = Array.isArray(renderRequest?.diagramOptions?.conservationBlastFiles)
+    ? renderRequest.diagramOptions.conservationBlastFiles
+    : [];
+  const hasCommittedComparison = comparisons.length > 0 || conservation.length > 0;
+  const editable = (message = '') => ({
+    disposition: IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE,
+    action: null,
+    message,
+    hasCommittedComparison
+  });
+  const preserved = (message) => ({
+    disposition: IMPORTED_COMPARISON_DISPOSITIONS.PRESERVED_READ_ONLY,
+    action: null,
+    message,
+    hasCommittedComparison
+  });
+  const decision = (message) => ({
+    disposition: IMPORTED_COMPARISON_DISPOSITIONS.DECISION_REQUIRED,
+    action: null,
+    message,
+    hasCommittedComparison
+  });
+
+  if (!hasCommittedComparison) return editable();
+  if (!['circular', 'linear'].includes(mode)) {
+    return decision('The saved comparison has no supported diagram mode.');
+  }
+
+  if (mode === 'circular') {
+    if (comparisons.length > 0) {
+      return decision('A Circular session contains unsupported Linear comparison data.');
+    }
+    for (const reference of conservation) {
+      const resourceId = String(reference?.resourceId || '').trim();
+      if (!resourceId || !isObject(resources?.[resourceId])) {
+        return decision('The saved Circular comparison is missing a required resource.');
+      }
+    }
+    return editable('The saved Circular comparison is represented by the current controls.');
+  }
+
+  const records = Array.isArray(renderRequest?.records) ? renderRequest.records : [];
+  if (records.length === 0) {
+    return decision('The saved comparison has no available records.');
+  }
+
+  let pipeline = null;
+  const singletonKinds = new Set();
+  for (const comparison of comparisons) {
+    const kind = String(comparison?.kind || '');
+    if (RESOURCE_BACKED_KINDS.has(kind)) {
+      const resourceIssue = comparisonResourceIssue(comparison, resources);
+      if (resourceIssue) return decision(resourceIssue);
+    } else if (kind === 'generatedProteinComparison') {
+      const issue = pipelineIssue(comparison, records.length);
+      if (issue) return decision(issue);
+      if (pipeline) return decision('The saved comparison contains more than one protein pipeline.');
+      pipeline = comparison;
+    } else {
+      return decision(`The saved comparison kind '${kind || 'unknown'}' is unsupported.`);
+    }
+    if (ENDPOINT_KINDS.has(kind)) {
+      const issue = endpointIssue(comparison, records.length);
+      if (issue) return decision(issue);
+    }
+    if (['orthogroupResult', 'collinearityResult'].includes(kind)) {
+      if (singletonKinds.has(kind)) {
+        return decision(`The saved comparison contains more than one ${kind}.`);
+      }
+      singletonKinds.add(kind);
+    }
+  }
+
+  const endpoints = comparisons.filter((comparison) => ENDPOINT_KINDS.has(comparison.kind));
+  const executableEndpoints = pipeline
+    ? [...endpoints, ...pipeline.pairs]
+    : endpoints;
+  if (!rowsAreEditable(records, executableEndpoints)) {
+    return decision(
+      'The saved comparison endpoints are not executable in the supported adjacent-row layout.'
+    );
+  }
+  const duplicateEndpoints = endpointKeys(records, endpoints);
+  if (new Set(duplicateEndpoints).size !== duplicateEndpoints.length) {
+    return preserved(
+      'The saved comparison contains repeated record pairs that current controls cannot represent losslessly.'
+    );
+  }
+  const hasDirectProteinInput = comparisons.some((comparison) => (
+    ['precomputedProteinComparison', 'orthogroupResult', 'collinearityResult']
+      .includes(comparison.kind)
+  ));
+  if (hasDirectProteinInput && !pipeline) {
+    return preserved(
+      'The saved comparison is executable, but current controls cannot edit this canonical protein input.'
+    );
+  }
+  if (pipeline && !generatedPipelineIsProjectable({ records, comparisons, pipeline })) {
+    return preserved(
+      'The saved protein comparison is executable, but current controls cannot represent it losslessly.'
+    );
+  }
+
+  return editable('The saved comparison is represented by the current controls.');
+};
+
+export const restoreImportedComparisonIntent = (
+  target,
+  classification,
+  storedResolution = null
+) => {
+  Object.assign(target, createImportedComparisonIntentState(), classification || {});
+  const storedAction = String(storedResolution?.action || '').trim().toUpperCase();
+  const allowed = target.disposition === IMPORTED_COMPARISON_DISPOSITIONS.PRESERVED_READ_ONLY
+    ? new Set(Object.values(IMPORTED_COMPARISON_ACTIONS))
+    : target.disposition === IMPORTED_COMPARISON_DISPOSITIONS.DECISION_REQUIRED
+      ? new Set([
+          IMPORTED_COMPARISON_ACTIONS.REPLACE,
+          IMPORTED_COMPARISON_ACTIONS.CLEAR
+        ])
+      : new Set();
+  target.action = allowed.has(storedAction) ? storedAction : null;
+  return target;
+};
+
+export const resolveImportedComparisonAction = ({
+  intent,
+  action,
+  draftResolution
+}) => {
+  const requested = String(action || '').trim().toUpperCase();
+  if (!VALID_ACTIONS.has(requested)) {
+    return { ok: false, message: 'Choose how to resolve the saved comparison.' };
+  }
+  if (
+    requested === IMPORTED_COMPARISON_ACTIONS.INHERIT
+    && (
+      intent.disposition !== IMPORTED_COMPARISON_DISPOSITIONS.PRESERVED_READ_ONLY
+      || intent.hasCommittedComparison !== true
+    )
+  ) {
+    return { ok: false, message: 'Only a complete preserved comparison can be inherited.' };
+  }
+  if (
+    requested === IMPORTED_COMPARISON_ACTIONS.REPLACE
+    && (draftResolution?.valid !== true || draftResolution?.hasComparisonIntent !== true)
+  ) {
+    return {
+      ok: false,
+      message: draftResolution?.error
+        || 'Set one complete, valid comparison in the current controls before replacing the saved comparison.'
+    };
+  }
+  if (
+    intent.disposition === IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE
+    && requested !== IMPORTED_COMPARISON_ACTIONS.CLEAR
+  ) {
+    return { ok: false, message: 'The saved comparison is already editable.' };
+  }
+  intent.action = requested;
+  return { ok: true, action: requested };
+};
+
+export const importedComparisonExecution = ({ intent, draftResolution }) => {
+  if (intent?.disposition === IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE) {
+    return { ok: true, mode: 'draft' };
+  }
+  if (intent?.action === IMPORTED_COMPARISON_ACTIONS.INHERIT) {
+    return { ok: true, mode: 'inherit' };
+  }
+  if (intent?.action === IMPORTED_COMPARISON_ACTIONS.CLEAR) {
+    return { ok: true, mode: 'clear' };
+  }
+  if (intent?.action === IMPORTED_COMPARISON_ACTIONS.REPLACE) {
+    if (draftResolution?.valid === true && draftResolution?.hasComparisonIntent === true) {
+      return { ok: true, mode: 'draft' };
+    }
+    return {
+      ok: false,
+      message: draftResolution?.error
+        || 'Set one complete, valid comparison before generating.'
+    };
+  }
+  return {
+    ok: false,
+    message: intent?.message || 'Choose how to resolve the saved comparison before generating.'
+  };
+};
+
+const collectComparisonResourceIds = (value, target = new Set()) => {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectComparisonResourceIds(entry, target));
+    return target;
+  }
+  if (!isObject(value)) return target;
+  if (Object.prototype.hasOwnProperty.call(value, 'resourceId')) {
+    const resourceId = String(value.resourceId || '').trim();
+    if (resourceId) target.add(resourceId);
+  }
+  Object.values(value).forEach((entry) => collectComparisonResourceIds(entry, target));
+  return target;
+};
+
+export const inheritCommittedComparisonIntent = ({ candidate, committed }) => {
+  if (!isObject(candidate?.renderRequest) || !isObject(committed?.renderRequest)) {
+    throw new Error('The preserved comparison is unavailable. Reload the Session and try again.');
+  }
+  const comparisons = committed.renderRequest.comparisons;
+  if (!Array.isArray(comparisons) || comparisons.length === 0) {
+    throw new Error('The preserved comparison is unavailable. Choose Replace or Clear.');
+  }
+  const committedRecords = Array.isArray(committed.renderRequest.records)
+    ? committed.renderRequest.records
+    : [];
+  const candidateRecords = Array.isArray(candidate.renderRequest.records)
+    ? candidate.renderRequest.records
+    : [];
+  const candidateIndexByKey = new Map();
+  candidateRecords.forEach((record, index) => {
+    const key = recordKey(record, index);
+    if (candidateIndexByKey.has(key)) {
+      throw new Error('The current draft has duplicate record identities. Choose Replace or Clear.');
+    }
+    candidateIndexByKey.set(key, index);
+  });
+  const remapIndex = (value) => {
+    const sourceIndex = Number(value);
+    if (!Number.isInteger(sourceIndex) || !committedRecords[sourceIndex]) {
+      throw new Error('The preserved comparison references an unavailable record.');
+    }
+    const key = recordKey(committedRecords[sourceIndex], sourceIndex);
+    const candidateIndex = candidateIndexByKey.get(key);
+    if (!Number.isInteger(candidateIndex)) {
+      throw new Error('The current draft no longer contains every record used by the preserved comparison.');
+    }
+    return candidateIndex;
+  };
+  const inheritedComparisons = structuredClone(comparisons);
+  inheritedComparisons.forEach((comparison) => {
+    if (ENDPOINT_KINDS.has(comparison?.kind)) {
+      comparison.queryRecordIndex = remapIndex(comparison.queryRecordIndex);
+      comparison.subjectRecordIndex = remapIndex(comparison.subjectRecordIndex);
+    }
+    if (comparison?.kind === 'generatedProteinComparison') {
+      comparison.pairs = (Array.isArray(comparison.pairs) ? comparison.pairs : [])
+        .map((pair) => ({
+          queryRecordIndex: remapIndex(pair?.queryRecordIndex),
+          subjectRecordIndex: remapIndex(pair?.subjectRecordIndex)
+        }));
+    }
+  });
+  candidate.renderRequest.comparisons = inheritedComparisons;
+  const committedOptions = committed.renderRequest.diagramOptions || {};
+  const candidateOptions = candidate.renderRequest.diagramOptions || {};
+  ['evalue', 'bitscore', 'identity', 'alignmentLength'].forEach((field) => {
+    if (Object.prototype.hasOwnProperty.call(committedOptions, field)) {
+      candidateOptions[field] = committedOptions[field];
+    } else {
+      delete candidateOptions[field];
+    }
+  });
+  candidate.renderRequest.diagramOptions = candidateOptions;
+
+  collectComparisonResourceIds(inheritedComparisons).forEach((resourceId) => {
+    const descriptor = committed.resources?.[resourceId];
+    if (!isObject(descriptor)) {
+      throw new Error('The preserved comparison is missing a required resource.');
+    }
+    const existing = candidate.resources?.[resourceId];
+    if (existing && existing !== descriptor) {
+      throw new Error(
+        'The preserved comparison resource conflicts with the current draft. Choose Replace or Clear.'
+      );
+    }
+    candidate.resources[resourceId] = descriptor;
+  });
+  return candidate;
+};

--- a/gbdraw/web/js/services/session-active-config-contract.js
+++ b/gbdraw/web/js/services/session-active-config-contract.js
@@ -46,12 +46,13 @@ export const CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS = Object.freeze([
   'form', 'adv', 'losat', 'cliOptions', 'colors', 'palette', 'paletteInstantPreviewEnabled', 'rules',
   'qualifierPriorityRules', 'filterMode', 'whitelist', 'blacklistText', 'losatProgram', 'circularConservation',
   'annotationSets', 'modeProfiles',
-  'linearRecordLayout', 'linearComparisonPlan', 'webEdits'
+  'linearRecordLayout', 'linearComparisonPlan', 'importedComparisonResolution', 'webEdits'
 ]);
 export const CURRENT_WRITER_FORM_FIELDS = Object.freeze([...Object.keys(createDefaultForm()), 'legend']);
 export const CURRENT_WRITER_ADV_FIELDS = Object.freeze([...Object.keys(createDefaultAdv()), 'plot_title_position', 'losatProgram']);
 const DOMAIN_SHAPES = Object.freeze({ form: 'object', adv: 'object', losat: 'object', cliOptions: 'object', colors: 'object',
   circularConservation: 'object', modeProfiles: 'object', linearRecordLayout: 'object', linearComparisonPlan: 'object', webEdits: 'object',
+  importedComparisonResolution: 'object',
   rules: 'array', qualifierPriorityRules: 'array', whitelist: 'array', annotationSets: 'array', palette: 'string', filterMode: 'string', blacklistText: 'string',
   losatProgram: 'string', paletteInstantPreviewEnabled: 'boolean' });
 const ROW_FIELDS = { rules: ['feat', 'qual', 'val', 'color', 'cap', 'fromFile'],
@@ -169,5 +170,18 @@ export const validateCurrentWriterActiveConfig = ({ mode, storedConfig: config }
   }
   if (has(config, 'filterMode') && !['None', 'Whitelist', 'Blacklist'].includes(config.filterMode)) throw new Error('Current session active configuration config.filterMode is invalid.');
   if (has(config, 'palette') && !config.palette.trim()) throw new Error('Current session active configuration config.palette cannot be empty.');
+  if (isObject(config.importedComparisonResolution)) {
+    assertFields(
+      config.importedComparisonResolution,
+      new Set(['action']),
+      'config.importedComparisonResolution'
+    );
+    if (
+      config.importedComparisonResolution.action !== null
+      && !['INHERIT', 'REPLACE', 'CLEAR'].includes(config.importedComparisonResolution.action)
+    ) {
+      throw new Error('Current session active configuration config.importedComparisonResolution.action is invalid.');
+    }
+  }
   validateImportedCircularTrackSlots(config); validateImportedLinearTrackSlots(config);
 };

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -2286,6 +2286,52 @@ const cloneCanonicalJsonValue = (value) => (
   value === undefined ? undefined : JSON.parse(JSON.stringify(value))
 );
 
+// Web controls own row membership and record order, not a distinct numeric
+// column value. Preserve the engine's row/column render order in the projected
+// record sequence, then retire the unsupported numeric column in the draft.
+export const normalizeWebGridColumnOrdering = (records = []) => {
+  const source = Array.isArray(records) ? records : [];
+  const entries = source.map((record, sourceIndex) => {
+    const rawRow = record?.presentation?.gridRow;
+    const rawColumn = record?.presentation?.gridColumn;
+    const row = Number(rawRow);
+    const column = Number(rawColumn);
+    return {
+      record,
+      sourceIndex,
+      row: rawRow !== null && rawRow !== undefined && Number.isInteger(row) ? row : sourceIndex + 1,
+      column: rawColumn !== null && rawColumn !== undefined && Number.isInteger(column)
+        ? column
+        : sourceIndex + 1
+    };
+  });
+  const hasColumns = source.some((record) => (
+    record?.presentation?.gridColumn !== null
+    && record?.presentation?.gridColumn !== undefined
+  ));
+  const ordered = hasColumns
+    ? entries.slice().sort((left, right) => (
+        left.row - right.row
+        || left.column - right.column
+        || left.sourceIndex - right.sourceIndex
+      ))
+    : entries;
+  const projectedIndexBySourceIndex = new Map(
+    ordered.map((entry, projectedIndex) => [entry.sourceIndex, projectedIndex])
+  );
+  return {
+    records: ordered.map(({ record }) => ({
+      ...record,
+      presentation: {
+        ...(record?.presentation || {}),
+        gridColumn: null
+      }
+    })),
+    sourceIndexByProjectedIndex: ordered.map((entry) => entry.sourceIndex),
+    projectedIndexBySourceIndex
+  };
+};
+
 const projectGeneratedProteinPipeline = (
   comparison,
   { adoptCanonicalPayloads = false } = {}
@@ -2967,10 +3013,23 @@ export const projectCanonicalSessionRequest = ({
   if (!['circular', 'linear'].includes(renderRequest.mode)) {
     throw new Error('Unsupported canonical renderRequest mode.');
   }
-  const records = Array.isArray(renderRequest.records) ? renderRequest.records : [];
+  const sourceRecords = Array.isArray(renderRequest.records) ? renderRequest.records : [];
+  const normalizedRecordOrdering = normalizeWebGridColumnOrdering(sourceRecords);
+  const records = normalizedRecordOrdering.records;
+  const reorderRecordIndexedValues = (values) => (
+    normalizedRecordOrdering.sourceIndexByProjectedIndex
+      .map((sourceIndex) => values?.[sourceIndex])
+  );
   if (records.length === 0) throw new Error('Canonical renderRequest records are required.');
   const grouping = canonicalGrouping(renderRequest, records);
-  const outputPrefixes = canonicalOutputPrefixes(renderRequest, grouping, records.length);
+  const sourceOutputPrefixes = canonicalOutputPrefixes(
+    renderRequest,
+    grouping,
+    records.length
+  );
+  const outputPrefixes = grouping === 'batch'
+    ? reorderRecordIndexedValues(sourceOutputPrefixes)
+    : sourceOutputPrefixes;
   const webMetadata = webFiles && typeof webFiles === 'object' && !Array.isArray(webFiles)
     ? webFiles
     : {};
@@ -3077,8 +3136,9 @@ export const projectCanonicalSessionRequest = ({
       const source = record.source || {};
       const region = record.region || null;
       const selector = region?.selector || record.selector;
+      const sourceIndex = normalizedRecordOrdering.sourceIndexByProjectedIndex[index];
       const savedMetadata = savedLinearRecordMetadataByKey.get(String(record.recordKey || '')) ||
-        savedLinearRecordMetadata[index] || legacyLinearSequences[index] || {};
+        savedLinearRecordMetadata[sourceIndex] || legacyLinearSequences[sourceIndex] || {};
       return {
         uid: String(record.recordKey || `canonical-seq-${index + 1}`),
         gb: source.kind === 'genbank'
@@ -3117,12 +3177,16 @@ export const projectCanonicalSessionRequest = ({
     (renderRequest.comparisons || [])
       .filter((comparison) => comparison?.kind === 'nucleotideBlast')
       .forEach((comparison, index) => {
-        const queryIndex = Number.isInteger(Number(comparison.queryRecordIndex))
+        const sourceQueryIndex = Number.isInteger(Number(comparison.queryRecordIndex))
           ? Number(comparison.queryRecordIndex)
           : index;
-        const subjectIndex = Number.isInteger(Number(comparison.subjectRecordIndex))
+        const sourceSubjectIndex = Number.isInteger(Number(comparison.subjectRecordIndex))
           ? Number(comparison.subjectRecordIndex)
           : index + 1;
+        const queryIndex = normalizedRecordOrdering.projectedIndexBySourceIndex
+          .get(sourceQueryIndex);
+        const subjectIndex = normalizedRecordOrdering.projectedIndexBySourceIndex
+          .get(sourceSubjectIndex);
         const file = resolveResourceFile
           ? resolveResourceFile(comparison.resourceId)
           : resourceAsLegacyFile(resources, comparison.resourceId);
@@ -3140,8 +3204,12 @@ export const projectCanonicalSessionRequest = ({
       });
     (renderRequest.comparisons || []).forEach((comparison) => {
       if (isResourceBackedCanonicalComparison(comparison)) {
-        const queryRecordIndex = Number(comparison.queryRecordIndex);
-        const subjectRecordIndex = Number(comparison.subjectRecordIndex);
+        const sourceQueryRecordIndex = Number(comparison.queryRecordIndex);
+        const sourceSubjectRecordIndex = Number(comparison.subjectRecordIndex);
+        const queryRecordIndex = normalizedRecordOrdering.projectedIndexBySourceIndex
+          .get(sourceQueryRecordIndex);
+        const subjectRecordIndex = normalizedRecordOrdering.projectedIndexBySourceIndex
+          .get(sourceSubjectRecordIndex);
         if (
           comparison.kind === 'precomputedProteinComparison' &&
           (
@@ -3159,6 +3227,9 @@ export const projectCanonicalSessionRequest = ({
                 ? resolveResourceFile(comparison.resourceId)
                 : resourceAsLegacyFile(resources, comparison.resourceId)
             ),
+            ...(comparison.kind === 'precomputedProteinComparison'
+              ? { queryRecordIndex, subjectRecordIndex }
+              : {}),
             // This is in-memory projection provenance, not a canonical-schema
             // field. Direct CLI/Python comparison options have no Web pipeline
             // marker and must survive a projection/rebuild unchanged.
@@ -3172,13 +3243,25 @@ export const projectCanonicalSessionRequest = ({
         return;
       }
       if (comparison?.kind === 'generatedProteinComparison') {
+        const projectedComparison = adoptCanonicalPayloads
+          ? { ...comparison }
+          : cloneCanonicalJsonValue(comparison);
+        projectedComparison.pairs = (Array.isArray(comparison.pairs) ? comparison.pairs : [])
+          .map((pair) => ({
+            queryRecordIndex: normalizedRecordOrdering.projectedIndexBySourceIndex
+              .get(Number(pair?.queryRecordIndex)),
+            subjectRecordIndex: normalizedRecordOrdering.projectedIndexBySourceIndex
+              .get(Number(pair?.subjectRecordIndex))
+          }));
         files.linearCanonicalComparisons.push(
-          adoptCanonicalPayloads ? comparison : cloneCanonicalJsonValue(comparison)
+          projectedComparison
         );
         (Array.isArray(comparison.pairs) ? comparison.pairs : [])
           .forEach((pair, index) => {
-            const queryIndex = Number(pair?.queryRecordIndex);
-            const subjectIndex = Number(pair?.subjectRecordIndex);
+            const queryIndex = normalizedRecordOrdering.projectedIndexBySourceIndex
+              .get(Number(pair?.queryRecordIndex));
+            const subjectIndex = normalizedRecordOrdering.projectedIndexBySourceIndex
+              .get(Number(pair?.subjectRecordIndex));
             if (!files.linearSeqs[queryIndex] || !files.linearSeqs[subjectIndex]) return;
             files.linearComparisons.push({
               id: `linear-comparison-canonical-losat-${index + 1}`,
@@ -3212,9 +3295,15 @@ export const projectCanonicalSessionRequest = ({
             )
       )
     : 'auto';
-  const depthRows = canonicalDepth?.sourceRows || (
+  const sourceDepthRows = canonicalDepth?.sourceRows || (
     Array.isArray(options.depthTrackFiles) ? options.depthTrackFiles : []
   );
+  const depthRows = sourceDepthRows.length > 0
+    ? reorderRecordIndexedValues(sourceDepthRows)
+    : sourceDepthRows;
+  const depthFileRows = canonicalDepth?.fileRows
+    ? reorderRecordIndexedValues(canonicalDepth.fileRows)
+    : null;
   if (depthRows.length > 0) {
     if (depthRows.length !== records.length || depthRows.some((row) => !Array.isArray(row))) {
       throw new Error(
@@ -3224,7 +3313,7 @@ export const projectCanonicalSessionRequest = ({
   }
   if (renderRequest.mode === 'circular' && depthRows.length > 0) {
     files.c_depth = normalizeRecordMajorDepthFileRows(
-      canonicalDepth?.fileRows || depthRows.map((row) => row.map((ref) => (
+      depthFileRows || depthRows.map((row) => row.map((ref) => (
         ref?.resourceId
           ? (resolveResourceFile
               ? resolveResourceFile(ref.resourceId)
@@ -3237,7 +3326,7 @@ export const projectCanonicalSessionRequest = ({
   if (renderRequest.mode === 'linear') {
     depthRows.forEach((row, index) => {
       if (!files.linearSeqs[index] || !Array.isArray(row)) return;
-      const depth = canonicalDepth?.fileRows[index] || row
+      const depth = depthFileRows?.[index] || row
         .map((ref) => ref?.resourceId
           ? (resolveResourceFile
               ? resolveResourceFile(ref.resourceId)

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -19,6 +19,7 @@ import {
 import { createModeProfileStateManager } from './mode-profiles.js';
 import { createDefaultFeatureRenderings } from './utils/feature-rendering.js';
 import { getCommittedSvgContent } from './services/svg-result-ingestion.js';
+import { createImportedComparisonIntentState } from './services/imported-comparison-intent.js';
 import {
   createDefaultAdv,
   createDefaultCircularConservation,
@@ -37,6 +38,7 @@ const sessionTitle = ref('');
 const semanticFileWatchersSuppressed = ref(false);
 const sessionResourceDiscoveryDeferred = ref(false);
 const sessionImportRollbackInProgress = ref(false);
+const importedComparisonIntent = reactive(createImportedComparisonIntentState());
 
 const results = ref([]);
 const selectedResultIndex = ref(0);
@@ -760,6 +762,7 @@ export const state = {
   semanticFileWatchersSuppressed,
   sessionResourceDiscoveryDeferred,
   sessionImportRollbackInProgress,
+  importedComparisonIntent,
   results,
   selectedResultIndex,
   failedGeneratePreservedResult,

--- a/tests/web/comparison-ui.playwright.spec.js
+++ b/tests/web/comparison-ui.playwright.spec.js
@@ -2,6 +2,49 @@ const { test, expect } = require('@playwright/test');
 const { readFileSync } = require('node:fs');
 const { gunzipSync } = require('node:zlib');
 
+const bgcSessionPath = 'tests/test_inputs/BGC0000708-BGC0000713.gbdraw-session.json';
+
+const preservedComparisonSession = () => {
+  const session = JSON.parse(readFileSync(bgcSessionPath, 'utf8'));
+  const comparisonText = 'unmatched-query\tunmatched-subject\t99\t10\t0\t0\t1\t10\t1\t10\t1e-5\t50\n';
+  session.resources['imported-repeated-comparison'] = {
+    kind: 'nucleotide-blast',
+    name: 'imported-repeated-comparison.tsv',
+    type: 'text/tab-separated-values',
+    size: Buffer.byteLength(comparisonText),
+    lastModified: 0,
+    encoding: 'base64',
+    data: Buffer.from(comparisonText).toString('base64')
+  };
+  session.renderRequest.comparisons = Array.from({ length: 2 }, () => ({
+    kind: 'nucleotideBlast',
+    resourceId: 'imported-repeated-comparison',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }));
+  session.config.linearComparisonPlan = {
+    mode: 'none',
+    defaultSource: 'losat',
+    edges: []
+  };
+  session.losatCache = { entries: [] };
+  session.losatDerivedCache = { entries: [] };
+  return session;
+};
+
+const decisionRequiredComparisonSession = () => {
+  const session = JSON.parse(readFileSync(bgcSessionPath, 'utf8'));
+  session.renderRequest.comparisons = [{
+    kind: 'nucleotideBlast',
+    resourceId: 'missing-comparison-resource',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }];
+  session.losatCache = { entries: [] };
+  session.losatDerivedCache = { entries: [] };
+  return session;
+};
+
 const makeGenbank = (recordId, base = 'atg') => {
   const sequence = base.repeat(100);
   const origin = sequence.match(/.{1,60}/g).map((chunk, index) => {
@@ -322,6 +365,154 @@ test('uploader, comparison commands, and native summaries work from the keyboard
   }
   const afterDisclosures = await serializedComparisonState();
   expect(afterDisclosures).toEqual(beforeDisclosures);
+});
+
+test('imported comparison resolutions are explicit and create one History entry each', async ({ page }) => {
+  await openLinear(page);
+  await inputHeaderAdd(page).click();
+  await comparisonCommands(page).getByRole('button', {
+    name: 'Run LOSAT for all adjacent pairs'
+  }).click();
+
+  const setIntent = (disposition, message) => page.evaluate(async ({ next, explanation }) => {
+    const { state } = await import('/gbdraw/web/js/state.js');
+    Object.assign(state.importedComparisonIntent, {
+      disposition: next,
+      action: null,
+      message: explanation,
+      hasCommittedComparison: true
+    });
+    await window.Vue.nextTick();
+  }, { next: disposition, explanation: message });
+  const resolution = page.locator('[data-imported-comparison-resolution]');
+
+  await setIntent(
+    'PRESERVED_READ_ONLY',
+    'The saved comparison cannot be represented losslessly by current controls.'
+  );
+  await expect(resolution).toContainText('Saved comparison preserved as read-only');
+  const historyBefore = await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount());
+  await resolution.getByRole('button', { name: 'Inherit saved comparison' }).click();
+  await expect(resolution).toContainText('Selected action: INHERIT');
+  expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount()))
+    .toBe(historyBefore + 1);
+
+  const dialogPromise = page.waitForEvent('dialog');
+  await page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  ).setInputFiles({
+    name: 'decision-required-comparison.gbdraw-session.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify(decisionRequiredComparisonSession()))
+  });
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+  await expect(resolution).toContainText('Saved comparison needs a decision');
+  await expect(resolution).toContainText('missing a required resource');
+  await expect(resolution.getByRole('button', { name: 'Inherit saved comparison' }))
+    .toHaveCount(0);
+  const historyBeforeBlockedGenerate = await page.evaluate(() => (
+    window.__GBDRAW_HISTORY__.getUndoCount()
+  ));
+  await page.getByRole('button', { name: 'Generate Diagram' }).click();
+  await expect(page.getByRole('alert', { name: 'Generation Error' })).toContainText(
+    'missing a required resource'
+  );
+  await expect(page.getByRole('region', { name: 'Result Preview' }))
+    .toContainText('Last Successful Result');
+  await expect(page.getByRole('button', { name: 'SVG', exact: true })).toBeEnabled();
+  expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount()))
+    .toBe(historyBeforeBlockedGenerate);
+  const beforeReplace = await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount());
+  await resolution.getByRole('button', { name: 'Replace with current controls' }).click();
+  await expect(resolution).toContainText('Selected action: REPLACE');
+  expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount()))
+    .toBe(beforeReplace + 1);
+
+  await setIntent(
+    'DECISION_REQUIRED',
+    'The saved comparison is incomplete and needs an explicit replacement or clear action.'
+  );
+  const beforeClear = await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount());
+  await resolution.getByRole('button', { name: 'Clear comparison' }).click();
+  await expect(resolution).toContainText('Selected action: CLEAR');
+  expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount()))
+    .toBe(beforeClear + 1);
+  await expect(comparisonCard(page).locator('[role="status"][aria-live="polite"]'))
+    .toContainText(
+    'Current: No comparison'
+    );
+});
+
+test('preserved imported comparison generates only after explicit inheritance', async ({ page }) => {
+  test.setTimeout(300000);
+  await page.goto('/gbdraw/web/index.html', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+  const dialogPromise = page.waitForEvent('dialog');
+  await page.locator(
+    'input[type="file"][accept*="application/json"][accept*="application/gzip"]'
+  ).setInputFiles({
+    name: 'preserved-comparison.gbdraw-session.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify(preservedComparisonSession()))
+  });
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+
+  const resolution = page.locator('[data-imported-comparison-resolution]');
+  await expect(resolution).toContainText('Saved comparison preserved as read-only');
+  const imported = await page.evaluate(() => ({
+    intent: JSON.parse(JSON.stringify(window.__GBDRAW_APP__.importedComparisonIntent)),
+    result: window.__GBDRAW_APP__.results[window.__GBDRAW_APP__.selectedResultIndex]?.content,
+    undoCount: window.__GBDRAW_HISTORY__.getUndoCount()
+  }));
+  expect(imported.intent).toMatchObject({
+    disposition: 'PRESERVED_READ_ONLY',
+    action: null,
+    hasCommittedComparison: true
+  });
+  expect(imported.undoCount).toBe(0);
+
+  await resolution.getByRole('button', { name: 'Inherit saved comparison' }).click();
+  const generated = await page.evaluate(async () => {
+    const app = window.__GBDRAW_APP__;
+    const { getCommittedCanonicalSession } = await import('./js/services/config.js');
+    const outcome = await app.runAnalysis();
+    const committed = getCommittedCanonicalSession();
+    return {
+      outcome,
+      error: app.errorLog,
+      action: app.importedComparisonIntent.action,
+      result: app.results[app.selectedResultIndex]?.content,
+      comparisons: committed?.renderRequest?.comparisons,
+      undoCount: window.__GBDRAW_HISTORY__.getUndoCount()
+    };
+  });
+  expect(generated.outcome, JSON.stringify(generated.error, null, 2)).toEqual({ status: 'ok' });
+  expect(generated.action).toBe('INHERIT');
+  expect(generated.result).not.toBe(imported.result);
+  expect(generated.comparisons).toHaveLength(2);
+  expect(generated.comparisons).toEqual(Array.from({ length: 2 }, () => ({
+    kind: 'nucleotideBlast',
+    resourceId: 'imported-repeated-comparison',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  })));
+  expect(generated.undoCount).toBe(imported.undoCount + 2);
+
+  const downloadPromise = page.waitForEvent('download');
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.saveSessionWithTitle()))
+    .toMatchObject({ status: 'saved' });
+  const download = await downloadPromise;
+  const savedSession = JSON.parse(
+    gunzipSync(readFileSync(await download.path())).toString('utf8')
+  );
+  expect(savedSession.config.importedComparisonResolution).toEqual({ action: 'INHERIT' });
+  expect(savedSession.renderRequest.comparisons).toEqual(generated.comparisons);
+  expect(savedSession.results[savedSession.ui.selectedResultIndex].content)
+    .toBe(generated.result);
 });
 
 test('LOSAT and LOSATP modes own their controls and mixed plans require explicit topology change', async ({ page }) => {

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -857,7 +857,12 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     return {
       originalPreview: String(selected?.content || ''),
       previewVisible: Boolean(document.querySelector('.shadow-xl.origin-top > svg')),
-      resultCount: Array.isArray(app.results) ? app.results.length : 0
+      resultCount: Array.isArray(app.results) ? app.results.length : 0,
+      undoCount: window.__GBDRAW_HISTORY__?.getUndoCount?.() ?? -1,
+      importedComparisonIntent: {
+        disposition: app.importedComparisonIntent?.disposition,
+        action: app.importedComparisonIntent?.action
+      }
     };
   });
   const loadedPreviewIdentity = svgSourceIdentity(loaded.originalPreview);
@@ -877,6 +882,11 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
   };
   expect(loaded.previewVisible).toBe(true);
   expect(loaded.resultCount).toBe(1);
+  expect(loaded.undoCount).toBe(0);
+  expect(loaded.importedComparisonIntent).toEqual({
+    disposition: 'EDITABLE',
+    action: null
+  });
   expect(ready).toMatchObject({ status: 'success', degradedRecovery: false });
   expect(previewMetrics).toEqual(Object.fromEntries(
     PREVIEW_ZERO_METRICS.map((name) => [name, 0])

--- a/tests/web/imported-comparison-intent.test.mjs
+++ b/tests/web/imported-comparison-intent.test.mjs
@@ -1,0 +1,272 @@
+import assert from 'node:assert/strict';
+
+import {
+  IMPORTED_COMPARISON_ACTIONS,
+  IMPORTED_COMPARISON_DISPOSITIONS,
+  classifyImportedComparisonIntent,
+  createImportedComparisonIntentState,
+  importedComparisonExecution,
+  inheritCommittedComparisonIntent,
+  resolveImportedComparisonAction,
+  restoreImportedComparisonIntent,
+  serializeImportedComparisonResolution
+} from '../../gbdraw/web/js/services/imported-comparison-intent.js';
+
+const records = [
+  {
+    recordKey: 'record-a',
+    presentation: { gridRow: 1, gridColumn: null }
+  },
+  {
+    recordKey: 'record-b',
+    presentation: { gridRow: 2, gridColumn: null }
+  }
+];
+const resources = {
+  comparison: {
+    kind: 'nucleotide-blast',
+    encoding: 'base64',
+    data: 'Ymxhc3Q='
+  },
+  protein: {
+    kind: 'canonical-tsv',
+    encoding: 'base64',
+    data: 'cHJvdGVpbg=='
+  }
+};
+const request = (comparisons, overrides = {}) => ({
+  schema: 6,
+  mode: 'linear',
+  records,
+  diagramOptions: {
+    bitscore: 50,
+    evalue: 1e-2,
+    identity: 0,
+    alignmentLength: 0
+  },
+  comparisons,
+  ...overrides
+});
+const pipelineSettings = {
+  collinearityParams: {
+    kind: 'lossless',
+    parameters: {
+      minAnchors: 1,
+      maxUnitGap: 0,
+      maxDiagonalDrift: 0,
+      maxConflicts: 1,
+      mergeOrientation: 'either'
+    }
+  },
+  collinearityUnitMode: 'auto',
+  collinearityAnchorMode: 'rbh',
+  collinearitySearchScope: 'adjacent',
+  collinearityColorMode: 'orientation',
+  losatpBin: 'losat',
+  ncbiBlastpBin: null,
+  losatpThreads: null,
+  proteinBlastpMaxHits: 5,
+  proteinBlastpCandidateLimit: null,
+  orthogroupMembershipMode: 'anchor_core_v1',
+  orthogroupMemberMaxHits: 5,
+  collinearMaxParalogLinksPerOrthogroup: 2,
+  alignOrthogroupFeature: null
+};
+
+const editable = classifyImportedComparisonIntent({
+  renderRequest: request([{
+    kind: 'nucleotideBlast',
+    resourceId: 'comparison',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }]),
+  resources
+});
+assert.equal(editable.disposition, IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE);
+assert.equal(editable.hasCommittedComparison, true);
+
+const editablePipeline = classifyImportedComparisonIntent({
+  renderRequest: request([{
+    kind: 'generatedProteinComparison',
+    mode: 'pairwise',
+    pairs: [{ queryRecordIndex: 0, subjectRecordIndex: 1 }],
+    settings: pipelineSettings
+  }]),
+  resources
+});
+assert.equal(
+  editablePipeline.disposition,
+  IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE
+);
+
+const preserved = classifyImportedComparisonIntent({
+  renderRequest: request([{
+    kind: 'precomputedProteinComparison',
+    resourceId: 'protein',
+    encoding: 'canonicalTsv',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }]),
+  resources
+});
+assert.equal(
+  preserved.disposition,
+  IMPORTED_COMPARISON_DISPOSITIONS.PRESERVED_READ_ONLY
+);
+assert.match(preserved.message, /cannot edit/i);
+
+const decision = classifyImportedComparisonIntent({
+  renderRequest: request([{
+    kind: 'nucleotideBlast',
+    resourceId: 'missing',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }]),
+  resources
+});
+assert.equal(
+  decision.disposition,
+  IMPORTED_COMPARISON_DISPOSITIONS.DECISION_REQUIRED
+);
+assert.match(decision.message, /missing/i);
+const incompletePipeline = classifyImportedComparisonIntent({
+  renderRequest: request([{
+    kind: 'generatedProteinComparison',
+    mode: 'pairwise',
+    pairs: [{ queryRecordIndex: 0, subjectRecordIndex: 1 }],
+    settings: {}
+  }]),
+  resources
+});
+assert.equal(
+  incompletePipeline.disposition,
+  IMPORTED_COMPARISON_DISPOSITIONS.DECISION_REQUIRED
+);
+const nonExecutableEndpoints = classifyImportedComparisonIntent({
+  renderRequest: request([{
+    kind: 'nucleotideBlast',
+    resourceId: 'comparison',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 2
+  }], {
+    records: [
+      ...records,
+      { recordKey: 'record-c', presentation: { gridRow: 3, gridColumn: null } }
+    ]
+  }),
+  resources
+});
+assert.equal(
+  nonExecutableEndpoints.disposition,
+  IMPORTED_COMPARISON_DISPOSITIONS.DECISION_REQUIRED
+);
+assert.match(nonExecutableEndpoints.message, /not executable/i);
+
+const inheritedState = createImportedComparisonIntentState();
+restoreImportedComparisonIntent(inheritedState, preserved, {
+  action: IMPORTED_COMPARISON_ACTIONS.INHERIT
+});
+assert.equal(inheritedState.action, IMPORTED_COMPARISON_ACTIONS.INHERIT);
+assert.deepEqual(serializeImportedComparisonResolution(inheritedState), {
+  action: IMPORTED_COMPARISON_ACTIONS.INHERIT
+});
+assert.deepEqual(importedComparisonExecution({
+  intent: inheritedState,
+  draftResolution: { valid: true, hasComparisonIntent: false }
+}), { ok: true, mode: 'inherit' });
+
+const decisionState = createImportedComparisonIntentState();
+restoreImportedComparisonIntent(decisionState, decision);
+assert.equal(importedComparisonExecution({
+  intent: decisionState,
+  draftResolution: { valid: true, hasComparisonIntent: false }
+}).ok, false);
+assert.equal(resolveImportedComparisonAction({
+  intent: decisionState,
+  action: IMPORTED_COMPARISON_ACTIONS.INHERIT,
+  draftResolution: { valid: true, hasComparisonIntent: true }
+}).ok, false);
+assert.equal(resolveImportedComparisonAction({
+  intent: decisionState,
+  action: IMPORTED_COMPARISON_ACTIONS.REPLACE,
+  draftResolution: { valid: false, hasComparisonIntent: true, error: 'Incomplete draft.' }
+}).ok, false);
+assert.deepEqual(resolveImportedComparisonAction({
+  intent: decisionState,
+  action: IMPORTED_COMPARISON_ACTIONS.REPLACE,
+  draftResolution: { valid: true, hasComparisonIntent: true }
+}), { ok: true, action: IMPORTED_COMPARISON_ACTIONS.REPLACE });
+assert.deepEqual(importedComparisonExecution({
+  intent: decisionState,
+  draftResolution: { valid: true, hasComparisonIntent: true }
+}), { ok: true, mode: 'draft' });
+
+restoreImportedComparisonIntent(decisionState, decision);
+assert.deepEqual(resolveImportedComparisonAction({
+  intent: decisionState,
+  action: IMPORTED_COMPARISON_ACTIONS.CLEAR,
+  draftResolution: { valid: false, hasComparisonIntent: false }
+}), { ok: true, action: IMPORTED_COMPARISON_ACTIONS.CLEAR });
+assert.deepEqual(importedComparisonExecution({
+  intent: decisionState,
+  draftResolution: { valid: false, hasComparisonIntent: false }
+}), { ok: true, mode: 'clear' });
+
+const committed = {
+  renderRequest: request([{
+    kind: 'precomputedProteinComparison',
+    resourceId: 'protein',
+    encoding: 'canonicalTsv',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }]),
+  resources
+};
+const candidate = {
+  renderRequest: request([], {
+    records: [records[1], records[0]],
+    diagramOptions: {
+      bitscore: 99,
+      evalue: 1e-20,
+      identity: 90,
+      alignmentLength: 200,
+      pairwiseMatchStyle: 'curve'
+    }
+  }),
+  resources: {}
+};
+inheritCommittedComparisonIntent({ candidate, committed });
+assert.deepEqual(candidate.renderRequest.comparisons, [{
+  kind: 'precomputedProteinComparison',
+  resourceId: 'protein',
+  encoding: 'canonicalTsv',
+  queryRecordIndex: 1,
+  subjectRecordIndex: 0
+}]);
+assert.equal(candidate.resources.protein, resources.protein);
+assert.deepEqual(
+  {
+    bitscore: candidate.renderRequest.diagramOptions.bitscore,
+    evalue: candidate.renderRequest.diagramOptions.evalue,
+    identity: candidate.renderRequest.diagramOptions.identity,
+    alignmentLength: candidate.renderRequest.diagramOptions.alignmentLength
+  },
+  { bitscore: 50, evalue: 1e-2, identity: 0, alignmentLength: 0 }
+);
+assert.equal(candidate.renderRequest.diagramOptions.pairwiseMatchStyle, 'curve');
+
+const circular = classifyImportedComparisonIntent({
+  renderRequest: {
+    schema: 6,
+    mode: 'circular',
+    records: [records[0]],
+    comparisons: [],
+    diagramOptions: {
+      conservationBlastFiles: [{ resourceId: 'comparison' }]
+    }
+  },
+  resources
+});
+assert.equal(circular.disposition, IMPORTED_COMPARISON_DISPOSITIONS.EDITABLE);
+
+console.log('imported comparison intent tests passed');

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -1480,4 +1480,26 @@ test('Linear mode none ignores dormant comparison state while active depth and a
   const retryResult = result('linear-none-retry.svg', 'linear-none-retry');
   workerResponses.push(response(retryResult, validCatalog(retryResult.name)));
   assert.deepEqual(await runner.runAnalysis(comparisonPlanSnapshot), { status: 'ok' });
+
+  let releaseSupersededCatalog;
+  prepareLinearRecordCatalogImpl = () => new Promise((resolve) => {
+    releaseSupersededCatalog = resolve;
+  });
+  const supersededRun = runner.runAnalysis(comparisonPlanSnapshot);
+  while (!releaseSupersededCatalog) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  prepareLinearRecordCatalogImpl = async () => ({
+    catalog: preparedRecordCatalog,
+    error: ''
+  });
+  const newestResult = result('linear-none-newest.svg', 'linear-none-newest');
+  workerResponses.push(response(newestResult, validCatalog(newestResult.name)));
+  assert.deepEqual(await runner.runAnalysis(comparisonPlanSnapshot), { status: 'ok' });
+  assert.deepEqual(state.results.value, [newestResult]);
+  releaseSupersededCatalog({ catalog: preparedRecordCatalog, error: '' });
+  assert.deepEqual(await supersededRun, { status: 'stale' });
+  assert.deepEqual(state.results.value, [newestResult]);
+  assert.equal(state.failedGeneratePreservedResult.value, false);
+  assert.equal(state.processing.value, false);
 });

--- a/tests/web/session-draft-authority.test.mjs
+++ b/tests/web/session-draft-authority.test.mjs
@@ -241,12 +241,36 @@ assert.deepEqual(CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS, [
   'modeProfiles',
   'linearRecordLayout',
   'linearComparisonPlan',
+  'importedComparisonResolution',
   'webEdits'
 ]);
 assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
   mode: 'circular',
   storedConfig
 }));
+assert.throws(
+  () => validateCurrentWriterActiveConfig({
+    mode: 'linear',
+    storedConfig: {
+      ...storedConfig,
+      importedComparisonResolution: { action: 'AUTOMATIC' }
+    }
+  }),
+  /importedComparisonResolution\.action is invalid/
+);
+Object.assign(state.importedComparisonIntent, {
+  disposition: 'PRESERVED_READ_ONLY',
+  action: 'INHERIT',
+  message: 'Preserved for the current Session.',
+  hasCommittedComparison: true
+});
+assert.deepEqual(buildConfigData().importedComparisonResolution, { action: 'INHERIT' });
+Object.assign(state.importedComparisonIntent, {
+  disposition: 'EDITABLE',
+  action: null,
+  message: '',
+  hasCommittedComparison: false
+});
 const restored = restoreCurrentWriterActiveConfig({
   mode: 'circular',
   projectedConfig,
@@ -402,6 +426,13 @@ const importEvent = {
 const imported = await importSession(importEvent);
 
 assert.equal(imported.status, 'ok', imported.error?.message);
+assert.equal(imported.comparisonDisposition, 'EDITABLE');
+assert.deepEqual(state.importedComparisonIntent, {
+  disposition: 'EDITABLE',
+  action: null,
+  message: 'The saved comparison is represented by the current controls.',
+  hasCommittedComparison: true
+});
 assert.equal(state.linearComparisonPlan.mode, 'none');
 assert.deepEqual(state.linearComparisonPlan.edges, []);
 assert.deepEqual({
@@ -478,6 +509,31 @@ const importPayload = async (payload) => importSession({
     value: 'selected'
   }
 });
+
+const decisionRequiredSession = structuredClone(divergentSession);
+decisionRequiredSession.renderRequest.comparisons = [{
+  kind: 'nucleotideBlast',
+  resourceId: 'missing-comparison-resource',
+  queryRecordIndex: 0,
+  subjectRecordIndex: 1
+}];
+decisionRequiredSession.losatCache = { entries: [] };
+decisionRequiredSession.losatDerivedCache = { entries: [] };
+const decisionRequiredImport = await importPayload(decisionRequiredSession);
+assert.equal(
+  decisionRequiredImport.status,
+  'ok',
+  decisionRequiredImport.error?.message
+);
+assert.equal(decisionRequiredImport.comparisonDisposition, 'DECISION_REQUIRED');
+assert.deepEqual(state.importedComparisonIntent, {
+  disposition: 'DECISION_REQUIRED',
+  action: null,
+  message: 'The saved comparison is missing a required resource.',
+  hasCommittedComparison: true
+});
+assert.equal(state.results.value.length, divergentSession.results.length);
+assert.deepEqual(state.files.linearCanonicalComparisons, []);
 
 for (const savedPlan of [{
   mode: 'adjacent',

--- a/tests/web/session-losat-cache-validation.test.mjs
+++ b/tests/web/session-losat-cache-validation.test.mjs
@@ -61,6 +61,7 @@ globalThis.alert = (message) => alerts.push(String(message));
 
 const {
   adoptCanonicalRenderArtifacts,
+  getCommittedCanonicalSession,
   importSession,
   serializeActiveRenderFiles,
   validateSessionLosatArtifacts
@@ -313,7 +314,7 @@ const importSessionPayload = async (payload) => importSession({
   }
 });
 
-test('canonical protein comparisons rehydrate typed files and pipeline state', async () => {
+test('decision-required protein comparisons stay committed without projecting a partial draft', async () => {
   alerts.length = 0;
   const genbank = `LOCUS       TEST                        4 bp    DNA     linear   UNK 01-JAN-1980
 FEATURES             Location/Qualifiers
@@ -488,41 +489,23 @@ protein-a\tprotein-b\t95\t20\t1\t0\t10\t30\t50\t70\t1e-20\t120
   const result = await importSession(event);
 
   assert.equal(result.status, 'ok');
-  assert.deepEqual(
-    state.files.linearCanonicalComparisons.map((comparison) => comparison.kind),
-    [
-      'precomputedProteinComparison',
-      'orthogroupResult',
-      'collinearityResult',
-      'generatedProteinComparison'
-    ]
-  );
+  assert.equal(result.comparisonDisposition, 'DECISION_REQUIRED');
+  assert.equal(state.importedComparisonIntent.disposition, 'DECISION_REQUIRED');
+  assert.equal(state.importedComparisonIntent.action, null);
+  assert.deepEqual(state.files.linearCanonicalComparisons, []);
   assert.equal(state.linearComparisonPlan.edges.length, 0);
-  assert.equal(
-    state.files.linearCanonicalComparisons[0].file.name,
-    'resolved-protein.tsv'
-  );
   assert.deepEqual(
-    state.files.linearCanonicalComparisons[3],
-    generatedProteinComparison
+    getCommittedCanonicalSession().renderRequest.comparisons,
+    renderRequest.comparisons
   );
-  assert.equal(
-    state.files.linearCanonicalComparisons[1].file.name,
-    'orthogroups.json'
-  );
-  assert.equal(
-    state.files.linearCanonicalComparisons[2].valueKind,
-    'blocks'
-  );
-  assert.equal(state.losatProgram.value, 'blastp');
+  assert.equal(state.losatProgram.value, 'blastn');
   assert.equal(state.losat.executionMode, 'threaded');
   assert.equal(state.losat.parallelWorkers, '3');
   assert.equal(state.losat.totalThreadBudget, '12');
   assert.equal(state.losat.blastn.task, 'dc-megablast');
   assert.equal(state.losat.blastp.mode, 'collinear');
-  assert.equal(state.losat.blastp.maxHits, 9);
-  assert.equal(state.losat.blastp.collinearSearchScope, 'all');
-  assert.equal(state.selectedOrthogroupAlignmentFeature.value, 'feature-anchor');
+  assert.equal(state.losat.blastp.maxHits, 1);
+  assert.equal(state.selectedOrthogroupAlignmentFeature.value, '');
 
   state.files.linearCanonicalComparisons = [];
   adoptCanonicalRenderArtifacts({ renderRequest, resources });

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -14,6 +14,7 @@ await writeFile(join(tempRoot, 'package.json'), '{"type":"module"}', 'utf8');
 const {
   buildCanonicalRenderRequest: buildCanonicalRenderRequestRaw,
   linearRecordLayoutHasSharedRow,
+  normalizeWebGridColumnOrdering,
   promoteCanonicalRenderRequestToCurrent,
   projectCanonicalSessionRequest
 } = await import(
@@ -44,6 +45,23 @@ assert.equal(linearRecordLayoutHasSharedRow(
   [{ uid: 'a' }, { uid: 'b' }],
   [{ uid: 'a', row: 1 }, { uid: 'b', row: 2 }]
 ), false);
+const normalizedGridOrdering = normalizeWebGridColumnOrdering([
+  { recordKey: 'later-row', presentation: { gridRow: 2, gridColumn: 1 } },
+  { recordKey: 'right', presentation: { gridRow: 1, gridColumn: 2 } },
+  { recordKey: 'left', presentation: { gridRow: 1, gridColumn: 1 } }
+]);
+assert.deepEqual(
+  normalizedGridOrdering.records.map((record) => [
+    record.recordKey,
+    record.presentation.gridRow,
+    record.presentation.gridColumn
+  ]),
+  [
+    ['left', 1, null],
+    ['right', 1, null],
+    ['later-row', 2, null]
+  ]
+);
 
 const buildCanonicalRenderRequest = (args) => buildCanonicalRenderRequestRaw({
   ...args,
@@ -1922,6 +1940,70 @@ assert.deepEqual(
     ['all', 1, null],
     ['exactly_one', 1, null],
     ['exactly_one', 2, null]
+  ]
+);
+const numericColumnCanonical = structuredClone(arrangedCanonical);
+numericColumnCanonical.renderRequest.records[0].cardinality = 'exactly_one';
+numericColumnCanonical.renderRequest.records[0].presentation.gridColumn = 2;
+numericColumnCanonical.renderRequest.records[1].presentation.gridColumn = 1;
+numericColumnCanonical.renderRequest.records[2].presentation.gridColumn = 1;
+numericColumnCanonical.resources['grid-column-comparison'] = {
+  kind: 'nucleotide-blast',
+  name: 'grid-column-comparison.tsv',
+  encoding: 'base64',
+  data: btoa('match')
+};
+['first', 'second', 'third'].forEach((name) => {
+  numericColumnCanonical.resources[`grid-column-depth-${name}`] = {
+    kind: 'depth',
+    name: `${name}.depth.tsv`,
+    type: 'text/tab-separated-values',
+    size: 1,
+    lastModified: 0,
+    encoding: 'base64',
+    data: btoa(name.slice(0, 1))
+  };
+});
+numericColumnCanonical.renderRequest.diagramOptions.depthTracks = [{
+  source: ['first', 'second', 'third'].map((name) => ({
+    resourceId: `grid-column-depth-${name}`,
+    representation: 'file'
+  })),
+  label: 'Depth',
+  color: '#4A90E2',
+  height: null,
+  largeTickInterval: null,
+  smallTickInterval: null,
+  tickFontSize: null
+}];
+numericColumnCanonical.renderRequest.comparisons = [{
+  kind: 'nucleotideBlast',
+  resourceId: 'grid-column-comparison',
+  queryRecordIndex: 0,
+  subjectRecordIndex: 2
+}];
+const numericColumnProjection = projectCanonicalSessionRequest(numericColumnCanonical);
+assert.deepEqual(
+  numericColumnProjection.files.linearSeqs.map((sequence) => sequence.uid),
+  ['second', 'first', 'third']
+);
+assert.deepEqual(
+  numericColumnProjection.files.linearComparisons.map((comparison) => [
+    comparison.queryUid,
+    comparison.subjectUid
+  ]),
+  [['first', 'third']]
+);
+assert.deepEqual(
+  numericColumnProjection.files.linearSeqs.map((sequence) => sequence.depth?.name),
+  ['second.depth.tsv', 'first.depth.tsv', 'third.depth.tsv']
+);
+assert.deepEqual(
+  numericColumnProjection.config.linearRecordLayout.rows,
+  [
+    { uid: 'second', row: 1 },
+    { uid: 'first', row: 1 },
+    { uid: 'third', row: 2 }
   ]
 );
 const schema5Arranged = structuredClone(arrangedCanonical.renderRequest);


### PR DESCRIPTION
## Plain-language summary

This PR preserves imported Linear comparison intent instead of silently reducing it to the subset exposed by the current controls. Imports now identify whether a comparison is editable, can be preserved read-only, or needs an explicit replace-or-clear decision before Generate. Generate also commits a new request and Result only after the complete candidate is admitted, so failure, cancellation, and stale completion leave the last successful output intact.

## What changed

- Classify every imported committed Linear comparison as `EDITABLE`, `PRESERVED_READ_ONLY`, or `DECISION_REQUIRED` before projecting it into editable controls.
- Persist one explicit `INHERIT`, `REPLACE`, or `CLEAR` resolution in the current Session writer and expose the choice inside the existing Linear Comparison panel.
- Build and admit Generate candidates transactionally; stale, canceled, validation-failed, rendering-failed, and adoption-failed attempts cannot replace the committed request or last successful Result.
- Normalize `grid_column` record order and all affected record-index references without retaining unsupported numeric-column semantics.

## Product impact

- Classification: `IMPLEMENT_EXISTING_AUTHORITY`.
- Existing authority implemented: `PD-OI-008`, `PD-OI-013`, `PD-OI-016`, `PD-OI-017`, and `OIPC-C02`, `OIPC-C04` through `OIPC-C08`.
- No new scientific semantics, Product choice, protocol, schema version, workflow status, required check, or branch-protection rule is introduced.
- Valid imported comparisons that current controls cannot represent remain executable only through explicit inheritance. Ambiguous, incomplete, or non-executable imports block Generate until the user explicitly replaces or clears them.

## Focused evidence

- `node tests/web/imported-comparison-intent.test.mjs`
- `node tests/web/session-request.test.mjs`
- `node tests/web/session-active-config-contract.test.mjs`
- `node tests/web/session-draft-authority.test.mjs`
- `node tests/web/session-losat-cache-validation.test.mjs`
- `node tests/web/run-analysis-simple-path.test.mjs`
- `node tests/web/history.test.mjs`
- Focused Playwright journeys: four passed for imported comparison resolution, inherited comparison generation, current Session round-trip behavior, and pre-worker validation isolation.
- `git diff --cached --check`
- `WEB_ARCHITECTURE_CHANGE=true node tools/check-web-change-budget.mjs --base origin/dev`: passed; no hard-rule violation, import cycle, or privileged allowlist change.

## Production-size acceptance

- Ran the designated `npm run test:web:vibrio-generate` lane once on commit `6d4759a2e62b2e6a19e74f959f9e68110918d9a1`.
- Playwright recorded `passed` with no failed tests. Both Generate attempts completed, imported intent was `EDITABLE`, the generated artifacts matched across repeated Generate, and the test's transaction, cache/provenance, resource-cleanup, and worker-reuse assertions passed.
- The candidate HEAD and clean worktree were unchanged after the run.
- The later required gate exposed one stale test expectation for decision-required imports. The final commit updates that test only; no production source changed after the production-size lane.

## Architecture Ratchet report

- State semantic owners before and after: draft controls remain in the existing reactive state owners; committed canonical Session data remains owned by `services/config.js`; Result and History remain with their existing owners. The new private `services/imported-comparison-intent.js` module owns only imported-comparison classification and explicit-resolution semantics.
- Canonical path before and after: import previously projected comparison data directly into current controls and Generate adopted committed canonical data before every admission step completed. The path is now import classification -> draft or explicit resolution -> candidate request -> worker -> complete Result admission -> committed canonical replacement -> one artifact History entry.
- Duplicate reset/fallback/direct-assignment paths removed: unmanaged comparison data is no longer partially projected, `INHERIT` overlays only the exact committed comparison, and state-backed comparison/cache data is not assigned until risky deserialization and projection finish. Stale completion no longer rolls an older artifact back over a newer success.
- Session compatibility before and after: the current writer stays single and adds one optional `importedComparisonResolution` field. There is no unreleased-reader migration, parallel state system, or legacy writer.
- New modules: one private semantic decomposition; no new public entry point.
- Worker/request/schema count before and after: unchanged. `services/session-request.js` remains the canonical request owner and `app/run-analysis.js` remains its canonical Generate entry edge.
- Changed-scope `delta(OE)`, `delta(PE)`, and `delta(CB)`: no privileged edge or cycle was added; one private semantic owner was added without duplicating canonical ownership. The Web change-budget checker passed with production files 187 -> 188 and modules 140 -> 141.
- Failure/cancel/stale publication evidence: focused transaction tests cover validation, rendering, adoption, cancellation, retry, and deterministic out-of-order stale completion after a newer success. Browser journeys verify that blocked Generate leaves the previous Result visible and exports remain truthful.
- Rollback: revert commit `de2e3c787514b949bd22e9fb5c620af197a1ebe7`.
