### PR TITLE
Preserve GUI-unmanaged configuration settings

### DIFF
--- a/gbdraw/config/modify.py
+++ b/gbdraw/config/modify.py
@@ -18,6 +18,35 @@ from gbdraw.exceptions import ValidationError
 from .models import GbdrawConfig  # type: ignore[reportMissingImports]
 
 
+_UNSAFE_CONFIG_KEYS = frozenset({"__proto__", "constructor", "prototype"})
+
+
+def _assert_safe_config_value(value: object, *, path: str) -> None:
+    pending = [value]
+    seen: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if not isinstance(current, (MappingABC, SequenceABC)) or isinstance(
+            current,
+            (str, bytes),
+        ):
+            continue
+        identity = id(current)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        if isinstance(current, MappingABC):
+            entries = current.items()
+        else:
+            entries = ((None, item) for item in current)
+        for key, item in entries:
+            if isinstance(key, str) and key in _UNSAFE_CONFIG_KEYS:
+                raise ValidationError(
+                    f"Config override {path!r} contains unsafe key {key!r}."
+                )
+            pending.append(item)
+
+
 def _nested_dataclass_type(annotation: object) -> type | None:
     if isinstance(annotation, type) and is_dataclass(annotation):
         return annotation
@@ -181,6 +210,14 @@ def _validate_override_path(path: object) -> tuple[str, object]:
     leaves, branches = _config_override_schema()
     if not isinstance(path, str) or not path:
         raise ValidationError("Config override paths must be non-empty strings.")
