### PR TITLE
Add Circular single-record presentation controls

### DIFF
--- a/gbdraw/render/groups/circular/definition.py
+++ b/gbdraw/render/groups/circular/definition.py
@@ -146,16 +146,25 @@ class DefinitionGroup:
         metadata = infer_record_source_metadata(self.gb_record)
         strain_name = metadata.strain
         record_name = metadata.organism
+        annotations = getattr(self.gb_record, "annotations", {}) or {}
+        explicit_label = str(annotations.get("gbdraw_record_label") or "").strip()
+        explicit_subtitle = str(
+            annotations.get("gbdraw_record_subtitle") or ""
+        ).strip()
         self.replicon = metadata.replicon
         self.organelle = metadata.organelle
 
-        if self.species:
+        if explicit_label:
+            self.species_parts = parse_mixed_content_text(explicit_label)
+        elif self.species:
             self.species_parts: List[Dict[str, str | bool | None]] = parse_mixed_content_text(self.species)
         else:
             self.species_parts = parse_mixed_content_text(record_name)
-        self.record_name = str(record_name).strip() or str(self.gb_record.id)
+        self.record_name = explicit_label or str(record_name).strip() or str(self.gb_record.id)
 
-        if self.strain:
+        if explicit_subtitle:
+            self.strain_parts = parse_mixed_content_text(explicit_subtitle)
+        elif self.strain:
             self.strain_parts: List[Dict[str, str | bool | None]] = parse_mixed_content_text(self.strain)
         else:
             self.strain_parts = parse_mixed_content_text(strain_name)

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1176,6 +1176,76 @@
                             <file-uploader label="GFF3 File" v-model="files.c_gff" accept=".gff,.gff3,.txt,text/plain,text/*"></file-uploader>
                             <file-uploader label="FASTA File" v-model="files.c_fasta" accept=".fa,.fas,.fasta,.fna,.ffn,.faa,.txt,text/plain,text/*"></file-uploader>
                         </div>
