### PR TITLE
Exclude Vibrio stress test from Gallery promotion readiness

### DIFF
--- a/.github/workflows/gallery-publication.yml
+++ b/.github/workflows/gallery-publication.yml
@@ -53,21 +53,13 @@ jobs:
         run: node tools/ci-impact.mjs plan
 
   browser:
-    name: Gallery browser (${{ matrix.example }})
+    name: Gallery browser (common 9)
     needs: ci-impact
     if: >-
       needs.ci-impact.result == 'success' &&
       contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'browser')
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - example: common 9
-            command: test:web:gallery-publication
-          - example: Vibrio
-            command: test:web:vibrio-generate
     steps:
       - name: Checkout exact test SHA
         uses: actions/checkout@v4
@@ -87,7 +79,7 @@ jobs:
           npx playwright install --with-deps chromium
           python tools/prepare_browser_wheel.py
       - name: Verify first-Generate parity
-        run: npm run ${{ matrix.command }}
+        run: npm run test:web:gallery-publication
 
   performance:
     name: Gallery publication performance (projection)

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -123,17 +123,20 @@ evidence, the `gallery` profile selects these jobs:
 | --- | --- |
 | `metadata` | `CI impact plan`, `Gallery readiness / gate` |
 | `documentation` | `CI impact plan`, `Gallery readiness / gate` |
-| `full` | `CI impact plan`, both `Gallery browser` matrix entries, `Gallery publication performance (projection)`, `Gallery readiness / gate` |
+| `full` | `CI impact plan`, `Gallery browser (common 9)`, `Gallery publication performance (projection)`, `Gallery readiness / gate` |
 
 Documentation tests remain in the `Tests` workflow's recipe suite. Public Markdown and
 files under `docs/` do not change the packaged Gallery sessions, Web bundle, browser
 generation path, or performance projection, so the Gallery profile does not rerun
 either Gallery test job for those changes.
 