+    unsafe = next(
+        (key for key in path.split(".") if key in _UNSAFE_CONFIG_KEYS),
+        None,
+    )
+    if unsafe is not None:
+        raise ValidationError(
+            f"Config override path {path!r} contains unsafe key {unsafe!r}."
+        )
     if path in branches:
         raise ValidationError(
             f"Config override path {path!r} is not a leaf field."
@@ -229,6 +266,7 @@ def validate_config_overrides(
     validated: list[tuple[str, object]] = []
     for raw_path, value in dict(overrides or {}).items():
         path, annotation = _validate_override_path(raw_path)
+        _assert_safe_config_value(value, path=path)
         if _has_literal_domain(annotation) and not _matches_literal_domain(
             annotation,
             value,
@@ -238,12 +276,12 @@ def validate_config_overrides(
                 for candidate in _literal_domain_values(annotation)
             )
             raise ValidationError(
-                f"Invalid value {value!r} for config override {path!r}; "
+                f"Invalid value for config override {path!r}; "
                 f"allowed literal values: {allowed}."
             )
         if not _matches_annotation(annotation, value):
             raise ValidationError(
-                f"Invalid value {value!r} for config override {path!r}; "
+                f"Invalid value for config override {path!r}; "
                 f"expected {annotation!r}."
             )
         validated.append((path, value))

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -2358,6 +2358,46 @@
                     </details>
                 </div>
 
+                <div
+                    v-if="unmanagedConfigOverrideEntries.length"
+                    data-unmanaged-config-overrides
+                    class="card border-blue-200 bg-blue-50/60"
+                >
+                    <div class="flex items-start gap-2">
+                        <i class="ph ph-shield-check mt-0.5 text-blue-600"></i>
+                        <div class="min-w-0 flex-1">
+                            <div class="text-xs font-bold text-slate-700">Preserved session settings</div>
+                            <p class="mt-0.5 text-[10px] leading-snug text-slate-600">
+                                These validated settings are not editable in the Web UI. They remain active until reset.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="mt-2 max-h-40 space-y-1.5 overflow-y-auto pr-1">
+                        <div
+                            v-for="entry in unmanagedConfigOverrideEntries"
+                            :key="entry.path"
+                            data-unmanaged-config-override
+                            class="rounded border border-blue-200 bg-white px-2 py-1.5"
+                        >
+                            <div class="flex items-start gap-2">
+                                <div class="min-w-0 flex-1">
+                                    <code class="block break-all text-[10px] font-semibold text-slate-700">{{ entry.path }}</code>
+                                    <code class="mt-0.5 block break-all text-[10px] text-slate-500">{{ entry.displayValue }}</code>
+                                </div>
+                                <button
+                                    type="button"
+                                    data-history-managed
+                                    class="btn btn-secondary shrink-0 px-2 py-1 text-[10px]"
+                                    :aria-label="`Reset preserved setting ${entry.path}`"
+                                    @click="resetUnmanagedConfigOverride(entry.path)"
+                                >
+                                    Reset
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
 
                 <div class="card bg-slate-50/50">
                     <details open>

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -21,6 +21,7 @@ import {
   SESSION_VERSION,
   serializeActiveRenderFiles,
   serializeResults,
+  setUnmanagedConfigOverrideValidator,
   setPreviewRuntime
 } from '../services/config.js';
 import { createHistoryManager } from '../services/history.js';
@@ -32,7 +33,11 @@ import { serializeCleanSvg } from '../services/svg-serialization.js';
 import { copyTextToClipboard } from '../utils/clipboard.js';
 import { downloadTextFile } from '../services/text-download.js';
 import { resetLayoutState, resetSettings as resetSettingsState } from '../services/reset.js';
-import { disposeDiagramGenerationWorker } from '../services/diagram-generation.js';
+import {
+  DIAGRAM_HELPER_OPERATIONS,
+  disposeDiagramGenerationWorker,
+  runDiagramHelperOperation
+} from '../services/diagram-generation.js';
 import { recordSessionLifecycleEvent } from '../services/runtime-test-hooks.js';
 import { createPanZoom, createSidebarResize, setupGlobalUiEvents } from './ui.js';
 import { colorValueMode, toNativeColorInputValue } from './color-utils.js';
@@ -184,6 +189,10 @@ export const createSessionImportRollbackState = ({
 });
 
 export const createAppSetup = () => {
+  setUnmanagedConfigOverrideValidator((payload) => runDiagramHelperOperation(
+    DIAGRAM_HELPER_OPERATIONS.VALIDATE_CONFIG_OVERRIDES,
+    payload
+  ));
   const {
     processing,
     processingStatus,
@@ -224,6 +233,7 @@ export const createAppSetup = () => {
     hasActiveLinearUploadIntent,
     form,
     adv,
+    unmanagedConfigOverrides,
     losat,
     losatCacheInfo,
     losatThreadingStatus,
@@ -1012,6 +1022,31 @@ export const createAppSetup = () => {
   });
   const undoHistory = () => history.undo();
   const redoHistory = () => history.redo();
+  const displayPreservedConfigValue = (value) => {
+    const serialized = JSON.stringify(value) ?? String(value);
+    return serialized.length <= 240
+      ? serialized
+      : `${serialized.slice(0, 237)}...`;
+  };
+  const unmanagedConfigOverrideEntries = computed(() => (
+    Object.entries(unmanagedConfigOverrides)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([path, value]) => ({
+        path,
+        value,
+        displayValue: displayPreservedConfigValue(value)
+      }))
+  ));
+  const resetUnmanagedConfigOverride = (path) => history.runUndoable(
+    `Reset preserved setting ${path}`,
+    () => {
+      if (!Object.prototype.hasOwnProperty.call(unmanagedConfigOverrides, path)) {
+        return false;
+      }
+      delete unmanagedConfigOverrides[path];
+      return true;
+    }
+  );
   const selectResult = (index) => previewRuntime.selectResult(index);
 
   const { handleWheel, startPan, doPan, endPan, resetPreviewViewport } = createPanZoom(state);
@@ -1111,6 +1146,7 @@ export const createAppSetup = () => {
     if (typeof disposeHistoryInputs === 'function') disposeHistoryInputs();
     if (window.__GBDRAW_HISTORY__ === history) delete window.__GBDRAW_HISTORY__;
     previewFeatureSearch.dispose();
+    setUnmanagedConfigOverrideValidator(null);
     disposeDiagramGenerationWorker();
   });
 
@@ -3224,6 +3260,8 @@ export const createAppSetup = () => {
     linearRecordSelectorWarning: linearRecordSelector.warningFor,
     form,
     adv,
+    unmanagedConfigOverrideEntries,
+    resetUnmanagedConfigOverride,
     comparisonProfileDefault,
     comparisonHeightValidationError,
     optionalNumberInputValue,

--- a/gbdraw/web/js/app/python-helpers.js
+++ b/gbdraw/web/js/app/python-helpers.js
@@ -17,6 +17,7 @@ from gbdraw.web_support.request_render import (
 )
 from gbdraw.session_request_codec import encode_canonical_typed_resource
 from gbdraw.api.prepared import PreparedBiologicalInputCache
+from gbdraw.web_support.config_overrides import validate_web_config_overrides_json
 
 _WEB_LOSATP_FILTERED_HIT_CACHE = {}
 _WEB_LOSATP_CONVERTED_PAYLOAD_CACHE = {}

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -73,6 +73,7 @@ import {
 } from '../app/match-sequences.js';
 import {
   buildCanonicalRenderRequest,
+  managedConfigOverridePathsForMode,
   promoteCanonicalRenderRequestToCurrent,
   projectCanonicalSessionRequest
 } from './session-request.js';
@@ -164,6 +165,7 @@ import {
   projectWebOnlyEditorMetadata,
   validateSessionAuthorityInventory
 } from './session-authority.js';
+import { assertSafeObjectKeys } from './safe-object-keys.js';
 import {
   recordSessionLifecycleEvent,
   recordStructuralMetric
@@ -906,6 +908,7 @@ export const buildConfigData = () => ({
   importedComparisonResolution: serializeImportedComparisonResolution(
     state.importedComparisonIntent
   ),
+  unmanagedConfigOverrides: cloneJsonData(state.unmanagedConfigOverrides || {}),
   webEdits: {
     orthogroupNameOverrides: cloneStringMap(state.orthogroupNameOverrides),
     orthogroupDescriptionOverrides: cloneStringMap(state.orthogroupDescriptionOverrides)
@@ -998,6 +1001,57 @@ const replacePlainObject = (target, source) => {
   Object.entries(source || {}).forEach(([key, value]) => {
     target[key] = value;
   });
+};
+
+let unmanagedConfigOverrideValidator = null;
+
+export const setUnmanagedConfigOverrideValidator = (validator) => {
+  unmanagedConfigOverrideValidator = typeof validator === 'function'
+    ? validator
+    : null;
+};
+
+const validateUnmanagedConfigOverrides = async ({
+  mode,
+  config = null,
+  configOverrides = {},
+  requireUnmanagedOnly = false
+}) => {
+  const managedPaths = managedConfigOverridePathsForMode(mode);
+  const overrides = isPlainObject(configOverrides)
+    ? cloneJsonData(configOverrides)
+    : configOverrides;
+  const overridePaths = isPlainObject(overrides) ? Object.keys(overrides) : [];
+  if (
+    config === null
+    && overridePaths.length === 0
+  ) {
+    return {};
+  }
+  if (
+    config === null
+    && !requireUnmanagedOnly
+    && overridePaths.every((path) => managedPaths.includes(path))
+  ) {
+    return {};
+  }
+  if (!unmanagedConfigOverrideValidator) {
+    throw new Error('Configuration validation service is unavailable.');
+  }
+  const result = await unmanagedConfigOverrideValidator({
+    mode,
+    config,
+    configOverrides: overrides,
+    managedPaths,
+    requireUnmanagedOnly
+  });
+  if (typeof result?.result?.error === 'string' && result.result.error.trim()) {
+    throw new Error(result.result.error.trim());
+  }
+  if (!isPlainObject(result?.result?.overrides)) {
+    throw new Error('Configuration validation returned an invalid preserved-settings result.');
+  }
+  return cloneJsonData(result.result.overrides);
 };
 
 export const applyEditorStateData = (
@@ -1532,6 +1586,26 @@ const preflightSessionImport = (rawData) => {
   if (!canonicalProjection && restoredConfig) {
     hydrateMissingMultiRecordPositionsFromCliInvocation(restoredConfig, data.cliInvocation);
   }
+  const hasCurrentStoredUnmanagedOverrides = currentSession
+    && isPlainObject(runtimeStoredConfig)
+    && Object.prototype.hasOwnProperty.call(
+      runtimeStoredConfig,
+      'unmanagedConfigOverrides'
+    );
+  const unmanagedConfigValidation = canonicalProjection
+    ? hasCurrentStoredUnmanagedOverrides
+      ? {
+          mode: canonicalProjection.mode,
+          configOverrides: runtimeStoredConfig.unmanagedConfigOverrides,
+          requireUnmanagedOnly: true
+        }
+      : {
+          mode: canonicalProjection.mode,
+          config: projectionRenderRequest?.diagramOptions?.config ?? null,
+          configOverrides:
+            projectionRenderRequest?.diagramOptions?.configOverrides ?? {}
+        }
+    : null;
   if (restoredConfig) {
     const activeDepthTrackCount = Array.isArray(restoredConfig?.adv?.depth_tracks)
       ? restoredConfig.adv.depth_tracks.length
@@ -1585,7 +1659,8 @@ const preflightSessionImport = (rawData) => {
     projectionResult,
     adoptedCanonicalSession: adoptedSession?.canonical || null,
     currentResourceTable,
-    comparisonClassification
+    comparisonClassification,
+    unmanagedConfigValidation
   };
 };
 
@@ -1667,6 +1742,12 @@ export const applyConfigData = (data) => {
   }
   if (data.form) safeDeepMerge(state.form, data.form);
   if (data.adv) safeDeepMerge(state.adv, data.adv);
+  replacePlainObject(
+    state.unmanagedConfigOverrides,
+    isPlainObject(data.unmanagedConfigOverrides)
+      ? cloneJsonData(data.unmanagedConfigOverrides)
+      : {}
+  );
   state.annotationSets.splice(
     0,
     state.annotationSets.length,
@@ -3643,6 +3724,11 @@ export const exportSession = async (
     storedConfig.adv,
     normalizedArrowGeometryState(storedConfig.adv)
   );
+  storedConfig.unmanagedConfigOverrides = await validateUnmanagedConfigOverrides({
+    mode: state.mode.value,
+    configOverrides: storedConfig.unmanagedConfigOverrides,
+    requireUnmanagedOnly: true
+  });
   let committed = isAdoptedCanonicalSession(committedCanonicalSession)
     ? committedCanonicalSession
     : cloneCanonicalSession(committedCanonicalSession);
@@ -3816,13 +3902,9 @@ export const importSession = async (e, options = {}) => {
     const text = await readSessionText(file);
     recordSessionLifecycleEvent('gzip-to-text-end', { characters: text.length });
     recordSessionLifecycleEvent('json-parse-start');
-    let data = JSON.parse(text, (key, value) => {
-      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-        return undefined;
-      }
-      return value;
-    });
+    let data = JSON.parse(text);
     recordSessionLifecycleEvent('json-parse-end');
+    assertSafeObjectKeys(data, 'Session');
     if (isLegacyConfigPayload(data)) {
       applyLegacyConfigPayload(data);
       alert('Legacy configuration loaded. Save as a session to use the current format.');
@@ -3840,8 +3922,14 @@ export const importSession = async (e, options = {}) => {
       projectionResult,
       adoptedCanonicalSession,
       currentResourceTable,
-      comparisonClassification
+      comparisonClassification,
+      unmanagedConfigValidation
     } = preflight;
+    if (restoredConfig && unmanagedConfigValidation) {
+      restoredConfig.unmanagedConfigOverrides = await validateUnmanagedConfigOverrides(
+        unmanagedConfigValidation
+      );
+    }
     const canonicalSession = Boolean(projectionResult);
     const currentSchemaSession = sourceSessionVersion === SESSION_VERSION;
     rollbackSnapshot = captureSessionImportSnapshot();

--- a/gbdraw/web/js/services/diagram-worker-protocol.js
+++ b/gbdraw/web/js/services/diagram-worker-protocol.js
@@ -11,7 +11,8 @@ export const DIAGRAM_HELPER_OPERATIONS = Object.freeze({
   MEASURE_LEGEND_TEXT: 'measureLegendText',
   PROMOTE_LEGACY_LOSATP_CACHE: 'promoteLegacyLosatpCache',
   REGENERATE_DEFINITION_SVGS: 'regenerateDefinitionSvgs',
-  RESOLVE_LEGACY_PROTEIN_REFERENCES: 'resolveLegacyProteinReferences'
+  RESOLVE_LEGACY_PROTEIN_REFERENCES: 'resolveLegacyProteinReferences',
+  VALIDATE_CONFIG_OVERRIDES: 'validateConfigOverrides'
 });
 
 export const DIAGRAM_HELPER_OPERATION_NAMES = Object.freeze(

--- a/gbdraw/web/js/services/reset.js
+++ b/gbdraw/web/js/services/reset.js
@@ -144,6 +144,7 @@ export const resetSettings = (state) => {
   state.modeProfileStateManager?.reset?.(state.mode.value, state.adv);
   replaceReactiveObject(state.losat, createDefaultLosat());
   replaceReactiveObject(state.circularConservation, createDefaultCircularConservation());
+  clearReactiveObject(state.unmanagedConfigOverrides);
   replaceReactiveArray(state.annotationSets);
   state.selectedAnnotation.value = null;
   resetLinearComparisonPlan(state);

--- a/gbdraw/web/js/services/safe-object-keys.js
+++ b/gbdraw/web/js/services/safe-object-keys.js
@@ -1,0 +1,18 @@
+const UNSAFE_OBJECT_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+export const assertSafeObjectKeys = (value, path = 'value') => {
+  if (!value || typeof value !== 'object') return;
+  const pending = [value];
+  const seen = new WeakSet();
+  while (pending.length) {
+    const current = pending.pop();
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    for (const key of Object.keys(current)) {
+      if (UNSAFE_OBJECT_KEYS.has(key)) {
+        throw new Error(`${path} contains unsafe key ${key}.`);
+      }
+      pending.push(current[key]);
+    }
+  }
+};

--- a/gbdraw/web/js/services/session-active-config-contract.js
+++ b/gbdraw/web/js/services/session-active-config-contract.js
@@ -2,6 +2,7 @@ import { createDefaultLinearDefinitionLineStyles } from '../app/definition-line-
 import { LEGACY_LINEAR_TRACK_SLOT_SCHEMA_VERSION, LINEAR_TRACK_RENDERERS, LINEAR_TRACK_SLOT_SCHEMA_VERSION, createDefaultLinearTrackSlots } from '../app/linear-track-slots.js'; import { validateTrackSlotBindingInvariants } from '../app/track-slot-validation.js';
 import { requireCurrentCircularMultiRecordSizeMode, requireCurrentCollinearAnchorMode, requireCurrentCollinearColorMode, requireCurrentCollinearMaxConflicts, requireCurrentCollinearMaxDiagonalDrift, requireCurrentCollinearMaxParalogLinks, requireCurrentCollinearMaxUnitGap, requireCurrentCollinearMergeOrientation, requireCurrentCollinearMinAnchors, requireCurrentCollinearSearchScope, requireCurrentCollinearUnitMode, requireCurrentLinearLabelPlacement, requireCurrentLinearTrackLayout, requireCurrentOrthogroupMemberMaxHits, requireCurrentOrthogroupMembershipMode, requireCurrentProteinBlastpCandidateLimit, requireCurrentProteinBlastpMaxHits, requireCurrentProteinBlastpMode, requireCurrentWebStateFieldNames } from '../app/current-option-values.js'; import { DEFAULT_ARROW_SHAFT_WIDTH_RATIO, createDefaultFeatureRenderings } from '../utils/feature-rendering.js';
 import { MODE_DEFAULT_FEATURE_TYPES, comparisonStateForMode, managedAdvStateForMode, trackDefaultsForMode } from '../mode-profiles.js'; import { WEB_UX_PROFILE } from '../web-ux-profile.js';
+import { assertSafeObjectKeys } from './safe-object-keys.js';
 const circularTracks = trackDefaultsForMode('circular'), linearTracks = trackDefaultsForMode('linear');
 export const CIRCULAR_TRACK_SLOT_SCHEMA_VERSION = 4, LEGACY_CIRCULAR_TRACK_SLOT_SCHEMA_VERSION = 3;
 const isObject = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value), has = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
@@ -45,34 +46,26 @@ export const createDefaultCircularConservation = () => ({ enabled: false, source
 export const CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS = Object.freeze([
   'form', 'adv', 'losat', 'cliOptions', 'colors', 'palette', 'paletteInstantPreviewEnabled', 'rules',
   'qualifierPriorityRules', 'filterMode', 'whitelist', 'blacklistText', 'losatProgram', 'circularConservation',
-  'annotationSets', 'modeProfiles',
+  'annotationSets', 'modeProfiles', 'unmanagedConfigOverrides',
   'linearRecordLayout', 'linearComparisonPlan', 'importedComparisonResolution', 'webEdits'
 ]);
 export const CURRENT_WRITER_FORM_FIELDS = Object.freeze([...Object.keys(createDefaultForm()), 'legend']);
 export const CURRENT_WRITER_ADV_FIELDS = Object.freeze([...Object.keys(createDefaultAdv()), 'plot_title_position', 'losatProgram']);
 const DOMAIN_SHAPES = Object.freeze({ form: 'object', adv: 'object', losat: 'object', cliOptions: 'object', colors: 'object',
   circularConservation: 'object', modeProfiles: 'object', linearRecordLayout: 'object', linearComparisonPlan: 'object', webEdits: 'object',
-  importedComparisonResolution: 'object',
+  importedComparisonResolution: 'object', unmanagedConfigOverrides: 'object',
   rules: 'array', qualifierPriorityRules: 'array', whitelist: 'array', annotationSets: 'array', palette: 'string', filterMode: 'string', blacklistText: 'string',
   losatProgram: 'string', paletteInstantPreviewEnabled: 'boolean' });
 const ROW_FIELDS = { rules: ['feat', 'qual', 'val', 'color', 'cap', 'fromFile'],
   qualifierPriorityRules: ['feat', 'order'], whitelist: ['feat', 'qual', 'key'],
   annotationSets: ['id', 'annotations', 'defaultStyle', 'legendLabel'] };
 const ANNOTATION_FIELDS = ['id', 'target', 'label', 'mark', 'lane', 'style', 'legendLabel', 'metadata'];
-const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 const OBSOLETE_SLOT_KEYS = new Set(['gapAfter', 'gap_after', 'innerRadius', 'inner_radius', 'outerRadius',
   'outer_radius', 'placement', 'spacing', 'strict', 'compress', 'reserve']);
 const OBSOLETE_SLOT_PARAM_KEYS = new Set(['side', 'radius', 'width', 'spacing', 'inner_gap_px', 'outer_gap_px', 'strict', 'compress', 'reserve']);
 const assertFields = (value, fields, path) => {
   const unknown = Object.keys(value).filter((key) => !fields.has(key));
   if (unknown.length) throw new Error(`Current session active configuration contains unknown ${path} field(s): ${unknown.join(', ')}.`);
-};
-const assertSafeKeys = (value, path = 'config') => {
-  if (!value || typeof value !== 'object') return;
-  for (const key of Object.keys(value)) {
-    if (UNSAFE_KEYS.has(key)) throw new Error(`Current session active configuration contains unsafe key ${path}.${key}.`);
-    assertSafeKeys(value[key], `${path}.${key}`);
-  }
 };
 const validateDomainShapes = (config) => {
   for (const [domain, shape] of Object.entries(DOMAIN_SHAPES)) {
@@ -131,7 +124,7 @@ export const validateImportedLinearTrackSlots = (config = {}, { depthTrackCount 
 export const validateCurrentWriterActiveConfig = ({ mode, storedConfig: config }) => {
   if (!['circular', 'linear'].includes(mode)) throw new Error(`Current session active configuration has unsupported mode: ${String(mode)}.`);
   if (!isObject(config)) throw new Error('Current session is missing its active Web configuration.');
-  assertSafeKeys(config);
+  assertSafeObjectKeys(config, 'Current session active configuration');
   const domains = new Set([...CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS, 'colorsAreOverrides']);
   const unknownDomains = Object.keys(config).filter((domain) => !domains.has(domain));
   if (unknownDomains.length)

--- a/gbdraw/web/js/services/session-authority.js
+++ b/gbdraw/web/js/services/session-authority.js
@@ -1,3 +1,5 @@
+import { assertSafeObjectKeys } from './safe-object-keys.js';
+
 export const SESSION_TOP_LEVEL_AUTHORITY = Object.freeze({
   format: 'document',
   version: 'document',
@@ -275,6 +277,7 @@ export const validateSessionAuthorityInventory = (sessionData, version) => {
   if (!sessionData || typeof sessionData !== 'object' || Array.isArray(sessionData)) {
     throw new Error('Session authority inventory requires an object.');
   }
+  assertSafeObjectKeys(sessionData, 'Session');
   if (Number(version) < 31) return;
   if (
     Number(version) >= 40 &&

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -252,6 +252,82 @@ const LINEAR_DEFINITION_STYLE_PATHS = Object.freeze(
 );
 const LINEAR_DEFINITION_STYLE_FIELDS = Object.freeze(['font_size', 'font_weight', 'fill']);
 
+const CIRCULAR_ONLY_GUI_CONFIG_OVERRIDE_PATHS = new Set([
+  CONFIG_OVERRIDE_PATHS.circularAxisStrokeColor,
+  CONFIG_OVERRIDE_PATHS.circularDefinitionFontSize,
+  CONFIG_OVERRIDE_PATHS.circularDefinitionInterval,
+  CONFIG_OVERRIDE_PATHS.plotTitleFontSize,
+  CONFIG_OVERRIDE_PATHS.circularLabelSpacing,
+  CONFIG_OVERRIDE_PATHS.circularLabelPlacement,
+  CONFIG_OVERRIDE_PATHS.trackType,
+  CONFIG_OVERRIDE_PATHS.tickLabelFontSize,
+  CONFIG_OVERRIDE_PATHS.outerLabelXRadiusOffset,
+  CONFIG_OVERRIDE_PATHS.outerLabelYRadiusOffset,
+  CONFIG_OVERRIDE_PATHS.innerLabelXRadiusOffset,
+  CONFIG_OVERRIDE_PATHS.innerLabelYRadiusOffset
+]);
+const LINEAR_ONLY_GUI_CONFIG_OVERRIDE_PATHS = new Set([
+  CONFIG_OVERRIDE_PATHS.linearAxisStrokeColor,
+  CONFIG_OVERRIDE_PATHS.linearDefinitionShowReplicon,
+  CONFIG_OVERRIDE_PATHS.linearDefinitionShowAccession,
+  CONFIG_OVERRIDE_PATHS.linearDefinitionShowLength,
+  CONFIG_OVERRIDE_PATHS.linearLabelSpacing,
+  CONFIG_OVERRIDE_PATHS.labelPlacement,
+  CONFIG_OVERRIDE_PATHS.labelRotation,
+  CONFIG_OVERRIDE_PATHS.alignCenter,
+  CONFIG_OVERRIDE_PATHS.keepDefinitionLeftAligned,
+  CONFIG_OVERRIDE_PATHS.linearTrackLayout,
+  CONFIG_OVERRIDE_PATHS.linearTrackAxisGap,
+  CONFIG_OVERRIDE_PATHS.linearRulerOnAxis,
+  CONFIG_OVERRIDE_PATHS.comparisonHeight,
+  CONFIG_OVERRIDE_PATHS.pairwiseMatchStyle,
+  CONFIG_OVERRIDE_PATHS.gcHeight,
+  CONFIG_OVERRIDE_PATHS.depthHeight,
+  CONFIG_OVERRIDE_PATHS.scaleStyle,
+  CONFIG_OVERRIDE_PATHS.scaleStrokeColor,
+  CONFIG_OVERRIDE_PATHS.scaleLabelColor,
+  CONFIG_OVERRIDE_PATHS.scaleStrokeWidth,
+  CONFIG_OVERRIDE_PATHS.normalizeLength
+]);
+
+export const managedConfigOverridePathsForMode = (mode) => {
+  if (!['circular', 'linear'].includes(mode)) {
+    throw new Error(`Unsupported config override mode: ${String(mode)}.`);
+  }
+  const excluded = mode === 'circular'
+    ? LINEAR_ONLY_GUI_CONFIG_OVERRIDE_PATHS
+    : CIRCULAR_ONLY_GUI_CONFIG_OVERRIDE_PATHS;
+  const paths = new Set(
+    Object.values(CONFIG_OVERRIDE_PATHS).filter((path) => !excluded.has(path))
+  );
+  paths.add(MODE_LABEL_SCOPE_PATHS[mode]);
+  for (const path of [
+    SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.blockStrokeWidth,
+    SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.lineStrokeWidth,
+    SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.legendBoxSize,
+    SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.legendFontSize,
+    ...(mode === 'circular'
+      ? [SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.circularAxisStrokeWidth, 'labels.font_size']
+      : [
+          SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.linearAxisStrokeWidth,
+          SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.linearDefinitionFontSize,
+          SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.defaultCdsHeight,
+          SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.scaleFontSize,
+          SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.rulerLabelFontSize,
+          'labels.font_size.linear'
+        ])
+  ]) {
+    paths.add(`${path}.short`);
+    paths.add(`${path}.long`);
+  }
+  if (mode === 'linear') {
+    Object.values(LINEAR_DEFINITION_STYLE_PATHS).forEach((prefix) => {
+      LINEAR_DEFINITION_STYLE_FIELDS.forEach((field) => paths.add(`${prefix}.${field}`));
+    });
+  }
+  return Object.freeze([...paths].sort());
+};
+
 const legacyFlatConfigKey = (semanticName) => (
   semanticName
     .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')
@@ -806,9 +882,18 @@ const buildConfigOverrides = (
       }
     }
   }
-  return Object.fromEntries(
+  const managedOverrides = Object.fromEntries(
     Object.entries(overrides).filter(([, value]) => value !== null && value !== undefined)
   );
+  const preservedOverrides = state.unmanagedConfigOverrides;
+  return {
+    ...(
+      preservedOverrides && typeof preservedOverrides === 'object' && !Array.isArray(preservedOverrides)
+        ? preservedOverrides
+        : {}
+    ),
+    ...managedOverrides
+  };
 };
 
 const addGeneratedTableResources = (state, resources, diagramOptions) => {

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -39,6 +39,7 @@ const semanticFileWatchersSuppressed = ref(false);
 const sessionResourceDiscoveryDeferred = ref(false);
 const sessionImportRollbackInProgress = ref(false);
 const importedComparisonIntent = reactive(createImportedComparisonIntentState());
+const unmanagedConfigOverrides = reactive({});
 
 const results = ref([]);
 const selectedResultIndex = ref(0);
@@ -763,6 +764,7 @@ export const state = {
   sessionResourceDiscoveryDeferred,
   sessionImportRollbackInProgress,
   importedComparisonIntent,
+  unmanagedConfigOverrides,
   results,
   selectedResultIndex,
   failedGeneratePreservedResult,

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -492,6 +492,27 @@ const callJsonHelper = (pyodide, helperName, args) => {
 const jsonArgument = (value, fallback) => JSON.stringify(value ?? fallback);
 
 const HELPER_OPERATION_SPECS = Object.freeze({
+  [DIAGRAM_HELPER_OPERATIONS.VALIDATE_CONFIG_OVERRIDES]: {
+    keys: [
+      'mode',
+      'config',
+      'configOverrides',
+      'managedPaths',
+      'requireUnmanagedOnly'
+    ],
+    fileRoles: [],
+    run: (pyodide, payload) => callJsonHelper(
+      pyodide,
+      'validate_web_config_overrides_json',
+      [
+        String(payload.mode || ''),
+        jsonArgument(payload.config, null),
+        jsonArgument(payload.configOverrides, {}),
+        jsonArgument(payload.managedPaths, []),
+        Boolean(payload.requireUnmanagedOnly)
+      ]
+    )
+  },
   [DIAGRAM_HELPER_OPERATIONS.EXTRACT_FIRST_FASTA]: {
     keys: ['files', 'format', 'regionSpec', 'recordSelector', 'reverseFlag'],
     fileRoles: ['source'],

--- a/gbdraw/web_support/config_overrides.py
+++ b/gbdraw/web_support/config_overrides.py
@@ -1,0 +1,154 @@
+"""Schema-owned validation for Web-preserved configuration leaves."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from gbdraw.api.config import apply_config_overrides
+from gbdraw.api.options import CircularDiagramOptions, LinearDiagramOptions
+from gbdraw.config.modify import (
+    canonical_config_override_paths,
+    config_to_raw_dict,
+    validate_config_overrides,
+)
+from gbdraw.config.models import GbdrawConfig
+from gbdraw.exceptions import ValidationError
+
+
+def _raw_config_leaf(config: Mapping[str, Any], path: str) -> object:
+    if path == "labels.filtering.raw":
+        return config["labels"]["filtering"]
+    current: object = config
+    for key in path.split("."):
+        if not isinstance(current, Mapping) or key not in current:
+            raise KeyError(path)
+        current = current[key]
+    return current
+
+
+def _validated_base_config(config: object) -> GbdrawConfig:
+    if config is None:
+        return apply_config_overrides(None, None)
+    if not isinstance(config, Mapping):
+        raise ValidationError("diagramOptions.config must be an object or null.")
+    try:
+        return GbdrawConfig.from_dict(config)
+    except ValidationError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValidationError("diagramOptions.config is invalid.") from exc
+
+
+def validate_and_project_web_config_overrides(
+    *,
+    mode: Literal["circular", "linear"],
+    config: object = None,
+    overrides: object = None,
+    managed_paths: object = None,
+    require_unmanaged_only: bool = False,
+) -> dict[str, object]:
+    """Return validated effective leaves that the active Web GUI does not own.
+
+    The typed configuration model remains the validity owner. ``managed_paths``
+    describes only the current GUI projection; it cannot make a path valid.
+    """
+
+    if mode not in {"circular", "linear"}:
+        raise ValidationError(f"Unsupported Web configuration mode: {mode!r}.")
+    if overrides is not None and not isinstance(overrides, Mapping):
+        raise ValidationError("diagramOptions.configOverrides must be an object or null.")
+    if managed_paths is None:
+        managed_paths = []
+    if not isinstance(managed_paths, list) or not all(
+        isinstance(path, str) for path in managed_paths
+    ):
+        raise ValidationError("Managed config override paths must be a string array.")
+
+    canonical_paths = canonical_config_override_paths()
+    unknown_managed = sorted(set(managed_paths) - canonical_paths)
+    if unknown_managed:
+        raise ValidationError(
+            "The Web GUI declares unknown managed config path(s): "
+            + ", ".join(unknown_managed)
+            + "."
+        )
+    managed = frozenset(managed_paths)
+    explicit = dict(overrides or {})
+    validated = dict(validate_config_overrides(explicit))
+
+    if require_unmanaged_only:
+        dual_owned = sorted(set(validated) & managed)
+        if dual_owned:
+            raise ValidationError(
+                "Preserved config override path is GUI-managed: "
+                + ", ".join(dual_owned)
+                + "."
+            )
+
+    options_type = CircularDiagramOptions if mode == "circular" else LinearDiagramOptions
+    options_type(config_overrides=validated)
+    base = _validated_base_config(config)
+    try:
+        effective = apply_config_overrides(base, validated)
+    except ValidationError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValidationError("Config override values are incompatible.") from exc
+
+    default_raw = config_to_raw_dict(apply_config_overrides(None, None))
+    effective_raw = config_to_raw_dict(effective)
+    candidates = {
+        path
+        for path in canonical_paths
+        if _raw_config_leaf(effective_raw, path) != _raw_config_leaf(default_raw, path)
+    }
+    candidates.update(validated)
+
+    projected: dict[str, object] = {}
+    for path in sorted(candidates - managed):
+        if path in validated:
+            projected[path] = validated[path]
+        else:
+            projected[path] = _raw_config_leaf(effective_raw, path)
+
+    # Re-run mode validation against values originating from a full config.
+    options_type(config_overrides=projected)
+    return projected
+
+
+def validate_web_config_overrides_json(
+    mode: object,
+    config_json: object,
+    overrides_json: object,
+    managed_paths_json: object,
+    require_unmanaged_only: object = False,
+) -> str:
+    """JSON boundary used by the existing diagram-Worker helper channel."""
+
+    try:
+        config = json.loads(str(config_json))
+        overrides = json.loads(str(overrides_json))
+        managed_paths = json.loads(str(managed_paths_json))
+        projected = validate_and_project_web_config_overrides(
+            mode=str(mode),  # type: ignore[arg-type]
+            config=config,
+            overrides=overrides,
+            managed_paths=managed_paths,
+            require_unmanaged_only=bool(require_unmanaged_only),
+        )
+    except ValidationError as exc:
+        return json.dumps({"error": str(exc)}, ensure_ascii=False)
+    except (KeyError, TypeError, ValueError):
+        return json.dumps(
+            {"error": "Web config override payload is invalid."},
+            ensure_ascii=False,
+        )
+    return json.dumps({"overrides": projected}, ensure_ascii=False)
+
+
+__all__ = [
+    "validate_and_project_web_config_overrides",
+    "validate_web_config_overrides_json",
+]

--- a/tests/test_web_config_overrides.py
+++ b/tests/test_web_config_overrides.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from gbdraw.api.config import load_default_config
+from gbdraw.exceptions import ValidationError
+from gbdraw.web_support.config_overrides import (
+    validate_and_project_web_config_overrides,
+    validate_web_config_overrides_json,
+)
+
+
+UNMANAGED_OPACITY_PATH = "objects.gc_content.percent_background_opacity"
+
+
+def test_known_typed_unmanaged_leaf_is_preserved_exactly() -> None:
+    projected = validate_and_project_web_config_overrides(
+        mode="circular",
+        overrides={UNMANAGED_OPACITY_PATH: 0.42},
+        managed_paths=["objects.scale.show"],
+    )
+
+    assert projected == {UNMANAGED_OPACITY_PATH: 0.42}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"objects.gc_content.unknown": 1}, "Unknown config override path"),
+        ({"objects.gc_content": {}}, "not a leaf field"),
+        (
+            {"objects.__proto__.percent_background_opacity": 0.42},
+            "unsafe key",
+        ),
+        (
+            {"labels.filtering.raw": {"constructor": {"leak": True}}},
+            "unsafe key",
+        ),
+        ({UNMANAGED_OPACITY_PATH: "0.42"}, "Invalid value"),
+        ({UNMANAGED_OPACITY_PATH: 1.1}, "finite number in.*0.0, 1.0"),
+        ({"objects.scale.style": "unknown"}, "allowed literal values"),
+    ],
+)
+def test_invalid_overlay_inputs_are_rejected_explicitly(
+    overrides: dict[str, object],
+    message: str,
+) -> None:
+    with pytest.raises(ValidationError, match=message):
+        validate_and_project_web_config_overrides(
+            mode="circular",
+            overrides=overrides,
+            managed_paths=[],
+        )
+
+
+@pytest.mark.parametrize(
+    ("mode", "path"),
+    [
+        ("circular", "objects.blast_match.curve_tension"),
+        ("linear", "objects.axis.circular.stroke_color"),
+    ],
+)
+def test_active_mode_incompatible_leaf_is_rejected(mode: str, path: str) -> None:
+    with pytest.raises(ValidationError, match="cannot target"):
+        validate_and_project_web_config_overrides(
+            mode=mode,  # type: ignore[arg-type]
+            overrides={path: 0.25 if path.endswith("curve_tension") else "black"},
+            managed_paths=[],
+        )
+
+
+def test_gui_managed_paths_are_filtered_and_cannot_be_stored_as_unmanaged() -> None:
+    projected = validate_and_project_web_config_overrides(
+        mode="circular",
+        overrides={
+            "objects.scale.show": False,
+            UNMANAGED_OPACITY_PATH: 0.42,
+        },
+        managed_paths=["objects.scale.show"],
+    )
+    assert projected == {UNMANAGED_OPACITY_PATH: 0.42}
+
+    with pytest.raises(ValidationError, match="GUI-managed.*objects.scale.show"):
+        validate_and_project_web_config_overrides(
+            mode="circular",
+            overrides={"objects.scale.show": False},
+            managed_paths=["objects.scale.show"],
+            require_unmanaged_only=True,
+        )
+
+
+def test_full_typed_config_projects_only_changed_unmanaged_leaves() -> None:
+    config = load_default_config()
+    config["objects"]["gc_content"]["percent_background_opacity"] = 0.42
+
+    projected = validate_and_project_web_config_overrides(
+        mode="circular",
+        config=config,
+        managed_paths=["objects.scale.show"],
+    )
+
+    assert projected == {UNMANAGED_OPACITY_PATH: 0.42}
+
+
+def test_json_boundary_returns_validated_overlay() -> None:
+    result = json.loads(validate_web_config_overrides_json(
+        "linear",
+        "null",
+        json.dumps({"objects.blast_match.curve_tension": 0.25}),
+        "[]",
+    ))
+
+    assert result == {
+        "overrides": {"objects.blast_match.curve_tension": 0.25}
+    }
+
+
+def test_json_boundary_returns_actionable_safe_rejection() -> None:
+    result = json.loads(validate_web_config_overrides_json(
+        "circular",
+        "null",
+        json.dumps({"objects.gc_content.unknown": "biological secret"}),
+        "[]",
+    ))
+
+    assert "objects.gc_content.unknown" in result["error"]
+    assert "biological secret" not in result["error"]

--- a/tests/web/mode-profiles.test.mjs
+++ b/tests/web/mode-profiles.test.mjs
@@ -409,6 +409,7 @@ assert.deepEqual(
     }
   );
   state.losat.blastp.collinearSearchScope = 'adjacent';
+  state.unmanagedConfigOverrides['objects.gc_content.percent_background_opacity'] = 0.42;
 
   resetSettings(state);
 
@@ -427,6 +428,7 @@ assert.deepEqual(
   assert.equal(state.adv.circular_track_slots_enabled, false);
   assert.equal(state.adv.linear_track_slots_enabled, false);
   assert.equal(state.form.show_scale, true);
+  assert.deepEqual(state.unmanagedConfigOverrides, {});
   assert.equal(
     state.losat.blastp.collinearSearchScope,
     'adjacent',
@@ -480,6 +482,7 @@ assert.deepEqual(
   state.adv.identity = 77;
   state.form.show_scale = false;
   state.losat.blastp.collinearSearchScope = 'adjacent';
+  state.unmanagedConfigOverrides['objects.blast_match.curve_tension'] = 0.25;
   const savedConfig = structuredClone(buildConfigData());
 
   assert.equal(savedConfig.form.show_scale, false);
@@ -488,13 +491,20 @@ assert.deepEqual(
   assert.equal(savedConfig.modeProfiles.profiles.linear.values.identity, 77);
   assert.equal(savedConfig.modeProfiles.profiles.linear.managed.identity, false);
   assert.equal(savedConfig.losat.blastp.collinearSearchScope, 'adjacent');
+  assert.deepEqual(savedConfig.unmanagedConfigOverrides, {
+    'objects.blast_match.curve_tension': 0.25
+  });
 
   Object.assign(state.adv, createDefaultAdv('linear'));
   state.modeProfileStateManager.reset('linear', state.adv);
   state.form.show_scale = true;
+  state.unmanagedConfigOverrides.stale = true;
   applyConfigData(savedConfig);
   assert.equal(state.form.show_scale, false);
   assert.equal(state.adv.identity, 77);
+  assert.deepEqual(state.unmanagedConfigOverrides, {
+    'objects.blast_match.curve_tension': 0.25
+  });
   assert.equal(
     state.losat.blastp.collinearSearchScope,
     'adjacent',
@@ -530,6 +540,9 @@ assert.deepEqual(
     migratedProfiles.profiles.circular.values,
     managedAdvStateForMode('circular')
   );
+  Object.keys(state.unmanagedConfigOverrides).forEach((path) => {
+    delete state.unmanagedConfigOverrides[path];
+  });
 
 }
 

--- a/tests/web/session-active-config-contract.test.mjs
+++ b/tests/web/session-active-config-contract.test.mjs
@@ -34,6 +34,36 @@ assert.equal(createDefaultLosat().blastp.candidateLimit, null);
 assert.equal(createDefaultLosat().blastp.collinearSearchScope, 'adjacent');
 assert.equal(createDefaultLosat().blastp.collinearMergeOrientation, 'either');
 
+assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
+  mode: 'circular',
+  storedConfig: {
+    ...storedConfig,
+    unmanagedConfigOverrides: {
+      'objects.gc_content.percent_background_opacity': 0.42
+    }
+  }
+}));
+assert.throws(
+  () => validateCurrentWriterActiveConfig({
+    mode: 'circular',
+    storedConfig: { ...storedConfig, unmanagedConfigOverrides: [] }
+  }),
+  /config\.unmanagedConfigOverrides must be object/
+);
+const unsafeStoredConfig = JSON.parse(JSON.stringify({
+  ...storedConfig,
+  unmanagedConfigOverrides: {
+    'labels.filtering.raw': JSON.parse('{"__proto__":{"polluted":true}}')
+  }
+}));
+assert.throws(
+  () => validateCurrentWriterActiveConfig({
+    mode: 'circular',
+    storedConfig: unsafeStoredConfig
+  }),
+  /unsafe key __proto__/
+);
+
 for (const [candidateLimit, collinearSearchScope] of [[null, 'adjacent'], [9, 'all']]) {
   assert.doesNotThrow(() => validateCurrentWriterActiveConfig({
     mode: 'linear',

--- a/tests/web/session-authority.test.mjs
+++ b/tests/web/session-authority.test.mjs
@@ -12,6 +12,11 @@ await writeFile(
   await readFile(join(repoRoot, 'gbdraw', 'web', 'js', 'services', 'session-authority.js'), 'utf8'),
   'utf8'
 );
+await writeFile(
+  join(tempRoot, 'safe-object-keys.js'),
+  await readFile(join(repoRoot, 'gbdraw', 'web', 'js', 'services', 'safe-object-keys.js'), 'utf8'),
+  'utf8'
+);
 
 const {
   SESSION_TOP_LEVEL_AUTHORITY,

--- a/tests/web/session-draft-authority.test.mjs
+++ b/tests/web/session-draft-authority.test.mjs
@@ -201,6 +201,9 @@ const projectedConfig = {
 };
 const storedConfig = {
   form: { track_type: 'tuckin' },
+  unmanagedConfigOverrides: {
+    'objects.gc_content.percent_background_opacity': 0.42
+  },
   adv: {
     ...projectedConfig.adv,
     circular_track_slots: [disabledDraft, canonicalFeature],
@@ -239,6 +242,7 @@ assert.deepEqual(CURRENT_WRITER_ACTIVE_CONFIG_DOMAINS, [
   'circularConservation',
   'annotationSets',
   'modeProfiles',
+  'unmanagedConfigOverrides',
   'linearRecordLayout',
   'linearComparisonPlan',
   'importedComparisonResolution',
@@ -281,6 +285,9 @@ assert.deepEqual(restored.adv.linear_track_slots, storedConfig.adv.linear_track_
 assert.equal(restored.adv.circular_track_slots_axis_index, 2);
 assert.equal(restored.adv.feature_width_circular, 19);
 assert.equal(restored.adv.depth_width_circular, 23);
+assert.deepEqual(restored.unmanagedConfigOverrides, {
+  'objects.gc_content.percent_background_opacity': 0.42
+});
 
 const galleryCompatibilityConfig = structuredClone(storedConfig);
 galleryCompatibilityConfig.colors = { CDS: '#123456' };

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -14,6 +14,7 @@ await writeFile(join(tempRoot, 'package.json'), '{"type":"module"}', 'utf8');
 const {
   buildCanonicalRenderRequest: buildCanonicalRenderRequestRaw,
   linearRecordLayoutHasSharedRow,
+  managedConfigOverridePathsForMode,
   normalizeWebGridColumnOrdering,
   promoteCanonicalRenderRequestToCurrent,
   projectCanonicalSessionRequest
@@ -396,7 +397,8 @@ const state = {
   linearRecordLayoutEnabled: ref(false),
   linearRecordGap: ref(24),
   linearRecordRows: [],
-  annotationSets: []
+  annotationSets: [],
+  unmanagedConfigOverrides: {}
 };
 
 const stateForCanonicalProjection = (projection) => {
@@ -555,6 +557,11 @@ assert.equal(
 const circularConfigOverrides = canonical.renderRequest.diagramOptions.configOverrides;
 assert.ok(Object.keys(circularConfigOverrides).every((path) => path.includes('.')));
 assert.ok(Object.values(circularConfigOverrides).every((value) => value !== null));
+assert.ok(
+  Object.keys(circularConfigOverrides).every((path) => (
+    managedConfigOverridePathsForMode('circular').includes(path)
+  ))
+);
 assert.equal(circularConfigOverrides['objects.scale.show'], true);
 assert.equal(
   circularConfigOverrides['objects.features.arrow_geometry.head_length_ratio'],
@@ -568,6 +575,41 @@ assert.equal(projectCanonicalSessionRequest(canonical).config.form.show_scale, t
 assert.equal(circularConfigOverrides['labels.circular.scope'], 'none');
 assert.equal(circularConfigOverrides['labels.circular.placement'], 'horizontal');
 assert.deepEqual(circularConfigOverrides['labels.filtering.blacklist_keywords'], []);
+assert.ok(managedConfigOverridePathsForMode('circular').includes('objects.scale.show'));
+assert.ok(
+  managedConfigOverridePathsForMode('circular').includes(
+    'objects.axis.circular.stroke_width.short'
+  )
+);
+assert.ok(
+  !managedConfigOverridePathsForMode('circular').includes(
+    'objects.blast_match.curve_tension'
+  )
+);
+assert.ok(
+  managedConfigOverridePathsForMode('linear').includes(
+    'objects.definition.linear.line_styles.name.font_weight'
+  )
+);
+state.unmanagedConfigOverrides = {
+  'objects.gc_content.percent_background_opacity': 0.42,
+  'objects.scale.show': false
+};
+const canonicalWithPreservedConfig = buildCanonicalRenderRequest({ state, filesData });
+assert.equal(
+  canonicalWithPreservedConfig.renderRequest.diagramOptions.configOverrides[
+    'objects.gc_content.percent_background_opacity'
+  ],
+  0.42
+);
+assert.equal(
+  canonicalWithPreservedConfig.renderRequest.diagramOptions.configOverrides[
+    'objects.scale.show'
+  ],
+  true,
+  'the GUI-managed value must win over a preserved value at the same path'
+);
+state.unmanagedConfigOverrides = {};
 state.adv.circular_definition_interval = 30;
 assert.equal(
   buildCanonicalRenderRequest({ state, filesData })
@@ -1752,6 +1794,10 @@ const linearCanonical = buildCanonicalRenderRequest({ state, filesData: linearFi
 assert.ok(
   Object.keys(linearCanonical.renderRequest.diagramOptions.configOverrides)
     .every((path) => path.includes('.'))
+);
+assert.ok(
+  Object.keys(linearCanonical.renderRequest.diagramOptions.configOverrides)
+    .every((path) => managedConfigOverridePathsForMode('linear').includes(path))
 );
 assert.ok(
   Object.values(linearCanonical.renderRequest.diagramOptions.configOverrides)

--- a/tests/web/unmanaged-config-overrides.playwright.spec.js
+++ b/tests/web/unmanaged-config-overrides.playwright.spec.js
@@ -1,0 +1,132 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { gunzipSync } = require('node:zlib');
+const {
+  generateAndWaitForResult,
+  openApp,
+  waitForAppShell
+} = require('./helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const sourceSession = JSON.parse(readFileSync(join(
+  repoRoot,
+  'gbdraw',
+  'web',
+  'gallery',
+  'sessions',
+  'HmmtDNA_basic_circular.gbdraw-session.json'
+), 'utf8'));
+const unmanagedPath = 'objects.gc_content.percent_background_opacity';
+
+const loadSessionPayload = async (page, payload) => {
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 180000 });
+  await page.locator('input[accept^=".json,"]').first().setInputFiles({
+    name: 'unmanaged-config.gbdraw-session.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify(payload))
+  });
+  const dialog = await dialogPromise;
+  const message = dialog.message();
+  await dialog.accept();
+  return message;
+};
+
+const readSessionDownload = async (download) => {
+  const path = await download.path();
+  expect(path).toBeTruthy();
+  return {
+    path,
+    session: JSON.parse(gunzipSync(readFileSync(path)).toString('utf8'))
+  };
+};
+
+test('GUI-unmanaged config survives disclosure, Generate, save/reload, reset, and rejects unknown paths', async ({
+  page
+}) => {
+  test.setTimeout(420000);
+  await page.addInitScript(() => {
+    window.__GBDRAW_RUN_CONFIG_OVERRIDES__ = [];
+    const nativePostMessage = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function trackedConfigOverridePostMessage(message, transfer) {
+      if (message?.type === 'run') {
+        window.__GBDRAW_RUN_CONFIG_OVERRIDES__.push(structuredClone(
+          message.payload?.request?.diagramOptions?.configOverrides || {}
+        ));
+      }
+      if (transfer === undefined) return nativePostMessage.call(this, message);
+      return nativePostMessage.call(this, message, transfer);
+    };
+  });
+  await openApp(page);
+
+  const preservedSession = structuredClone(sourceSession);
+  preservedSession.renderRequest.diagramOptions.configOverrides[unmanagedPath] = 0.42;
+  preservedSession.renderRequest.diagramOptions.configOverrides[
+    'objects.gc_content.mode'
+  ] = 'percent';
+
+  expect(await loadSessionPayload(page, preservedSession)).toBe(
+    'Session loaded successfully!'
+  );
+  const disclosure = page.locator('[data-unmanaged-config-override]');
+  await expect(disclosure).toHaveCount(1);
+  await expect(disclosure).toContainText(unmanagedPath);
+  await expect(disclosure).toContainText('0.42');
+
+  await page.evaluate(() => {
+    window.__GBDRAW_APP__.form.plot_title = 'Preserved overlay journey';
+  });
+  await generateAndWaitForResult(page);
+  expect(await page.evaluate((path) => {
+    const runs = window.__GBDRAW_RUN_CONFIG_OVERRIDES__;
+    return runs.at(-1)?.[path];
+  }, unmanagedPath)).toBe(0.42);
+
+  const downloadPromise = page.waitForEvent('download', { timeout: 120000 });
+  await page.evaluate(async () => window.__GBDRAW_APP__.saveSessionWithTitle());
+  const saved = await readSessionDownload(await downloadPromise);
+  expect(saved.session.version).toBe(40);
+  expect(saved.session.config.unmanagedConfigOverrides).toEqual({
+    [unmanagedPath]: 0.42
+  });
+  expect(
+    saved.session.renderRequest.diagramOptions.configOverrides[unmanagedPath]
+  ).toBe(0.42);
+  expect(saved.session.config.form.plot_title).toBe('Preserved overlay journey');
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForAppShell(page);
+  const reloadDialog = page.waitForEvent('dialog', { timeout: 180000 });
+  await page.locator('input[accept^=".json,"]').first().setInputFiles(saved.path);
+  const loaded = await reloadDialog;
+  expect(loaded.message()).toBe('Session loaded successfully!');
+  await loaded.accept();
+  await expect(disclosure).toContainText(unmanagedPath);
+
+  await disclosure.getByRole('button', { name: `Reset preserved setting ${unmanagedPath}` })
+    .click();
+  await expect(disclosure).toHaveCount(0);
+  await page.getByRole('button', { name: 'Undo' }).click();
+  await expect(disclosure).toContainText(unmanagedPath);
+  await page.getByRole('button', { name: 'Redo' }).click();
+  await expect(disclosure).toHaveCount(0);
+
+  await generateAndWaitForResult(page);
+  expect(await page.evaluate((path) => {
+    const runs = window.__GBDRAW_RUN_CONFIG_OVERRIDES__;
+    return Object.prototype.hasOwnProperty.call(runs.at(-1) || {}, path);
+  }, unmanagedPath)).toBe(false);
+
+  const rejectedSession = structuredClone(sourceSession);
+  rejectedSession.renderRequest.diagramOptions.configOverrides[
+    'objects.gc_content.unknown'
+  ] = 1;
+  const rejectedMessage = await loadSessionPayload(page, rejectedSession);
+  expect(rejectedMessage).toContain('Unknown config override path');
+  expect(rejectedMessage).toContain('objects.gc_content.unknown');
+  await expect(disclosure).toHaveCount(0);
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.form.plot_title)).toBe(
+    'Preserved overlay journey'
+  );
+});


### PR DESCRIPTION
## Plain-language summary

Web sessions now keep valid configuration settings that the GUI does not edit instead of silently dropping them. Preserved settings remain active through unrelated edits, Generate, save, and reload; the UI discloses each value and provides a narrow Undo/Redo-aware reset. Unknown, non-leaf, unsafe, invalid, and active-mode-incompatible settings are rejected with a path-specific message.

## Change class

Select exactly one:

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `9cb3c1dbd54c4cc752df356edc6c39f0a28584aa`; protected selective CI owns broad regression; focused owners are typed configuration overrides, current Session projection/writing, and the Web Generate journey.

## User-visible impact

Loading a Session with a schema-known setting that has no Web control now shows a bounded “Preserved session settings” card. The setting is passed through to generation and future Session files until the user explicitly resets it.

## Changes

- Derive leaf validity from `GbdrawConfig`, apply existing mode-specific option validation, and reject unsafe object keys without echoing values in errors.
- Preserve one flat dotted-leaf overlay in active Web state; GUI-managed leaves win at their own paths without recursively merging configuration objects.
- Validate the overlay before Session admission and save through the existing diagram Worker helper envelope, then include it in current canonical requests and current Session config.
- Add bounded disclosure plus per-leaf History-aware reset, and clear the overlay through the existing Reset Settings owner.

## Verification

- `python -m pytest tests/test_web_config_overrides.py tests/test_config_override_paths.py -q` — 52 passed.
- `node tests/web/session-request.test.mjs`, `session-active-config-contract.test.mjs`, `session-draft-authority.test.mjs`, `mode-profiles.test.mjs`, `pyodide-startup.test.mjs`, and `diagram-generation-worker.test.mjs` — passed.
- `npx playwright test tests/web/unmanaged-config-overrides.playwright.spec.js --project=chromium --workers=1` — 1 passed using the HmmtDNA Session journey.
- `node tests/web/architecture-contracts.test.mjs` — 133 passed; Architecture and Product Impact ratchet fixture suites — 14 and 36 passed.
- `WEB_ARCHITECTURE_CHANGE=true node tools/check-web-change-budget.mjs --base origin/dev` — Gate PASS, Review REQUIRED, no blocking violations.
- Focused Ruff and `git diff --check` — passed.

## Risk and review notes

- Gate result and any blocker: PASS; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: REQUIRED because Session paths and report-only architecture inventories change.
- Architecture impact: **This is architecture-bearing**; it extends current Session active-config state and request projection while retaining the typed Python configuration model as the semantic validation owner.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: before and after, schema/default/type validity is owned by `gbdraw/config` and mode compatibility by `gbdraw/api/options.py`; the new `gbdraw/web_support/config_overrides.py` module is a bounded Web adapter, not a schema/default owner. The canonical path is Session import → typed validation → flat unmanaged overlay → GUI-precedence request projection → existing typed Generate → current Session writer. Disclosure reads validated state and does not decide validity. The duplicated recursive unsafe-key check in the active-config contract was replaced by one shared safe-key predicate; no recursive merge/default registry was added. Released schemas 5/6 continue through their existing projection, no Session version or compatibility reader was added, and current writers serialize only version 40. Changed-scope totals are `OE 0 → 0; delta(OE) = 0`, `PE 0 → 0; delta(PE) = 0`, and `CB 0 → 0; delta(CB) = 0`.
- `architecture-change` label, if relevant: required and applied.
- Security and rollback: unsafe keys are rejected iteratively before admission, values are omitted from rejection text, and failed import occurs before state mutation. Revert this commit before relying on newly written overlay-bearing Sessions; after release, prefer a forward fix because those current Sessions intentionally contain the new active-config domain.

## Rollback

Revert commit `8f50fda0d50d8aad5db8669a27a0092f4f91aea6` before overlay-bearing Sessions are distributed. A later rollback would need a deliberate reader decision for those Sessions rather than silently discarding the stored values.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Affected concern(s), if known: GUI-unmanaged typed configuration preservation and disclosure.
- Affected journey/checkpoint effects: Session import → disclosure → unrelated GUI edit → canonical projection → Generate → save/reload → explicit reset.
- Authority and decision references: `PD-OI-009`, `PD-OI-015`, `OIPC-C03`, `OIPC-C05`, `OIPC-C06`, `OIPC-C08`; acceptance rows `CFG-001..CFG-005`, `ARC-001`, `ARC-003`, `ARC-005`, `ARC-006`, `ARC-008`.
- Decision Pack or evidence reference, if required: N/A.
- Behavior contracts and residual risk: existing Product authority is implemented without a new Product decision; risk is bounded to current Web Session/request configuration handling.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

N/A.

### ARCHITECTURE_EXCEPTION

N/A.

### PROMOTION

N/A.
