### PR TITLE
Align session and overlapping-generate tests with current contracts

### DIFF
--- a/tests/web/contracts/session-regenerate-intent.playwright.spec.js
+++ b/tests/web/contracts/session-regenerate-intent.playwright.spec.js
@@ -52,6 +52,7 @@ const ACTIVE_CONFIG_DOMAINS = Object.freeze([
   'modeProfiles',
   'linearRecordLayout',
   'linearComparisonPlan',
+  'importedComparisonResolution',
   'webEdits'
 ]);
 

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -2029,7 +2029,10 @@ ${origin}
   expect(staleResponse).toEqual({
     firstResult: { status: 'stale' },
     secondResult: { status: 'error' },
-    errorLog: null,
+    errorLog: {
+      summary: 'A diagram generation request is already running.',
+      details: []
+    },
     snapshotPreserved: true,
     changedFields: []
   });


### PR DESCRIPTION
## Plain-language summary

This corrective PR updates two staging test expectations left behind by PR #434. Current Session saves now include `importedComparisonResolution` in the active configuration, and an overlapping Generate keeps the older attempt stale while the newest attempt surfaces the existing safe busy error. No production code changes.

## Product contract basis

PR-SESSION-05 and `OIPC-C07`/`PD-OI-016` require stale output to remain unadmitted while failures present an actionable safe error. The delayed first Generate therefore remains `stale`, and the newer rejected Generate reports `A diagram generation request is already running.` without changing the committed Result snapshot.

## Verification

- `npx playwright test tests/web/contracts/session-regenerate-intent.playwright.spec.js tests/web/linear-multi-record.playwright.spec.js --grep "no-draft session preserves preview, active config, canonical request, and catalog|Label-scoped feature colors and legends survive linear regeneration" --workers=1` — 2 passed
- `git diff --check`

The maximum Vibrio journey was not run because this is a test-only correction.
