### PR TITLE
Keep Circular record discovery lazy after Session load

### DIFF
--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -1536,7 +1536,12 @@ export const createRunAnalysis = ({
     const preserveCanonicalRecordKeys = circularDiscoveryTargetsCurrentInput();
     const preservedRecordKeys = new Map();
     if (preserveCanonicalRecordKeys) {
-      (Array.isArray(circularRecordList.value) ? circularRecordList.value : [])
+      [
+        ...(Array.isArray(circularRecordDiscovery.canonicalRecordIdentities)
+          ? circularRecordDiscovery.canonicalRecordIdentities
+          : []),
+        ...(Array.isArray(circularRecordList.value) ? circularRecordList.value : [])
+      ]
         .forEach((record) => {
           const recordKey = String(record?.recordKey || '').trim();
           if (!recordKey) return;
@@ -1551,7 +1556,10 @@ export const createRunAnalysis = ({
       error: '',
       inputType,
       primaryFile: primaryFile || null,
-      pairedFile: pairedFile || null
+      pairedFile: pairedFile || null,
+      canonicalRecordIdentities: preserveCanonicalRecordKeys
+        ? circularRecordDiscovery.canonicalRecordIdentities
+        : []
     });
     if (
       !hasActiveInput
@@ -1602,6 +1610,7 @@ export const createRunAnalysis = ({
       });
       circularRecordList.value = nextRecords;
       circularRecordDiscovery.status = 'ready';
+      circularRecordDiscovery.canonicalRecordIdentities = [];
       const nextPositions = mergeCircularRecordPositions(nextRecords, adv.multi_record_positions);
       adv.multi_record_positions.splice(0, adv.multi_record_positions.length, ...nextPositions);
     } catch (error) {

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -2871,7 +2871,8 @@ const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
     error: '',
     inputType: '',
     primaryFile: null,
-    pairedFile: null
+    pairedFile: null,
+    canonicalRecordIdentities: []
   });
   state.files.c_gb = null;
   state.files.c_gff = null;
@@ -2929,20 +2930,20 @@ const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
     ? filesData.circularRecords
     : [];
   if (canonicalCircularRecords.length > 0) {
-    state.circularRecordList.value = canonicalCircularRecords.map((record, index) => {
-      const selector = record?.region?.selector || record?.selector;
-      const selectorValue = selector?.kind === 'recordId'
-        ? String(selector.value || '')
-        : selector?.kind === 'recordIndex'
-          ? `#${Number(selector.index) + 1}`
-          : `#${index + 1}`;
-      return {
-        selector: selectorValue,
-        record_id: selector?.kind === 'recordId' ? selectorValue : '',
-        record_length: null,
-        recordKey: String(record?.recordKey || '')
-      };
-    });
+    state.circularRecordDiscovery.canonicalRecordIdentities = canonicalCircularRecords
+      .map((record, index) => {
+        const selector = record?.region?.selector || record?.selector;
+        const selectorValue = selector?.kind === 'recordId'
+          ? String(selector.value || '')
+          : selector?.kind === 'recordIndex'
+            ? `#${Number(selector.index) + 1}`
+            : `#${index + 1}`;
+        return {
+          selector: selectorValue,
+          record_id: selector?.kind === 'recordId' ? selectorValue : '',
+          recordKey: String(record?.recordKey || '')
+        };
+      });
     Object.assign(state.circularRecordDiscovery, {
       status: 'loading',
       error: '',

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -286,7 +286,8 @@ const circularRecordDiscovery = reactive({
   error: '',
   inputType: '',
   primaryFile: null,
-  pairedFile: null
+  pairedFile: null,
+  canonicalRecordIdentities: []
 });
 
 // Color & Filter State

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -608,18 +608,18 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
       }
     });
   }));
-  state.circularRecordList.value = [{
-    selector: '#1',
-    record_id: 'audit',
-    record_length: 10,
-    recordKey: 'record-1'
-  }];
+  state.circularRecordList.value = [];
   Object.assign(state.circularRecordDiscovery, {
-    status: 'ready',
+    status: 'loading',
     error: '',
     inputType: 'gb',
     primaryFile: fallbackPrimary,
-    pairedFile: null
+    pairedFile: null,
+    canonicalRecordIdentities: [{
+      selector: '#1',
+      record_id: 'audit',
+      recordKey: 'record-1'
+    }]
   });
   const firstCoalescedDiscovery = runner.refreshCircularRecordOrder();
   const secondCoalescedDiscovery = runner.refreshCircularRecordOrder();
@@ -628,6 +628,7 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   releaseCoalescedDiscovery();
   await Promise.all([firstCoalescedDiscovery, secondCoalescedDiscovery]);
   assert.equal(state.circularRecordList.value[0].recordKey, 'record-1');
+  assert.deepEqual(state.circularRecordDiscovery.canonicalRecordIdentities, []);
 
   state.form.multi_record_canvas = true;
   state.files.c_depth = null;


### PR DESCRIPTION
## Plain-language summary

PR #441 preserved canonical Circular record keys by populating the discovered record list while a current Session was loading. That made record identity stable across the first Generate, but it also made records appear discovered before the browser had read the input. The dev staging test for a sparse Circular depth Session caught this contract violation.

## Change

- Keep Session-provided Circular record identities pending in the existing discovery state.
- Leave the public record list empty until discovery completes.
- Transfer matching canonical record keys to discovered records, then clear the pending identities.
- Preserve the pending discovery state in Session import rollback.

No Gallery assets, expected SVGs, Product Contracts, Session schema, or CI workflows change.

## Verification

- `node tests/web/run-analysis-simple-path.test.mjs`
- `node tests/web/session-request.test.mjs`
- `node tests/web/session-draft-authority.test.mjs`
- `npx playwright test --config=playwright.functional.config.js tests/web/depth-track-session.playwright.spec.js --grep "Circular sparse diagonal depth survives a session round trip and track removal" --project=chromium`
- `npx playwright test --config=playwright.functional.config.js tests/web/contracts/session-regenerate-intent.playwright.spec.js --grep "loaded current preview supports direct edits before the first Generate" --project=chromium`
- `npx playwright test --config=playwright.gallery-publication.config.js --grep "tobacco-chloroplast preserves committed SVG semantics on first Generate" --project=chromium`
- `python -m pytest tests/test_web_config_overrides.py -q`
- `node tools/check-web-change-budget.mjs`
- `git diff --check HEAD^ HEAD`