+                        <details data-circular-record-presentation class="rounded border border-slate-200 bg-white/70 p-2">
+                            <summary aria-label="Circular record presentation">
+                                <i class="ph ph-selection"></i>
+                                Single-record presentation
+                            </summary>
+                            <div class="pt-2 space-y-2">
+                                <div>
+                                    <label class="input-label text-[10px]">Record <help-tip text="Select one stable record identity for a single Circular diagram. Leave this on All records to keep separate-diagram batch output."></help-tip></label>
+                                    <select
+                                        :value="form.circular_record_selector"
+                                        @change="setCircularRecordPresentationSelector($event.target.value)"
+                                        :disabled="form.multi_record_canvas"
+                                        aria-label="Circular record"
+                                        class="form-select w-full px-1 py-1 text-xs disabled:bg-slate-100 disabled:text-slate-500"
+                                    >
+                                        <option
+                                            v-for="option in circularRecordPresentationOptions"
+                                            :key="`${option.value}:${option.synthetic ? 'synthetic' : 'record'}`"
+                                            :value="option.value"
+                                        >{{ option.label }}</option>
+                                    </select>
+                                    <p v-if="form.multi_record_canvas" class="mt-1 text-[9px] text-slate-500">Turn off Multi-Record Canvas to edit one record.</p>
+                                    <p v-else-if="circularRecordPresentationError" class="mt-1 text-[9px] text-red-600">{{ circularRecordPresentationError }}</p>
+                                    <p v-else-if="!circularSingleRecordPresentationEnabled" class="mt-1 text-[9px] text-slate-500">Select one record to edit crop, orientation, and title lines.</p>
+                                </div>
+                                <div class="grid grid-cols-1 gap-2" :class="circularSingleRecordPresentationEnabled ? '' : 'opacity-60'">
+                                    <div>
+                                        <label class="input-label text-[10px]">Record label <help-tip text="Overrides the inferred organism line for this Circular record. Leave empty to keep inference."></help-tip></label>
+                                        <input
+                                            type="text"
+                                            v-model="form.circular_record_label"
+                                            :disabled="!circularSingleRecordPresentationEnabled"
+                                            aria-label="Circular record label"
+                                            placeholder="e.g. Streptomyces fradiae"
+                                            class="form-input px-1 py-1 text-xs"
+                                        >
+                                    </div>
+                                    <div>
+                                        <label class="input-label text-[10px]">Subtitle <help-tip text="Overrides the inferred strain line for this Circular record. Leave empty to keep inference."></help-tip></label>
+                                        <input
+                                            type="text"
+                                            v-model="form.circular_record_subtitle"
+                                            :disabled="!circularSingleRecordPresentationEnabled"
+                                            aria-label="Circular record subtitle"
+                                            placeholder="e.g. Neomycin biosynthetic gene cluster"
+                                            class="form-input px-1 py-1 text-xs"
+                                        >
+                                    </div>
+                                    <div class="pt-1 border-t border-slate-200 border-dashed">
+                                        <div class="text-[10px] text-slate-500 font-bold mb-1 flex items-center gap-1">
+                                            <i class="ph ph-crop"></i> Region (optional)
+                                            <help-tip text="Use 1-based inclusive coordinates within the selected record. Both values are required and must be within record bounds."></help-tip>
+                                        </div>
+                                        <div class="grid grid-cols-2 gap-2">
+                                            <div>
+                                                <label class="text-[9px] block">Start</label>
+                                                <input type="number" min="1" step="1" v-model.number="form.circular_region_start" :disabled="!circularSingleRecordPresentationEnabled" aria-label="Circular region start" placeholder="1000" class="form-input px-1 py-0.5 text-xs">
+                                            </div>
+                                            <div>
+                                                <label class="text-[9px] block">End</label>
+                                                <input type="number" min="1" step="1" v-model.number="form.circular_region_end" :disabled="!circularSingleRecordPresentationEnabled" aria-label="Circular region end" placeholder="9000" class="form-input px-1 py-0.5 text-xs">
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <label class="flex items-center gap-2 text-[10px] text-slate-600">
+                                        <input type="checkbox" v-model="form.circular_reverse" :disabled="!circularSingleRecordPresentationEnabled" aria-label="Circular reverse complement" class="form-checkbox"> Reverse complement
+                                    </label>
+                                </div>
+                            </div>
+                        </details>
                         <details class="rounded border border-slate-200 bg-white/70 p-2">
                             <summary aria-label="Depth TSV tracks">
                                 <i class="ph ph-chart-bar"></i>

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -82,6 +82,11 @@ import { createLosatSettings } from './losat-settings.js';
 import { createAutoValueDisplay } from './auto-value-display.js';
 import { createLinearRecordSelector } from './linear-record-selector.js';
 import {
+  buildDisambiguatedRecordEntries,
+  formatRecordLength,
+  resolveDisambiguatedRecordSelection
+} from './record-options.js';
+import {
   linearRecordPositionTokens,
   moveLinearRecordInRow,
   reconcileLinearRecordLayout,
@@ -2916,6 +2921,72 @@ export const createAppSetup = () => {
     return `${normalized} (${String(matched.record_id || '').trim() || 'Unknown'})`;
   };
 
+  const circularRecordPresentationEntries = () => buildDisambiguatedRecordEntries(
+    (Array.isArray(circularRecordList.value) ? circularRecordList.value : []).map(
+      (record) => ({
+        ...record,
+        recordId: record?.record_id ?? record?.recordId,
+        recordLength: record?.record_length ?? record?.recordLength
+      })
+    )
+  );
+
+  const circularRecordPresentationOptions = computed(() => {
+    const entries = circularRecordPresentationEntries();
+    const current = String(form.circular_record_selector || '').trim();
+    const selection = resolveDisambiguatedRecordSelection(entries, current);
+    const automaticLabel = entries.length > 1
+      ? 'All records (separate diagrams)'
+      : 'Automatic (only record)';
+    return [
+      { value: '', label: automaticLabel, synthetic: false },
+      ...(current && selection.status !== 'resolved'
+        ? [{
+            value: current,
+            label: `${current} (${selection.status === 'ambiguous' ? 'ambiguous' : 'not found'})`,
+            synthetic: true
+          }]
+        : []),
+      ...entries.map((record) => ({
+        value: record.value,
+        label: `${record.recordId} (${formatRecordLength(record.recordLength)})${record.usesIndex ? ` [${record.selector}]` : ''}`,
+        synthetic: false
+      }))
+    ];
+  });
+
+  const circularRecordPresentationError = computed(() => {
+    const current = String(form.circular_record_selector || '').trim();
+    if (!current) return '';
+    const selection = resolveDisambiguatedRecordSelection(
+      circularRecordPresentationEntries(),
+      current
+    );
+    if (selection.status === 'ambiguous') {
+      return `Record selector '${current}' is ambiguous in the current input.`;
+    }
+    if (selection.status === 'missing') {
+      return `Record selector '${current}' was not found in the current input.`;
+    }
+    return '';
+  });
+
+  const circularSingleRecordPresentationEnabled = computed(() => {
+    if (form.multi_record_canvas) return false;
+    const entries = circularRecordPresentationEntries();
+    if (entries.length === 1) return true;
+    const current = String(form.circular_record_selector || '').trim();
+    if (!current && entries.length !== 1) return false;
+    if (entries.length === 0) return Boolean(current);
+    return resolveDisambiguatedRecordSelection(entries, current).status === 'resolved';
+  });
+
+  const setCircularRecordPresentationSelector = (value) => {
+    const normalized = String(value || '').trim();
+    form.circular_record_selector = normalized;
+    adv.circular_grouping_intent = normalized ? 'single' : 'auto';
+  };
+
   const buildDefaultCircularRecordPositions = () => {
     const selectors = Array.isArray(circularRecordList.value)
       ? circularRecordList.value
@@ -3431,6 +3502,10 @@ export const createAppSetup = () => {
     closeRightDrawer: rightDrawerActions.closeRightDrawer,
     openOrthogroupInDrawer,
     circularRecordList,
+    circularRecordPresentationOptions,
+    circularRecordPresentationError,
+    circularSingleRecordPresentationEnabled,
+    setCircularRecordPresentationSelector,
     paletteDefinitions,
     paletteNames,
     selectedPalette,

--- a/gbdraw/web/js/app/record-options.js
+++ b/gbdraw/web/js/app/record-options.js
@@ -22,6 +22,7 @@ export const formatRecordLength = (value) => {
 export const buildDisambiguatedRecordEntries = (records) => {
   const normalized = (Array.isArray(records) ? records : []).map((record, index) => ({
     ...record,
+    sourceIndex: Number.isInteger(record?.sourceIndex) ? record.sourceIndex : index,
     selector: cleanText(record?.selector) || `#${index + 1}`,
     recordId: cleanText(record?.recordId) || `Record_${index + 1}`
   }));
@@ -39,4 +40,21 @@ export const buildDisambiguatedRecordEntries = (records) => {
       value: usesIndex ? record.selector : record.recordId
     };
   });
+};
+
+export const resolveDisambiguatedRecordSelection = (records, requestedValue) => {
+  const entries = buildDisambiguatedRecordEntries(records);
+  const requested = cleanText(requestedValue);
+  if (!requested) return { status: 'unspecified', requested, entries, record: null };
+
+  for (const field of ['value', 'selector', 'recordId']) {
+    const matches = entries.filter((record) => record[field] === requested);
+    if (matches.length === 1) {
+      return { status: 'resolved', requested, entries, record: matches[0] };
+    }
+    if (matches.length > 1) {
+      return { status: 'ambiguous', requested, entries, record: null };
+    }
+  }
+  return { status: 'missing', requested, entries, record: null };
 };

--- a/gbdraw/web/js/services/session-active-config-contract.js
+++ b/gbdraw/web/js/services/session-active-config-contract.js
@@ -9,6 +9,8 @@ const isObject = (value) => Boolean(value) && typeof value === 'object' && !Arra
 export const createDefaultForm = () => ({
   prefix: '', species: '', strain: '', plot_title: '', track_type: 'tuckin', linear_track_layout: 'middle', show_scale: true, scale_style: 'bar',
   linear_ruler_on_axis: false, labels_mode: 'none', show_labels_linear: 'none', multi_record_canvas: WEB_UX_PROFILE.circular.gridByDefault,
+  circular_record_selector: '', circular_region_start: null, circular_region_end: null, circular_reverse: false,
+  circular_record_label: '', circular_record_subtitle: '',
   separate_strands: WEB_UX_PROFILE.separateStrands, suppress_gc: !circularTracks.gc, suppress_skew: !circularTracks.skew, align_center: false,
   keep_definition_left_aligned: false, show_gc: linearTracks.gc, show_skew: linearTracks.skew, show_depth: false, normalize_length: false
 });

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -39,7 +39,10 @@ import {
   normalizeRecordMajorDepthFileRows,
   parseDepthTrackIndexIdentity
 } from '../app/depth-track-state.js';
-import { buildDisambiguatedRecordEntries } from '../app/record-options.js';
+import {
+  buildDisambiguatedRecordEntries,
+  resolveDisambiguatedRecordSelection
+} from '../app/record-options.js';
 import {
   orderedConservationSources,
   orderedOptionalConservationFiles
@@ -589,13 +592,61 @@ const selectorPayload = (rawValue) => {
   return { kind: 'recordId', value: raw };
 };
 
-const presentationPayload = ({ label = null, subtitle = null, gridRow = null } = {}) => ({
+const presentationPayload = ({
+  label = null,
+  subtitle = null,
+  reverseComplement = false,
+  gridRow = null
+} = {}) => ({
   label: String(label || '').trim() || null,
   subtitle: String(subtitle || '').trim() || null,
-  reverseComplement: false,
+  reverseComplement: Boolean(reverseComplement),
   gridRow,
   gridColumn: null
 });
+
+const circularPresentationPayload = (form, { hasRegion = false } = {}) => (
+  presentationPayload({
+    label: form.circular_record_label,
+    subtitle: form.circular_record_subtitle,
+    reverseComplement: !hasRegion && form.circular_reverse
+  })
+);
+
+const circularRegionPayload = (form, record) => {
+  const rawStart = form.circular_region_start;
+  const rawEnd = form.circular_region_end;
+  const hasStart = rawStart !== null && rawStart !== undefined && String(rawStart).trim() !== '';
+  const hasEnd = rawEnd !== null && rawEnd !== undefined && String(rawEnd).trim() !== '';
+  if (!hasStart && !hasEnd) return null;
+  if (hasStart !== hasEnd) {
+    throw new Error('Circular region requires both Start and End coordinates.');
+  }
+  const start = Number(rawStart);
+  const end = Number(rawEnd);
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < 1) {
+    throw new Error('Circular region Start and End must be positive integers.');
+  }
+  if (start > end) {
+    throw new Error('Circular region Start must not exceed End. Use Reverse complement to change display orientation.');
+  }
+  const recordLength = Number(record?.recordLength ?? record?.record_length);
+  if (Number.isInteger(recordLength) && recordLength > 0 && end > recordLength) {
+    throw new Error(`Circular region End (${end}) exceeds the selected record length (${recordLength}).`);
+  }
+  return {
+    selector: selectorPayload(record.value),
+    start,
+    end,
+    reverseComplement: Boolean(form.circular_reverse)
+  };
+};
+
+const circularRecordKey = (record) => {
+  const recordId = safePrefix(record?.recordId, 'record');
+  const selector = safePrefix(record?.selector, '1');
+  return `circular-${recordId}-${selector}`;
+};
 
 const linearRegionPayload = (seq) => {
   const start = optionalPositiveInteger(seq?.region_start);
@@ -617,7 +668,7 @@ const buildRecords = ({ state, filesData, resources }) => {
     const resolvedRows = state.linearRecordLayoutEnabled?.value
       ? resolvedLinearRecordRows(filesData.linearSeqs, state.linearRecordRows)
       : [];
-    return (filesData.linearSeqs || []).map((seq, index) => {
+    const records = (filesData.linearSeqs || []).map((seq, index) => {
       const source = state.lInputType.value === 'gff'
         ? {
             kind: 'gffFasta',
@@ -646,10 +697,11 @@ const buildRecords = ({ state, filesData, resources }) => {
         }
       };
     });
+    return { records, circularSourceIndexes: null, circularSourceCount: null };
   }
 
   if (Array.isArray(filesData.circularRecords) && filesData.circularRecords.length > 0) {
-    return filesData.circularRecords.map((record, index) => {
+    const records = filesData.circularRecords.map((record, index) => {
       const source = record.sourceKind === 'gffFasta'
         ? { kind: 'gffFasta',
             gffResourceId: resources.addFile(`record-${index + 1}-gff3`, 'gff3', record.gff),
@@ -665,6 +717,58 @@ const buildRecords = ({ state, filesData, resources }) => {
         presentation: publicationClone(record.presentation) || presentationPayload()
       };
     });
+    const singleJourney = (
+      records.length === 1 &&
+      !state.form.multi_record_canvas &&
+      state.adv.circular_grouping_intent !== 'batch'
+    );
+    if (singleJourney) {
+      const record = records[0];
+      const savedSelector = canonicalRecordSelector(record);
+      const requestedSelector = String(
+        state.form.circular_record_selector || savedSelector || ''
+      ).trim();
+      const knownRecords = (Array.isArray(state.circularRecordList.value)
+        ? state.circularRecordList.value
+        : []).map((entry) => ({
+          ...entry,
+          recordId: entry?.record_id ?? entry?.recordId
+        }));
+      const selection = resolveDisambiguatedRecordSelection(
+        knownRecords,
+        requestedSelector
+      );
+      const selectedKnownRecord = selection.record || (
+        !requestedSelector && selection.entries.length === 1
+          ? selection.entries[0]
+          : null
+      );
+      if (knownRecords.length > 0 && !selectedKnownRecord) {
+        const reason = selection.status === 'ambiguous' ? 'is ambiguous' : 'was not found';
+        const label = requestedSelector || '(automatic)';
+        throw new Error(`Circular record selector '${label}' ${reason} in the current input.`);
+      }
+      const selected = selectedKnownRecord || {
+        value: requestedSelector,
+        selector: requestedSelector,
+        recordId: requestedSelector
+      };
+      const region = circularRegionPayload(state.form, selected);
+      records[0] = {
+        ...record,
+        recordKey: record.recordKey || circularRecordKey(selected),
+        selector: region ? null : selectorPayload(selected.value),
+        region,
+        presentation: circularPresentationPayload(state.form, {
+          hasRegion: Boolean(region)
+        })
+      };
+    }
+    return {
+      records,
+      circularSourceIndexes: records.map((_, index) => index),
+      circularSourceCount: records.length
+    };
   }
   const source = state.cInputType.value === 'gff'
     ? {
@@ -679,21 +783,63 @@ const buildRecords = ({ state, filesData, resources }) => {
   const knownRecords = Array.isArray(state.circularRecordList.value)
     ? state.circularRecordList.value
     : [];
-  const selectedRecords = knownRecords.length > 0 ? knownRecords : [null];
   const recordSelectors = buildDisambiguatedRecordEntries(
     knownRecords.map((record) => ({
       ...record,
       recordId: record?.record_id ?? record?.recordId
     }))
   );
-  return selectedRecords.map((record, index) => ({
-    recordKey: `record-${index + 1}`,
-    cardinality: 'exactly_one',
-    source,
-    selector: selectorPayload(recordSelectors[index]?.value ?? record?.selector),
-    region: null,
-    presentation: presentationPayload()
-  }));
+  const requestedSelector = String(state.form.circular_record_selector || '').trim();
+  const selection = resolveDisambiguatedRecordSelection(
+    recordSelectors,
+    requestedSelector
+  );
+  const singlePresentationRequested = (
+    !state.form.multi_record_canvas &&
+    state.adv.circular_grouping_intent !== 'batch'
+  );
+  if (
+    singlePresentationRequested &&
+    requestedSelector &&
+    selection.status !== 'resolved'
+  ) {
+    const reason = selection.status === 'ambiguous' ? 'is ambiguous' : 'was not found';
+    throw new Error(`Circular record selector '${requestedSelector}' ${reason} in the current input.`);
+  }
+  const selectedRecords = singlePresentationRequested && selection.record
+    ? [selection.record]
+    : (recordSelectors.length > 0 ? recordSelectors : [null]);
+  const singleJourney = (
+    selectedRecords.length === 1 &&
+    singlePresentationRequested
+  );
+  const records = selectedRecords.map((record, index) => {
+    const region = singleJourney
+      ? circularRegionPayload(state.form, record)
+      : null;
+    return {
+      recordKey: singleJourney && record
+        ? circularRecordKey(record)
+        : `record-${index + 1}`,
+      cardinality: 'exactly_one',
+      source,
+      selector: region
+        ? null
+        : selectorPayload(record?.value ?? record?.selector),
+      region,
+      presentation: singleJourney
+        ? circularPresentationPayload(state.form, { hasRegion: Boolean(region) })
+        : presentationPayload()
+    };
+  });
+  const circularSourceIndexes = selectedRecords.map((record, index) => (
+    record && Number.isInteger(record.sourceIndex) ? record.sourceIndex : index
+  ));
+  return {
+    records,
+    circularSourceIndexes,
+    circularSourceCount: recordSelectors.length || records.length
+  };
 };
 
 const buildConfigOverrides = (
@@ -1895,11 +2041,26 @@ export const buildCanonicalRenderRequest = ({
   );
   const resources = createResourceBuilder();
   const webFiles = {};
-  const records = buildRecords({ state, filesData, resources });
+  const recordPlan = buildRecords({ state, filesData, resources });
+  const records = recordPlan.records;
   if (records.length === 0) throw new Error('A canonical request requires at least one record.');
+  const selectedCircularFilesData = (
+    state.mode.value === 'circular' &&
+    isRecordMajorDepthFileMatrix(filesData.c_depth) &&
+    Array.isArray(recordPlan.circularSourceIndexes) &&
+    recordPlan.circularSourceIndexes.length < recordPlan.circularSourceCount &&
+    filesData.c_depth.length === recordPlan.circularSourceCount
+  )
+    ? {
+        ...filesData,
+        c_depth: recordPlan.circularSourceIndexes.map((sourceIndex) => (
+          filesData.c_depth[sourceIndex] || []
+        ))
+      }
+    : filesData;
   const trackPlan = buildTrackPlan({
     state,
-    filesData,
+    filesData: selectedCircularFilesData,
     recordCount: records.length,
     resolvedCircularConservation
   });
@@ -1929,9 +2090,22 @@ export const buildCanonicalRenderRequest = ({
   const knownCircularRecords = Array.isArray(state.circularRecordList.value)
     ? state.circularRecordList.value
     : [];
-  const circularOutputRecords = knownCircularRecords.length > 0
-    ? knownCircularRecords
-    : records.map(() => ({ record_id: 'out' }));
+  const knownCircularEntries = buildDisambiguatedRecordEntries(
+    knownCircularRecords.map((record) => ({
+      ...record,
+      recordId: record?.record_id ?? record?.recordId
+    }))
+  );
+  const circularOutputRecords = records.map((record, index) => {
+    const selector = canonicalRecordSelector(record);
+    const resolved = resolveDisambiguatedRecordSelection(
+      knownCircularEntries,
+      selector
+    );
+    return {
+      record_id: resolved.record?.recordId || selector || `Record_${index + 1}`
+    };
+  });
   const defaultCircularPrefix = safePrefix(circularRecordId(circularOutputRecords[0], 0));
   const output = grouping === 'batch'
     ? resolveCircularBatchPrefixes(circularOutputRecords, explicitPrefix)
@@ -2096,7 +2270,7 @@ export const buildCanonicalRenderRequest = ({
   if (trackPlan.depthRequested) {
     buildDepthResources({
       state,
-      filesData,
+      filesData: selectedCircularFilesData,
       resources,
       diagramOptions,
       recordCount: records.length
@@ -3700,6 +3874,10 @@ export const projectCanonicalSessionRequest = ({
       tick_font_size: optionalNumber(options.depthTrackTickFontSizes?.[index])
     })
   );
+  const circularPresentationRecord = (
+    renderRequest.mode === 'circular' && grouping === 'single' && records.length === 1
+  ) ? records[0] : null;
+  const circularPresentationRegion = circularPresentationRecord?.region || null;
   const form = {
     prefix: projectedOutputPrefix(
       renderRequest,
@@ -3711,6 +3889,17 @@ export const projectCanonicalSessionRequest = ({
     plot_title: options.plotTitle || '',
     legend: options.output?.legend || 'right',
     multi_record_canvas: renderRequest.mode === 'circular' && grouping === 'grid',
+    circular_record_selector: circularPresentationRecord
+      ? (canonicalRecordSelector(circularPresentationRecord) || '')
+      : '',
+    circular_region_start: circularPresentationRegion?.start ?? null,
+    circular_region_end: circularPresentationRegion?.end ?? null,
+    circular_reverse: Boolean(
+      circularPresentationRegion?.reverseComplement ||
+      circularPresentationRecord?.presentation?.reverseComplement
+    ),
+    circular_record_label: circularPresentationRecord?.presentation?.label || '',
+    circular_record_subtitle: circularPresentationRecord?.presentation?.subtitle || '',
     suppress_gc: renderRequest.mode === 'circular' ? overrides.show_gc === false : false,
     suppress_skew: renderRequest.mode === 'circular' ? overrides.show_skew === false : false,
     show_gc: renderRequest.mode === 'linear' ? Boolean(overrides.show_gc) : false,

--- a/tests/test_api_request_render.py
+++ b/tests/test_api_request_render.py
@@ -1465,6 +1465,38 @@ def test_render_request_circular_smoke_creates_svg(tmp_path: Path) -> None:
 
 
 @pytest.mark.circular
+def test_render_request_circular_consumes_record_title_presentation(
+    tmp_path: Path,
+) -> None:
+    record = _seqrecord("record-title", "ATGCGC" * 200)
+    record.annotations["topology"] = "circular"
+    request = CircularDiagramRequest(
+        records=(
+            RecordInput(
+                source=InMemoryRecordSource(record),
+                presentation=RecordPresentation(
+                    label="長い <i>環状ゲノム</i> ラベル",
+                    subtitle="Selected record subtitle",
+                ),
+            ),
+        ),
+        output=RenderOutputRequest(
+            output_prefix="record-title",
+            output_directory=tmp_path,
+            formats=("svg",),
+        ),
+    )
+
+    result = render_request(request)
+    svg = result.output_paths[0].read_text(encoding="utf-8")
+
+    assert "長い " in svg
+    assert "環状ゲノム" in svg
+    assert "Selected record subtitle" in svg
+    assert 'font-style="italic"' in svg
+
+
+@pytest.mark.circular
 def test_render_request_preserves_dotted_output_prefix(tmp_path: Path) -> None:
     record = _seqrecord("dotted-prefix", "ATGCGC" * 200)
     record.annotations["topology"] = "circular"

--- a/tests/test_circular_definition_bounds.py
+++ b/tests/test_circular_definition_bounds.py
@@ -19,10 +19,16 @@ def _definition(
     *,
     plot_title: str | None = None,
     profile: str = "full",
+    record_label: str = "",
+    record_subtitle: str = "",
 ) -> DefinitionGroup:
     cfg = GbdrawConfig.from_dict(load_config_toml("gbdraw.data", "config.toml"))
     render_profile = CircularRenderProfile(cfg)
     record = SeqRecord(Seq("ATGC" * 250), id="NC_TEST.1")
+    if record_label:
+        record.annotations["gbdraw_record_label"] = record_label
+    if record_subtitle:
+        record.annotations["gbdraw_record_subtitle"] = record_subtitle
     canvas = CircularCanvasConfigurator("test", render_profile, "none", record)
     return DefinitionGroup(
         record,
@@ -74,3 +80,28 @@ def test_circular_definition_local_bounds_center_on_record_axis() -> None:
     translate_x, translate_y = getattr(group, "_gbdraw_plot_translation")
     assert translate_x + 0.5 * (local_bounds.min_x + local_bounds.max_x) == pytest.approx(400.0)
     assert translate_y + 0.5 * (local_bounds.min_y + local_bounds.max_y) == pytest.approx(300.0)
+
+
+def test_circular_record_label_and_subtitle_override_inferred_title_lines() -> None:
+    definition = _definition(
+        record_label="長い <i>環状ゲノム</i> ラベル",
+        record_subtitle="Selected record subtitle",
+    )
+
+    svg = definition.get_group().tostring()
+
+    assert "長い " in svg
+    assert "環状ゲノム" in svg
+    assert 'font-style="italic"' in svg
+    assert "Selected record subtitle" in svg
+    assert "Testus boundsii" not in svg
+    assert "strain A" not in svg
+    assert definition.local_bounds.width > 100.0
+
+
+def test_empty_circular_record_title_values_preserve_inference() -> None:
+    definition = _definition()
+    svg = definition.get_group().tostring()
+
+    assert "Testus boundsii" in svg
+    assert "strain A" in svg

--- a/tests/test_record_planning.py
+++ b/tests/test_record_planning.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 from Bio import SeqIO
 from Bio.Seq import Seq
+from Bio.SeqFeature import FeatureLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from gbdraw.api.options import LinearDiagramOptions
@@ -158,6 +159,36 @@ def test_selection_reverse_region_order_and_provenance(tmp_path: Path) -> None:
     assert provenance.record_key == "chosen-row"
     assert provenance.selector is not None
     assert provenance.region is not None
+
+
+def test_region_reverse_crops_once_and_flips_boundary_crossing_feature(
+    tmp_path: Path,
+) -> None:
+    source_record = _record("chosen", "AAACCGTT")
+    source_record.features = [
+        SeqFeature(FeatureLocation(1, 7, strand=1), type="CDS")
+    ]
+
+    resolved = _resolve(
+        (
+            RecordInput(
+                source=GenBankInputSource(tmp_path / "records.gb"),
+                selector=parse_record_selector("chosen"),
+                region=parse_region_spec("3-6:rc"),
+                record_key="chosen-crop",
+            ),
+        ),
+        lambda _paths: [source_record],
+    )
+
+    record = resolved.records[0]
+    assert str(record.seq) == "CGGT"
+    assert len(record.features) == 1
+    assert int(record.features[0].location.start) == 0
+    assert int(record.features[0].location.end) == 4
+    assert record.features[0].location.strand == -1
+    assert str(source_record.seq) == "AAACCGTT"
+    assert source_record.features[0].location.strand == 1
 
 
 def test_batch_output_policy_disambiguates_duplicate_record_ids() -> None:

--- a/tests/web/circular-record-presentation.playwright.spec.js
+++ b/tests/web/circular-record-presentation.playwright.spec.js
@@ -1,0 +1,156 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const {
+  generateAndWaitForResult,
+  openApp,
+  waitForAppShell
+} = require('./helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const firstGenbank = readFileSync(
+  join(repoRoot, 'tests/test_inputs/BGC0000708.gbk'),
+  'utf8'
+);
+const secondGenbank = readFileSync(
+  join(repoRoot, 'tests/test_inputs/BGC0000709.gbk'),
+  'utf8'
+);
+
+const inspectCircularResult = (page) => page.evaluate(() => {
+  const app = window.__GBDRAW_APP__;
+  const content = String(app.results?.[0]?.content || '');
+  const svg = new DOMParser().parseFromString(content, 'image/svg+xml').documentElement;
+  return {
+    content,
+    text: String(svg.textContent || '').replace(/\s+/g, ' ').trim(),
+    recordIds: [...svg.querySelectorAll('[data-gbdraw-record-id]')]
+      .map((element) => element.getAttribute('data-gbdraw-record-id'))
+      .filter(Boolean),
+    canonicalRecord: structuredClone(
+      window.__GBDRAW_CIRCULAR_REQUESTS__?.at(-1)?.records?.[0] || null
+    )
+  };
+});
+
+test('Circular single-record presentation selects, transforms, titles, and round-trips one record', async ({ page }, testInfo) => {
+  test.setTimeout(420000);
+  await page.addInitScript(() => {
+    window.__GBDRAW_CIRCULAR_REQUESTS__ = [];
+    const nativePostMessage = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function trackedCircularRequest(message, transfer) {
+      if (message?.type === 'run' && message.payload?.request?.mode === 'circular') {
+        window.__GBDRAW_CIRCULAR_REQUESTS__.push(
+          structuredClone(message.payload.request)
+        );
+      }
+      if (transfer === undefined) return nativePostMessage.call(this, message);
+      return nativePostMessage.call(this, message, transfer);
+    };
+  });
+  await openApp(page, { waitForPalette: false });
+
+  await page.evaluate(({ first, second }) => {
+    const app = window.__GBDRAW_APP__;
+    app.mode = 'circular';
+    app.cInputType = 'gb';
+    app.files.c_gb = new File([`${first}\n${second}`], 'two-records.gbk', {
+      type: 'text/plain',
+      lastModified: 1
+    });
+    Object.assign(app.form, {
+      multi_record_canvas: false,
+      suppress_gc: true,
+      suppress_skew: true,
+      labels_mode: 'none',
+      legend: 'none'
+    });
+    app.sessionTitle = 'circular-record-presentation';
+  }, { first: firstGenbank, second: secondGenbank });
+
+  await page.waitForFunction(() => (
+    window.__GBDRAW_APP__?.circularRecordList?.length === 2
+  ), null, { timeout: 180000 });
+  const presentationDetails = page.locator('[data-circular-record-presentation]');
+  await presentationDetails.locator('summary').click();
+  const recordSelect = page.getByLabel('Circular record', { exact: true });
+  await expect(recordSelect).toContainText('BGC0000708');
+  await expect(recordSelect).toContainText('BGC0000709');
+  await recordSelect.selectOption('BGC0000709');
+  await page.getByLabel('Circular record label').fill('長い 環状ゲノム ラベル');
+  await page.getByLabel('Circular record subtitle').fill('Selected second record');
+
+  await page.getByLabel('Circular reverse complement').check();
+  await generateAndWaitForResult(page);
+  const reverseOnly = await inspectCircularResult(page);
+  expect(new Set(reverseOnly.recordIds)).toEqual(new Set(['BGC0000709']));
+  expect(reverseOnly.text).toContain('長い 環状ゲノム ラベル');
+  expect(reverseOnly.text).toContain('Selected second record');
+  expect(reverseOnly.canonicalRecord.selector).toEqual({
+    kind: 'recordId',
+    value: 'BGC0000709'
+  });
+  expect(reverseOnly.canonicalRecord.region).toBeNull();
+  expect(reverseOnly.canonicalRecord.presentation.reverseComplement).toBe(true);
+
+  await page.getByLabel('Circular region start').fill('1000');
+  await page.getByLabel('Circular region end').fill('12000');
+  await generateAndWaitForResult(page);
+  const cropReverse = await inspectCircularResult(page);
+  expect(cropReverse.text).toContain('11,001 bp');
+  expect(cropReverse.canonicalRecord.selector).toBeNull();
+  expect(cropReverse.canonicalRecord.region).toEqual({
+    selector: { kind: 'recordId', value: 'BGC0000709' },
+    start: 1000,
+    end: 12000,
+    reverseComplement: true
+  });
+  expect(cropReverse.canonicalRecord.presentation.reverseComplement).toBe(false);
+  const renderedSvg = page.locator('main svg').last();
+  await expect(renderedSvg).toBeVisible();
+  await renderedSvg.screenshot({
+    path: testInfo.outputPath('circular-record-presentation.png')
+  });
+
+  const downloadPromise = page.waitForEvent('download', { timeout: 180000 });
+  await page.evaluate(() => window.__GBDRAW_APP__.saveSessionWithTitle());
+  const savedSessionPath = await (await downloadPromise).path();
+  expect(savedSessionPath).toBeTruthy();
+
+  await page.getByLabel('Circular region end').fill('60000');
+  const failed = await generateAndWaitForResult(page, {
+    expectedStatus: 'error',
+    requireCommittedResult: true
+  });
+  expect(failed.errorSummary).toContain(
+    'Circular region End (60000) exceeds the selected record length (50466).'
+  );
+  expect((await inspectCircularResult(page)).content).toBe(cropReverse.content);
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await waitForAppShell(page, { waitForPalette: false });
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 180000 });
+  await page.locator('input[accept^=".json,"]').first().setInputFiles(savedSessionPath);
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+  await expect(page.getByLabel('Circular record', { exact: true })).toHaveValue('BGC0000709');
+  await expect(page.getByLabel('Circular region start')).toHaveValue('1000');
+  await expect(page.getByLabel('Circular region end')).toHaveValue('12000');
+  await expect(page.getByLabel('Circular reverse complement')).toBeChecked();
+
+  await generateAndWaitForResult(page);
+  const regenerated = await inspectCircularResult(page);
+  expect(regenerated.content).toBe(cropReverse.content);
+  expect(regenerated.canonicalRecord.region.reverseComplement).toBe(true);
+  expect(regenerated.canonicalRecord.presentation.reverseComplement).toBe(false);
+  expect(new Set(regenerated.recordIds)).toEqual(new Set(['BGC0000709']));
+
+  await presentationDetails.locator('summary').click();
+  await page.getByLabel('Circular record label').fill('');
+  await page.getByLabel('Circular record subtitle').fill('');
+  await generateAndWaitForResult(page);
+  const inferred = await inspectCircularResult(page);
+  expect(inferred.text).toContain('Streptomyces fradiae');
+  expect(inferred.text).not.toContain('Selected second record');
+});

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -686,6 +686,116 @@ assert.deepEqual(
 assert.equal(implicitSingleCanonical.renderRequest.output.prefix, 'single.id');
 assert.equal(projectCanonicalSessionRequest(implicitSingleCanonical).config.form.prefix, '');
 
+state.circularRecordList.value = [
+  { selector: '#1', record_id: 'first-record', record_length: 12 },
+  { selector: '#2', record_id: 'second-record', record_length: 18 }
+];
+Object.assign(state.form, {
+  circular_record_selector: 'second-record',
+  circular_region_start: 3,
+  circular_region_end: 14,
+  circular_reverse: true,
+  circular_record_label: '長い <i>環状ゲノム</i> ラベル',
+  circular_record_subtitle: 'Selected second record'
+});
+const selectedCircularCanonical = buildCanonicalRenderRequest({ state, filesData });
+assert.equal(selectedCircularCanonical.renderRequest.grouping, 'single');
+assert.equal(selectedCircularCanonical.renderRequest.records.length, 1);
+assert.match(selectedCircularCanonical.renderRequest.records[0].recordKey, /second-record/);
+assert.equal(selectedCircularCanonical.renderRequest.records[0].selector, null);
+assert.deepEqual(selectedCircularCanonical.renderRequest.records[0].region, {
+  selector: { kind: 'recordId', value: 'second-record' },
+  start: 3,
+  end: 14,
+  reverseComplement: true
+});
+assert.deepEqual(selectedCircularCanonical.renderRequest.records[0].presentation, {
+  label: '長い <i>環状ゲノム</i> ラベル',
+  subtitle: 'Selected second record',
+  reverseComplement: false,
+  gridRow: null,
+  gridColumn: null
+});
+assert.equal(selectedCircularCanonical.renderRequest.output.prefix, 'second-record');
+
+const selectedCircularProjection = projectCanonicalSessionRequest(selectedCircularCanonical);
+assert.deepEqual(
+  {
+    selector: selectedCircularProjection.config.form.circular_record_selector,
+    start: selectedCircularProjection.config.form.circular_region_start,
+    end: selectedCircularProjection.config.form.circular_region_end,
+    reverse: selectedCircularProjection.config.form.circular_reverse,
+    label: selectedCircularProjection.config.form.circular_record_label,
+    subtitle: selectedCircularProjection.config.form.circular_record_subtitle
+  },
+  {
+    selector: 'second-record',
+    start: 3,
+    end: 14,
+    reverse: true,
+    label: '長い <i>環状ゲノム</i> ラベル',
+    subtitle: 'Selected second record'
+  }
+);
+Object.assign(state.form, selectedCircularProjection.config.form);
+Object.assign(state.adv, selectedCircularProjection.config.adv);
+const selectedCircularRebuilt = buildCanonicalRenderRequest({
+  state,
+  filesData: selectedCircularProjection.files
+});
+assert.deepEqual(
+  selectedCircularRebuilt.renderRequest.records[0].region,
+  selectedCircularCanonical.renderRequest.records[0].region
+);
+assert.equal(
+  selectedCircularRebuilt.renderRequest.records[0].presentation.reverseComplement,
+  false
+);
+assert.equal(
+  selectedCircularRebuilt.renderRequest.records[0].presentation.label,
+  '長い <i>環状ゲノム</i> ラベル'
+);
+
+const invalidCircularCases = [
+  [{ circular_region_start: 3, circular_region_end: null }, /requires both Start and End/],
+  [{ circular_region_start: 8, circular_region_end: 3 }, /must not exceed End/],
+  [{ circular_region_start: 3, circular_region_end: 19 }, /exceeds the selected record length/],
+  [{ circular_record_selector: 'missing-record', circular_region_start: null, circular_region_end: null }, /was not found/]
+];
+for (const [overrides, message] of invalidCircularCases) {
+  Object.assign(state.form, {
+    circular_record_selector: 'second-record',
+    circular_region_start: null,
+    circular_region_end: null,
+    ...overrides
+  });
+  assert.throws(() => buildCanonicalRenderRequest({ state, filesData }), message);
+}
+state.circularRecordList.value = [
+  { selector: '#1', record_id: 'duplicate-record', record_length: 18 },
+  { selector: '#2', record_id: 'duplicate-record', record_length: 18 }
+];
+Object.assign(state.form, {
+  circular_record_selector: 'duplicate-record',
+  circular_region_start: null,
+  circular_region_end: null
+});
+assert.throws(
+  () => buildCanonicalRenderRequest({ state, filesData }),
+  /is ambiguous/
+);
+
+Object.assign(state.form, {
+  circular_record_selector: '',
+  circular_region_start: null,
+  circular_region_end: null,
+  circular_reverse: false,
+  circular_record_label: '',
+  circular_record_subtitle: ''
+});
+state.adv.circular_grouping_intent = 'auto';
+state.circularRecordList.value = [{ selector: '#1', record_id: 'single.id' }];
+
 state.form.prefix = 'release.v1';
 const explicitSingleCanonical = buildCanonicalRenderRequest({ state, filesData });
 assert.equal(explicitSingleCanonical.renderRequest.output.prefix, 'release.v1');
@@ -762,6 +872,11 @@ const gridCanonical = buildCanonicalRenderRequest({ state, filesData });
 assert.equal(gridCanonical.renderRequest.grouping, 'grid');
 assert.equal(gridCanonical.renderRequest.output.prefix, 'dup');
 assert.equal(projectCanonicalSessionRequest(gridCanonical).config.form.multi_record_canvas, true);
+state.form.circular_record_selector = 'dup_2';
+const gridWithRetainedSingleSelector = buildCanonicalRenderRequest({ state, filesData });
+assert.equal(gridWithRetainedSingleSelector.renderRequest.grouping, 'grid');
+assert.equal(gridWithRetainedSingleSelector.renderRequest.records.length, 3);
+state.form.circular_record_selector = '';
 
 for (const schema of [3, 4]) {
   const branchOnlyCanonical = structuredClone(implicitBatchCanonical);


### PR DESCRIPTION
## Plain-language summary

This adds one deterministic Circular workflow for selecting a single record, applying a valid 1-based inclusive crop, reversing its display once, and setting its record label and subtitle. Stable record identity and source order now survive Session save/load, while empty title fields keep the existing inferred title. Invalid selection or crop state fails before replacement output is committed, and existing grid and separate-diagram batch behavior remains unchanged.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: current `dev`; protected selective CI profile; `CIR-001`–`CIR-006`, `SES-011`, `ARC-001`, `ARC-003`, `ARC-005`, `ARC-008`, and `CI-001`–`CI-007`.

## User-visible impact

Circular input now exposes a bounded single-record presentation panel. A user can select one discovered record, optionally crop it, reverse-complement its display, and override the two title lines; invalid or stale identity and coordinate states produce actionable errors without replacing the prior Result.

## Changes

- Resolve one stable Circular record identity from the existing source-ordered discovery list, including duplicate-ID disambiguation.
- Project selection, crop, orientation, label, and subtitle through the existing canonical request and current Session writer.
- Apply reverse complement through either the region or presentation field, never both, and preserve per-record Depth row alignment after selection.
- Consume explicit per-record label and subtitle annotations in the Circular definition renderer while preserving inference for empty values.
- Keep retained single-record selectors inactive in grid and separate-diagram batch journeys.

## Verification

- Focused Python request/render/planning/definition/Session selection: 11 passed.
- `node tests/web/session-request.test.mjs`: passed.
- `node tests/web/record-selector.test.mjs`: passed.
- `npx playwright test tests/web/circular-record-presentation.playwright.spec.js --reporter=line`: 1 passed in Chromium.
- `node tools/check-web-change-budget.mjs`: PASS; no blocking violations, new cycles, privileged expansion, dependency changes, or architecture-authority delta.
- `node tests/web/architecture-contracts.test.mjs`: 133 passed.
- Architecture ratchet fixtures: 14 passed; Product Impact ratchet fixtures: 36 passed.
- Focused Ruff checks and `git diff --check`: passed.
- Visual lane: selected BGC0000709 from two production-size BGC records, rendered reverse-only and cropped reverse-complement output at 1,000–12,000 (11,001 bp), reviewed explicit/inferred titles, features, coordinates, clipping, and exact SVG regeneration after Session reload.

## Risk and review notes

- Gate result and any blocker: PASS; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: REQUIRED because the existing Web canonical request/current-writer contract gains presentation fields and production net additions exceed the ordinary size-review threshold.
- Architecture impact: This is architecture-bearing within the existing `services/session-request.js` semantic owner and canonical render-request path; no owner, path, privileged boundary, compatibility reader, or lifecycle responsibility is added or moved.
- Architecture baseline and changed-scope conclusion: before, Circular discovery selected all records and the renderer did not consume per-record title annotations; after, the existing discovery/form owner resolves a stable identity, the existing canonical request/current writer carries the transform and presentation, typed `RecordInput`/`RegionSpec` applies the transform, and the existing Circular definition owner consumes the title. The canonical path remains form/discovery → `session-request.js` → Worker typed render → admitted Result/Session. Accepted-but-unused title annotations are now consumed, reverse is owned by exactly one of region or presentation, stale selectors fail explicitly, the current writer gains fields without a schema migration or compatibility reader, grid/batch and `gridColumn` normalization remain unchanged, and no production module is added. Changed-scope `delta(OE) <= 0`, `delta(PE) <= 0`, and `delta(CB) <= 0`; no superseded owner or path remains.
- `architecture-change` label, if relevant: not applied; this does not add, remove, move, duplicate, or redefine an architecture owner, canonical/compatibility path, privileged boundary, or lifecycle responsibility.

## Rollback

Revert commit `4656543f`; no persisted compatibility migration or generated artifact requires separate cleanup.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Affected concern(s), if known: `OIPC-C01`, `OIPC-C03`, `OIPC-C04`, `OIPC-C05`, `OIPC-C06`, `OIPC-C08`.
- Affected journey/checkpoint effects: deterministic Circular single-record selection, valid crop, exactly-once orientation, explicit/inferred title lines, Session round trip, prior-Result preservation, and unchanged grid/batch placement.
- Authority and decision references: `PD-OI-010`, `PD-OI-012`, `PD-OI-013`, `PD-OI-014`, `PD-OI-015`; no current Product decision is required.
- Decision Pack or evidence reference, if required: N/A.
- Behavior contracts and residual risk: the focused realistic browser lane and typed transform/render tests cover the defined journey; protected selective CI owns broader regression.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

N/A for `STANDARD`.
