### PR TITLE
Remove nested repetition from the test import regex

### DIFF
--- a/tests/web/run-analysis-derived-cache.test.mjs
+++ b/tests/web/run-analysis-derived-cache.test.mjs
@@ -27,7 +27,7 @@ const identityProbeSource = (await readFile(runAnalysisPath, 'utf8'))
     'const buildLosatCachePayload = ({',
     'export const buildLosatCachePayload = ({'
   )
-  .replace(/from '(\.\.?(?:\/[^']+)+)'/g, (_match, specifier) => (
+  .replace(/from '(\.\.?\/[^']+)'/g, (_match, specifier) => (
     `from '${new URL(specifier, runAnalysisUrl).href}'`
   ));
 await writeFile(identityProbePath, identityProbeSource, 'utf8');


### PR DESCRIPTION
## Plain-language summary

This PR rewrites the relative-import matching regex in `tests/web/run-analysis-derived-cache.test.mjs` to remove nested repetition reported by CodeQL. It preserves the same captured relative module specifiers and changes no production or runtime code.

## Change class

Select exactly one:

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

Clear the CodeQL inefficient-regular-expression finding that blocks the `dev` result from promotion.

## User-visible impact

None. The change affects only a test helper used to rewrite relative imports in a temporary probe module.

## Changes

- Replace `(?:\/[^']+)+` with `\/[^']+` in the test helper's relative-import matcher.
- Keep the existing capture group, replacement callback, and accepted relative specifiers unchanged.

## Verification

- `node tests/web/run-analysis-derived-cache.test.mjs`: passed.
- `git diff --check`: passed.

## Risk and review notes

- Gate result and any blocker: focused verification is green; required PR checks remain pending.
- Review result and why it is `CLEAR` or `REQUIRED`: `CLEAR`; this is a one-line test-only correction with unchanged matcher semantics.
- Architecture impact: **This is not architecture-bearing**; no production owner, path, or responsibility changes.
- `architecture-change` label, if relevant: N/A.

## Rollback

Revert commit `6598f698b3c942a6d3b6855311654ef3d4c85a03` if the test helper no longer recognizes an intended relative import.

## Conditional Product Impact

- Product-impact role: N/A
- Affected concern(s), if known: N/A
- Authority and decision references: N/A
- Behavior contracts and residual risk: No product behavior changes; residual risk is limited to the test helper's import rewriting.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

N/A for this `STANDARD` test-only change.
