### PR TITLE
Preserve current Circular session record identity on Generate

### DIFF
--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -1533,6 +1533,19 @@ export const createRunAnalysis = ({
     const pairedFile = inputType === 'gff' ? files.c_fasta : null;
     const hasCompleteInput = Boolean(primaryFile && (inputType !== 'gff' || pairedFile));
     const hasActiveInput = mode.value === 'circular' && hasCompleteInput;
+    const preserveCanonicalRecordKeys = circularDiscoveryTargetsCurrentInput();
+    const preservedRecordKeys = new Map();
+    if (preserveCanonicalRecordKeys) {
+      (Array.isArray(circularRecordList.value) ? circularRecordList.value : [])
+        .forEach((record) => {
+          const recordKey = String(record?.recordKey || '').trim();
+          if (!recordKey) return;
+          [record?.selector, record?.record_id, record?.recordId]
+            .map((value) => String(value || '').trim())
+            .filter(Boolean)
+            .forEach((value) => preservedRecordKeys.set(value, recordKey));
+        });
+    }
     Object.assign(circularRecordDiscovery, {
       status: hasActiveInput ? 'loading' : 'idle',
       error: '',
@@ -1576,11 +1589,17 @@ export const createRunAnalysis = ({
         (inputType === 'gff' ? files.c_gff : files.c_gb) !== primaryFile ||
         (inputType === 'gff' ? files.c_fasta : null) !== pairedFile
       ) return;
-      const nextRecords = records.map((entry) => ({
-        selector: entry.selector,
-        record_id: entry.recordId,
-        record_length: entry.recordLength
-      }));
+      const nextRecords = records.map((entry) => {
+        const recordKey = preservedRecordKeys.get(String(entry.selector || '').trim())
+          || preservedRecordKeys.get(String(entry.recordId || '').trim())
+          || '';
+        return {
+          selector: entry.selector,
+          record_id: entry.recordId,
+          record_length: entry.recordLength,
+          ...(recordKey ? { recordKey } : {})
+        };
+      });
       circularRecordList.value = nextRecords;
       circularRecordDiscovery.status = 'ready';
       const nextPositions = mergeCircularRecordPositions(nextRecords, adv.multi_record_positions);

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -2865,6 +2865,14 @@ export const getCommittedCanonicalSession = () => committedCanonicalSession;
 
 const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
   state.matchSequenceRegistry?.reset?.();
+  state.circularRecordList.value = [];
+  Object.assign(state.circularRecordDiscovery, {
+    status: 'idle',
+    error: '',
+    inputType: '',
+    primaryFile: null,
+    pairedFile: null
+  });
   state.files.c_gb = null;
   state.files.c_gff = null;
   state.files.c_fasta = null;
@@ -2916,6 +2924,37 @@ const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
   state.files.blacklist = deserializeFile(filesData.blacklist);
   state.files.whitelist = deserializeFile(filesData.whitelist);
   state.files.qualifier_priority = deserializeFile(filesData.qualifier_priority);
+
+  const canonicalCircularRecords = Array.isArray(filesData.circularRecords)
+    ? filesData.circularRecords
+    : [];
+  if (canonicalCircularRecords.length > 0) {
+    state.circularRecordList.value = canonicalCircularRecords.map((record, index) => {
+      const selector = record?.region?.selector || record?.selector;
+      const selectorValue = selector?.kind === 'recordId'
+        ? String(selector.value || '')
+        : selector?.kind === 'recordIndex'
+          ? `#${Number(selector.index) + 1}`
+          : `#${index + 1}`;
+      return {
+        selector: selectorValue,
+        record_id: selector?.kind === 'recordId' ? selectorValue : '',
+        record_length: null,
+        recordKey: String(record?.recordKey || '')
+      };
+    });
+    Object.assign(state.circularRecordDiscovery, {
+      status: 'loading',
+      error: '',
+      inputType: state.cInputType.value,
+      primaryFile: state.cInputType.value === 'gff'
+        ? state.files.c_gff
+        : state.files.c_gb,
+      pairedFile: state.cInputType.value === 'gff'
+        ? state.files.c_fasta
+        : null
+    });
+  }
 
   if (Array.isArray(filesData.linearSeqs)) {
     const loadedLinearSeqs = filesData.linearSeqs.map((seq) => ({
@@ -3085,6 +3124,8 @@ const cloneLiveFileState = () => ({
         : cloneJsonData(comparison)
     ))
   },
+  circularRecordList: cloneJsonData(state.circularRecordList.value),
+  circularRecordDiscovery: { ...state.circularRecordDiscovery },
   linearSeqs: state.linearSeqs.map((seq) => ({
     ...seq,
     depth: Array.isArray(seq.depth) ? [...seq.depth] : seq.depth
@@ -3102,6 +3143,8 @@ const restoreLiveFileState = (snapshot) => {
   Object.keys(state.files).forEach((key) => {
     state.files[key] = snapshot.files[key] ?? null;
   });
+  state.circularRecordList.value = cloneJsonData(snapshot.circularRecordList);
+  Object.assign(state.circularRecordDiscovery, snapshot.circularRecordDiscovery);
   state.linearSeqs.splice(0, state.linearSeqs.length, ...snapshot.linearSeqs);
   state.linearRecordRows.splice(0, state.linearRecordRows.length, ...snapshot.linearRecordRows);
   replaceLinearComparisonPlan(state.linearComparisonPlan, snapshot.linearComparisonPlan);

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -644,6 +644,8 @@ const circularRegionPayload = (form, record) => {
 };
 
 const circularRecordKey = (record) => {
+  const preserved = String(record?.recordKey || '').trim();
+  if (preserved) return preserved;
   const recordId = safePrefix(record?.recordId, 'record');
   const selector = safePrefix(record?.selector, '1');
   return `circular-${recordId}-${selector}`;

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -608,8 +608,18 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
       }
     });
   }));
+  state.circularRecordList.value = [{
+    selector: '#1',
+    record_id: 'audit',
+    record_length: 10,
+    recordKey: 'record-1'
+  }];
   Object.assign(state.circularRecordDiscovery, {
-    status: 'idle', error: '', inputType: '', primaryFile: null, pairedFile: null
+    status: 'ready',
+    error: '',
+    inputType: 'gb',
+    primaryFile: fallbackPrimary,
+    pairedFile: null
   });
   const firstCoalescedDiscovery = runner.refreshCircularRecordOrder();
   const secondCoalescedDiscovery = runner.refreshCircularRecordOrder();
@@ -617,6 +627,7 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   await Promise.resolve();
   releaseCoalescedDiscovery();
   await Promise.all([firstCoalescedDiscovery, secondCoalescedDiscovery]);
+  assert.equal(state.circularRecordList.value[0].recordKey, 'record-1');
 
   state.form.multi_record_canvas = true;
   state.files.c_depth = null;

--- a/tests/web/session-request.test.mjs
+++ b/tests/web/session-request.test.mjs
@@ -692,11 +692,16 @@ assert.equal(
 );
 state.form.labels_mode = 'none';
 
-state.circularRecordList.value = [{ selector: '#1', record_id: 'single.id' }];
+state.circularRecordList.value = [{
+  selector: '#1',
+  record_id: 'single.id',
+  recordKey: 'record-1'
+}];
 state.form.prefix = '';
 const implicitSingleCanonical = buildCanonicalRenderRequest({ state, filesData });
 assert.equal(implicitSingleCanonical.renderRequest.grouping, 'single');
 assert.equal(implicitSingleCanonical.webFiles.circularOutputPrefixExplicit, false);
+assert.equal(implicitSingleCanonical.renderRequest.records[0].recordKey, 'record-1');
 assert.deepEqual(
   implicitSingleCanonical.renderRequest.records[0].selector,
   { kind: 'recordId', value: 'single.id' }


### PR DESCRIPTION
## Plain-language summary

Current Circular sessions could assign a new record key on the first Generate after loading. Direct feature edits remained stored under the saved key, so the regenerated diagram did not apply those edits.

Preserve the saved canonical record key while record discovery still targets the same input file. A replacement input does not inherit the old key.

## Why this follow-up is needed

This is the focused corrective for the post-merge dev staging failure after #440. The failing contract was `loaded current preview supports direct edits before the first Generate`.

The Gallery Session assets, expected SVGs, Product Contract, Session schema, and CI workflows are unchanged.

## What changed

- Seed Circular record discovery with canonical record identities restored from a current Session.
- Carry those identities through discovery only while it still targets the same input.
- Reuse the preserved key when building the next canonical render request.
- Include the discovery identity state in Session import rollback.

## Verification

- `python -m pytest tests/test_web_config_overrides.py -q`
- `node tests/web/session-request.test.mjs`
- `node tests/web/run-analysis-simple-path.test.mjs`
- `node tests/web/session-draft-authority.test.mjs`
- Focused Playwright: loaded current preview direct edits before first Generate
- Focused Playwright: tobacco-chloroplast first-Generate parity
- `node tools/check-web-change-budget.mjs`
- `git diff --check`

## Architecture evidence

Canonical request projection remains owned by `services/session-request.js`. Session file application and rollback remain owned by `services/config.js`, and Circular record discovery remains owned by `app/run-analysis.js`. No new owner, compatibility framework, Session schema field, or architecture authority was added.

## Rollback

Revert this commit to restore the previous record-key derivation behavior.
