### PR TITLE
Restore uncached protein LOSAT session regeneration

### DIFF
--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -4199,9 +4199,15 @@ export const createRunAnalysis = ({
         ...entry,
         fasta: candidateFiles.c_conservation_fastas?.[entry.sourceIndex] || null
       }));
+      const candidateRequestState = {
+        ...state,
+        selectedOrthogroupAlignmentFeature: {
+          value: workingSelectedOrthogroupAlignmentFeature
+        }
+      };
       recordSessionLifecycleEvent('canonical-request-construction-start');
       const canonical = buildCanonicalRenderRequest({
-        state,
+        state: candidateRequestState,
         filesData: candidateFiles,
         comparisonPlanSnapshot: activeComparisonPlanSnapshot,
         resolvedComparisons,


### PR DESCRIPTION
## Plain-language summary

A loaded Gallery Session could fail to regenerate after switching to uncached pairwise protein LOSAT. The render itself succeeded, but a stale saved orthogroup alignment target leaked into the canonical pairwise request and caused post-render validation to reject the candidate. This change builds that request from the candidate alignment state, so pairwise regeneration works while committed UI state remains unchanged until the candidate succeeds.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `e11e1d02a32885108375b4aef4429219c62d02b7`.
- Restore the existing loaded-Session regeneration workflow for uncached pairwise protein LOSAT without changing its schema, scientific settings, or output topology.

## User-visible impact

Loaded Gallery Sessions can again regenerate after switching from saved orthogroup state to uncached pairwise protein LOSAT. This changes the regressed failure back to the supported successful continuation; it adds no workflow, default, or new product outcome.

## Changes

- Project the working alignment selection into the shallow candidate-state view used to build the canonical render request.
- Keep committed UI state unchanged until candidate generation and admission succeed.
- Change one production file: `gbdraw/web/js/app/run-analysis.js`.
- Make no schema, scientific default or threshold, output topology, Worker ownership, catalog/admission ownership, direct-mount, architecture authority, Product Impact authority, or workflow change.

## Root cause

The transactional generation refactor cleared the alignment target only in working state. Canonical request construction still read committed state, so the saved `og_1` target leaked into a pairwise LOSATP request that correctly contained no orthogroup metadata.

## Regression provenance

- Old base `5128236...`: PASS
- First causal commit `c75529cb...`: FAIL
- Merged `dev` `e11e1d02...`: FAIL
- Correction `b2d7ffb1...`: PASS

## Verification

- Focused Gallery Session regeneration: PASS
- Functional shard 3/4: PASS
- Focused Node LOSAT, Generate, and admission contracts: PASS
- Architecture contracts: 133/133 PASS
- Web policy: Gate PASS / Review CLEAR
- Exact Hepatoplasmataceae saved-Session Chromium contract: PASS
- Actual Microsoft Edge 152.0.4191.53 on Windows: PASS
- Session 06 structural hard counts: PASS

## Risk and review notes

- Gate result and any blocker: PASS; no blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: CLEAR; the one-file correction is below ordinary size thresholds and changes no registered architecture inventory.
- Architecture impact: **This is not architecture-bearing**. Generate-button orchestration remains in `gbdraw/web/js/app/run-analysis.js`, and canonical request construction remains in `gbdraw/web/js/services/session-request.js`.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: N/A. Semantic owners, canonical paths, compatibility paths, and `OE`/`PE`/`CB` are unchanged.
- `architecture-change` label, if relevant: N/A.
- Current Result admission owner/path remain unchanged: `gbdraw/web/js/services/svg-result-ingestion.js`; `gbdraw/web/js/app/candidate-render.js` -> `gbdraw/web/js/services/svg-result-ingestion.js`.

## Rollback

Revert `b2d7ffb1e2c345074e8286c4dc2c3fa86102b8c2` to restore the prior request-state projection. No data migration or artifact rollback is required.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Affected concern(s), if known: No registered Product Impact subject changed; the restored journey is loaded Gallery Session -> uncached pairwise protein LOSAT -> Generate -> candidate admission.
- Affected journey/checkpoint effects: A valid fresh Result is admitted after regeneration instead of being rejected because of stale orthogroup selection state.
- Authority and decision references: Existing Web runtime and request/session boundaries in `gbdraw/web/CLAUDE.md`; no durable Product Decision is required or claimed.
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: The focused Gallery Session regeneration contract, exact Hepatoplasmataceae Chromium contract, Microsoft Edge run, and focused LOSAT/Generate/admission contracts passed. Residual risk is limited to untested saved-Session variants that combine stale alignment state with other LOSAT inputs.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
