### PR TITLE
Preserve valid config leaves when importing current Circular sessions

### DIFF
--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -123,6 +123,7 @@ import {
   setResourcePayloadOwner
 } from './resource-payload-owner.js';
 import { sha256Hex } from './byte-utils.js';
+import { cloneJsonData } from './json-clone.js';
 
 export const CANONICAL_REQUEST_SCHEMA = 6;
 const SUPPORTED_CANONICAL_REQUEST_SCHEMAS = new Set([
@@ -1032,12 +1033,13 @@ const buildConfigOverrides = (
     Object.entries(overrides).filter(([, value]) => value !== null && value !== undefined)
   );
   const preservedOverrides = state.unmanagedConfigOverrides;
+  const plainPreservedOverrides = (
+    preservedOverrides && typeof preservedOverrides === 'object' && !Array.isArray(preservedOverrides)
+  )
+    ? cloneJsonData(preservedOverrides)
+    : {};
   return {
-    ...(
-      preservedOverrides && typeof preservedOverrides === 'object' && !Array.isArray(preservedOverrides)
-        ? preservedOverrides
-        : {}
-    ),
+    ...plainPreservedOverrides,
     ...managedOverrides
   };
 };

--- a/gbdraw/web_support/config_overrides.py
+++ b/gbdraw/web_support/config_overrides.py
@@ -111,7 +111,14 @@ def validate_and_project_web_config_overrides(
         if path in validated:
             projected[path] = validated[path]
         else:
-            projected[path] = _raw_config_leaf(effective_raw, path)
+            value = _raw_config_leaf(effective_raw, path)
+            try:
+                options_type(config_overrides={path: value})
+            except ValidationError:
+                # Full configs contain both mode branches. Only derived leaves
+                # accepted by the active typed options become preserved overrides.
+                continue
+            projected[path] = value
 
     # Re-run mode validation against values originating from a full config.
     options_type(config_overrides=projected)

--- a/tests/test_web_config_overrides.py
+++ b/tests/test_web_config_overrides.py
@@ -104,6 +104,30 @@ def test_full_typed_config_projects_only_changed_unmanaged_leaves() -> None:
     assert projected == {UNMANAGED_OPACITY_PATH: 0.42}
 
 
+def test_full_typed_circular_config_ignores_inactive_linear_leaf() -> None:
+    config = load_default_config()
+    config["labels"]["linear"]["scope"] = "all"
+    config["objects"]["gc_content"]["percent_background_opacity"] = 0.42
+
+    projected = validate_and_project_web_config_overrides(
+        mode="circular",
+        config=config,
+        managed_paths=["objects.scale.show"],
+    )
+
+    assert projected == {UNMANAGED_OPACITY_PATH: 0.42}
+
+
+def test_explicit_circular_unmanaged_override_rejects_linear_label_scope() -> None:
+    with pytest.raises(ValidationError, match="cannot target Linear label settings"):
+        validate_and_project_web_config_overrides(
+            mode="circular",
+            overrides={"labels.linear.scope": "all"},
+            managed_paths=[],
+            require_unmanaged_only=True,
+        )
+
+
 def test_json_boundary_returns_validated_overlay() -> None:
     result = json.loads(validate_web_config_overrides_json(
         "linear",

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -609,6 +609,24 @@ assert.equal(
   true,
   'the GUI-managed value must win over a preserved value at the same path'
 );
+state.unmanagedConfigOverrides = new Proxy({
+  'labels.filtering.raw': new Proxy({
+    priority_map: { CDS: ['gene', 'old_locus_tag'] }
+  }, {})
+}, {});
+const canonicalWithReactivePreservedConfig = buildCanonicalRenderRequest({
+  state,
+  filesData
+});
+assert.doesNotThrow(() => structuredClone(
+  canonicalWithReactivePreservedConfig.renderRequest.diagramOptions.configOverrides
+));
+assert.deepEqual(
+  canonicalWithReactivePreservedConfig.renderRequest.diagramOptions.configOverrides[
+    'labels.filtering.raw'
+  ],
+  { priority_map: { CDS: ['gene', 'old_locus_tag'] } }
+);
 state.unmanagedConfigOverrides = {};
 state.adv.circular_definition_interval = 30;
 assert.equal(


### PR DESCRIPTION
## Plain-language summary

This PR restores imports of current Circular sessions whose full typed config contains a non-default Linear-only leaf. The compatibility projection now ignores inactive-mode leaves derived from the full config while still rejecting explicit wrong-mode `unmanagedConfigOverrides`. Preserved nested settings are converted to plain JSON data before Worker transfer, so the tobacco chloroplast Gallery session can complete its first Generate without losing valid GUI-unmanaged settings.

## Behavior and scope

- Keep `CircularDiagramOptions` and `LinearDiagramOptions` as the mode-validity owners.
- Filter only leaves derived from `diagramOptions.config`; explicit `unmanagedConfigOverrides` remain strict.
- Preserve valid active-mode and shared GUI-unmanaged leaves, including structured values such as `labels.filtering.raw`.
- Leave the Gallery session, expected SVG, Product Contract, Session schema, and CI workflows unchanged.

## Verification

- `python -m pytest tests/test_web_config_overrides.py -q` — 16 passed.
- `node tests/web/session-request.test.mjs` — passed.
- `npx playwright test --config=playwright.gallery-publication.config.js --grep "tobacco-chloroplast preserves committed SVG semantics on first Generate" --project=chromium` — passed; import, first Generate, no external requests, and SVG semantic parity all succeeded.
- `ruff check gbdraw/web_support/config_overrides.py tests/test_web_config_overrides.py` — passed.
- `git diff --check` — passed.

## Architecture and product impact

- Product preflight: `IMPLEMENT_EXISTING_AUTHORITY`. Existing typed mode validation and the current-session compatibility requirement select one outcome.
- Owner and path before/after: unchanged. `gbdraw/web_support/config_overrides.py` remains the compatibility projection adapter, typed Python config/options remain the validation owner, and `services/session-request.js` remains the canonical request projection owner.
- No semantic owner, canonical path, or compatibility path is added (`OE`, `PE`, and `CB` are unchanged). No superseded owner or path exists to remove; the existing current-session reader remains required.
- User-visible verification is the focused tobacco chloroplast Gallery import-to-first-Generate parity test above.
- Rollback: revert commit `f541ab22`.
