### PR TITLE
Preserve independent Linear scale and ruler label font sizes

### DIFF
--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -4075,11 +4075,42 @@
                                         :class="canUseLinearRulerOnAxis ? '' : 'opacity-50'">
                                     <span class="inline-flex items-center gap-1">Ruler on Axis <help-tip text="Use each record axis as the ruler and hide the bottom ruler. Effective when Track Layout is Above/Below and Scale Style is Ruler."></help-tip></span>
                                 </label>
+                                <div class="space-y-1">
+                                    <label class="option-label flex items-center gap-2 text-xs text-slate-700 cursor-pointer select-none">
+                                        <input
+                                            type="checkbox"
+                                            :checked="linearTypographyLinked"
+                                            @change="setLinearTypographyLinked($event.target.checked)"
+                                            class="form-checkbox"
+                                            aria-label="Link Linear scale and ruler label font sizes">
+                                        <span>Link Scale and Ruler Label Font Sizes</span>
+                                    </label>
+                                    <p class="text-[10px] text-slate-500">
+                                        Relinking copies the current Scale Font Size to Ruler Label Font Size once.
+                                    </p>
+                                </div>
                                 <div class="grid grid-cols-2 gap-1.5">
                                     <div>
-                                        <label class="input-label text-[10px]">Scale Font Size <help-tip text="Font size for scale label text. Used by bar style and ruler labels."></help-tip></label>
+                                        <label class="input-label text-[10px]">Scale Font Size <help-tip text="Font size for the simple bar scale label."></help-tip></label>
                                         <auto-value-field :visible="autoValueVisible(adv.scale_font_size, 'scaleFontSize')" :text="autoValueText('scaleFontSize')">
-                                            <input type="number" v-model.number="adv.scale_font_size" class="form-input form-input-compact auto-value-input" aria-label="Linear scale font size">
+                                            <input
+                                                type="number"
+                                                :value="optionalNumberInputValue(adv.scale_font_size)"
+                                                @input="setLinearScaleFontSize($event.target.value)"
+                                                class="form-input form-input-compact auto-value-input"
+                                                aria-label="Linear scale font size">
+                                        </auto-value-field>
+                                    </div>
+                                    <div>
+                                        <label class="input-label text-[10px]">Ruler Label Font Size <help-tip text="Font size for ruler tick labels, including rulers drawn on record axes."></help-tip></label>
+                                        <auto-value-field :visible="autoValueVisible(adv.ruler_label_font_size, 'rulerLabelFontSize')" :text="autoValueText('rulerLabelFontSize')">
+                                            <input
+                                                type="number"
+                                                :value="optionalNumberInputValue(adv.ruler_label_font_size)"
+                                                @input="setLinearRulerLabelFontSize($event.target.value)"
+                                                :disabled="linearTypographyLinked"
+                                                class="form-input form-input-compact auto-value-input disabled:opacity-50 disabled:cursor-not-allowed"
+                                                aria-label="Linear ruler label font size">
                                         </auto-value-field>
                                     </div>
                                     <div v-if="form.scale_style === 'ruler'">

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -81,6 +81,7 @@ import { classifyOptionalPositiveNumber } from '../utils/optional-positive-numbe
 import { createLosatSettings } from './losat-settings.js';
 import { createAutoValueDisplay } from './auto-value-display.js';
 import { createLinearRecordSelector } from './linear-record-selector.js';