-The `browser` and `performance` job IDs retain their existing commands, matrices,
-timeouts, and performance baseline. Every `workflow_dispatch` run is full. When
-`complete_refresh=true`, the full performance job still runs its three-trial projection
-and complete-refresh gates.
+The blocking `browser` job runs the common 9 Gallery parity suite. The heavyweight
+Vibrio Generate test remains available as `test:web:vibrio-generate` and continues to
+run in the separate exact-SHA main deployment workflow as stress and health evidence;
+it is not part of Gallery promotion readiness. The `browser` and `performance` job IDs
+retain their timeouts and performance baseline. Every `workflow_dispatch` run is full.
+When `complete_refresh=true`, the full performance job still runs its three-trial
+projection and complete-refresh gates.
 
 `Gallery readiness / gate` validates the Gallery plan and current-run job results with
 the protected branch's shared gate validator. A selective run therefore still creates

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1115,13 +1115,18 @@ test('Gallery readiness routes jobs from direct-parent evidence and aggregates t
   assert.doesNotMatch(planner, /node --test/);
 
   const browser = workflowJob('browser', GALLERY_PUBLICATION_WORKFLOW);
+  assert.match(browser, /\n    name: Gallery browser \(common 9\)\n/);
   assert.match(browser, /needs: ci-impact/);
   assert.match(browser, /needs\.ci-impact\.result == 'success'/);
   assert.match(browser, /requiredJobs, 'browser'/);
-  assert.match(browser, /example: common 9\n            command: test:web:gallery-publication/);
-  assert.match(browser, /example: Vibrio\n            command: test:web:vibrio-generate/);
   assert.match(browser, /ref: \$\{\{ github\.sha \}\}/);
-  assert.match(browser, /npm run \$\{\{ matrix\.command \}\}/);
+  assert.match(browser, /npm run test:web:gallery-publication/);
+  assert.doesNotMatch(browser, /matrix|Vibrio|test:web:vibrio-generate/);
+  assert.equal(
+    PACKAGE_SCRIPTS['test:web:vibrio-generate'],
+    'playwright test --config=playwright.vibrio.config.js'
+  );
+  assert.match(DEPLOY_WORKFLOW, /npm run test:web:vibrio-generate/);
 
   const performance = workflowJob('performance', GALLERY_PUBLICATION_WORKFLOW);
   assert.match(performance, /\n    name: Gallery publication performance \(projection\)\n/);


### PR DESCRIPTION
## Plain-language summary

This PR removes the heavyweight Vibrio Generate test from the `Gallery readiness / gate` path because its known reliability timeout should not block routine `dev` to `main` promotion. After merge, Gallery promotion readiness is formed from the common 9 browser suite and the publication performance projection, while the Vibrio command and test implementation remain available and continue to run in the separate exact-SHA main deployment workflow.

## Change class

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `origin/dev` at `da78d6035122c050a13a40a8ff16fe9c8b7f90b4`; current `Gallery readiness / gate` and trusted exact-SHA `Promotion / gate` contracts; focused Gallery workflow, gate-result, and promotion-evidence tests.

## User-visible impact

There is no production runtime, Product Contract, Session, Gallery asset, SVG, LOSAT/cache, Option Integrity, or scientific-output change. Maintainers can promote a green common 9 and performance result without a Vibrio stress-test timeout making Gallery readiness fail.

## Changes

- Make the existing `browser` job run only `test:web:gallery-publication` and display `Gallery browser (common 9)`.
- Keep `browser`, `performance`, and `Gallery readiness / gate` IDs and aggregation unchanged, so either blocking suite still fails readiness.
- Preserve `test:web:vibrio-generate`, its Playwright implementation, and its separate exact-SHA main deployment invocation.
- Update the focused workflow contract and selective-CI documentation.

## Verification

- `node --test --test-name-pattern='Gallery readiness routes jobs from direct-parent evidence and aggregates the current SHA' tests/web/architecture-contracts.test.mjs`
- `node --test --test-name-pattern='Gallery gate accepts both light routes and requires both full jobs' tests/ci/ci-impact-gate.test.mjs`
- `node --test --test-name-pattern='exact Tests and Gallery workflow evidence succeeds with auditable output' tests/web/promotion-readiness.test.mjs`
- `git diff --check`

All passed. The Vibrio browser test and repository-wide suites were not run, as required for this policy-only change.

## Risk and review notes

- Gate result and any blocker: focused contracts pass; no local blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; this implements the maintainer-selected CI governance outcome without changing product semantics or adding an exception mechanism.
- Architecture impact: **This is architecture-bearing** because `.github/workflows/gallery-publication.yml` owns the promotion-readiness evidence path and this change narrows that path.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: the semantic owner remains `.github/workflows/gallery-publication.yml`; the canonical promotion evidence remains `Gallery readiness / gate`; the superseded Vibrio readiness edge is removed while the separate deployment health route remains. No owner or compatibility path is added, so `OE 0 -> 0`, `PE 0 -> 0`, and `CB 0 -> 0` for the changed scope.
- `architecture-change` label, if relevant: not required; this is a non-increasing governance-path contraction with focused deterministic contract coverage.

## Rollback

Revert `1362cd33fe433f07e724c368ff2d9604616e2514` to restore the two-entry Gallery browser matrix. No repository settings or persisted data need restoration.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concern(s), if known: N/A
- Affected journey/checkpoint effects: N/A
- Authority and decision references: N/A
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: N/A; CI evidence composition changes, not product behavior.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/gallery-publication.yml`, `docs/internal/SELECTIVE_CI.md`.
- Checker implementation files touched: none; `tools/check-promotion-readiness.mjs`, `tools/ci-impact.mjs`, and `tools/ci-impact-policy.mjs` are unchanged.
- Self-authorization separation evidence: this PR changes the existing Gallery evidence producer but does not change the trusted promotion checker or shared gate validator.
- Branch-protection or ruleset impact, including unchanged settings: none; stable check names and the `Gallery readiness / gate` aggregate remain unchanged.
- Governance-specific rollback or protection restore point: revert commit `1362cd33fe433f07e724c368ff2d9604616e2514`; no protection-setting change is required.
