### PR TITLE
Add detectors for generated Result ownership

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -607,7 +607,9 @@ test('versioned architecture detectors expose stable normalized subjects', () =>
   const canonical = WEB_ARCHITECTURE_DETECTORS['canonical-path.render-request.v1'];
 
   assert.deepEqual(Object.keys(WEB_ARCHITECTURE_DETECTORS).sort(), [
+    'canonical-path.current-result-admission.v1',
     'canonical-path.render-request.v1',
+    'semantic-owner.current-result-admission.v1',
     'semantic-owner.render-request.v1'
   ]);
   assert.equal(semantic.subjectCategory, 'definition-path');
@@ -641,6 +643,33 @@ test('versioned architecture detectors expose stable normalized subjects', () =>
     }),
     'app/run-analysis.js -> services/session-request.js'
   );
+});
+
+test('current Result admission detectors characterize the merged runtime source facts', () => {
+  const semantic = WEB_ARCHITECTURE_DETECTORS[
+    'semantic-owner.current-result-admission.v1'
+  ];
+  const canonical = WEB_ARCHITECTURE_DETECTORS[
+    'canonical-path.current-result-admission.v1'
+  ];
+
+  assert.deepEqual(semantic.detect(productionSources), {
+    definitionCount: 1,
+    observedDefinitions: [{
+      path: 'services/svg-result-ingestion.js',
+      count: 1,
+      subject: 'services/svg-result-ingestion.js'
+    }],
+    subjects: ['services/svg-result-ingestion.js']
+  });
+  assert.deepEqual(canonical.detect(productionSources), {
+    observedEdges: [{
+      from: 'app/candidate-render.js',
+      to: 'services/svg-result-ingestion.js',
+      subject: 'app/candidate-render.js -> services/svg-result-ingestion.js'
+    }],
+    subjects: ['app/candidate-render.js -> services/svg-result-ingestion.js']
+  });
 });
 
 test('declared architecture rules actively govern the current source tree', () => {

--- a/tests/web/architecture-ratchet-fixtures.test.mjs
+++ b/tests/web/architecture-ratchet-fixtures.test.mjs
@@ -49,6 +49,229 @@ const validationCodes = (value, catalog = WEB_ARCHITECTURE_DETECTORS, options = 
   validateArchitectureRuleRegistry(value, catalog, options).errors.map(({ code }) => code)
 );
 
+const currentResultSemantic = WEB_ARCHITECTURE_DETECTORS[
+  'semantic-owner.current-result-admission.v1'
+];
+const currentResultCanonical = WEB_ARCHITECTURE_DETECTORS[
+  'canonical-path.current-result-admission.v1'
+];
+const currentResultOwner = (
+  'export const admitCurrentGeneratedResults = (generationResponse) => generationResponse.results;\n'
+);
+const currentResultCaller = (
+  "import { admitCurrentGeneratedResults } from '../services/svg-result-ingestion.js';\n"
+  + 'export const prepare = (response) => admitCurrentGeneratedResults(response);\n'
+);
+const noCurrentResultDefinitions = Object.freeze({
+  definitionCount: 0,
+  observedDefinitions: Object.freeze([]),
+  subjects: Object.freeze([])
+});
+const noCurrentResultEdges = Object.freeze({
+  observedEdges: Object.freeze([]),
+  subjects: Object.freeze([])
+});
+
+test('current Result semantic-owner detector characterizes exact executable definitions', () => {
+  const conforming = new Map([
+    ['services/svg-result-ingestion.js', currentResultOwner],
+    ['app/candidate-render.js', currentResultCaller]
+  ]);
+  const expected = {
+    definitionCount: 1,
+    observedDefinitions: [{
+      path: 'services/svg-result-ingestion.js',
+      count: 1,
+      subject: 'services/svg-result-ingestion.js'
+    }],
+    subjects: ['services/svg-result-ingestion.js']
+  };
+  assert.deepEqual(currentResultSemantic.detect(conforming), expected);
+  assert.deepEqual(currentResultSemantic.detect(new Map([...conforming].reverse())), expected);
+  assert.equal(currentResultSemantic.subjectCategory, 'definition-path');
+  assert.equal(
+    currentResultSemantic.encodeSubject({
+      path: 'gbdraw/web/js/services/svg-result-ingestion.js'
+    }),
+    'services/svg-result-ingestion.js'
+  );
+
+  assert.deepEqual(currentResultSemantic.detect({
+    'app/candidate-render.js': currentResultCaller
+  }), noCurrentResultDefinitions);
+  assert.deepEqual(currentResultSemantic.detect({
+    'services/svg-result-ingestion.js': currentResultOwner,
+    'services/alternate-ingestion.js': currentResultOwner
+  }), {
+    definitionCount: 2,
+    observedDefinitions: [
+      {
+        path: 'services/alternate-ingestion.js',
+        count: 1,
+        subject: 'services/alternate-ingestion.js'
+      },
+      {
+        path: 'services/svg-result-ingestion.js',
+        count: 1,
+        subject: 'services/svg-result-ingestion.js'
+      }
+    ],
+    subjects: [
+      'services/alternate-ingestion.js',
+      'services/svg-result-ingestion.js'
+    ]
+  });
+  assert.deepEqual(currentResultSemantic.detect({
+    'services/alternate-ingestion.js': currentResultOwner
+  }), {
+    definitionCount: 1,
+    observedDefinitions: [{
+      path: 'services/alternate-ingestion.js',
+      count: 1,
+      subject: 'services/alternate-ingestion.js'
+    }],
+    subjects: ['services/alternate-ingestion.js']
+  });
+  assert.deepEqual(currentResultSemantic.detect({
+    'services/duplicate-ingestion.js': currentResultOwner + currentResultOwner
+  }), {
+    definitionCount: 2,
+    observedDefinitions: [{
+      path: 'services/duplicate-ingestion.js',
+      count: 2,
+      subject: 'services/duplicate-ingestion.js'
+    }],
+    subjects: ['services/duplicate-ingestion.js']
+  });
+
+  const maskedAndUnrelated = {
+    'services/ignored.js': [
+      '// export const admitCurrentGeneratedResults = () => fake();',
+      'const quoted = "export const admitCurrentGeneratedResults = () => fake();";',
+      'const templated = `export const admitCurrentGeneratedResults = () => fake();`;',
+      'export const admitCurrentGeneratedResult = () => null;',
+      'export const admitCurrentGeneratedResultsWrapper = () => null;'
+    ].join('\n')
+  };
+  assert.deepEqual(
+    currentResultSemantic.detect(maskedAndUnrelated),
+    noCurrentResultDefinitions
+  );
+  assert.deepEqual(currentResultSemantic.detect({
+    'services/malformed.js': 'export const admitCurrentGeneratedResults = (value) value;\n'
+  }), noCurrentResultDefinitions);
+});
+
+test('current Result canonical-path detector characterizes named-import call edges', () => {
+  const conforming = new Map([
+    ['services/svg-result-ingestion.js', currentResultOwner],
+    ['app/candidate-render.js', currentResultCaller]
+  ]);
+  const expected = {
+    observedEdges: [{
+      from: 'app/candidate-render.js',
+      to: 'services/svg-result-ingestion.js',
+      subject: 'app/candidate-render.js -> services/svg-result-ingestion.js'
+    }],
+    subjects: ['app/candidate-render.js -> services/svg-result-ingestion.js']
+  };
+  assert.deepEqual(currentResultCanonical.detect(conforming), expected);
+  assert.deepEqual(currentResultCanonical.detect(new Map([...conforming].reverse())), expected);
+  assert.equal(currentResultCanonical.subjectCategory, 'canonical-entry-edge');
+  assert.equal(
+    currentResultCanonical.encodeSubject({
+      from: 'gbdraw/web/js/app/candidate-render.js',
+      to: 'gbdraw/web/js/services/svg-result-ingestion.js'
+    }),
+    'app/candidate-render.js -> services/svg-result-ingestion.js'
+  );
+
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/svg-result-ingestion.js': currentResultOwner
+  }), noCurrentResultEdges);
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/svg-result-ingestion.js': currentResultOwner,
+    'app/unused.js': (
+      "import { admitCurrentGeneratedResults } from '../services/svg-result-ingestion.js';\n"
+      + 'export const prepare = (object, response) => '
+      + 'object.admitCurrentGeneratedResults(response);\n'
+    )
+  }), noCurrentResultEdges);
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/svg-result-ingestion.js': currentResultOwner,
+    'app/a.js': currentResultCaller,
+    'app/b.js': currentResultCaller
+  }), {
+    observedEdges: [
+      {
+        from: 'app/a.js',
+        to: 'services/svg-result-ingestion.js',
+        subject: 'app/a.js -> services/svg-result-ingestion.js'
+      },
+      {
+        from: 'app/b.js',
+        to: 'services/svg-result-ingestion.js',
+        subject: 'app/b.js -> services/svg-result-ingestion.js'
+      }
+    ],
+    subjects: [
+      'app/a.js -> services/svg-result-ingestion.js',
+      'app/b.js -> services/svg-result-ingestion.js'
+    ]
+  });
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/alternate-ingestion.js': currentResultOwner,
+    'app/alternate.js': (
+      "import { admitCurrentGeneratedResults } from '../services/alternate-ingestion.js';\n"
+      + 'export const prepare = (response) => admitCurrentGeneratedResults(response);\n'
+    )
+  }), {
+    observedEdges: [{
+      from: 'app/alternate.js',
+      to: 'services/alternate-ingestion.js',
+      subject: 'app/alternate.js -> services/alternate-ingestion.js'
+    }],
+    subjects: ['app/alternate.js -> services/alternate-ingestion.js']
+  });
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/svg-result-ingestion.js': currentResultOwner,
+    'app/aliased.js': (
+      'import { admitCurrentGeneratedResults as admitResults } '
+      + "from '../services/svg-result-ingestion.js';\n"
+      + 'export const prepare = (response) => admitResults(response);\n'
+    )
+  }), {
+    observedEdges: [{
+      from: 'app/aliased.js',
+      to: 'services/svg-result-ingestion.js',
+      subject: 'app/aliased.js -> services/svg-result-ingestion.js'
+    }],
+    subjects: ['app/aliased.js -> services/svg-result-ingestion.js']
+  });
+
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/svg-result-ingestion.js': currentResultOwner,
+    'app/ignored.js': [
+      '// import { admitCurrentGeneratedResults } from "../services/svg-result-ingestion.js";',
+      '// admitCurrentGeneratedResults(response);',
+      'const quoted = "import admitCurrentGeneratedResults; admitCurrentGeneratedResults(response)";',
+      'const templated = `',
+      'import { admitCurrentGeneratedResults } from "../services/svg-result-ingestion.js";',
+      'admitCurrentGeneratedResults(response);',
+      '`;',
+      'export const admitCurrentGeneratedResultsWrapper = (response) => response;'
+    ].join('\n')
+  }), noCurrentResultEdges);
+  assert.deepEqual(currentResultCanonical.detect({
+    'services/svg-result-ingestion.js': currentResultOwner,
+    'app/malformed.js': (
+      'import { admitCurrentGeneratedResults } '
+      + "'../services/svg-result-ingestion.js';\n"
+      + 'admitCurrentGeneratedResults(response);\n'
+    )
+  }), noCurrentResultEdges);
+});
+
 test('stable inventory deltas expose additions, removals, totals, and signed change', () => {
   assert.deepEqual(
     summarizeArchitectureInventory(['beta', 'alpha', 'alpha'], ['gamma', 'beta']),
@@ -131,7 +354,7 @@ test('acyclic graph evaluation passes with duplicate edges normalized away', () 
 test('schema version 1 accepts only the two discriminated initial rule kinds', () => {
   assert.deepEqual(WEB_ARCHITECTURE_RULE_SCHEMA, {
     schemaVersion: 1,
-    maximumRuleCount: 3,
+    maximumRuleCount: 4,
     kinds: ['single-canonical-entry-edge', 'single-semantic-owner'],
     enforcementModes: ['frozen', 'hard', 'report-only']
   });
@@ -143,6 +366,25 @@ test('schema version 1 accepts only the two discriminated initial rule kinds', (
     ),
     { valid: true, errors: [] }
   );
+});
+
+test('schema version 1 accepts four bounded rules and rejects a fifth', () => {
+  const boundedRules = ['alpha', 'beta', 'delta', 'gamma'].map((key) => semanticRule({
+    key: `semantic-owner.${key}`,
+    allowedDefinitionPaths: [`services/${key}.js`]
+  }));
+  assert.deepEqual(validateArchitectureRuleRegistry(
+    registry(boundedRules),
+    WEB_ARCHITECTURE_DETECTORS,
+    AVAILABLE_ENFORCEMENTS
+  ), { valid: true, errors: [] });
+  assert.ok(validationCodes(registry([
+    ...boundedRules,
+    semanticRule({
+      key: 'semantic-owner.epsilon',
+      allowedDefinitionPaths: ['services/epsilon.js']
+    })
+  ])).includes('too-many-rules'));
 });
 
 test('strict schema rejects unknown, executable-looking, duplicate, and unsorted data', () => {
@@ -210,12 +452,13 @@ test('strict schema rejects unknown, executable-looking, duplicate, and unsorted
       code: 'unsorted-rules'
     },
     {
-      name: 'more than three rules',
+      name: 'more than four rules',
       value: registry([
         canonicalRule(),
         semanticRule({ key: 'semantic-owner.alpha' }),
         semanticRule({ key: 'semantic-owner.beta' }),
-        semanticRule({ key: 'semantic-owner.gamma' })
+        semanticRule({ key: 'semantic-owner.gamma' }),
+        semanticRule({ key: 'semantic-owner.zeta' })
       ]),
       code: 'too-many-rules'
     }

--- a/tools/web-architecture-detectors.mjs
+++ b/tools/web-architecture-detectors.mjs
@@ -237,6 +237,96 @@ const detectCanonicalRenderRequestPath = (sources) => {
   });
 };
 
+const CURRENT_RESULT_ADMISSION_NAME = 'admitCurrentGeneratedResults';
+const CURRENT_RESULT_ADMISSION_DEFINITION_PATTERN = new RegExp(
+  `\\bexport\\s+const\\s+${CURRENT_RESULT_ADMISSION_NAME}`
+    + '\\s*=\\s*\\([^)]*\\)\\s*=>',
+  'g'
+);
+
+const currentResultAdmissionNamedImportsV1 = (source) => {
+  const commentsMasked = maskJavaScript(source, { strings: false });
+  const code = maskJavaScript(source);
+  const imports = [];
+  const pattern = /(?:^|\n)\s*import\s*\{([\s\S]*?)\}\s*from\s*(['"])([^'"\r\n]+)\2\s*;?/g;
+  for (const match of commentsMasked.matchAll(pattern)) {
+    const keywordOffset = match[0].search(/\bimport\b/);
+    const keywordIndex = match.index + keywordOffset;
+    if (!/^import\b/.test(code.slice(keywordIndex))) continue;
+    match[1].split(',').forEach((entry) => {
+      const binding = entry.trim().match(
+        new RegExp(
+          `^${CURRENT_RESULT_ADMISSION_NAME}`
+            + '(?:\\s+as\\s+([A-Za-z_$][\\w$]*))?$'
+        )
+      );
+      if (!binding) return;
+      imports.push(Object.freeze({
+        specifier: match[3],
+        local: binding[1] || CURRENT_RESULT_ADMISSION_NAME
+      }));
+    });
+  }
+  return imports;
+};
+
+const currentResultAdmissionCallPatternV1 = (local) => new RegExp(
+  `(?:^|[^A-Za-z0-9_$.])${local.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`,
+  'g'
+);
+
+const detectCurrentResultAdmissionAuthorityV1 = (sources) => {
+  const observedDefinitions = sourceEntries(sources).flatMap(([path, source]) => {
+    const count = matches(
+      maskJavaScript(source),
+      CURRENT_RESULT_ADMISSION_DEFINITION_PATTERN
+    ).length;
+    return count ? [Object.freeze({
+      path,
+      count,
+      subject: encodeDefinitionPathSubject({ path })
+    })] : [];
+  });
+  return Object.freeze({
+    definitionCount: observedDefinitions.reduce((total, { count }) => total + count, 0),
+    observedDefinitions: Object.freeze(observedDefinitions),
+    subjects: Object.freeze(observedDefinitions.map(({ subject }) => subject))
+  });
+};
+
+const detectCanonicalCurrentResultAdmissionPathV1 = (sources) => {
+  const definitionPaths = new Set(
+    detectCurrentResultAdmissionAuthorityV1(sources).observedDefinitions
+      .map(({ path }) => path)
+  );
+  const edgesBySubject = new Map();
+  sourceEntries(sources).forEach(([from, source]) => {
+    const code = maskJavaScript(source);
+    currentResultAdmissionNamedImportsV1(source)
+      .map(({ specifier, local }) => ({
+        local,
+        to: resolvedProductionImport(from, specifier)
+      }))
+      .filter(({ to }) => definitionPaths.has(to))
+      .filter(({ local }) => matches(
+        code,
+        currentResultAdmissionCallPatternV1(local)
+      ).length > 0)
+      .forEach(({ to }) => {
+        const edge = Object.freeze({ from, to });
+        edgesBySubject.set(encodeCanonicalEntryEdgeSubject(edge), edge);
+      });
+  });
+  const subjects = [...edgesBySubject.keys()].sort();
+  return Object.freeze({
+    observedEdges: Object.freeze(subjects.map((subject) => Object.freeze({
+      ...edgesBySubject.get(subject),
+      subject
+    }))),
+    subjects: Object.freeze(subjects)
+  });
+};
+
 // Keep each detector ID and its transitive helpers executable-identical while referenced.
 // Add a versioned detector beside it, then migrate authority in a separate pull request.
 export const WEB_ARCHITECTURE_DETECTORS = Object.freeze({
@@ -249,5 +339,15 @@ export const WEB_ARCHITECTURE_DETECTORS = Object.freeze({
     subjectCategory: 'canonical-entry-edge',
     encodeSubject: encodeCanonicalEntryEdgeSubject,
     detect: detectCanonicalRenderRequestPath
+  }),
+  'semantic-owner.current-result-admission.v1': Object.freeze({
+    subjectCategory: 'definition-path',
+    encodeSubject: encodeDefinitionPathSubject,
+    detect: detectCurrentResultAdmissionAuthorityV1
+  }),
+  'canonical-path.current-result-admission.v1': Object.freeze({
+    subjectCategory: 'canonical-entry-edge',
+    encodeSubject: encodeCanonicalEntryEdgeSubject,
+    detect: detectCanonicalCurrentResultAdmissionPathV1
   })
 });

--- a/tools/web-architecture-evaluation.mjs
+++ b/tools/web-architecture-evaluation.mjs
@@ -1,5 +1,5 @@
 const SCHEMA_VERSION = 1;
-const MAXIMUM_RULE_COUNT = 3;
+const MAXIMUM_RULE_COUNT = 4;
 const RULE_KINDS = Object.freeze([
   'single-canonical-entry-edge',
   'single-semantic-owner'


### PR DESCRIPTION
## Plain-language summary

This PR adds two deterministic source detectors for the current generated Result admission owner and its canonical caller edge. The detector subjects remain unchanged after the Gallery runtime correction, and the schema-version-1 evaluator capacity increases from three rules to four for later authority activation. This is a checker-only change; runtime behavior and architecture, Product Impact, and workflow authority remain unchanged.

## Change class

Select exactly one:

- [ ] STANDARD
- [x] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: corrected `dev` at `a3d80dd2fe4863262bdbeef725c6cc8f9050f5c4`; active architecture authority remains the two existing hard rules, and checker-specific validation covers detector fixtures, architecture contracts, trusted-base separation, and the Web change policy.

## User-visible impact

None. No Web or Python runtime code changes.

## Changes

- Add `semantic-owner.current-result-admission.v1`, which emits the single definition-path subject `services/svg-result-ingestion.js`.
- Add `canonical-path.current-result-admission.v1`, which emits the single canonical-entry-edge subject `app/candidate-render.js -> services/svg-result-ingestion.js`.
- Raise the schema-version-1 evaluator maximum from 3 rules to 4, with fixtures proving that 4 valid rules are accepted and a fifth is rejected.
- Intentionally omit generated-artifact-replacement and preview-readiness detectors because the merged syntax does not support sound static detection; their dynamic contracts remain authoritative.
- Add no architecture rule, allowed path, accepted violation, Product Impact map or decision, runtime change, or workflow change.

## Verification

- `node --test tests/web/architecture-ratchet-fixtures.test.mjs` — PASS
- `node --test tests/web/architecture-contracts.test.mjs` — PASS (134 tests)
- `node tools/check-web-change-budget.mjs --base origin/dev --head HEAD` — Gate PASS; Review REQUIRED
- `git diff --check origin/dev...HEAD` — PASS
- Changed-path audit — exactly the two checker implementation files and two characterization test files expected for Session 07.

## Risk and review notes

- Gate result and any blocker: `PASS`; no blocking violations.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because Web checker implementation changes require governance review.
- Architecture impact: **This is not architecture-bearing**. It records deterministic source facts without changing runtime semantic owners, canonical paths, compatibility paths, or active architecture authority.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: N/A; runtime `OE`, `PE`, and `CB` are unchanged because no production path changes.
- `architecture-change` label, if relevant: N/A.

## Rollback

Revert commit `6ca50dac01388ef7b6b2f3ea1454a41617539782` before any later authority references these detector IDs. If dependent authority has already been added, remove that authority in a separate authority-only change before reverting the detector implementation.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concern(s), if known: None
- Affected journey/checkpoint effects: None; there is no runtime change.
- Authority and decision references: None
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: Existing dynamic generated-artifact and preview-readiness contracts remain authoritative; no Product Impact authority changes.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: None.
- Checker implementation files touched: `tools/web-architecture-detectors.mjs` and `tools/web-architecture-evaluation.mjs`; characterization is in `tests/web/architecture-ratchet-fixtures.test.mjs` and `tests/web/architecture-contracts.test.mjs`.
- Self-authorization separation evidence: runtime, active rule authority, accepted violations, Product Impact authority, and workflows are unchanged. Architecture contracts prove that proposed detector code is not executed by trusted-base evaluation and that checker implementation remains isolated from authority.
- Branch-protection or ruleset impact, including unchanged settings: None; no workflow or repository-setting change.
- Governance-specific rollback or protection restore point: corrected `dev` at `a3d80dd2fe4863262bdbeef725c6cc8f9050f5c4`.