+import { createLinearTypographyController } from './linear-typography.js';
 import {
   buildDisambiguatedRecordEntries,
   formatRecordLength,
@@ -238,6 +239,7 @@ export const createAppSetup = () => {
     hasActiveLinearUploadIntent,
     form,
     adv,
+    linearTypographyLinked,
     unmanagedConfigOverrides,
     losat,
     losatCacheInfo,
@@ -388,6 +390,10 @@ export const createAppSetup = () => {
     fileLegendCaptions,
     filteredFeatures
   } = state;
+  const linearTypography = createLinearTypographyController({
+    adv,
+    linked: linearTypographyLinked
+  });
   const rightDrawerActions = createRightDrawerController({ state, watch });
 
   const comparisonHeightValidationError = computed(() => {
@@ -3331,6 +3337,10 @@ export const createAppSetup = () => {
     linearRecordSelectorWarning: linearRecordSelector.warningFor,
     form,
     adv,
+    linearTypographyLinked,
+    setLinearTypographyLinked: linearTypography.setLinked,
+    setLinearRulerLabelFontSize: linearTypography.setRulerLabelFontSize,
+    setLinearScaleFontSize: linearTypography.setScaleFontSize,
     unmanagedConfigOverrideEntries,
     resetUnmanagedConfigOverride,
     comparisonProfileDefault,

--- a/gbdraw/web/js/app/auto-value-display.js
+++ b/gbdraw/web/js/app/auto-value-display.js
@@ -409,10 +409,8 @@ const autoTextByKey = (state, key, context = null) => {
         ? lengthDependentPx(state, DEFAULTS.circular.axisStrokeWidthPx)
         : lengthDependentPx(state, DEFAULTS.linear.axisStrokeWidthPx);
     case 'scaleStrokeWidth': return withAuto(formatPx(DEFAULTS.scale.strokeWidthPx));
-    case 'scaleFontSize':
-      return String(state?.form?.scale_style || 'bar') === 'ruler'
-        ? lengthDependentPx(state, DEFAULTS.linear.rulerLabelFontSizePx)
-        : lengthDependentPx(state, DEFAULTS.linear.scaleFontSizePx);
+    case 'scaleFontSize': return lengthDependentPx(state, DEFAULTS.linear.scaleFontSizePx);
+    case 'rulerLabelFontSize': return lengthDependentPx(state, DEFAULTS.linear.rulerLabelFontSizePx);
     case 'scaleInterval': return scaleIntervalText(state);
     case 'tickLabelFontSize': return withAuto(formatPx(DEFAULTS.circular.tickLabelFontSizePx));
     case 'dinucleotideWindow': return dinucleotideWindowText(state, 'window');

--- a/gbdraw/web/js/app/linear-typography.js
+++ b/gbdraw/web/js/app/linear-typography.js
@@ -1,0 +1,48 @@
+const optionalNumberInputValue = (value) => {
+  const text = String(value ?? '').trim();
+  if (text === '') return null;
+  const numeric = Number(text);
+  return Number.isNaN(numeric) ? text : numeric;
+};
+
+const linearTypographyValuesMatch = (adv = {}) => (
+  Object.is(adv.scale_font_size, adv.ruler_label_font_size)
+);
+
+export const reconcileImportedLinearTypographyLink = ({ adv, linked, ui = {} }) => {
+  if (!linked || typeof linked !== 'object' || !('value' in linked)) return false;
+  linked.value = (
+    ui.linearTypographyLinked === true
+    && linearTypographyValuesMatch(adv)
+  );
+  return linked.value;
+};
+
+export const createLinearTypographyController = ({ adv, linked }) => {
+  const setScaleFontSize = (value) => {
+    const nextValue = optionalNumberInputValue(value);
+    adv.scale_font_size = nextValue;
+    if (linked.value) adv.ruler_label_font_size = nextValue;
+    return nextValue;
+  };
+
+  const setRulerLabelFontSize = (value) => {
+    if (linked.value) return false;
+    adv.ruler_label_font_size = optionalNumberInputValue(value);
+    return true;
+  };
+
+  const setLinked = (nextLinked) => {
+    const nextValue = Boolean(nextLinked);
+    if (linked.value === nextValue) return false;
+    linked.value = nextValue;
+    if (nextValue) adv.ruler_label_font_size = adv.scale_font_size;
+    return true;
+  };
+
+  return {
+    setLinked,
+    setRulerLabelFontSize,
+    setScaleFontSize
+  };
+};

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -55,6 +55,7 @@ import {
   migrateLegacyLayoutPreferences,
   replaceLayoutPreferences
 } from '../app/layout-preferences.js';
+import { reconcileImportedLinearTypographyLink } from '../app/linear-typography.js';
 import {
   serializeFeatureVisibilityRules,
   normalizeFeatureVisibilityRule,
@@ -1416,6 +1417,15 @@ export const restoreCurrentWriterActiveConfig = ({
   }
   if (isPlainObject(restored.adv)) delete restored.adv.losatProgram;
 
+  const projectedRulerLabelFontSize = projectedConfig?.adv?.ruler_label_font_size;
+  if (
+    projectedRulerLabelFontSize !== undefined
+    && isPlainObject(restored.adv)
+    && !Object.prototype.hasOwnProperty.call(restored.adv, 'ruler_label_font_size')
+  ) {
+    restored.adv.ruler_label_font_size = cloneJsonData(projectedRulerLabelFontSize);
+  }
+
   // Current sessions written before the anchor control became editable omitted
   // this value. Preserve their committed projection only when active config has
   // no value of its own; new sessions store the explicit editor value above.
@@ -1741,7 +1751,14 @@ export const applyConfigData = (data) => {
     requireCurrentCircularMultiRecordSizeMode(data.adv.multi_record_size_mode);
   }
   if (data.form) safeDeepMerge(state.form, data.form);
-  if (data.adv) safeDeepMerge(state.adv, data.adv);
+  if (data.adv) {
+    safeDeepMerge(state.adv, data.adv);
+    ['scale_font_size', 'ruler_label_font_size'].forEach((field) => {
+      if (Object.prototype.hasOwnProperty.call(data.adv, field)) {
+        state.adv[field] = cloneJsonData(data.adv[field]);
+      }
+    });
+  }
   replacePlainObject(
     state.unmanagedConfigOverrides,
     isPlainObject(data.unmanagedConfigOverrides)
@@ -3385,6 +3402,7 @@ export const buildUiStateData = ({ includePreviewNavigation = true } = {}) => {
     losatProgram: state.losatProgram.value,
     downloadDpi: state.downloadDpi.value,
     autoLabelReflow: Boolean(state.autoLabelReflowEnabled.value),
+    linearTypographyLinked: Boolean(state.linearTypographyLinked.value),
     paletteInstantPreviewEnabled: Boolean(state.paletteInstantPreviewEnabled.value),
     appliedPaletteName: state.appliedPaletteName.value,
     appliedPaletteColors: cloneColors(state.appliedPaletteColors.value),
@@ -3415,6 +3433,11 @@ export const applyUiStateData = (ui = {}, { restorePreviewNavigation = true } = 
   }
   if (ui.downloadDpi) state.downloadDpi.value = ui.downloadDpi;
   state.autoLabelReflowEnabled.value = Boolean(ui.autoLabelReflow);
+  reconcileImportedLinearTypographyLink({
+    adv: state.adv,
+    linked: state.linearTypographyLinked,
+    ui
+  });
   state.paletteInstantPreviewEnabled.value = Boolean(ui.paletteInstantPreviewEnabled);
   if (ui.featurePanelTab === 'labels' || ui.featurePanelTab === 'colors') {
     state.featurePanelTab.value = ui.featurePanelTab;
@@ -3815,6 +3838,7 @@ export const exportSession = async (
       lInputType: state.lInputType.value,
       downloadDpi: state.downloadDpi.value,
       autoLabelReflow: Boolean(state.autoLabelReflowEnabled.value),
+      linearTypographyLinked: Boolean(state.linearTypographyLinked.value),
       paletteInstantPreviewEnabled: Boolean(state.paletteInstantPreviewEnabled.value),
       appliedPaletteName: state.appliedPaletteName.value,
       appliedPaletteColors: cloneColors(state.appliedPaletteColors.value),
@@ -3996,6 +4020,11 @@ export const importSession = async (e, options = {}) => {
       );
       applyConfigData(restoredConfig);
     }
+    reconcileImportedLinearTypographyLink({
+      adv: state.adv,
+      linked: state.linearTypographyLinked,
+      ui
+    });
     restorePaletteStateFromSession(ui);
     restoreLayoutPreferences(ui, { preserveActive: Boolean(canonicalSession) });
 

--- a/gbdraw/web/js/services/reset.js
+++ b/gbdraw/web/js/services/reset.js
@@ -141,6 +141,7 @@ const resetLinearComparisonPlan = (state) => {
 export const resetSettings = (state) => {
   replaceReactiveObject(state.form, createDefaultForm());
   replaceReactiveObject(state.adv, createDefaultAdv(state.mode.value));
+  state.linearTypographyLinked.value = true;
   state.modeProfileStateManager?.reset?.(state.mode.value, state.adv);
   replaceReactiveObject(state.losat, createDefaultLosat());
   replaceReactiveObject(state.circularConservation, createDefaultCircularConservation());

--- a/gbdraw/web/js/services/session-active-config-contract.js
+++ b/gbdraw/web/js/services/session-active-config-contract.js
@@ -28,7 +28,7 @@ export const createDefaultAdv = (mode = 'circular') => ({
   linear_track_slots_axis_index: null, linear_track_slots: createDefaultLinearTrackSlots(), gc_content_mode: 'deviation', gc_content_min_percent: 0,
   gc_content_max_percent: 100, gc_content_show_axis: true, gc_content_show_ticks: true, gc_content_tick_interval: 20, gc_content_small_tick_interval: null,
   gc_content_tick_font_size: null, comparison_height: null, pairwise_match_style: 'ribbon', ...comparisonStateForMode(mode), scale_interval: null,
-  scale_font_size: null, scale_stroke_width: null, scale_stroke_color: null, ruler_label_color: null, circular_grouping_intent: 'auto',
+  scale_font_size: null, ruler_label_font_size: null, scale_stroke_width: null, scale_stroke_color: null, ruler_label_color: null, circular_grouping_intent: 'auto',
   multi_record_size_mode: 'auto', multi_record_min_radius_ratio: 0.55, multi_record_column_gap_ratio: 0.10, multi_record_row_gap_ratio: 0.05,
   multi_record_positions: [], tick_label_font_size: null, plot_title_font_size: null, keep_full_definition_with_plot_title: false,
   center_reserved_radius: null, feature_width_circular: null, depth_width_circular: null, gc_content_width_circular: null, gc_content_radius_circular: null,

--- a/gbdraw/web/js/services/session-authority.js
+++ b/gbdraw/web/js/services/session-authority.js
@@ -31,6 +31,7 @@ const WEB_EDITOR_UI_FIELDS = Object.freeze([
   'featurePanelTab',
   'downloadDpi',
   'autoLabelReflow',
+  'linearTypographyLinked',
   'paletteInstantPreviewEnabled',
   'appliedPaletteName',
   'appliedPaletteColors',

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -1007,7 +1007,7 @@ const buildConfigOverrides = (
           [SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.scaleFontSize]:
             optionalNumber(adv.scale_font_size),
           [SHARED_LENGTH_CONFIG_OVERRIDE_PATHS.rulerLabelFontSize]:
-            optionalNumber(adv.scale_font_size),
+            optionalNumber(adv.ruler_label_font_size),
           'labels.font_size.linear': optionalNumber(adv.label_font_size)
         })
   };
@@ -4043,9 +4043,8 @@ export const projectCanonicalSessionRequest = ({
     scale_stroke_color: overrides.scale_stroke_color ?? null,
     ruler_label_color: overrides.scale_label_color ?? null,
     scale_stroke_width: overrides.scale_stroke_width ?? null,
-    scale_font_size: form.scale_style === 'ruler'
-      ? (overrides.ruler_label_font_size ?? overrides.scale_font_size ?? null)
-      : (overrides.scale_font_size ?? overrides.ruler_label_font_size ?? null),
+    scale_font_size: overrides.scale_font_size ?? null,
+    ruler_label_font_size: overrides.ruler_label_font_size ?? null,
     scale_interval: overrides.scale_interval ?? null,
     tick_label_font_size: overrides.tick_label_font_size ?? null,
     outer_label_x_offset: renderRequest.mode === 'circular'

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -208,6 +208,7 @@ const form = reactive(createDefaultForm());
 
 // Extended Advanced Config
 const adv = reactive(createDefaultAdv(mode.value));
+const linearTypographyLinked = ref(true);
 const modeProfileStateManager = createModeProfileStateManager(mode.value, adv);
 const activeLayoutPreferences = computed(() => resolveActiveLayoutPreference(
   layoutPreferences,
@@ -802,6 +803,7 @@ export const state = {
   hasActiveLinearUploadIntent,
   form,
   adv,
+  linearTypographyLinked,
   modeProfileStateManager,
   losat,
   losatCacheInfo,

--- a/tests/test_linear_track_layout.py
+++ b/tests/test_linear_track_layout.py
@@ -1519,11 +1519,15 @@ def test_linear_bar_uses_scale_font_size_for_length_bar_label(tmp_path: Path) ->
             "bar",
             "--scale_font_size",
             "23",
+            "--ruler_label_font_size",
+            "9",
         ],
     )
     assert returncode == 0, f"stdout={stdout}\nstderr={stderr}"
     svg_content = output_svg.read_text(encoding="utf-8")
-    assert 'font-size="23.0"' in _extract_group_xml(svg_content, "length_bar")
+    length_bar = _extract_group_xml(svg_content, "length_bar")
+    assert 'font-size="23.0"' in length_bar
+    assert 'font-size="9.0"' not in length_bar
 
 
 @pytest.mark.linear
@@ -1540,6 +1544,8 @@ def test_linear_ruler_label_options_apply_to_axis_ruler(tmp_path: Path) -> None:
             "50000",
             "--ruler_label_font_size",
             "22",
+            "--scale_font_size",
+            "31",
             "--ruler_label_color",
             "tomato",
         ],
@@ -1548,6 +1554,7 @@ def test_linear_ruler_label_options_apply_to_axis_ruler(tmp_path: Path) -> None:
     svg_content = output_svg.read_text(encoding="utf-8")
     ruler_text_tags = _extract_ruler_text_tags(svg_content)
     assert any('fill="tomato"' in tag and 'font-size="22.0"' in tag for tag in ruler_text_tags)
+    assert all('font-size="31.0"' not in tag for tag in ruler_text_tags)
 
 
 @pytest.mark.linear

--- a/tests/web/linear-typography.playwright.spec.js
+++ b/tests/web/linear-typography.playwright.spec.js
@@ -1,0 +1,201 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const genbankPath = join(repoRoot, 'tests/test_inputs/HmmtDNA.gbk');
+const sessionInputSelector = 'input[accept^=".json,"]';
+
+const runDiagram = async (page) => page.evaluate(async () => {
+  const app = window.__GBDRAW_APP__;
+  const result = await app.runAnalysis();
+  return {
+    result,
+    errorSummary: String(app.errorLog?.summary || ''),
+    errorDetails: Array.isArray(app.errorLog?.details)
+      ? app.errorLog.details.map((detail) => String(detail))
+      : []
+  };
+});
+
+const lengthBarFontSizes = (page) => page.evaluate(() => {
+  const content = window.__GBDRAW_APP__.results?.[0]?.content || '';
+  const svg = new DOMParser().parseFromString(content, 'image/svg+xml').documentElement;
+  const lengthBar = svg.getElementById('length_bar');
+  return [...(lengthBar?.querySelectorAll('text') || [])]
+    .map((text) => Number(text.getAttribute('font-size')))
+    .filter(Number.isFinite);
+});
+
+const saveSession = async (page, title) => {
+  await page.evaluate((nextTitle) => {
+    window.__GBDRAW_APP__.sessionTitle = nextTitle;
+  }, title);
+  const downloadPromise = page.waitForEvent('download', { timeout: 120000 });
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.saveSessionWithTitle()))
+    .toMatchObject({ status: 'saved' });
+  return (await downloadPromise).path();
+};
+
+const importSession = async (page, path) => {
+  const dialogPromise = page.waitForEvent('dialog', { timeout: 120000 });
+  await page.locator(sessionInputSelector).first().setInputFiles(path);
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+  await page.waitForFunction(() => window.__GBDRAW_APP__?.mode === 'linear');
+};
+
+const focusAfterHistoryCapture = async (page, locator) => {
+  await locator.focus();
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+};
+
+test('independent Linear typography follows linked, imported, and History journeys @pr-smoke', async ({ page }, testInfo) => {
+  test.setTimeout(300000);
+  const genbank = readFileSync(genbankPath, 'utf8');
+
+  await openApp(page);
+  await page.evaluate(async (genbankText) => {
+    const app = window.__GBDRAW_APP__;
+    app.mode = 'linear';
+    app.lInputType = 'gb';
+    app.setLinearSeqPrimaryFile(0, 'gb', new File([genbankText], 'HmmtDNA.gbk', {
+      type: 'text/plain',
+      lastModified: 1
+    }));
+    Object.assign(app.form, {
+      show_scale: true,
+      scale_style: 'bar',
+      show_gc: false,
+      show_skew: false,
+      show_depth: false,
+      show_labels_linear: 'none'
+    });
+    app.setLinearTrackSlotsEnabled(false);
+    await window.Vue.nextTick();
+  }, genbank);
+
+  const axisCard = page.locator('.card').filter({
+    has: page.locator('summary').filter({ hasText: 'Axis & Scale' })
+  }).first();
+  await axisCard.locator('summary').click();
+  const link = page.getByLabel('Link Linear scale and ruler label font sizes');
+  const scaleSize = page.getByLabel('Linear scale font size');
+  const rulerSize = page.getByLabel('Linear ruler label font size');
+
+  await expect(link).toBeChecked();
+  await expect(scaleSize).toHaveValue('');
+  await expect(rulerSize).toHaveValue('');
+  await expect(rulerSize).toBeDisabled();
+
+  await focusAfterHistoryCapture(page, scaleSize);
+  await scaleSize.fill('26');
+  await scaleSize.press('Tab');
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.undoLabel()))
+    .toBe('Edit setting');
+  expect(await page.evaluate(() => ({
+    scale: window.__GBDRAW_APP__.adv.scale_font_size,
+    ruler: window.__GBDRAW_APP__.adv.ruler_label_font_size
+  }))).toEqual({ scale: 26, ruler: 26 });
+  await page.evaluate(() => window.__GBDRAW_APP__.undoHistory());
+  await expect(scaleSize).toHaveValue('');
+  await expect(rulerSize).toHaveValue('');
+  await page.evaluate(() => window.__GBDRAW_APP__.redoHistory());
+  await expect(scaleSize).toHaveValue('26');
+  await expect(rulerSize).toHaveValue('26');
+
+  await focusAfterHistoryCapture(page, link);
+  await link.uncheck();
+  await expect(rulerSize).toBeEnabled();
+  await expect(scaleSize).toHaveValue('26');
+  await expect(rulerSize).toHaveValue('26');
+  await focusAfterHistoryCapture(page, rulerSize);
+  await rulerSize.fill('13');
+  await rulerSize.press('Tab');
+  await expect(scaleSize).toHaveValue('26');
+  await expect(rulerSize).toHaveValue('13');
+
+  await axisCard.locator('summary').click();
+  await axisCard.locator('summary').click();
+  await expect(link).not.toBeChecked();
+  await expect(scaleSize).toHaveValue('26');
+  await expect(rulerSize).toHaveValue('13');
+
+  expect(await runDiagram(page)).toEqual({
+    result: { status: 'ok' },
+    errorSummary: '',
+    errorDetails: []
+  });
+  expect(await lengthBarFontSizes(page)).toEqual([26]);
+
+  await page.getByLabel('Linear scale style').selectOption('ruler');
+  expect(await runDiagram(page)).toEqual({
+    result: { status: 'ok' },
+    errorSummary: '',
+    errorDetails: []
+  });
+  const rulerFonts = await lengthBarFontSizes(page);
+  expect(rulerFonts.length).toBeGreaterThan(1);
+  expect(new Set(rulerFonts)).toEqual(new Set([13]));
+  await page.screenshot({
+    path: testInfo.outputPath('linear-typography-ruler.png'),
+    fullPage: true
+  });
+
+  const unequalSession = await saveSession(page, 'linear-typography-unequal');
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+  await importSession(page, unequalSession);
+  expect(await page.evaluate(() => ({
+    linked: window.__GBDRAW_APP__.linearTypographyLinked,
+    scale: window.__GBDRAW_APP__.adv.scale_font_size,
+    ruler: window.__GBDRAW_APP__.adv.ruler_label_font_size,
+    canUndo: window.__GBDRAW_APP__.canUndoHistory
+  }))).toEqual({ linked: false, scale: 26, ruler: 13, canUndo: false });
+
+  await page.locator('.card').filter({
+    has: page.locator('summary').filter({ hasText: 'Axis & Scale' })
+  }).first().locator('summary').click();
+  const importedLink = page.getByLabel('Link Linear scale and ruler label font sizes');
+  await focusAfterHistoryCapture(page, importedLink);
+  await importedLink.check();
+  await expect(page.getByText(
+    'Relinking copies the current Scale Font Size to Ruler Label Font Size once.'
+  )).toBeVisible();
+  expect(await page.evaluate(() => ({
+    linked: window.__GBDRAW_APP__.linearTypographyLinked,
+    scale: window.__GBDRAW_APP__.adv.scale_font_size,
+    ruler: window.__GBDRAW_APP__.adv.ruler_label_font_size
+  }))).toEqual({ linked: true, scale: 26, ruler: 26 });
+  await page.evaluate(() => window.__GBDRAW_APP__.undoHistory());
+  expect(await page.evaluate(() => ({
+    linked: window.__GBDRAW_APP__.linearTypographyLinked,
+    scale: window.__GBDRAW_APP__.adv.scale_font_size,
+    ruler: window.__GBDRAW_APP__.adv.ruler_label_font_size
+  }))).toEqual({ linked: false, scale: 26, ruler: 13 });
+  await page.evaluate(() => window.__GBDRAW_APP__.redoHistory());
+
+  const linkedScaleSize = page.getByLabel('Linear scale font size');
+  await focusAfterHistoryCapture(page, linkedScaleSize);
+  await linkedScaleSize.fill('30');
+  await linkedScaleSize.press('Tab');
+  expect(await page.evaluate(() => ({
+    linked: window.__GBDRAW_APP__.linearTypographyLinked,
+    scale: window.__GBDRAW_APP__.adv.scale_font_size,
+    ruler: window.__GBDRAW_APP__.adv.ruler_label_font_size
+  }))).toEqual({ linked: true, scale: 30, ruler: 30 });
+
+  const equalLinkedSession = await saveSession(page, 'linear-typography-linked');
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+  await importSession(page, equalLinkedSession);
+  expect(await page.evaluate(() => ({
+    linked: window.__GBDRAW_APP__.linearTypographyLinked,
+    scale: window.__GBDRAW_APP__.adv.scale_font_size,
+    ruler: window.__GBDRAW_APP__.adv.ruler_label_font_size
+  }))).toEqual({ linked: true, scale: 30, ruler: 30 });
+});

--- a/tests/web/linear-typography.test.mjs
+++ b/tests/web/linear-typography.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+
+import {
+  createLinearTypographyController,
+  reconcileImportedLinearTypographyLink
+} from '../../gbdraw/web/js/app/linear-typography.js';
+import { createAutoValueDisplay } from '../../gbdraw/web/js/app/auto-value-display.js';
+
+const autoValues = createAutoValueDisplay({
+  mode: { value: 'linear' },
+  form: { scale_style: 'ruler' },
+  adv: {}
+});
+assert.equal(autoValues.autoValueText('scaleFontSize'), '24/16 px (s/l auto)');
+assert.equal(autoValues.autoValueText('rulerLabelFontSize'), '20/12 px (s/l auto)');
+
+const linked = { value: true };
+const adv = { scale_font_size: null, ruler_label_font_size: null };
+const typography = createLinearTypographyController({ adv, linked });
+
+assert.equal(linked.value, true);
+typography.setScaleFontSize('18');
+assert.deepEqual(adv, { scale_font_size: 18, ruler_label_font_size: 18 });
+
+assert.equal(typography.setLinked(false), true);
+assert.deepEqual(adv, { scale_font_size: 18, ruler_label_font_size: 18 });
+typography.setRulerLabelFontSize('12');
+assert.deepEqual(adv, { scale_font_size: 18, ruler_label_font_size: 12 });
+
+assert.equal(typography.setLinked(true), true);
+assert.deepEqual(adv, { scale_font_size: 18, ruler_label_font_size: 18 });
+assert.equal(typography.setLinked(true), false);
+assert.deepEqual(adv, { scale_font_size: 18, ruler_label_font_size: 18 });
+typography.setScaleFontSize('21');
+assert.deepEqual(adv, { scale_font_size: 21, ruler_label_font_size: 21 });
+assert.equal(typography.setRulerLabelFontSize('9'), false);
+assert.deepEqual(adv, { scale_font_size: 21, ruler_label_font_size: 21 });
+
+const importedUnequal = { scale_font_size: 17, ruler_label_font_size: 29 };
+const importedUnequalLink = { value: true };
+assert.equal(reconcileImportedLinearTypographyLink({
+  adv: importedUnequal,
+  linked: importedUnequalLink,
+  ui: { linearTypographyLinked: true }
+}), false);
+assert.deepEqual(importedUnequal, { scale_font_size: 17, ruler_label_font_size: 29 });
+
+const importedEqual = { scale_font_size: 14, ruler_label_font_size: 14 };
+for (const [ui, expected] of [
+  [{}, false],
+  [{ linearTypographyLinked: false }, false],
+  [{ linearTypographyLinked: true }, true]
+]) {
+  const importedEqualLink = { value: true };
+  assert.equal(reconcileImportedLinearTypographyLink({
+    adv: importedEqual,
+    linked: importedEqualLink,
+    ui
+  }), expected);
+  assert.deepEqual(importedEqual, { scale_font_size: 14, ruler_label_font_size: 14 });
+}

--- a/tests/web/mode-profiles.test.mjs
+++ b/tests/web/mode-profiles.test.mjs
@@ -332,6 +332,9 @@ assert.deepEqual(
   state.mode.value = 'linear';
   state.adv.identity = 77;
   state.form.show_scale = false;
+  state.linearTypographyLinked.value = false;
+  state.adv.scale_font_size = 18;
+  state.adv.ruler_label_font_size = 11;
   state.adv.circular_track_slots_enabled = true;
   state.adv.circular_track_slots_axis_index = 1;
   state.adv.circular_track_slots.splice(
@@ -428,6 +431,9 @@ assert.deepEqual(
   assert.equal(state.adv.circular_track_slots_enabled, false);
   assert.equal(state.adv.linear_track_slots_enabled, false);
   assert.equal(state.form.show_scale, true);
+  assert.equal(state.linearTypographyLinked.value, true);
+  assert.equal(state.adv.scale_font_size, null);
+  assert.equal(state.adv.ruler_label_font_size, null);
   assert.deepEqual(state.unmanagedConfigOverrides, {});
   assert.equal(
     state.losat.blastp.collinearSearchScope,

--- a/tests/web/run-analysis-derived-cache.test.mjs
+++ b/tests/web/run-analysis-derived-cache.test.mjs
@@ -49,7 +49,9 @@ const rawIdentity = buildLosatCachePayload(rawIdentityInput);
 for (const appearanceOnly of [
   { pairwiseMatchStyle: 'curve' },
   { comparisonHeight: 90 },
-  { comparisonDisclosureOpen: true }
+  { comparisonDisclosureOpen: true },
+  { scaleFontSize: 27 },
+  { rulerLabelFontSize: 11 }
 ]) {
   assert.deepEqual(
     buildLosatCachePayload({ ...rawIdentityInput, ...appearanceOnly }),
@@ -193,7 +195,9 @@ assert.deepEqual(
 for (const appearanceOnly of [
   { pairwiseMatchStyle: 'curve' },
   { comparisonHeight: 90 },
-  { comparisonDisclosureOpen: true }
+  { comparisonDisclosureOpen: true },
+  { scaleFontSize: 27 },
+  { rulerLabelFontSize: 11 }
 ]) {
   assert.deepEqual(
     buildIdentity(appearanceOnly),

--- a/tests/web/session-authority.test.mjs
+++ b/tests/web/session-authority.test.mjs
@@ -42,6 +42,7 @@ const session = {
   ui: {
     mode: 'linear', legend: 'left', linearPlotTitlePosition: 'top', zoom: 1.5,
     canvasPan: { x: 3, y: 4 }, generatedLegendPosition: 'right', downloadDpi: 300,
+    linearTypographyLinked: false,
     appliedPaletteName: 'orchid', appliedPaletteColors: { CDS: '#123456' },
     pendingPaletteName: 'mint', pendingPaletteColors: { CDS: '#abcdef' }
   },
@@ -312,6 +313,7 @@ assert.deepEqual(projectWebOnlyEditorMetadata(session).ui, {
   zoom: 1.5,
   canvasPan: { x: 3, y: 4 },
   downloadDpi: 300,
+  linearTypographyLinked: false,
   appliedPaletteName: 'orchid',
   appliedPaletteColors: { CDS: '#123456' },
   pendingPaletteName: 'mint',

--- a/tests/web/session-draft-authority.test.mjs
+++ b/tests/web/session-draft-authority.test.mjs
@@ -189,6 +189,7 @@ const projectedConfig = {
   form: { track_type: 'tuckin' },
   adv: {
     nt: 'GC',
+    ruler_label_font_size: 13,
     circular_track_slots_enabled: true,
     circular_track_slots_schema_version: 4,
     circular_track_slots: [canonicalFeature],
@@ -288,6 +289,17 @@ assert.equal(restored.adv.depth_width_circular, 23);
 assert.deepEqual(restored.unmanagedConfigOverrides, {
   'objects.gc_content.percent_background_opacity': 0.42
 });
+
+const storedBeforeIndependentRulerFont = structuredClone(storedConfig);
+delete storedBeforeIndependentRulerFont.adv.ruler_label_font_size;
+assert.equal(
+  restoreCurrentWriterActiveConfig({
+    mode: 'linear',
+    projectedConfig,
+    storedConfig: storedBeforeIndependentRulerFont
+  }).adv.ruler_label_font_size,
+  13
+);
 
 const galleryCompatibilityConfig = structuredClone(storedConfig);
 galleryCompatibilityConfig.colors = { CDS: '#123456' };

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -1930,6 +1930,8 @@ assert.equal(projectCanonicalSessionRequest(linearCanonical).config.form.show_sc
 state.adv.block_stroke_width = 2;
 state.adv.def_font_size = 16;
 state.adv.label_font_size = 14;
+state.adv.scale_font_size = 21;
+state.adv.ruler_label_font_size = 12;
 state.adv.linear_definition_line_styles = {
   name: { font_size: 13, font_weight: 'bold', fill: '#112233' }
 };
@@ -1944,6 +1946,13 @@ assert.equal(styledLinearOverrides['objects.definition.linear.font_size.short'],
 assert.equal(styledLinearOverrides['objects.definition.linear.font_size.long'], 16);
 assert.equal(styledLinearOverrides['labels.font_size.linear.short'], 14);
 assert.equal(styledLinearOverrides['labels.font_size.linear.long'], 14);
+assert.equal(styledLinearOverrides['objects.scale.font_size.short'], 21);
+assert.equal(styledLinearOverrides['objects.scale.font_size.long'], 21);
+assert.equal(styledLinearOverrides['objects.scale.ruler_label_font_size.short'], 12);
+assert.equal(styledLinearOverrides['objects.scale.ruler_label_font_size.long'], 12);
+const styledLinearProjection = projectCanonicalSessionRequest(styledLinearCanonical);
+assert.equal(styledLinearProjection.config.adv.scale_font_size, 21);
+assert.equal(styledLinearProjection.config.adv.ruler_label_font_size, 12);
 assert.equal(
   styledLinearOverrides['objects.definition.linear.line_styles.name.font_size'],
   13
@@ -1966,6 +1975,8 @@ assert.equal(
 delete state.adv.block_stroke_width;
 delete state.adv.def_font_size;
 delete state.adv.label_font_size;
+delete state.adv.scale_font_size;
+delete state.adv.ruler_label_font_size;
 delete state.adv.linear_definition_line_styles;
 const legacyLinearOptions = structuredClone(linearCanonical);
 legacyLinearOptions.renderRequest.schema = 2;
@@ -2748,6 +2759,7 @@ assert.equal(pythonConfigProjection.config.adv.label_placement, 'above_feature')
 assert.equal(pythonConfigProjection.config.adv.legend_box_size, 17);
 assert.equal(pythonConfigProjection.config.adv.legend_font_size, 19);
 assert.equal(pythonConfigProjection.config.adv.scale_font_size, 21);
+assert.equal(pythonConfigProjection.config.adv.ruler_label_font_size, 22);
 assert.deepEqual(
   pythonConfigProjection.config.adv.linear_definition_line_styles,
   { name: { font_weight: 'bold', fill: '#112233' } }
@@ -2757,7 +2769,8 @@ assert.equal(pythonConfigProjection.config.blacklistText, 'hypothetical');
 
 const rulerFontCanonical = structuredClone(pythonConfigCanonical);
 rulerFontCanonical.renderRequest.diagramOptions.config.objects.scale.style = 'ruler';
-assert.equal(projectCanonicalSessionRequest(rulerFontCanonical).config.adv.scale_font_size, 22);
+assert.equal(projectCanonicalSessionRequest(rulerFontCanonical).config.adv.scale_font_size, 21);
+assert.equal(projectCanonicalSessionRequest(rulerFontCanonical).config.adv.ruler_label_font_size, 22);
 
 const sparsePythonScaleCanonical = structuredClone(pythonConfigCanonical);
 delete sparsePythonScaleCanonical.renderRequest.diagramOptions.config.objects.scale.show;


### PR DESCRIPTION
## Plain-language summary

This PR keeps Linear `Scale Font Size` and `Ruler Label Font Size` as separate rendering values while linking their controls by default in a fresh Web session. Users can unlink the controls to edit either value independently, and relinking clearly copies the current scale size to the ruler-label size once. Session import, save/reload, History, and the canonical render request now preserve that distinction instead of collapsing both values into one.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `origin/dev` at `721f01d8d451a94ff6fc2b9f77db48c266c398ea`; protected selective CI; Product Contract `PD-OI-011`, `PD-OI-015`, and `OIPC-C01`, `OIPC-C03` through `OIPC-C06`, `OIPC-C08`; focused Linear request, Session, History, renderer, browser, and cache tests.

## User-visible impact

- Fresh Linear Web state links the two font-size controls.
- Unlinking preserves both current values and enables independent edits.
- Imported unequal values remain unequal and open unlinked without adding a synthetic History edit.
- Relinking discloses and performs one scale-to-ruler copy; later scale edits propagate while linked.
- Saved equal values restore as linked only when the Session explicitly records that local UI state.

## Changes

- Add one local Linear typography controller for link, unlink, scale edits, ruler edits, and import reconciliation.
- Give `ruler_label_font_size` its own Web state, canonical-request projection, Session projection, and automatic-value display.
- Remove the scale-to-ruler request alias and the scale-style-dependent Session projection.
- Add focused state, Session, browser, renderer, and scientific-cache assertions.

## Verification

- `node tests/web/linear-typography.test.mjs` and the focused request/Session/authority/mode/cache test files: passed.
- `python -m pytest tests/test_linear_track_layout.py -q -k "linear_ruler_uses_scale_font_size_when_ruler_size_unset or linear_bar_uses_scale_font_size_for_length_bar_label or linear_ruler_label_options_apply_to_axis_ruler or linear_ruler_label_options_apply_to_bottom_ruler"`: 4 passed.
- `npx playwright test tests/web/linear-typography.playwright.spec.js --config=playwright.config.js --project=chromium --workers=1`: 1 passed.
- `npx --yes node@20.20.2 tools/check-web-change-budget.mjs`: Gate PASS; review REQUIRED for architecture-bearing inventory and bounded size signals, with no blocking violations.
- `npx --yes node@20.20.2 tests/web/product-impact-ratchet-fixtures.test.mjs`: 36 passed.
- `npx --yes node@20.20.2 tests/web/architecture-contracts.test.mjs`: 133 passed.
- `ruff check tests/test_linear_track_layout.py`: passed.
- `git diff --check`: passed.
- Visual review: the real `HmmtDNA.gbk` browser journey rendered ruler labels at the independent value at readable scale without overlap; the focused renderer cases used the 306,008 bp `MjeNMV.gb` example.

## Risk and review notes

- Gate result and any blocker: PASS; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because one production module, one reactive field, Session/request fields, 10 production files, and 119 net production lines changed.
- Architecture impact: **This is architecture-bearing**. The affected responsibility is Web ownership of the local Linear link relation and the separate request/Session paths for the existing two public values.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: before and after, `objects.scale.font_size` owns the scale-bar label and `objects.scale.ruler_label_font_size` owns ruler labels. The new private UI controller is the only link-state/action owner; no watcher, mirror, reverse copy, alternate request path, or generic dependency framework was added. The request retains one path per public value, Session adds the independent ruler value and local UI flag without changing the schema version, and scientific cache identities remain invariant. Changed-scope totals are `OE 0 -> 0; delta(OE) = 0`, `PE 0 -> 0; delta(PE) = 0`, and `CB 0 -> 0; delta(CB) = 0`.
- `architecture-change` label, if relevant: applied because the deterministic production-module, export, reactive, and Session inventories change.

## Rollback

Revert this PR to restore the single Web scale-font control and its former request/Session projection. No reference output, Product authority, schema version, workflow, dependency, or scientific-cache key needs separate rollback.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Affected concern(s), if known: independent Linear scale and ruler typography with a local linked-control journey.
- Affected journey/checkpoint effects: fresh linked state; explicit unlink with independent edits; unequal import preservation; disclosed one-time relink copy; deterministic History and Session restore.
- Authority and decision references: `PD-OI-011`, `PD-OI-015`, `OIPC-C01`, `OIPC-C03`, `OIPC-C04`, `OIPC-C05`, `OIPC-C06`, `OIPC-C08`.
- Decision Pack or evidence reference, if required: N/A.
- Behavior contracts and residual risk: existing authority is implemented without a Product Decision. Equal imports restore linked only from explicit current Session UI metadata; equality alone never infers intent.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

N/A for `STANDARD`.
