### PR TITLE
perf(web): suspend delegated hover work during preview transforms

### DIFF
--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -655,6 +655,16 @@
         .gbdraw-preview-feature-search-updating rect[id^="f"] {
             transition: none !important;
         }
+        .gbdraw-preview-surface :is(
+            path[data-gbdraw-feature-id],
+            polygon[data-gbdraw-feature-id],
+            rect[data-gbdraw-feature-id],
+            path[id^="f"],
+            polygon[id^="f"],
+            rect[id^="f"]
+        ) {
+            cursor: pointer;
+        }
         .gbdraw-preview-feature-search-dimmed {
             opacity: 0.18;
             transition: opacity 120ms ease, filter 120ms ease, stroke 120ms ease, stroke-width 120ms ease;
@@ -4740,11 +4750,13 @@
                          @mousedown="startPan"
                          @mousemove="doPan"
                          @mouseup="endPan"
+                         @pointercancel="endPan"
+                         @lostpointercapture="endPan"
                          @mouseleave="endPan">
                         <div v-if="svgContent" v-html="svgContent" ref="svgContainer"
                             :key="`svg-${mode}-${selectedResultIndex}-${results.length}`"
                             :style="{transform: `translate(${canvasPan.x}px, ${canvasPan.y}px) scale(${zoom})`, transformOrigin: 'top center', transition: isPanning ? 'none' : 'transform 0.2s'}"
-                            class="shadow-xl bg-white m-auto origin-top">
+                            class="gbdraw-preview-surface shadow-xl bg-white m-auto origin-top">
                         </div>
                     </div>
 

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -1066,7 +1066,16 @@ export const createAppSetup = () => {
   );
   const selectResult = (index) => previewRuntime.selectResult(index);
 
-  const { handleWheel, startPan, doPan, endPan, resetPreviewViewport } = createPanZoom(state);
+  const {
+    handleWheel,
+    startPan,
+    doPan,
+    endPan,
+    resetPreviewViewport,
+    cancelPreviewTransformInteraction,
+    disposePanZoom,
+    previewTransformInteraction
+  } = createPanZoom(state);
   const { startResizing } = createSidebarResize(state);
 
   const legendActions = createLegendManager({
@@ -1088,7 +1097,8 @@ export const createAppSetup = () => {
     legendActions,
     svgActions,
     featureSelection,
-    previewRuntime
+    previewRuntime,
+    previewTransformInteraction
   });
   const previewFeatureSearch = createPreviewFeatureSearch({
     state,
@@ -1164,6 +1174,8 @@ export const createAppSetup = () => {
     if (typeof disposeHistoryInputs === 'function') disposeHistoryInputs();
     if (window.__GBDRAW_HISTORY__ === history) delete window.__GBDRAW_HISTORY__;
     previewFeatureSearch.dispose();
+    featureActions.dispose();
+    disposePanZoom();
     setUnmanagedConfigOverrideValidator(null);
     disposeDiagramGenerationWorker();
   });
@@ -1927,6 +1939,7 @@ export const createAppSetup = () => {
       legendLayout.setupDiagramDrag(Boolean(context.bindingOptions.isIncrementalEdit));
     },
     installDelegatedInteractions(context) {
+      cancelPreviewTransformInteraction({ reconcile: false });
       featureActions.attachSvgFeatureHandlers({
         root: context.root,
         phase: context.phase,

--- a/gbdraw/web/js/app/feature-dom.js
+++ b/gbdraw/web/js/app/feature-dom.js
@@ -45,7 +45,7 @@ export const isFeatureFillTarget = (element) => getFeaturePart(element) === FEAT
 export const filterFeatureFillTargets = (elements) =>
   Array.from(elements || []).filter(isFeatureFillTarget);
 
-export const buildFeatureElementIndex = (svg, { markCursor = false } = {}) => {
+export const buildFeatureElementIndex = (svg) => {
   const indexed = new Map();
   if (!svg) return indexed;
   Array.from(svg.querySelectorAll(FEATURE_SELECTOR)).forEach((element) => {
@@ -53,22 +53,16 @@ export const buildFeatureElementIndex = (svg, { markCursor = false } = {}) => {
     if (!id) return;
     if (!indexed.has(id)) indexed.set(id, []);
     indexed.get(id).push(element);
-    if (markCursor && element?.style) element.style.cursor = 'pointer';
   });
   featureElementIndexCache.set(svg, indexed);
   return indexed;
 };
 
-export const getFeatureElementIndex = (svg, { rebuild = false, markCursor = false } = {}) => {
+export const getFeatureElementIndex = (svg, { rebuild = false } = {}) => {
   if (!svg) return new Map();
   const indexed = rebuild || !featureElementIndexCache.has(svg)
-    ? buildFeatureElementIndex(svg, { markCursor })
+    ? buildFeatureElementIndex(svg)
     : (featureElementIndexCache.get(svg) || new Map());
-  if (markCursor) {
-    indexed.forEach((elements) => elements.forEach((element) => {
-      if (element?.style) element.style.cursor = 'pointer';
-    }));
-  }
   return indexed;
 };
 

--- a/gbdraw/web/js/app/feature-editor.js
+++ b/gbdraw/web/js/app/feature-editor.js
@@ -10,7 +10,8 @@ export const createFeatureEditor = ({
   legendActions,
   svgActions,
   featureSelection = null,
-  previewRuntime = null
+  previewRuntime = null,
+  previewTransformInteraction = null
 }) => {
   const ruleActions = createFeatureRuleActions({ state, nextTick, legendActions });
   const labelActions = createFeatureLabelActions({ state, previewRuntime });
@@ -20,7 +21,8 @@ export const createFeatureEditor = ({
     getEffectiveLegendCaption: ruleActions.getEffectiveLegendCaption,
     onFeaturePopupOpened: labelActions.syncLabelEditor,
     featureSelection,
-    previewRuntime
+    previewRuntime,
+    previewTransformInteraction
   });
   const colorActions = createFeatureColorActions({
     state,
@@ -95,6 +97,7 @@ export const createFeatureEditor = ({
     attachSvgFeatureHandlers: featureSvgActions.attachSvgFeatureHandlers,
     preparePairwiseInteractionAffordances:
       featureSvgActions.preparePairwiseInteractionAffordances,
+    dispose: featureSvgActions.dispose,
     openFeatureEditorForFeature,
     refreshFeatureOverrides: ruleActions.refreshFeatureOverrides,
     getEditableLabelByFeatureId: labelActions.getEditableLabelByFeatureId,

--- a/gbdraw/web/js/app/feature-editor/svg-actions.js
+++ b/gbdraw/web/js/app/feature-editor/svg-actions.js
@@ -41,12 +41,12 @@ export const createFeatureSvgActions = ({
   getEffectiveLegendCaption,
   onFeaturePopupOpened = null,
   featureSelection = null,
-  previewRuntime = null
+  previewRuntime = null,
+  previewTransformInteraction = null
 }) => {
   const {
     results,
     selectedResultIndex,
-    isPanning,
     orthogroups,
     collinearGroups,
     orthogroupNameOverrides,
@@ -69,6 +69,9 @@ export const createFeatureSvgActions = ({
     adv
   } = state;
   let delegatedFeatureHandlers = null;
+  const isPreviewTransformInteractionActive = () => Boolean(
+    previewTransformInteraction?.isActive?.()
+  );
   const hoverSummaryState = {
     element: null,
     timer: null,
@@ -423,7 +426,7 @@ export const createFeatureSvgActions = ({
   const hoverSummaryIsAllowed = () => {
     if (clickedFeature.value) return false;
     if (clickedPairwiseMatch?.value) return false;
-    if (isPanning?.value) return false;
+    if (isPreviewTransformInteractionActive()) return false;
     if (window.matchMedia && !window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
       return false;
     }
@@ -770,6 +773,12 @@ export const createFeatureSvgActions = ({
       activeHoverKey: '',
       activeMatchHoverElement: null,
       activeMatchHoverKey: '',
+      activeHoverElements: new Set(),
+      transformPointer: null,
+      reconcileHoverAfterTransform: false,
+      hoverReconcileFrame: null,
+      beginPreviewTransformInteraction: null,
+      endPreviewTransformInteraction: null,
       cleanup: null
     };
 
@@ -781,7 +790,7 @@ export const createFeatureSvgActions = ({
     const ensureFeaturePaths = () => {
       if (!handlerState.pathsByIdMap) {
         recordStructuralMetric('featureDomFullScanCount', 1, { phase: 'interaction' });
-        handlerState.pathsByIdMap = getFeatureElementIndex(svg, { markCursor: true });
+        handlerState.pathsByIdMap = getFeatureElementIndex(svg);
       }
       return handlerState.pathsByIdMap;
     };
@@ -830,6 +839,7 @@ export const createFeatureSvgActions = ({
           }
           element.style.opacity = '0.7';
           element.style.filter = 'brightness(1.2)';
+          handlerState.activeHoverElements.add(element);
           return;
         }
         if (element.hasAttribute('data-gbdraw-hover-opacity')) {
@@ -838,11 +848,12 @@ export const createFeatureSvgActions = ({
           element.removeAttribute('data-gbdraw-hover-opacity');
           element.removeAttribute('data-gbdraw-hover-filter');
         }
+        handlerState.activeHoverElements.delete(element);
       };
 
-      const setFeatureHover = (svgId, highlight) => {
+      const setFeatureHover = (svgId) => {
         (ensureFeaturePaths().get(svgId) || []).forEach((element) => {
-          setHoverStyle(element, highlight);
+          setHoverStyle(element, true);
         });
       };
 
@@ -852,35 +863,35 @@ export const createFeatureSvgActions = ({
         return orthogroupId ? `orthogroup:${orthogroupId}` : `feature:${svgId}`;
       };
 
-      const setOrthogroupHover = (orthogroupId, highlight) => {
+      const setOrthogroupHover = (orthogroupId) => {
         const id = String(orthogroupId || '').trim();
         if (!id) return;
         ensureComparisonIndexes();
         (ensureFeatureOrthogroupIndex().get(id) || new Set()).forEach((featureId) => {
-          setFeatureHover(featureId, highlight);
+          setFeatureHover(featureId);
         });
         (handlerState.comparisonElementsByOrthogroupId.get(id) || []).forEach((element) => {
-          setHoverStyle(element, highlight);
+          setHoverStyle(element, true);
         });
       };
 
-      const setCollinearityBlockHover = (blockId, highlight) => {
+      const setCollinearityBlockHover = (blockId) => {
         const id = String(blockId || '').trim();
         if (!id) return;
         ensureComparisonIndexes();
         (handlerState.comparisonElementsByCollinearityBlockId.get(id) || []).forEach((element) => {
-          setHoverStyle(element, highlight);
+          setHoverStyle(element, true);
         });
       };
 
-      const setHoverHighlight = (svgId, highlight) => {
+      const setHoverHighlight = (svgId) => {
         const feat = ensureFeatureLookup().get(svgId);
         const orthogroupId = String(feat?.orthogroupId || '').trim();
         if (orthogroupId) {
-          setOrthogroupHover(orthogroupId, highlight);
+          setOrthogroupHover(orthogroupId);
           return;
         }
-        setFeatureHover(svgId, highlight);
+        setFeatureHover(svgId);
       };
 
       const matchAttr = (element, name) => String(element?.getAttribute?.(name) || '').trim();
@@ -893,72 +904,150 @@ export const createFeatureSvgActions = ({
         return `match:${matchAttr(matchElement, 'data-gbdraw-pairwise-match-id') || matchAttr(matchElement, 'd')}`;
       };
 
-      const setMatchHover = (matchElement, highlight) => {
+      const setMatchHover = (matchElement) => {
         if (!matchElement) return;
         const blockId = matchAttr(matchElement, 'data-collinearity-block-id');
         const orthogroupId = matchAttr(matchElement, 'data-orthogroup-id');
-        setHoverStyle(matchElement, highlight);
+        setHoverStyle(matchElement, true);
         if (blockId) {
-          setCollinearityBlockHover(blockId, highlight);
+          setCollinearityBlockHover(blockId);
           return;
         }
         if (orthogroupId) {
-          setOrthogroupHover(orthogroupId, highlight);
+          setOrthogroupHover(orthogroupId);
         }
+      };
+
+      const clearTrackedHoverStyles = () => {
+        [...handlerState.activeHoverElements].forEach((element) => {
+          setHoverStyle(element, false);
+        });
       };
 
       const clearActiveFeatureHover = () => {
         if (!handlerState.activeHoverSvgId) return;
-        setHoverHighlight(handlerState.activeHoverSvgId, false);
+        clearTrackedHoverStyles();
         handlerState.activeHoverSvgId = null;
         handlerState.activeHoverKey = '';
       };
 
       const clearActiveMatchHover = () => {
         if (!handlerState.activeMatchHoverElement) return;
-        setMatchHover(handlerState.activeMatchHoverElement, false);
+        clearTrackedHoverStyles();
         handlerState.activeMatchHoverElement = null;
         handlerState.activeMatchHoverKey = '';
       };
 
+      const rememberTransformPointer = (eventLike) => {
+        if (!Number.isFinite(eventLike?.clientX) || !Number.isFinite(eventLike?.clientY)) return;
+        handlerState.transformPointer = {
+          clientX: eventLike.clientX,
+          clientY: eventLike.clientY
+        };
+        handlerState.reconcileHoverAfterTransform = true;
+      };
+
+      const activateFeatureHover = (featureEl, eventLike) => {
+        clearActiveMatchHover();
+        const svgId = getFeatureIdentity(featureEl);
+        if (!svgId) return false;
+        const hoverKey = getFeatureHoverKey(svgId);
+        if (handlerState.activeHoverKey !== hoverKey && handlerState.activeHoverSvgId) {
+          clearActiveFeatureHover();
+        }
+        if (handlerState.activeHoverKey !== hoverKey) {
+          setHoverHighlight(svgId);
+        }
+        handlerState.activeHoverSvgId = svgId;
+        handlerState.activeHoverKey = hoverKey;
+        scheduleHoverSummary(ensureFeatureLookup().get(svgId), featureEl, eventLike);
+        return true;
+      };
+
+      const activateMatchHover = (matchEl, eventLike) => {
+        clearActiveFeatureHover();
+        const matchKey = getMatchHoverKey(matchEl);
+        if (handlerState.activeMatchHoverKey !== matchKey && handlerState.activeMatchHoverElement) {
+          clearActiveMatchHover();
+        }
+        if (handlerState.activeMatchHoverKey !== matchKey) {
+          setMatchHover(matchEl);
+        }
+        handlerState.activeMatchHoverElement = matchEl;
+        handlerState.activeMatchHoverKey = matchKey;
+        scheduleMatchHoverSummary(buildMatchPayload(matchEl, ensureFeatureLookup()), eventLike);
+        return true;
+      };
+
+      handlerState.beginPreviewTransformInteraction = (eventLike, kind = '') => {
+        if (handlerState.hoverReconcileFrame !== null) {
+          window.cancelAnimationFrame(handlerState.hoverReconcileFrame);
+          handlerState.hoverReconcileFrame = null;
+        }
+        handlerState.reconcileHoverAfterTransform = Boolean(
+          handlerState.activeHoverSvgId || handlerState.activeMatchHoverElement
+        );
+        rememberTransformPointer(eventLike);
+        clearActiveFeatureHover();
+        clearActiveMatchHover();
+        hideHoverSummary();
+        recordStructuralMetric('previewTransformHoverCleanupCount', 1, { kind });
+      };
+
+      handlerState.endPreviewTransformInteraction = ({ reconcile = true } = {}) => {
+        if (!reconcile || !handlerState.reconcileHoverAfterTransform || !handlerState.transformPointer) {
+          handlerState.reconcileHoverAfterTransform = false;
+          handlerState.transformPointer = null;
+          return;
+        }
+        if (handlerState.hoverReconcileFrame !== null) {
+          window.cancelAnimationFrame(handlerState.hoverReconcileFrame);
+        }
+        handlerState.hoverReconcileFrame = window.requestAnimationFrame(() => {
+          handlerState.hoverReconcileFrame = null;
+          if (isPreviewTransformInteractionActive() || delegatedFeatureHandlers !== handlerState) return;
+          const pointer = handlerState.transformPointer;
+          handlerState.transformPointer = null;
+          handlerState.reconcileHoverAfterTransform = false;
+          recordStructuralMetric('previewTransformHoverReconcileCount', 1);
+          const target = getTopmostSvgTarget(
+            pointer,
+            svg,
+            `${PAIRWISE_MATCH_SELECTOR}, ${FEATURE_SELECTOR}`
+          );
+          const matchEl = getPairwiseMatchTarget(target, svg);
+          if (matchEl) {
+            activateMatchHover(matchEl, pointer);
+            return;
+          }
+          const featureEl = getFeatureTarget(target, svg);
+          if (featureEl) activateFeatureHover(featureEl, pointer);
+        });
+      };
+
       const handleMouseOver = (e) => {
+        if (isPreviewTransformInteractionActive()) {
+          rememberTransformPointer(e);
+          return;
+        }
         const featureEl = getFeatureTarget(e.target, svg);
         if (featureEl) {
-          clearActiveMatchHover();
-          const svgId = getFeatureIdentity(featureEl);
-          if (!svgId) return;
-          const hoverKey = getFeatureHoverKey(svgId);
-          if (handlerState.activeHoverKey !== hoverKey && handlerState.activeHoverSvgId) {
-            setHoverHighlight(handlerState.activeHoverSvgId, false);
-          }
-          if (handlerState.activeHoverKey !== hoverKey) {
-            setHoverHighlight(svgId, true);
-          }
-          handlerState.activeHoverSvgId = svgId;
-          handlerState.activeHoverKey = hoverKey;
-          scheduleHoverSummary(ensureFeatureLookup().get(svgId), featureEl, e);
+          activateFeatureHover(featureEl, e);
           return;
         }
         const matchEl = getPairwiseMatchTarget(e.target, svg);
         if (!matchEl) return;
-        clearActiveFeatureHover();
-        const matchKey = getMatchHoverKey(matchEl);
-        if (handlerState.activeMatchHoverKey !== matchKey && handlerState.activeMatchHoverElement) {
-          setMatchHover(handlerState.activeMatchHoverElement, false);
-        }
-        if (handlerState.activeMatchHoverKey !== matchKey) {
-          setMatchHover(matchEl, true);
-        }
-        handlerState.activeMatchHoverElement = matchEl;
-        handlerState.activeMatchHoverKey = matchKey;
-        scheduleMatchHoverSummary(buildMatchPayload(matchEl, ensureFeatureLookup()), e);
+        activateMatchHover(matchEl, e);
       };
 
       const handleMouseMove = (e) => {
+        if (isPreviewTransformInteractionActive()) {
+          rememberTransformPointer(e);
+          return;
+        }
         if (
           clickedFeature.value ||
           clickedPairwiseMatch?.value ||
-          isPanning?.value ||
           featureSelectionDrag?.active
         ) {
           hideHoverSummary();
@@ -970,6 +1059,10 @@ export const createFeatureSvgActions = ({
       };
 
       const handleMouseOut = (e) => {
+        if (isPreviewTransformInteractionActive()) {
+          rememberTransformPointer(e);
+          return;
+        }
         const featureEl = getFeatureTarget(e.target, svg);
         if (featureEl) {
           const svgId = getFeatureIdentity(featureEl);
@@ -1107,6 +1200,12 @@ export const createFeatureSvgActions = ({
         svg.removeEventListener('pointermove', handlePointerMove, true);
         svg.removeEventListener('pointerup', handlePointerUp, true);
         svg.removeEventListener('pointercancel', handlePointerCancel, true);
+        if (handlerState.hoverReconcileFrame !== null) {
+          window.cancelAnimationFrame(handlerState.hoverReconcileFrame);
+          handlerState.hoverReconcileFrame = null;
+        }
+        handlerState.reconcileHoverAfterTransform = false;
+        handlerState.transformPointer = null;
         clearActiveFeatureHover();
         clearActiveMatchHover();
         hideHoverSummary();
@@ -1117,6 +1216,28 @@ export const createFeatureSvgActions = ({
       rootGeneration
     });
     return true;
+  };
+
+  const unsubscribePreviewTransformInteraction = previewTransformInteraction?.subscribe?.(({
+    active,
+    kind,
+    event,
+    reconcile
+  }) => {
+    if (active) {
+      delegatedFeatureHandlers?.beginPreviewTransformInteraction?.(event, kind);
+      return;
+    }
+    delegatedFeatureHandlers?.endPreviewTransformInteraction?.({ reconcile });
+  }) || null;
+
+  const dispose = () => {
+    if (typeof unsubscribePreviewTransformInteraction === 'function') {
+      unsubscribePreviewTransformInteraction();
+    }
+    cleanupDelegatedFeatureHandlers();
+    if (hoverSummaryState.element?.isConnected) hoverSummaryState.element.remove();
+    hoverSummaryState.element = null;
   };
 
   const preparePairwiseInteractionAffordances = ({
@@ -1146,6 +1267,7 @@ export const createFeatureSvgActions = ({
     getFeatureElements,
     getFeatureFillElements,
     openFeatureEditorForFeature,
-    preparePairwiseInteractionAffordances
+    preparePairwiseInteractionAffordances,
+    dispose
   };
 };

--- a/gbdraw/web/js/app/ui.js
+++ b/gbdraw/web/js/app/ui.js
@@ -1,7 +1,132 @@
+import { recordStructuralMetric } from '../services/runtime-test-hooks.js';
+
+// Keep one burst alive through the existing 0.2 s transform transition. This
+// also absorbs browser delivery delay between nominally 80 ms wheel inputs.
+const WHEEL_BURST_QUIET_MS = 220;
+const WHEEL_TRANSITION_FALLBACK_MS = 260;
+
 export const createPanZoom = (state) => {
   const { zoom, layoutRepositionMode, isPanning, panStart, canvasPan, canvasContainerRef, svgContainer } = state;
   let panFrameId = null;
   let pendingPanPointer = null;
+  const previewTransformInteractionSources = new Set();
+  let wheelBurstTimerId = null;
+  let wheelFallbackTimerId = null;
+  let wheelTransitionTarget = null;
+  let wheelBurstComplete = false;
+  let wheelTransitionComplete = false;
+  const previewTransformInteractionListeners = new Set();
+
+  const previewTransformInteraction = Object.freeze({
+    isActive: () => previewTransformInteractionSources.size > 0,
+    subscribe(listener) {
+      if (typeof listener !== 'function') return () => {};
+      previewTransformInteractionListeners.add(listener);
+      return () => previewTransformInteractionListeners.delete(listener);
+    }
+  });
+
+  const notifyPreviewTransformInteraction = (active, kind, event, reconcile) => {
+    previewTransformInteractionListeners.forEach((listener) => {
+      listener({ active, kind, event, reconcile });
+    });
+  };
+
+  const beginPreviewTransformInteraction = (kind, event) => {
+    const wasActive = previewTransformInteractionSources.size > 0;
+    previewTransformInteractionSources.add(kind);
+    if (wasActive) return false;
+    recordStructuralMetric('previewTransformInteractionStartCount', 1, { kind });
+    notifyPreviewTransformInteraction(true, kind, event, false);
+    return true;
+  };
+
+  const endPreviewTransformInteraction = (kind, { reconcile = true } = {}) => {
+    if (!previewTransformInteractionSources.delete(kind)) return false;
+    if (previewTransformInteractionSources.size > 0) return false;
+    recordStructuralMetric('previewTransformInteractionEndCount', 1, { kind });
+    notifyPreviewTransformInteraction(false, kind, null, reconcile);
+    return true;
+  };
+
+  const clearWheelTimers = () => {
+    if (wheelBurstTimerId !== null) {
+      window.clearTimeout(wheelBurstTimerId);
+      wheelBurstTimerId = null;
+    }
+    if (wheelFallbackTimerId !== null) {
+      window.clearTimeout(wheelFallbackTimerId);
+      wheelFallbackTimerId = null;
+    }
+  };
+
+  const detachWheelTransitionListener = () => {
+    wheelTransitionTarget?.removeEventListener?.('transitionend', handleWheelTransitionEnd);
+    wheelTransitionTarget = null;
+  };
+
+  const finishWheelInteraction = ({ reconcile = true } = {}) => {
+    if (!previewTransformInteractionSources.has('wheel')) return false;
+    clearWheelTimers();
+    detachWheelTransitionListener();
+    wheelBurstComplete = false;
+    wheelTransitionComplete = false;
+    return endPreviewTransformInteraction('wheel', { reconcile });
+  };
+
+  function handleWheelTransitionEnd(event) {
+    if (
+      !previewTransformInteractionSources.has('wheel')
+      || event?.target !== wheelTransitionTarget
+      || event?.propertyName !== 'transform'
+    ) return;
+    wheelTransitionComplete = true;
+    if (wheelBurstComplete) finishWheelInteraction();
+  }
+
+  const scheduleWheelInteractionEnd = () => {
+    clearWheelTimers();
+    wheelBurstComplete = false;
+    wheelTransitionComplete = false;
+    wheelBurstTimerId = window.setTimeout(() => {
+      wheelBurstTimerId = null;
+      wheelBurstComplete = true;
+      if (wheelTransitionComplete) finishWheelInteraction();
+    }, WHEEL_BURST_QUIET_MS);
+    // A clamped zoom may not produce transitionend. Bound that path just past
+    // the existing 0.2 s transform transition without changing the transition.
+    wheelFallbackTimerId = window.setTimeout(() => {
+      wheelFallbackTimerId = null;
+      finishWheelInteraction();
+    }, WHEEL_TRANSITION_FALLBACK_MS);
+  };
+
+  const beginWheelInteraction = (event) => {
+    const isNewWheelInteraction = !previewTransformInteractionSources.has('wheel');
+    beginPreviewTransformInteraction('wheel', event);
+    if (isNewWheelInteraction) {
+      wheelTransitionTarget = svgContainer.value;
+      wheelTransitionTarget?.addEventListener?.('transitionend', handleWheelTransitionEnd);
+    }
+    scheduleWheelInteractionEnd();
+  };
+
+  const cancelPreviewTransformInteraction = ({ reconcile = false } = {}) => {
+    const wasActive = previewTransformInteractionSources.size > 0;
+    cancelPanFrame();
+    pendingPanPointer = null;
+    isPanning.value = false;
+    if (canvasContainerRef.value) canvasContainerRef.value.style.cursor = 'grab';
+    clearWheelTimers();
+    detachWheelTransitionListener();
+    wheelBurstComplete = false;
+    wheelTransitionComplete = false;
+    previewTransformInteractionSources.clear();
+    if (!wasActive) return false;
+    recordStructuralMetric('previewTransformInteractionEndCount', 1, { kind: 'cancel' });
+    notifyPreviewTransformInteraction(false, 'cancel', null, reconcile);
+    return true;
+  };
 
   const isLayoutRepositionModeEnabled = () => Boolean(layoutRepositionMode?.value);
 
@@ -57,9 +182,7 @@ export const createPanZoom = (state) => {
   };
 
   const resetPreviewViewport = ({ resetZoom = false, pan = null } = {}) => {
-    cancelPanFrame();
-    pendingPanPointer = null;
-    isPanning.value = false;
+    cancelPreviewTransformInteraction({ reconcile: false });
     panStart.x = 0;
     panStart.y = 0;
     panStart.panX = 0;
@@ -78,6 +201,7 @@ export const createPanZoom = (state) => {
   };
 
   const handleWheel = (event) => {
+    beginWheelInteraction(event);
     const delta = event.deltaY > 0 ? -0.1 : 0.1;
     const newZoom = Math.max(0.1, Math.min(5, zoom.value + delta));
     zoom.value = Math.round(newZoom * 10) / 10;
@@ -107,6 +231,7 @@ export const createPanZoom = (state) => {
 
     cancelPanFrame();
     pendingPanPointer = null;
+    beginPreviewTransformInteraction('pan', event);
     isPanning.value = true;
     panStart.x = event.clientX;
     panStart.y = event.clientY;
@@ -128,6 +253,7 @@ export const createPanZoom = (state) => {
   };
 
   const endPan = (event) => {
+    const wasPanning = isPanning.value;
     const finalPointer =
       typeof event?.clientX === 'number' && typeof event?.clientY === 'number'
         ? { x: event.clientX, y: event.clientY }
@@ -147,9 +273,24 @@ export const createPanZoom = (state) => {
       container.style.cursor = 'grab';
     }
     applyPreviewTransform(canvasPan.x, canvasPan.y, zoom.value, false);
+    if (wasPanning) endPreviewTransformInteraction('pan');
   };
 
-  return { handleWheel, startPan, doPan, endPan, resetPreviewViewport };
+  const disposePanZoom = () => {
+    cancelPreviewTransformInteraction({ reconcile: false });
+    previewTransformInteractionListeners.clear();
+  };
+
+  return {
+    handleWheel,
+    startPan,
+    doPan,
+    endPan,
+    resetPreviewViewport,
+    cancelPreviewTransformInteraction,
+    disposePanZoom,
+    previewTransformInteraction
+  };
 };
 
 export const createSidebarResize = (state) => {

--- a/playwright.perf.config.js
+++ b/playwright.perf.config.js
@@ -4,6 +4,10 @@ const baseConfig = require('./playwright.config.js');
 
 module.exports = defineConfig({
   ...baseConfig,
+  metadata: {
+    ...baseConfig.metadata,
+    gbdrawPerformanceProfile: true
+  },
   testMatch: /.*performance\.playwright\.spec\.js/,
   testIgnore: [],
   fullyParallel: false,

--- a/tests/web/helpers/responsiveness-guardrail.cjs
+++ b/tests/web/helpers/responsiveness-guardrail.cjs
@@ -1,0 +1,47 @@
+const median = (values) => {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new TypeError('median requires at least one numeric value.');
+  }
+  if (values.some((value) => !Number.isFinite(value))) {
+    throw new TypeError('median accepts only finite numeric values.');
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2
+    ? sorted[middle]
+    : (sorted[middle - 1] + sorted[middle]) / 2;
+};
+
+const aggregateResponsivenessSamples = (samples) => {
+  if (!Array.isArray(samples) || samples.length === 0) {
+    throw new TypeError('At least one responsiveness sample is required.');
+  }
+  return Object.freeze({
+    repetitions: samples.length,
+    medianLongTaskTotalMs: median(samples.map(({ longTasks }) => longTasks.totalDurationMs)),
+    medianLongestLongTaskMs: median(
+      samples.map(({ longTasks }) => longTasks.longestDurationMs)
+    ),
+    medianRafP95Ms: median(samples.map(({ raf }) => raf.p95Ms)),
+    maximumHeartbeatGapMs: Math.max(
+      ...samples.map(({ heartbeat }) => heartbeat.maximumGapMs)
+    )
+  });
+};
+
+const evaluateResponsivenessGuardrail = (aggregate, thresholds) => Object.freeze([
+  aggregate.medianLongTaskTotalMs > thresholds.maximumMedianLongTaskTotalMs
+    ? `median Long Task total ${aggregate.medianLongTaskTotalMs} ms exceeded `
+      + `${thresholds.maximumMedianLongTaskTotalMs} ms`
+    : null,
+  aggregate.medianLongestLongTaskMs > thresholds.maximumMedianLongestLongTaskMs
+    ? `median longest Long Task ${aggregate.medianLongestLongTaskMs} ms exceeded `
+      + `${thresholds.maximumMedianLongestLongTaskMs} ms`
+    : null
+].filter(Boolean));
+
+module.exports = {
+  aggregateResponsivenessSamples,
+  evaluateResponsivenessGuardrail,
+  median
+};

--- a/tests/web/large-preview-transform-interaction.performance.playwright.spec.js
+++ b/tests/web/large-preview-transform-interaction.performance.playwright.spec.js
@@ -7,6 +7,10 @@ const {
   getDiagramWorkerActivity,
   openApp
 } = require('./helpers/app-lifecycle.cjs');
+const {
+  aggregateResponsivenessSamples,
+  evaluateResponsivenessGuardrail
+} = require('./helpers/responsiveness-guardrail.cjs');
 
 const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
 const fixturePath = join(
@@ -26,6 +30,12 @@ const PAN_INTERVAL_MS = 16;
 const WHEEL_STEPS = 30;
 const WHEEL_INTERVAL_MS = 80;
 const POST_INTERACTION_SETTLE_MS = 300;
+const CONTROLLED_TIMING_SETTLE_MS = 500;
+const RESPONSIVENESS_REPETITIONS = 3;
+const RESPONSIVENESS_THRESHOLDS = Object.freeze({
+  maximumMedianLongTaskTotalMs: 500,
+  maximumMedianLongestLongTaskMs: 250
+});
 const installInteractionProbe = (page) => page.addInitScript(() => {
   const FEATURE_SELECTOR = [
     'path[data-gbdraw-feature-id]',
@@ -563,24 +573,222 @@ const installInteractionProbe = (page) => page.addInitScript(() => {
   };
 });
 
-const loadExactSession = async (page, dialogs) => {
-  const chooserPromise = page.waitForEvent('filechooser', { timeout: OPERATION_TIMEOUT_MS });
-  await page.getByRole('button', { name: 'Load Session', exact: true }).click();
-  const chooser = await chooserPromise;
-  await chooser.setFiles(fixturePath);
-  await page.waitForFunction(() => (
-    window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__?.snapshot?.().lifecycle.some(
-      (event) => event.name === 'interactiveReady'
-    )
-  ), null, { timeout: OPERATION_TIMEOUT_MS });
+const installResponsivenessProbe = (page, { trackLifecycle = false } = {}) => page.addInitScript(
+  ({ shouldTrackLifecycle }) => {
+    const longTasks = [];
+    let measurement = null;
+    let longTaskObserver = null;
+    let longTaskSupported = false;
+    const lifecycle = { starts: 0, ends: 0 };
+
+    const quantile = (values, probability) => {
+      if (values.length === 0) return 0;
+      const sorted = [...values].sort((left, right) => left - right);
+      const index = Math.min(
+        sorted.length - 1,
+        Math.max(0, Math.ceil(probability * sorted.length) - 1)
+      );
+      return sorted[index];
+    };
+    const summarizeIntervals = (values) => ({
+      count: values.length,
+      p50Ms: quantile(values, 0.5),
+      p95Ms: quantile(values, 0.95),
+      maximumGapMs: values.length ? Math.max(...values) : 0,
+      over33ms: values.filter((value) => value > 33).length,
+      over50ms: values.filter((value) => value > 50).length,
+      over100ms: values.filter((value) => value > 100).length
+    });
+    const appendLongTasks = (entries) => {
+      for (const entry of entries) {
+        longTasks.push({
+          startTime: Number(entry.startTime || 0),
+          duration: Number(entry.duration || 0)
+        });
+      }
+    };
+
+    try {
+      longTaskObserver = new PerformanceObserver((list) => appendLongTasks(list.getEntries()));
+      longTaskObserver.observe({ type: 'longtask', buffered: true });
+      longTaskSupported = true;
+    } catch (_error) {
+      longTaskObserver = null;
+      longTaskSupported = false;
+    }
+
+    if (shouldTrackLifecycle) {
+      window.__GBDRAW_TEST_HOOKS__ = {
+        onStructuralMetric(metric) {
+          if (metric?.name === 'previewTransformInteractionStartCount') lifecycle.starts += 1;
+          if (metric?.name === 'previewTransformInteractionEndCount') lifecycle.ends += 1;
+        }
+      };
+    }
+
+    window.addEventListener('wheel', (event) => {
+      if (!measurement || !measurement.svg.contains(event.target)) return;
+      measurement.inputTimestamps.push(performance.now());
+    }, true);
+
+    const beginMeasurement = () => {
+      if (measurement) throw new Error('A responsiveness measurement is already active.');
+      const wrapper = document.querySelector(
+        '.gbdraw-preview-surface, .shadow-xl.bg-white.m-auto.origin-top'
+      );
+      const svg = wrapper?.querySelector?.('svg');
+      if (!wrapper || !svg) throw new Error('The exact-fixture preview is not mounted.');
+      const startedAt = performance.now();
+      const activeMeasurement = {
+        startedAt,
+        svg,
+        dispatchTimestamps: [],
+        inputTimestamps: [],
+        rafIntervals: [],
+        rafLast: null,
+        rafHandle: null,
+        heartbeatGaps: [],
+        heartbeatLast: startedAt,
+        heartbeatHandle: null,
+        lifecycleBefore: { ...lifecycle }
+      };
+      measurement = activeMeasurement;
+      const sampleAnimationFrame = (timestamp) => {
+        if (measurement !== activeMeasurement) return;
+        if (activeMeasurement.rafLast !== null) {
+          activeMeasurement.rafIntervals.push(timestamp - activeMeasurement.rafLast);
+        }
+        activeMeasurement.rafLast = timestamp;
+        activeMeasurement.rafHandle = requestAnimationFrame(sampleAnimationFrame);
+      };
+      activeMeasurement.rafHandle = requestAnimationFrame(sampleAnimationFrame);
+      activeMeasurement.heartbeatHandle = setInterval(() => {
+        const now = performance.now();
+        activeMeasurement.heartbeatGaps.push(now - activeMeasurement.heartbeatLast);
+        activeMeasurement.heartbeatLast = now;
+      }, 50);
+    };
+
+    const recordDispatch = () => {
+      if (!measurement) throw new Error('No responsiveness measurement is active.');
+      measurement.dispatchTimestamps.push(performance.now());
+    };
+
+    const endMeasurement = () => {
+      if (!measurement) throw new Error('No responsiveness measurement is active.');
+      const activeMeasurement = measurement;
+      const endedAt = performance.now();
+      measurement = null;
+      cancelAnimationFrame(activeMeasurement.rafHandle);
+      clearInterval(activeMeasurement.heartbeatHandle);
+      if (longTaskObserver) appendLongTasks(longTaskObserver.takeRecords());
+      const phaseLongTasks = longTasks.filter((entry) => (
+        entry.startTime >= activeMeasurement.startedAt && entry.startTime <= endedAt
+      ));
+      const inputIntervals = activeMeasurement.inputTimestamps.slice(1).map(
+        (timestamp, index) => timestamp - activeMeasurement.inputTimestamps[index]
+      );
+      const dispatchIntervals = activeMeasurement.dispatchTimestamps.slice(1).map(
+        (timestamp, index) => timestamp - activeMeasurement.dispatchTimestamps[index]
+      );
+      return {
+        measurementDurationMs: endedAt - activeMeasurement.startedAt,
+        deliveredEventCount: activeMeasurement.inputTimestamps.length,
+        inputIntervals: summarizeIntervals(inputIntervals),
+        dispatchIntervals: summarizeIntervals(dispatchIntervals),
+        longTasks: {
+          supported: longTaskSupported,
+          count: phaseLongTasks.length,
+          totalDurationMs: phaseLongTasks.reduce(
+            (total, entry) => total + entry.duration,
+            0
+          ),
+          longestDurationMs: phaseLongTasks.length
+            ? Math.max(...phaseLongTasks.map((entry) => entry.duration))
+            : 0
+        },
+        raf: summarizeIntervals(activeMeasurement.rafIntervals),
+        heartbeat: {
+          count: activeMeasurement.heartbeatGaps.length,
+          maximumGapMs: activeMeasurement.heartbeatGaps.length
+            ? Math.max(...activeMeasurement.heartbeatGaps)
+            : 0
+        },
+        lifecycle: {
+          interactionStarts:
+            lifecycle.starts - activeMeasurement.lifecycleBefore.starts,
+          interactionEnds:
+            lifecycle.ends - activeMeasurement.lifecycleBefore.ends
+        }
+      };
+    };
+
+    window.__GBDRAW_LARGE_PREVIEW_RESPONSIVENESS_PROBE__ = {
+      beginMeasurement,
+      endMeasurement,
+      recordDispatch
+    };
+  },
+  { shouldTrackLifecycle: trackLifecycle }
+);
+
+const loadExactSession = async (page, dialogs, { browserFetch = false } = {}) => {
+  if (browserFetch) {
+    await page.evaluate(async () => {
+      const response = await fetch(
+        '/gbdraw/web/gallery/sessions/hepatoplasmataceae_collinear.gbdraw-session.json.gz',
+        { cache: 'no-store' }
+      );
+      if (!response.ok) throw new Error(`Session fetch failed with ${response.status}.`);
+      const file = new File(
+        [await response.arrayBuffer()],
+        'hepatoplasmataceae_collinear.gbdraw-session.json.gz',
+        { type: 'application/gzip' }
+      );
+      const transfer = new DataTransfer();
+      transfer.items.add(file);
+      const input = document.querySelector('input[accept*=".json"][accept*=".gz"]');
+      if (!input) throw new Error('The Session file input was not found.');
+      input.files = transfer.files;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  } else {
+    const chooserPromise = page.waitForEvent('filechooser', { timeout: OPERATION_TIMEOUT_MS });
+    await page.getByRole('button', { name: 'Load Session', exact: true }).click();
+    const chooser = await chooserPromise;
+    await chooser.setFiles(fixturePath);
+  }
+  await page.waitForFunction((requireStructuralReady) => {
+    const wrapper = document.querySelector(
+      '.gbdraw-preview-surface, .shadow-xl.bg-white.m-auto.origin-top'
+    );
+    const svg = wrapper?.querySelector?.('svg');
+    const structuralProbe = window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__;
+    const structuralReady = !requireStructuralReady || Boolean(
+      structuralProbe?.snapshot?.().lifecycle.some((event) => event.name === 'interactiveReady')
+    );
+    return Boolean(svg && window.__GBDRAW_APP__?.results?.length && structuralReady);
+  }, !browserFetch, { timeout: OPERATION_TIMEOUT_MS });
   await page.evaluate(() => new Promise((resolveFrame) => (
     requestAnimationFrame(() => requestAnimationFrame(resolveFrame))
   )));
   expect(dialogs).toContain('Session loaded successfully!');
 };
 
+const openExactApp = async (page, { structural = false } = {}) => {
+  if (structural) return openApp(page);
+  await page.goto('/gbdraw/web/index.html', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => (
+    Boolean(window.__GBDRAW_APP__)
+      && Object.keys(window.__GBDRAW_APP__?.paletteDefinitions || {}).length > 0
+  ), null, { timeout: OPERATION_TIMEOUT_MS });
+  return null;
+};
+
 const ensureDenseRegionVisible = (page) => page.evaluate(() => {
-  const wrapper = document.querySelector('.gbdraw-preview-surface');
+  const wrapper = document.querySelector(
+    '.gbdraw-preview-surface, .shadow-xl.bg-white.m-auto.origin-top'
+  );
   const feature = wrapper?.querySelector?.(
     '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"])'
   );
@@ -589,7 +797,9 @@ const ensureDenseRegionVisible = (page) => page.evaluate(() => {
 });
 
 const readGeometry = (page) => page.evaluate(() => {
-  const wrapper = document.querySelector('.gbdraw-preview-surface');
+  const wrapper = document.querySelector(
+    '.gbdraw-preview-surface, .shadow-xl.bg-white.m-auto.origin-top'
+  );
   const svg = wrapper?.querySelector?.('svg');
   const container = window.__GBDRAW_APP__?.canvasContainerRef;
   if (!wrapper || !svg || !container) throw new Error('Preview geometry is unavailable.');
@@ -680,12 +890,11 @@ const metricDelta = (before, after) => {
   ]).filter(([, value]) => value !== 0));
 };
 
-const prewarmHoverIndexes = async (page, geometry) => {
-  const before = await page.evaluate(() => (
-    window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot().metrics
-  ));
+const warmOrdinaryFeatureHover = async (page, geometry) => {
   const feature = page.locator(
     '.gbdraw-preview-surface > svg '
+      + '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"]), '
+      + '.shadow-xl.bg-white.m-auto.origin-top > svg '
       + '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"])'
   ).first();
   await expect(feature).toBeVisible({ timeout: INTERACTION_TIMEOUT_MS });
@@ -693,10 +902,16 @@ const prewarmHoverIndexes = async (page, geometry) => {
   await expect(feature).toHaveAttribute('data-gbdraw-hover-opacity', /.*/);
   await page.mouse.move(geometry.panPoint.x, geometry.panPoint.y);
   await page.waitForFunction(() => (
-    document.querySelector('.gbdraw-preview-surface > svg')
-      ?.querySelectorAll('[data-gbdraw-hover-opacity]').length === 0
+    document.querySelectorAll('[data-gbdraw-hover-opacity]').length === 0
   ));
   await page.waitForTimeout(100);
+};
+
+const prewarmHoverIndexes = async (page, geometry) => {
+  const before = await page.evaluate(() => (
+    window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot().metrics
+  ));
+  await warmOrdinaryFeatureHover(page, geometry);
   const after = await page.evaluate(() => (
     window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot().metrics
   ));
@@ -779,6 +994,133 @@ const runWheel = async (page, geometry, beforeMetrics) => {
     intervalMs: WHEEL_INTERVAL_MS
   });
   await waitForInteractionStart(page, beforeMetrics);
+};
+
+const runControlledWheelTiming = (page, geometry) => page.evaluate(
+  ({ x, y, steps, intervalMs, settleMs }) => new Promise((resolve, reject) => {
+    const probe = window.__GBDRAW_LARGE_PREVIEW_RESPONSIVENESS_PROBE__;
+    if (!probe) {
+      reject(new Error('The P0 responsiveness probe is unavailable.'));
+      return;
+    }
+    probe.beginMeasurement();
+    let index = 0;
+    const dispatchWheel = () => {
+      const target = document.elementFromPoint(x, y);
+      if (!target) {
+        reject(new Error('The controlled wheel target left the viewport.'));
+        return;
+      }
+      probe.recordDispatch();
+      target.dispatchEvent(new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        deltaY: index < steps / 2 ? -100 : 100,
+        view: window
+      }));
+      index += 1;
+      if (index < steps) {
+        setTimeout(dispatchWheel, intervalMs);
+      } else {
+        setTimeout(() => resolve(probe.endMeasurement()), settleMs);
+      }
+    };
+    dispatchWheel();
+  }),
+  {
+    x: geometry.zoomPoint.x,
+    y: geometry.zoomPoint.y,
+    steps: WHEEL_STEPS,
+    intervalMs: WHEEL_INTERVAL_MS,
+    settleMs: CONTROLLED_TIMING_SETTLE_MS
+  }
+);
+
+const runNativeWheelDiagnostic = async (page, geometry) => {
+  await page.mouse.move(geometry.zoomPoint.x, geometry.zoomPoint.y);
+  await page.evaluate(() => {
+    window.__GBDRAW_LARGE_PREVIEW_RESPONSIVENESS_PROBE__.beginMeasurement();
+  });
+  const pendingDispatches = [];
+  await new Promise((resolveSchedule) => {
+    let index = 0;
+    const dispatchWheel = () => {
+      pendingDispatches.push(page.mouse.wheel(
+        0,
+        index < WHEEL_STEPS / 2 ? -100 : 100
+      ));
+      index += 1;
+      if (index < WHEEL_STEPS) {
+        setTimeout(dispatchWheel, WHEEL_INTERVAL_MS);
+      } else {
+        resolveSchedule();
+      }
+    };
+    dispatchWheel();
+  });
+  await Promise.all(pendingDispatches);
+  await page.waitForTimeout(CONTROLLED_TIMING_SETTLE_MS);
+  return page.evaluate(() => (
+    window.__GBDRAW_LARGE_PREVIEW_RESPONSIVENESS_PROBE__.endMeasurement()
+  ));
+};
+
+const collectWarmResponsivenessSample = async ({
+  browser,
+  testInfo,
+  trackLifecycle = false,
+  nativeInput = false
+}) => {
+  const context = await browser.newContext({
+    baseURL: testInfo.project.use.baseURL,
+    viewport: { width: 1440, height: 1000 }
+  });
+  const page = await context.newPage();
+  page.setDefaultTimeout(INTERACTION_TIMEOUT_MS);
+  const dialogs = [];
+  const pageErrors = [];
+  const consoleErrors = [];
+  page.on('dialog', async (dialog) => {
+    dialogs.push(dialog.message());
+    await dialog.accept();
+  });
+  page.on('pageerror', (error) => pageErrors.push(String(error?.message || error)));
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+
+  try {
+    await installResponsivenessProbe(page, { trackLifecycle });
+    await openExactApp(page);
+    await loadExactSession(page, dialogs, { browserFetch: true });
+    await ensureDenseRegionVisible(page);
+    const geometry = await readGeometry(page);
+    await warmOrdinaryFeatureHover(page, geometry);
+    const timing = nativeInput
+      ? await runNativeWheelDiagnostic(page, geometry)
+      : await runControlledWheelTiming(page, geometry);
+    return {
+      fixtureSha,
+      geometry,
+      schedule: {
+        viewport: { width: 1440, height: 1000 },
+        requestedEvents: WHEEL_STEPS,
+        sequence: '15 zoom-in + 15 zoom-out',
+        nominalIntervalMs: WHEEL_INTERVAL_MS,
+        delivery: nativeInput
+          ? 'Playwright mouse wheel input'
+          : 'controlled browser-timer synthetic WheelEvent',
+        postInputSettleMs: CONTROLLED_TIMING_SETTLE_MS
+      },
+      timing,
+      pageErrors,
+      consoleErrors
+    };
+  } finally {
+    await context.close();
+  }
 };
 
 const workerTotals = (activity) => ({
@@ -867,77 +1209,130 @@ const assertStructuralContract = ({ interaction, summary, workerDelta }) => {
   }
 };
 
-test.describe.configure({ mode: 'serial' });
+test.describe('Structural Contract', () => {
+  test.describe.configure({ mode: 'serial' });
 
-for (const interaction of ['pan', 'wheel']) {
-  for (const thermalState of ['cold', 'warm']) {
-    test(`${thermalState} sustained ${interaction} preserves the exact-fixture interaction contract`, async ({
-      page,
-      browser
-    }, testInfo) => {
-      test.setTimeout(1_800_000);
-      page.setDefaultTimeout(INTERACTION_TIMEOUT_MS);
-      await page.setViewportSize({ width: 1440, height: 1000 });
-      expect(fixtureSha).toBe(EXPECTED_FIXTURE_SHA);
+  for (const interaction of ['pan', 'wheel']) {
+    for (const thermalState of ['cold', 'warm']) {
+      test(`${thermalState} sustained ${interaction} preserves the exact-fixture interaction contract`, async ({
+        page,
+        browser
+      }, testInfo) => {
+        test.setTimeout(1_800_000);
+        page.setDefaultTimeout(INTERACTION_TIMEOUT_MS);
+        await page.setViewportSize({ width: 1440, height: 1000 });
+        expect(fixtureSha).toBe(EXPECTED_FIXTURE_SHA);
 
-      const dialogs = [];
-      const pageErrors = [];
-      const consoleErrors = [];
-      page.on('dialog', async (dialog) => {
-        dialogs.push(dialog.message());
-        await dialog.accept();
+        const dialogs = [];
+        const pageErrors = [];
+        const consoleErrors = [];
+        page.on('dialog', async (dialog) => {
+          dialogs.push(dialog.message());
+          await dialog.accept();
+        });
+        page.on('pageerror', (error) => pageErrors.push(String(error?.message || error)));
+        page.on('console', (message) => {
+          if (message.type() === 'error') consoleErrors.push(message.text());
+        });
+
+        await installInteractionProbe(page);
+        await openExactApp(page, { structural: true });
+        await loadExactSession(page, dialogs);
+        await ensureDenseRegionVisible(page);
+        const geometry = await readGeometry(page);
+        const loadWorker = workerTotals(await getDiagramWorkerActivity(page));
+        expect(loadWorker).toEqual({ constructions: 0, initializations: 0, helpers: 0, runs: 0 });
+
+        const prewarmMetricDelta = thermalState === 'warm'
+          ? await prewarmHoverIndexes(page, geometry)
+          : {};
+        const begin = await startMeasurement(page, `${thermalState}-${interaction}`);
+        expect(begin.transition).toEqual({
+          property: 'transform',
+          duration: '0.2s',
+          timingFunction: 'ease',
+          delay: '0s'
+        });
+
+        const gestureStartedAt = Date.now();
+        if (interaction === 'pan') {
+          await runPan(page, geometry, begin.metricBefore);
+        } else {
+          await runWheel(page, geometry, begin.metricBefore);
+        }
+        await waitForInteractionEnd(page, begin.metricBefore);
+        const gestureWallDurationMs = Date.now() - gestureStartedAt;
+        await page.waitForTimeout(POST_INTERACTION_SETTLE_MS);
+        const summary = await page.evaluate(() => (
+          window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.endMeasurement()
+        ));
+        const afterWorker = workerTotals(await getDiagramWorkerActivity(page));
+        const workerDelta = subtractWorkerTotals(loadWorker, afterWorker);
+        console.log(`GBDRAW_LARGE_PREVIEW_INTERACTION_PREASSERT ${JSON.stringify({
+          profile: { thermalState, interaction },
+          geometry,
+          summary,
+          workerDelta
+        })}`);
+        assertStructuralContract({ interaction, summary, workerDelta });
+        await assertPostSettleInteraction(page);
+
+        expect(pageErrors).toEqual([]);
+        expect(consoleErrors).toEqual([]);
+        const evidence = {
+          fixtureSha,
+          browser: {
+            project: testInfo.project.name,
+            version: browser.version(),
+            platform: process.platform,
+            node: process.version,
+            osRelease: os.release()
+          },
+          profile: { thermalState, interaction },
+          schedule: {
+            viewport: { width: 1440, height: 1000 },
+            panSteps: PAN_STEPS,
+            panIntervalMs: PAN_INTERVAL_MS,
+            wheelSteps: WHEEL_STEPS,
+            wheelIntervalMs: WHEEL_INTERVAL_MS,
+            wheelDelivery: 'browser-timer-dispatched WheelEvent',
+            postInteractionSettleMs: POST_INTERACTION_SETTLE_MS
+          },
+          geometry,
+          prewarmMetricDelta,
+          gestureWallDurationMs,
+          workerBefore: loadWorker,
+          workerAfter: afterWorker,
+          workerDelta,
+          summary,
+          pageErrors,
+          consoleErrors
+        };
+        console.log(`GBDRAW_LARGE_PREVIEW_INTERACTION_EVIDENCE ${JSON.stringify(evidence)}`);
+        await testInfo.attach(`${thermalState}-${interaction}-evidence.json`, {
+          body: Buffer.from(JSON.stringify(evidence, null, 2)),
+          contentType: 'application/json'
+        });
       });
-      page.on('pageerror', (error) => pageErrors.push(String(error?.message || error)));
-      page.on('console', (message) => {
-        if (message.type() === 'error') consoleErrors.push(message.text());
-      });
+    }
+  }
+});
 
-      await installInteractionProbe(page);
-      await openApp(page);
-      await loadExactSession(page, dialogs);
-      await ensureDenseRegionVisible(page);
-      const geometry = await readGeometry(page);
-      const loadWorker = workerTotals(await getDiagramWorkerActivity(page));
-      expect(loadWorker).toEqual({ constructions: 0, initializations: 0, helpers: 0, runs: 0 });
-
-      const prewarmMetricDelta = thermalState === 'warm'
-        ? await prewarmHoverIndexes(page, geometry)
-        : {};
-      const begin = await startMeasurement(page, `${thermalState}-${interaction}`);
-      expect(begin.transition).toEqual({
-        property: 'transform',
-        duration: '0.2s',
-        timingFunction: 'ease',
-        delay: '0s'
-      });
-
-      const gestureStartedAt = Date.now();
-      if (interaction === 'pan') {
-        await runPan(page, geometry, begin.metricBefore);
-      } else {
-        await runWheel(page, geometry, begin.metricBefore);
-      }
-      await waitForInteractionEnd(page, begin.metricBefore);
-      const gestureWallDurationMs = Date.now() - gestureStartedAt;
-      await page.waitForTimeout(POST_INTERACTION_SETTLE_MS);
-      const summary = await page.evaluate(() => (
-        window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.endMeasurement()
-      ));
-      const afterWorker = workerTotals(await getDiagramWorkerActivity(page));
-      const workerDelta = subtractWorkerTotals(loadWorker, afterWorker);
-      console.log(`GBDRAW_LARGE_PREVIEW_INTERACTION_PREASSERT ${JSON.stringify({
-        profile: { thermalState, interaction },
-        geometry,
-        summary,
-        workerDelta
-      })}`);
-      assertStructuralContract({ interaction, summary, workerDelta });
-      await assertPostSettleInteraction(page);
-
-      expect(pageErrors).toEqual([]);
-      expect(consoleErrors).toEqual([]);
-      const evidence = {
-        fixtureSha,
+test.describe('Low-overhead responsiveness guardrail', () => {
+  test('warm controlled synthetic wheel stays below the calibrated Chromium limit', async ({
+    browser
+  }, testInfo) => {
+    test.skip(
+      testInfo.config.metadata?.gbdrawPerformanceProfile !== true,
+      'The timing guardrail requires the dedicated serial performance profile.'
+    );
+    test.setTimeout(1_800_000);
+    expect(fixtureSha).toBe(EXPECTED_FIXTURE_SHA);
+    const samples = [];
+    for (let repetition = 1; repetition <= RESPONSIVENESS_REPETITIONS; repetition += 1) {
+      const sample = await collectWarmResponsivenessSample({ browser, testInfo });
+      console.log(`GBDRAW_LARGE_PREVIEW_RESPONSIVENESS_SAMPLE ${JSON.stringify({
+        repetition,
         browser: {
           project: testInfo.project.name,
           version: browser.version(),
@@ -945,31 +1340,69 @@ for (const interaction of ['pan', 'wheel']) {
           node: process.version,
           osRelease: os.release()
         },
-        profile: { thermalState, interaction },
-        schedule: {
-          viewport: { width: 1440, height: 1000 },
-          panSteps: PAN_STEPS,
-          panIntervalMs: PAN_INTERVAL_MS,
-          wheelSteps: WHEEL_STEPS,
-          wheelIntervalMs: WHEEL_INTERVAL_MS,
-          wheelDelivery: 'browser-timer-dispatched WheelEvent',
-          postInteractionSettleMs: POST_INTERACTION_SETTLE_MS
-        },
-        geometry,
-        prewarmMetricDelta,
-        gestureWallDurationMs,
-        workerBefore: loadWorker,
-        workerAfter: afterWorker,
-        workerDelta,
-        summary,
-        pageErrors,
-        consoleErrors
-      };
-      console.log(`GBDRAW_LARGE_PREVIEW_INTERACTION_EVIDENCE ${JSON.stringify(evidence)}`);
-      await testInfo.attach(`${thermalState}-${interaction}-evidence.json`, {
-        body: Buffer.from(JSON.stringify(evidence, null, 2)),
-        contentType: 'application/json'
-      });
+        ...sample
+      })}`);
+      expect(sample.timing.longTasks.supported).toBe(true);
+      expect(sample.timing.deliveredEventCount).toBe(WHEEL_STEPS);
+      expect(sample.timing.raf.count).toBeGreaterThan(0);
+      expect(sample.pageErrors).toEqual([]);
+      expect(sample.consoleErrors).toEqual([]);
+      samples.push(sample.timing);
+    }
+    const aggregate = aggregateResponsivenessSamples(samples);
+    const guardrailApplied = testInfo.project.name === 'chromium';
+    const violations = guardrailApplied
+      ? evaluateResponsivenessGuardrail(aggregate, RESPONSIVENESS_THRESHOLDS)
+      : [];
+    const evidence = {
+      repetitions: RESPONSIVENESS_REPETITIONS,
+      guardrailApplied,
+      thresholds: RESPONSIVENESS_THRESHOLDS,
+      aggregate,
+      violations,
+      samples
+    };
+    console.log(`GBDRAW_LARGE_PREVIEW_RESPONSIVENESS_AGGREGATE ${JSON.stringify(evidence)}`);
+    await testInfo.attach('warm-controlled-wheel-responsiveness.json', {
+      body: Buffer.from(JSON.stringify(evidence, null, 2)),
+      contentType: 'application/json'
     });
-  }
-}
+    if (guardrailApplied) expect(violations, JSON.stringify(evidence, null, 2)).toEqual([]);
+  });
+});
+
+test.describe('Native headless diagnostic', () => {
+  test('warm Playwright wheel delivery is reported without an absolute timing gate', async ({
+    browser
+  }, testInfo) => {
+    test.skip(
+      testInfo.config.metadata?.gbdrawPerformanceProfile !== true,
+      'The native-input diagnostic requires the dedicated serial performance profile.'
+    );
+    test.setTimeout(1_800_000);
+    expect(fixtureSha).toBe(EXPECTED_FIXTURE_SHA);
+    const sample = await collectWarmResponsivenessSample({
+      browser,
+      testInfo,
+      trackLifecycle: true,
+      nativeInput: true
+    });
+    const evidence = {
+      browser: {
+        project: testInfo.project.name,
+        version: browser.version(),
+        platform: process.platform,
+        node: process.version,
+        osRelease: os.release()
+      },
+      ...sample,
+      coalescingRatio: sample.timing.deliveredEventCount / WHEEL_STEPS,
+      quietWindowSplitCount: sample.timing.lifecycle.interactionStarts
+    };
+    console.log(`GBDRAW_LARGE_PREVIEW_NATIVE_HEADLESS_DIAGNOSTIC ${JSON.stringify(evidence)}`);
+    expect(sample.timing.deliveredEventCount).toBeGreaterThan(0);
+    expect(sample.timing.raf.count).toBeGreaterThan(0);
+    expect(sample.pageErrors).toEqual([]);
+    expect(sample.consoleErrors).toEqual([]);
+  });
+});

--- a/tests/web/large-preview-transform-interaction.performance.playwright.spec.js
+++ b/tests/web/large-preview-transform-interaction.performance.playwright.spec.js
@@ -1,0 +1,975 @@
+const { test, expect } = require('@playwright/test');
+const { createHash } = require('node:crypto');
+const { readFileSync } = require('node:fs');
+const os = require('node:os');
+const { join, resolve } = require('node:path');
+const {
+  getDiagramWorkerActivity,
+  openApp
+} = require('./helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const fixturePath = join(
+  repoRoot,
+  'gbdraw',
+  'web',
+  'gallery',
+  'sessions',
+  'hepatoplasmataceae_collinear.gbdraw-session.json.gz'
+);
+const EXPECTED_FIXTURE_SHA = '2afba7111520b9dd7b00dffd351a1f4a21d4e0d9bfbaebc25ba7b5a937288577';
+const fixtureSha = createHash('sha256').update(readFileSync(fixturePath)).digest('hex');
+const OPERATION_TIMEOUT_MS = 900_000;
+const INTERACTION_TIMEOUT_MS = 60_000;
+const PAN_STEPS = 150;
+const PAN_INTERVAL_MS = 16;
+const WHEEL_STEPS = 30;
+const WHEEL_INTERVAL_MS = 80;
+const POST_INTERACTION_SETTLE_MS = 300;
+const installInteractionProbe = (page) => page.addInitScript(() => {
+  const FEATURE_SELECTOR = [
+    'path[data-gbdraw-feature-id]',
+    'polygon[data-gbdraw-feature-id]',
+    'rect[data-gbdraw-feature-id]',
+    'path[id^="f"]',
+    'polygon[id^="f"]',
+    'rect[id^="f"]'
+  ].join(', ');
+  const MATCH_SELECTOR = [
+    'path[data-gbdraw-match-id]',
+    'path[data-gbdraw-pairwise-match-id]',
+    'path[data-match-kind]',
+    'path[data-pairwise-match-style]'
+  ].join(', ');
+  const metrics = Object.create(null);
+  const details = [];
+  const lifecycle = [];
+  const longTasks = [];
+  let measurement = null;
+  let transformInteractionActive = false;
+  let heartbeatLast = performance.now();
+  const nativeRequestAnimationFrame = window.requestAnimationFrame.bind(window);
+  const nativeCancelAnimationFrame = window.cancelAnimationFrame.bind(window);
+  const animationFrameOwners = new Map();
+
+  const currentWrapper = () => document.querySelector('.gbdraw-preview-surface');
+  const currentSvg = () => currentWrapper()?.querySelector?.('svg') || null;
+  const copyMetrics = () => Object.fromEntries(
+    Object.entries(metrics).map(([name, value]) => [name, Number(value || 0)])
+  );
+  const deltaMetrics = (before, after = metrics) => {
+    const names = new Set([...Object.keys(before || {}), ...Object.keys(after || {})]);
+    return Object.fromEntries([...names].sort().map((name) => [
+      name,
+      Number(after?.[name] || 0) - Number(before?.[name] || 0)
+    ]).filter(([, value]) => value !== 0));
+  };
+  const quantile = (values, probability) => {
+    if (values.length === 0) return 0;
+    const sorted = [...values].sort((left, right) => left - right);
+    const index = Math.min(
+      sorted.length - 1,
+      Math.max(0, Math.ceil(probability * sorted.length) - 1)
+    );
+    return sorted[index];
+  };
+  const summarizeIntervals = (values) => ({
+    count: values.length,
+    p50Ms: quantile(values, 0.5),
+    p90Ms: quantile(values, 0.9),
+    p95Ms: quantile(values, 0.95),
+    p99Ms: quantile(values, 0.99),
+    maximumGapMs: values.length ? Math.max(...values) : 0,
+    over33ms: values.filter((value) => value > 33).length,
+    over50ms: values.filter((value) => value > 50).length,
+    over100ms: values.filter((value) => value > 100).length
+  });
+  const emptyMutationCounts = () => ({
+    featureMatchStyle: 0,
+    featureMatchOpacityFilter: 0,
+    featureMatchHoverState: 0,
+    featureMatchCursorStyle: 0,
+    wrapperStyle: 0
+  });
+  const emptyEventCounts = () => ({
+    mouseover: 0,
+    mouseout: 0,
+    mousemove: 0,
+    pointermove: 0,
+    wheel: 0
+  });
+  const isFeatureOrMatch = (element) => Boolean(
+    element?.matches?.(FEATURE_SELECTOR) || element?.matches?.(MATCH_SELECTOR)
+  );
+  const styleTouches = (record, names) => {
+    const pattern = new RegExp(`(?:^|;)\\s*(?:${names.join('|')})\\s*:`, 'i');
+    return pattern.test(String(record.oldValue || ''))
+      || pattern.test(String(record.target?.getAttribute?.('style') || ''));
+  };
+  const shouldCountActive = () => Boolean(
+    measurement?.sustainedStarted && transformInteractionActive
+  );
+
+  const processSvgMutations = (records) => {
+    if (!measurement) return;
+    for (const record of records) {
+      if (!isFeatureOrMatch(record.target)) continue;
+      const name = String(record.attributeName || '').toLowerCase();
+      const active = shouldCountActive();
+      if (name === 'style') {
+        measurement.totalMutations.featureMatchStyle += 1;
+        if (active) measurement.activeMutations.featureMatchStyle += 1;
+        if (styleTouches(record, ['opacity', 'filter'])) {
+          measurement.totalMutations.featureMatchOpacityFilter += 1;
+          if (active) measurement.activeMutations.featureMatchOpacityFilter += 1;
+        }
+        if (styleTouches(record, ['cursor'])) {
+          measurement.totalMutations.featureMatchCursorStyle += 1;
+          if (active) measurement.activeMutations.featureMatchCursorStyle += 1;
+        }
+      }
+      if (name === 'opacity' || name === 'filter') {
+        measurement.totalMutations.featureMatchOpacityFilter += 1;
+        if (active) measurement.activeMutations.featureMatchOpacityFilter += 1;
+      }
+      if (name === 'data-gbdraw-hover-opacity' || name === 'data-gbdraw-hover-filter') {
+        measurement.totalMutations.featureMatchHoverState += 1;
+        if (active) measurement.activeMutations.featureMatchHoverState += 1;
+      }
+    }
+  };
+  const processWrapperMutations = (records) => {
+    if (!measurement) return;
+    for (const record of records) {
+      if (record.attributeName !== 'style') continue;
+      measurement.totalMutations.wrapperStyle += 1;
+      if (shouldCountActive()) measurement.activeMutations.wrapperStyle += 1;
+    }
+  };
+
+  let longTaskSupported = false;
+  try {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        longTasks.push({
+          startTime: Number(entry.startTime || 0),
+          duration: Number(entry.duration || 0)
+        });
+      }
+    });
+    observer.observe({ type: 'longtask', buffered: true });
+    longTaskSupported = true;
+  } catch (_error) {
+    longTaskSupported = false;
+  }
+
+  setInterval(() => {
+    const now = performance.now();
+    const gap = now - heartbeatLast;
+    heartbeatLast = now;
+    if (!measurement) return;
+    measurement.heartbeatCount += 1;
+    measurement.maximumHeartbeatGapMs = Math.max(measurement.maximumHeartbeatGapMs, gap);
+    if (performance.memory) {
+      measurement.memoryHighWaterBytes = Math.max(
+        measurement.memoryHighWaterBytes,
+        Number(performance.memory.usedJSHeapSize || 0)
+      );
+    }
+  }, 100);
+
+  const nativeQuerySelectorAll = Element.prototype.querySelectorAll;
+  Element.prototype.querySelectorAll = function measuredQuerySelectorAll(selector) {
+    const active = shouldCountActive() && this === currentSvg();
+    const result = nativeQuerySelectorAll.call(this, selector);
+    if (active) {
+      const key = String(selector);
+      measurement.activeSvgQueries[key] = Number(measurement.activeSvgQueries[key] || 0) + 1;
+    }
+    return result;
+  };
+
+  ['mouseover', 'mouseout', 'mousemove', 'pointermove', 'wheel'].forEach((type) => {
+    window.addEventListener(type, (event) => {
+      if (!measurement) return;
+      const svg = currentSvg();
+      if (!svg || (!svg.contains(event.target) && !svg.contains(event.relatedTarget))) return;
+      measurement.totalEvents[type] += 1;
+      if (shouldCountActive()) measurement.activeEvents[type] += 1;
+    }, true);
+  });
+
+  ['mousedown', 'mouseup', 'mouseleave', 'pointercancel', 'lostpointercapture'].forEach((type) => {
+    window.addEventListener(type, (event) => {
+      if (!measurement || event.target !== window.__GBDRAW_APP__?.canvasContainerRef) return;
+      measurement.panBoundaryEvents.push({
+        type,
+        timestamp: performance.now(),
+        clientX: Number(event.clientX || 0),
+        clientY: Number(event.clientY || 0),
+        buttons: Number(event.buttons || 0),
+        pointerId: Number(event.pointerId || 0),
+        relatedTarget: event.relatedTarget?.tagName || null,
+        relatedTargetClass: event.relatedTarget?.getAttribute?.('class') || '',
+        interactionActive: transformInteractionActive
+      });
+    }, true);
+  });
+
+  const nativeAddEventListener = EventTarget.prototype.addEventListener;
+  const nativeRemoveEventListener = EventTarget.prototype.removeEventListener;
+  EventTarget.prototype.addEventListener = function measuredAddEventListener(type, listener, options) {
+    const result = nativeAddEventListener.call(this, type, listener, options);
+    if (measurement && this === currentWrapper() && type === 'transitionend') {
+      measurement.listeners.transitionAdds += 1;
+      measurement.listeners.activeTransitionListeners.add(listener);
+      measurement.listeners.maximumTransitionListeners = Math.max(
+        measurement.listeners.maximumTransitionListeners,
+        measurement.listeners.activeTransitionListeners.size
+      );
+    }
+    if (
+      measurement
+      && this === currentSvg()
+      && ['mouseover', 'mouseout', 'mousemove', 'click', 'keydown'].includes(type)
+    ) {
+      measurement.listeners.delegatedAdds += 1;
+    }
+    return result;
+  };
+  EventTarget.prototype.removeEventListener = function measuredRemoveEventListener(type, listener, options) {
+    const result = nativeRemoveEventListener.call(this, type, listener, options);
+    if (measurement && this === currentWrapper() && type === 'transitionend') {
+      measurement.listeners.transitionRemoves += 1;
+      measurement.listeners.activeTransitionListeners.delete(listener);
+    }
+    if (
+      measurement
+      && this === currentSvg()
+      && ['mouseover', 'mouseout', 'mousemove', 'click', 'keydown'].includes(type)
+    ) {
+      measurement.listeners.delegatedRemoves += 1;
+    }
+    return result;
+  };
+
+  window.requestAnimationFrame = (callback) => {
+    let frameId = null;
+    const wrapped = (timestamp) => {
+      const owner = animationFrameOwners.get(frameId);
+      owner?.frames.live.delete(frameId);
+      animationFrameOwners.delete(frameId);
+      callback(timestamp);
+    };
+    frameId = nativeRequestAnimationFrame(wrapped);
+    if (measurement) {
+      animationFrameOwners.set(frameId, measurement);
+      measurement.frames.requests += 1;
+      measurement.frames.live.add(frameId);
+      measurement.frames.maximumLive = Math.max(
+        measurement.frames.maximumLive,
+        measurement.frames.live.size
+      );
+    }
+    return frameId;
+  };
+  window.cancelAnimationFrame = (frameId) => {
+    const owner = animationFrameOwners.get(frameId);
+    if (owner) {
+      owner.frames.cancellations += 1;
+      owner.frames.live.delete(frameId);
+      animationFrameOwners.delete(frameId);
+    }
+    return nativeCancelAnimationFrame(frameId);
+  };
+
+  const nativeSetTimeout = window.setTimeout.bind(window);
+  const nativeClearTimeout = window.clearTimeout.bind(window);
+  window.setTimeout = (callback, delay = 0, ...args) => {
+    const numericDelay = Number(delay || 0);
+    const tracked = Boolean(measurement && (numericDelay === 220 || numericDelay === 260));
+    let timerId = null;
+    const wrapped = (...callbackArgs) => {
+      if (tracked && measurement) {
+        measurement.timers.liveByDelay[numericDelay].delete(timerId);
+      }
+      if (typeof callback === 'function') return callback(...callbackArgs);
+      return undefined;
+    };
+    timerId = nativeSetTimeout(wrapped, delay, ...args);
+    if (tracked) {
+      measurement.timers.setsByDelay[numericDelay] += 1;
+      measurement.timers.liveByDelay[numericDelay].add(timerId);
+      measurement.timers.maximumLiveByDelay[numericDelay] = Math.max(
+        measurement.timers.maximumLiveByDelay[numericDelay],
+        measurement.timers.liveByDelay[numericDelay].size
+      );
+    }
+    return timerId;
+  };
+  window.clearTimeout = (timerId) => {
+    if (measurement) {
+      for (const delay of [220, 260]) {
+        if (measurement.timers.liveByDelay[delay].delete(timerId)) {
+          measurement.timers.clearsByDelay[delay] += 1;
+        }
+      }
+    }
+    return nativeClearTimeout(timerId);
+  };
+
+  const beginMeasurement = (label) => {
+    if (measurement) throw new Error('An interaction measurement is already active.');
+    const wrapper = currentWrapper();
+    const svg = currentSvg();
+    if (!wrapper || !svg) throw new Error('The exact-fixture preview is not mounted.');
+    const result = window.__GBDRAW_APP__?.results?.[
+      Number(window.__GBDRAW_APP__?.selectedResultIndex || 0)
+    ];
+    const startedAt = performance.now();
+    measurement = {
+      label,
+      startedAt,
+      metricBefore: copyMetrics(),
+      activeMetricBefore: null,
+      activeMetricAfter: null,
+      detailStart: details.length,
+      lifecycleStart: lifecycle.length,
+      resultReferenceBefore: result,
+      resultBefore: String(result?.content || ''),
+      resultCountBefore: Number(window.__GBDRAW_APP__?.results?.length || 0),
+      selectedResultIndexBefore: Number(window.__GBDRAW_APP__?.selectedResultIndex || 0),
+      sustainedStarted: false,
+      totalEvents: emptyEventCounts(),
+      activeEvents: emptyEventCounts(),
+      totalMutations: emptyMutationCounts(),
+      activeMutations: emptyMutationCounts(),
+      activeSvgQueries: Object.create(null),
+      panBoundaryEvents: [],
+      rafIntervals: [],
+      rafLast: null,
+      heartbeatCount: 0,
+      maximumHeartbeatGapMs: 0,
+      memoryStartBytes: Number(performance.memory?.usedJSHeapSize || 0),
+      memoryHighWaterBytes: Number(performance.memory?.usedJSHeapSize || 0),
+      listeners: {
+        transitionAdds: 0,
+        transitionRemoves: 0,
+        maximumTransitionListeners: 0,
+        activeTransitionListeners: new Set(),
+        delegatedAdds: 0,
+        delegatedRemoves: 0
+      },
+      frames: {
+        requests: 0,
+        cancellations: 0,
+        maximumLive: 0,
+        live: new Set()
+      },
+      timers: {
+        setsByDelay: { 220: 0, 260: 0 },
+        clearsByDelay: { 220: 0, 260: 0 },
+        maximumLiveByDelay: { 220: 0, 260: 0 },
+        liveByDelay: { 220: new Set(), 260: new Set() }
+      },
+      svgObserver: new MutationObserver(processSvgMutations),
+      wrapperObserver: new MutationObserver(processWrapperMutations)
+    };
+    measurement.svgObserver.observe(svg, {
+      subtree: true,
+      attributes: true,
+      attributeOldValue: true
+    });
+    measurement.wrapperObserver.observe(wrapper, {
+      attributes: true,
+      attributeFilter: ['style'],
+      attributeOldValue: true
+    });
+    heartbeatLast = startedAt;
+    const activeMeasurement = measurement;
+    const rafTick = (timestamp) => {
+      if (measurement !== activeMeasurement) return;
+      if (activeMeasurement.rafLast !== null) {
+        activeMeasurement.rafIntervals.push(timestamp - activeMeasurement.rafLast);
+      }
+      activeMeasurement.rafLast = timestamp;
+      if (performance.memory) {
+        activeMeasurement.memoryHighWaterBytes = Math.max(
+          activeMeasurement.memoryHighWaterBytes,
+          Number(performance.memory.usedJSHeapSize || 0)
+        );
+      }
+      nativeRequestAnimationFrame(rafTick);
+    };
+    nativeRequestAnimationFrame(rafTick);
+    const style = getComputedStyle(wrapper);
+    return {
+      metricBefore: { ...measurement.metricBefore },
+      transition: {
+        property: style.transitionProperty,
+        duration: style.transitionDuration,
+        timingFunction: style.transitionTimingFunction,
+        delay: style.transitionDelay
+      }
+    };
+  };
+
+  const markSustainedWindow = () => {
+    if (!measurement || !transformInteractionActive) {
+      throw new Error('Cannot mark a sustained window before transform interaction activation.');
+    }
+    processSvgMutations(measurement.svgObserver.takeRecords());
+    processWrapperMutations(measurement.wrapperObserver.takeRecords());
+    measurement.activeEvents = emptyEventCounts();
+    measurement.activeMutations = emptyMutationCounts();
+    measurement.activeSvgQueries = Object.create(null);
+    measurement.activeMetricBefore = copyMetrics();
+    measurement.sustainedStarted = true;
+  };
+
+  const endMeasurement = async () => {
+    if (!measurement) throw new Error('No interaction measurement is active.');
+    const activeMeasurement = measurement;
+    await new Promise((resolve) => nativeRequestAnimationFrame(() => (
+      nativeRequestAnimationFrame(resolve)
+    )));
+    processSvgMutations(activeMeasurement.svgObserver.takeRecords());
+    processWrapperMutations(activeMeasurement.wrapperObserver.takeRecords());
+    const endedAt = performance.now();
+    activeMeasurement.svgObserver.disconnect();
+    activeMeasurement.wrapperObserver.disconnect();
+    const result = window.__GBDRAW_APP__?.results?.[
+      Number(window.__GBDRAW_APP__?.selectedResultIndex || 0)
+    ];
+    const phaseLongTasks = longTasks.filter((entry) => (
+      entry.startTime >= activeMeasurement.startedAt && entry.startTime <= endedAt
+    ));
+    const wrapper = currentWrapper();
+    const style = wrapper ? getComputedStyle(wrapper) : null;
+    const summary = {
+      label: activeMeasurement.label,
+      wallDurationMs: endedAt - activeMeasurement.startedAt,
+      interactionActiveAtEnd: transformInteractionActive,
+      raf: summarizeIntervals(activeMeasurement.rafIntervals),
+      heartbeat: {
+        count: activeMeasurement.heartbeatCount,
+        maximumGapMs: activeMeasurement.maximumHeartbeatGapMs
+      },
+      longTasks: {
+        supported: longTaskSupported,
+        count: phaseLongTasks.length,
+        totalDurationMs: phaseLongTasks.reduce((total, entry) => total + entry.duration, 0),
+        longestDurationMs: phaseLongTasks.length
+          ? Math.max(...phaseLongTasks.map((entry) => entry.duration))
+          : 0
+      },
+      memory: {
+        supported: Boolean(performance.memory),
+        startBytes: activeMeasurement.memoryStartBytes,
+        highWaterBytes: activeMeasurement.memoryHighWaterBytes,
+        highWaterDeltaBytes:
+          activeMeasurement.memoryHighWaterBytes - activeMeasurement.memoryStartBytes
+      },
+      totalEvents: { ...activeMeasurement.totalEvents },
+      activeEvents: { ...activeMeasurement.activeEvents },
+      totalMutations: { ...activeMeasurement.totalMutations },
+      activeMutations: { ...activeMeasurement.activeMutations },
+      activeSvgQueries: { ...activeMeasurement.activeSvgQueries },
+      panBoundaryEvents: activeMeasurement.panBoundaryEvents.map((entry) => ({ ...entry })),
+      structuralMetricDelta: deltaMetrics(activeMeasurement.metricBefore),
+      activeStructuralMetricDelta: deltaMetrics(
+        activeMeasurement.activeMetricBefore || {},
+        activeMeasurement.activeMetricAfter || copyMetrics()
+      ),
+      structuralDetails: details.slice(activeMeasurement.detailStart).map((entry) => ({ ...entry })),
+      lifecycleEvents: lifecycle.slice(activeMeasurement.lifecycleStart).map((entry) => ({ ...entry })),
+      listeners: {
+        transitionAdds: activeMeasurement.listeners.transitionAdds,
+        transitionRemoves: activeMeasurement.listeners.transitionRemoves,
+        maximumTransitionListeners: activeMeasurement.listeners.maximumTransitionListeners,
+        activeTransitionListeners: activeMeasurement.listeners.activeTransitionListeners.size,
+        delegatedAdds: activeMeasurement.listeners.delegatedAdds,
+        delegatedRemoves: activeMeasurement.listeners.delegatedRemoves
+      },
+      frames: {
+        requests: activeMeasurement.frames.requests,
+        cancellations: activeMeasurement.frames.cancellations,
+        maximumLive: activeMeasurement.frames.maximumLive,
+        live: activeMeasurement.frames.live.size
+      },
+      timers: {
+        setsByDelay: { ...activeMeasurement.timers.setsByDelay },
+        clearsByDelay: { ...activeMeasurement.timers.clearsByDelay },
+        maximumLiveByDelay: { ...activeMeasurement.timers.maximumLiveByDelay },
+        liveByDelay: {
+          220: activeMeasurement.timers.liveByDelay[220].size,
+          260: activeMeasurement.timers.liveByDelay[260].size
+        }
+      },
+      result: {
+        sameObject: activeMeasurement.resultReferenceBefore === result,
+        unchanged: activeMeasurement.resultBefore === String(result?.content || ''),
+        sameCount:
+          activeMeasurement.resultCountBefore
+            === Number(window.__GBDRAW_APP__?.results?.length || 0),
+        sameSelectedIndex:
+          activeMeasurement.selectedResultIndexBefore
+            === Number(window.__GBDRAW_APP__?.selectedResultIndex || 0),
+        beforeLength: activeMeasurement.resultBefore.length,
+        afterLength: String(result?.content || '').length
+      },
+      transition: style ? {
+        property: style.transitionProperty,
+        duration: style.transitionDuration,
+        timingFunction: style.transitionTimingFunction,
+        delay: style.transitionDelay
+      } : null
+    };
+    measurement = null;
+    return summary;
+  };
+
+  window.__GBDRAW_TEST_HOOKS__ = {
+    onStructuralMetric(metric) {
+      const name = String(metric?.name || '');
+      metrics[name] = Number(metrics[name] || 0) + Number(metric?.value || 0);
+      details.push({ ...metric, timestamp: performance.now() });
+      if (name === 'previewTransformInteractionStartCount') {
+        transformInteractionActive = true;
+      } else if (name === 'previewTransformHoverCleanupCount') {
+        if (measurement && transformInteractionActive && !measurement.sustainedStarted) {
+          markSustainedWindow();
+        }
+      } else if (name === 'previewTransformInteractionEndCount') {
+        if (measurement?.sustainedStarted) measurement.activeMetricAfter = copyMetrics();
+        transformInteractionActive = false;
+      }
+    },
+    onSessionLifecycleEvent(event) {
+      lifecycle.push({ ...event, timestamp: performance.now() });
+    }
+  };
+
+  window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__ = {
+    beginMeasurement,
+    endMeasurement,
+    snapshot() {
+      return {
+        metrics: copyMetrics(),
+        lifecycle: lifecycle.map((entry) => ({ ...entry })),
+        transformInteractionActive
+      };
+    }
+  };
+});
+
+const loadExactSession = async (page, dialogs) => {
+  const chooserPromise = page.waitForEvent('filechooser', { timeout: OPERATION_TIMEOUT_MS });
+  await page.getByRole('button', { name: 'Load Session', exact: true }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles(fixturePath);
+  await page.waitForFunction(() => (
+    window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__?.snapshot?.().lifecycle.some(
+      (event) => event.name === 'interactiveReady'
+    )
+  ), null, { timeout: OPERATION_TIMEOUT_MS });
+  await page.evaluate(() => new Promise((resolveFrame) => (
+    requestAnimationFrame(() => requestAnimationFrame(resolveFrame))
+  )));
+  expect(dialogs).toContain('Session loaded successfully!');
+};
+
+const ensureDenseRegionVisible = (page) => page.evaluate(() => {
+  const wrapper = document.querySelector('.gbdraw-preview-surface');
+  const feature = wrapper?.querySelector?.(
+    '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"])'
+  );
+  feature?.scrollIntoView?.({ block: 'center', inline: 'center' });
+  return new Promise((resolveFrame) => requestAnimationFrame(() => requestAnimationFrame(resolveFrame)));
+});
+
+const readGeometry = (page) => page.evaluate(() => {
+  const wrapper = document.querySelector('.gbdraw-preview-surface');
+  const svg = wrapper?.querySelector?.('svg');
+  const container = window.__GBDRAW_APP__?.canvasContainerRef;
+  if (!wrapper || !svg || !container) throw new Error('Preview geometry is unavailable.');
+  const containerRect = container.getBoundingClientRect();
+  const wrapperRect = wrapper.getBoundingClientRect();
+  const viewport = {
+    left: Math.max(0, containerRect.left + 8),
+    right: Math.min(window.innerWidth, containerRect.right - 8),
+    top: Math.max(0, containerRect.top + 8),
+    bottom: Math.min(window.innerHeight, containerRect.bottom - 8)
+  };
+  const featureSelector =
+    '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"])';
+  const feature = svg.querySelector(featureSelector);
+  const featureRect = feature?.getBoundingClientRect?.();
+  if (!featureRect || featureRect.width <= 0 || featureRect.height <= 0) {
+    throw new Error('The selected rendered Feature has no visible geometry.');
+  }
+  const zoomPoint = {
+    x: Math.max(
+      viewport.left + 4,
+      Math.min(viewport.right - 4, (featureRect.left + featureRect.right) / 2)
+    ),
+    y: Math.max(
+      viewport.top + 4,
+      Math.min(viewport.bottom - 4, (featureRect.top + featureRect.bottom) / 2)
+    )
+  };
+  const editingSelector = [
+    '[data-gbdraw-feature-id]',
+    'path[id^="f"]',
+    'polygon[id^="f"]',
+    'rect[id^="f"]',
+    '[data-gbdraw-pairwise-match-id]',
+    '[data-match-kind]',
+    '[data-pairwise-match-style]',
+    '[data-collinearity-block-id]',
+    '[data-collinear-group-scope]',
+    'text[data-label-editable="true"]'
+  ].join(',');
+  const offsets = [0, -5, 5, -10, 10, -16, 16, -24, 24, -32, 32, -45, 45, -60, 60];
+  const visibleWrapperCenterY = (
+    Math.max(viewport.top, wrapperRect.top) + Math.min(viewport.bottom, wrapperRect.bottom)
+  ) / 2;
+  const yAnchors = [visibleWrapperCenterY, zoomPoint.y];
+  const centerX = (viewport.left + viewport.right) / 2;
+  const xCandidates = [0, -40, 40, -80, 80, -120, 120, -170, 170, -220, 220]
+    .map((delta) => centerX + delta);
+  let panPoint = null;
+  for (const yAnchor of yAnchors) {
+    for (const yOffset of offsets) {
+      const y = Math.max(viewport.top + 20, Math.min(viewport.bottom - 20, yAnchor + yOffset));
+      for (const rawX of xCandidates) {
+        const x = Math.max(viewport.left + 30, Math.min(viewport.right - 30, rawX));
+        const target = document.elementFromPoint(x, y);
+        if (!target || !wrapper.contains(target)) continue;
+        if (target.closest?.(editingSelector)) continue;
+        if (target.closest?.('button,input,textarea,select,a,[role="button"]')) continue;
+        panPoint = { x, y, tag: target.tagName, id: target.id || '' };
+        break;
+      }
+      if (panPoint) break;
+    }
+    if (panPoint) break;
+  }
+  if (!panPoint) throw new Error('Could not find a non-editing SVG background point.');
+  const panAmplitude = Math.max(40, Math.min(
+    180,
+    panPoint.x - viewport.left - 20,
+    viewport.right - panPoint.x - 20
+  ));
+  return {
+    viewport,
+    panPoint,
+    panAmplitude,
+    zoomPoint,
+    renderedFeatureElementCount: svg.querySelectorAll(featureSelector).length,
+    wrapperRect: wrapperRect.toJSON(),
+    svgRect: svg.getBoundingClientRect().toJSON()
+  };
+});
+
+const metricDelta = (before, after) => {
+  const names = new Set([...Object.keys(before || {}), ...Object.keys(after || {})]);
+  return Object.fromEntries([...names].sort().map((name) => [
+    name,
+    Number(after?.[name] || 0) - Number(before?.[name] || 0)
+  ]).filter(([, value]) => value !== 0));
+};
+
+const prewarmHoverIndexes = async (page, geometry) => {
+  const before = await page.evaluate(() => (
+    window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot().metrics
+  ));
+  const feature = page.locator(
+    '.gbdraw-preview-surface > svg '
+      + '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"])'
+  ).first();
+  await expect(feature).toBeVisible({ timeout: INTERACTION_TIMEOUT_MS });
+  await feature.hover();
+  await expect(feature).toHaveAttribute('data-gbdraw-hover-opacity', /.*/);
+  await page.mouse.move(geometry.panPoint.x, geometry.panPoint.y);
+  await page.waitForFunction(() => (
+    document.querySelector('.gbdraw-preview-surface > svg')
+      ?.querySelectorAll('[data-gbdraw-hover-opacity]').length === 0
+  ));
+  await page.waitForTimeout(100);
+  const after = await page.evaluate(() => (
+    window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot().metrics
+  ));
+  return metricDelta(before, after);
+};
+
+const startMeasurement = (page, label) => page.evaluate((phase) => (
+  window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.beginMeasurement(phase)
+), label);
+
+const waitForInteractionStart = async (page, beforeMetrics) => {
+  await page.waitForFunction((before) => {
+    const metrics = window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot().metrics;
+    return (
+      Number(metrics.previewTransformInteractionStartCount || 0)
+        > Number(before.previewTransformInteractionStartCount || 0)
+      && Number(metrics.previewTransformHoverCleanupCount || 0)
+        > Number(before.previewTransformHoverCleanupCount || 0)
+    );
+  }, beforeMetrics, { timeout: INTERACTION_TIMEOUT_MS });
+};
+
+const waitForInteractionEnd = (page, beforeMetrics) => page.waitForFunction((before) => {
+  const snapshot = window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.snapshot();
+  return (
+    !snapshot.transformInteractionActive
+    && Number(snapshot.metrics.previewTransformInteractionEndCount || 0)
+      > Number(before.previewTransformInteractionEndCount || 0)
+  );
+}, beforeMetrics, { timeout: INTERACTION_TIMEOUT_MS });
+
+const runPan = async (page, geometry, beforeMetrics) => {
+  const { x, y } = geometry.panPoint;
+  await page.mouse.move(x, y);
+  await page.mouse.down({ button: 'left' });
+  await waitForInteractionStart(page, beforeMetrics);
+  for (let index = 1; index <= PAN_STEPS; index += 1) {
+    const progress = index / PAN_STEPS;
+    await page.mouse.move(
+      x + geometry.panAmplitude * Math.sin(progress * Math.PI * 8),
+      y + 18 * Math.sin(progress * Math.PI * 16)
+    );
+    await page.waitForTimeout(PAN_INTERVAL_MS);
+  }
+  await page.mouse.move(x, y);
+  await page.mouse.up({ button: 'left' });
+};
+
+const runWheel = async (page, geometry, beforeMetrics) => {
+  await page.mouse.move(geometry.zoomPoint.x, geometry.zoomPoint.y);
+  await page.waitForTimeout(40);
+  await page.evaluate(({ x, y, steps, intervalMs }) => new Promise((resolve, reject) => {
+    let index = 0;
+    const dispatchWheel = () => {
+      const target = document.elementFromPoint(x, y);
+      if (!target) {
+        reject(new Error('The wheel target left the viewport.'));
+        return;
+      }
+      target.dispatchEvent(new WheelEvent('wheel', {
+        bubbles: true,
+        cancelable: true,
+        clientX: x,
+        clientY: y,
+        deltaY: index < 15 ? -100 : 100,
+        view: window
+      }));
+      index += 1;
+      if (index < steps) {
+        window.setTimeout(dispatchWheel, intervalMs);
+      } else {
+        resolve();
+      }
+    };
+    dispatchWheel();
+  }), {
+    x: geometry.zoomPoint.x,
+    y: geometry.zoomPoint.y,
+    steps: WHEEL_STEPS,
+    intervalMs: WHEEL_INTERVAL_MS
+  });
+  await waitForInteractionStart(page, beforeMetrics);
+};
+
+const workerTotals = (activity) => ({
+  constructions: Number(activity.constructions || 0),
+  initializations: Number(activity.initializations || 0),
+  helpers: Number(activity.helpers || 0),
+  runs: Number(activity.runs || 0)
+});
+
+const subtractWorkerTotals = (before, after) => Object.fromEntries(
+  Object.keys(before).map((name) => [name, Number(after[name] || 0) - Number(before[name] || 0)])
+);
+
+const assertPostSettleInteraction = async (page) => {
+  const feature = page.locator(
+    '.gbdraw-preview-surface > svg '
+      + '[data-gbdraw-feature-id]:not([data-gbdraw-auto-feature-underlay="true"])'
+  ).first();
+  await page.mouse.move(5, 5);
+  await feature.hover();
+  await expect(feature).toHaveCSS('cursor', 'pointer');
+  expect(await feature.evaluate((element) => element.style.cursor)).toBe('');
+  await expect(feature).toHaveAttribute('data-gbdraw-hover-opacity', /.*/);
+  await feature.click();
+  const dialog = page.getByRole('dialog', { name: /Feature details:/ });
+  await expect(dialog).toBeVisible({ timeout: INTERACTION_TIMEOUT_MS });
+  await dialog.getByRole('button', { name: 'Close feature popup' }).click();
+  await expect(dialog).toHaveCount(0);
+};
+
+const assertStructuralContract = ({ interaction, summary, workerDelta }) => {
+  const allowedStructuralMetrics = new Set([
+    'featureDomFullScanCount',
+    'previewTransformHoverCleanupCount',
+    'previewTransformHoverReconcileCount',
+    'previewTransformInteractionEndCount',
+    'previewTransformInteractionStartCount'
+  ]);
+  expect(summary.interactionActiveAtEnd).toBe(false);
+  expect(summary.result.sameObject).toBe(true);
+  expect(summary.result.unchanged).toBe(true);
+  expect(summary.result.sameCount).toBe(true);
+  expect(summary.result.sameSelectedIndex).toBe(true);
+  expect(workerDelta).toEqual({ constructions: 0, initializations: 0, helpers: 0, runs: 0 });
+  expect(summary.lifecycleEvents).toEqual([]);
+  expect(
+    Object.keys(summary.structuralMetricDelta)
+      .filter((name) => !allowedStructuralMetrics.has(name))
+  ).toEqual([]);
+  expect(Number(summary.structuralMetricDelta.previewTransformInteractionStartCount || 0)).toBe(1);
+  expect(Number(summary.structuralMetricDelta.previewTransformInteractionEndCount || 0)).toBe(1);
+  expect(Number(summary.structuralMetricDelta.previewTransformHoverCleanupCount || 0)).toBe(1);
+  expect(Number(summary.activeStructuralMetricDelta.featureDomFullScanCount || 0)).toBe(0);
+  expect(Number(summary.activeStructuralMetricDelta.comparisonDomFullScanCount || 0)).toBe(0);
+  expect(Number(summary.activeStructuralMetricDelta.featureSearchIndexBuildCount || 0)).toBe(0);
+  expect(summary.activeMutations.featureMatchStyle).toBe(0);
+  expect(summary.activeMutations.featureMatchOpacityFilter).toBe(0);
+  expect(summary.activeMutations.featureMatchHoverState).toBe(0);
+  expect(summary.activeMutations.featureMatchCursorStyle).toBe(0);
+  expect(Object.values(summary.activeSvgQueries).reduce((total, count) => total + count, 0)).toBe(0);
+  expect(summary.activeMutations.wrapperStyle).toBeGreaterThan(0);
+  expect(summary.listeners.delegatedAdds).toBe(0);
+  expect(summary.listeners.delegatedRemoves).toBe(0);
+  expect(summary.listeners.activeTransitionListeners).toBe(0);
+  expect(summary.frames.live).toBe(0);
+  expect(summary.timers.liveByDelay).toEqual({ 220: 0, 260: 0 });
+  expect(summary.raf.count).toBeGreaterThan(0);
+  expect(summary.transition).toEqual({
+    property: 'transform',
+    duration: '0.2s',
+    timingFunction: 'ease',
+    delay: '0s'
+  });
+  if (interaction === 'wheel') {
+    expect(summary.activeMutations.wrapperStyle).toBeGreaterThanOrEqual(WHEEL_STEPS - 1);
+    expect(summary.listeners.transitionAdds).toBe(1);
+    expect(summary.listeners.transitionRemoves).toBe(1);
+    expect(summary.listeners.maximumTransitionListeners).toBe(1);
+    expect(summary.timers.setsByDelay).toEqual({ 220: WHEEL_STEPS, 260: WHEEL_STEPS });
+    expect(summary.timers.maximumLiveByDelay).toEqual({ 220: 1, 260: 1 });
+  } else {
+    expect(summary.activeMutations.wrapperStyle).toBeGreaterThanOrEqual(PAN_STEPS);
+    expect(summary.listeners.transitionAdds).toBe(0);
+    expect(summary.listeners.transitionRemoves).toBe(0);
+    expect(summary.timers.setsByDelay).toEqual({ 220: 0, 260: 0 });
+  }
+};
+
+test.describe.configure({ mode: 'serial' });
+
+for (const interaction of ['pan', 'wheel']) {
+  for (const thermalState of ['cold', 'warm']) {
+    test(`${thermalState} sustained ${interaction} preserves the exact-fixture interaction contract`, async ({
+      page,
+      browser
+    }, testInfo) => {
+      test.setTimeout(1_800_000);
+      page.setDefaultTimeout(INTERACTION_TIMEOUT_MS);
+      await page.setViewportSize({ width: 1440, height: 1000 });
+      expect(fixtureSha).toBe(EXPECTED_FIXTURE_SHA);
+
+      const dialogs = [];
+      const pageErrors = [];
+      const consoleErrors = [];
+      page.on('dialog', async (dialog) => {
+        dialogs.push(dialog.message());
+        await dialog.accept();
+      });
+      page.on('pageerror', (error) => pageErrors.push(String(error?.message || error)));
+      page.on('console', (message) => {
+        if (message.type() === 'error') consoleErrors.push(message.text());
+      });
+
+      await installInteractionProbe(page);
+      await openApp(page);
+      await loadExactSession(page, dialogs);
+      await ensureDenseRegionVisible(page);
+      const geometry = await readGeometry(page);
+      const loadWorker = workerTotals(await getDiagramWorkerActivity(page));
+      expect(loadWorker).toEqual({ constructions: 0, initializations: 0, helpers: 0, runs: 0 });
+
+      const prewarmMetricDelta = thermalState === 'warm'
+        ? await prewarmHoverIndexes(page, geometry)
+        : {};
+      const begin = await startMeasurement(page, `${thermalState}-${interaction}`);
+      expect(begin.transition).toEqual({
+        property: 'transform',
+        duration: '0.2s',
+        timingFunction: 'ease',
+        delay: '0s'
+      });
+
+      const gestureStartedAt = Date.now();
+      if (interaction === 'pan') {
+        await runPan(page, geometry, begin.metricBefore);
+      } else {
+        await runWheel(page, geometry, begin.metricBefore);
+      }
+      await waitForInteractionEnd(page, begin.metricBefore);
+      const gestureWallDurationMs = Date.now() - gestureStartedAt;
+      await page.waitForTimeout(POST_INTERACTION_SETTLE_MS);
+      const summary = await page.evaluate(() => (
+        window.__GBDRAW_LARGE_PREVIEW_INTERACTION_PROBE__.endMeasurement()
+      ));
+      const afterWorker = workerTotals(await getDiagramWorkerActivity(page));
+      const workerDelta = subtractWorkerTotals(loadWorker, afterWorker);
+      console.log(`GBDRAW_LARGE_PREVIEW_INTERACTION_PREASSERT ${JSON.stringify({
+        profile: { thermalState, interaction },
+        geometry,
+        summary,
+        workerDelta
+      })}`);
+      assertStructuralContract({ interaction, summary, workerDelta });
+      await assertPostSettleInteraction(page);
+
+      expect(pageErrors).toEqual([]);
+      expect(consoleErrors).toEqual([]);
+      const evidence = {
+        fixtureSha,
+        browser: {
+          project: testInfo.project.name,
+          version: browser.version(),
+          platform: process.platform,
+          node: process.version,
+          osRelease: os.release()
+        },
+        profile: { thermalState, interaction },
+        schedule: {
+          viewport: { width: 1440, height: 1000 },
+          panSteps: PAN_STEPS,
+          panIntervalMs: PAN_INTERVAL_MS,
+          wheelSteps: WHEEL_STEPS,
+          wheelIntervalMs: WHEEL_INTERVAL_MS,
+          wheelDelivery: 'browser-timer-dispatched WheelEvent',
+          postInteractionSettleMs: POST_INTERACTION_SETTLE_MS
+        },
+        geometry,
+        prewarmMetricDelta,
+        gestureWallDurationMs,
+        workerBefore: loadWorker,
+        workerAfter: afterWorker,
+        workerDelta,
+        summary,
+        pageErrors,
+        consoleErrors
+      };
+      console.log(`GBDRAW_LARGE_PREVIEW_INTERACTION_EVIDENCE ${JSON.stringify(evidence)}`);
+      await testInfo.attach(`${thermalState}-${interaction}-evidence.json`, {
+        body: Buffer.from(JSON.stringify(evidence, null, 2)),
+        contentType: 'application/json'
+      });
+    });
+  }
+}

--- a/tests/web/preview-transform-interaction.test.mjs
+++ b/tests/web/preview-transform-interaction.test.mjs
@@ -1,0 +1,698 @@
+import nodeAssert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = process.cwd();
+const ref = (value) => ({ value });
+let assertionCount = 0;
+const caseNames = [];
+const assert = {
+  equal(...args) {
+    assertionCount += 1;
+    nodeAssert.equal(...args);
+  },
+  match(...args) {
+    assertionCount += 1;
+    nodeAssert.match(...args);
+  },
+  doesNotMatch(...args) {
+    assertionCount += 1;
+    nodeAssert.doesNotMatch(...args);
+  }
+};
+const completeCase = (name) => caseNames.push(name);
+
+const metrics = [];
+globalThis.__GBDRAW_TEST_HOOKS__ = {
+  onStructuralMetric(metric) {
+    metrics.push({ ...metric });
+  }
+};
+
+const tempDir = await mkdtemp(join(tmpdir(), 'gbdraw-preview-transform-'));
+await writeFile(join(tempDir, 'package.json'), '{"type":"module"}\n', 'utf8');
+await mkdir(join(tempDir, 'app', 'feature-editor'), { recursive: true });
+await mkdir(join(tempDir, 'app', 'legend'), { recursive: true });
+await mkdir(join(tempDir, 'services'), { recursive: true });
+
+const copyModule = async (source, destination) => {
+  await writeFile(
+    join(tempDir, destination),
+    await readFile(join(repoRoot, 'gbdraw', 'web', 'js', source), 'utf8'),
+    'utf8'
+  );
+};
+
+await copyModule('app/ui.js', 'app/ui.js');
+await copyModule('app/feature-dom.js', 'app/feature-dom.js');
+await copyModule('app/feature-editor/svg-actions.js', 'app/feature-editor/svg-actions.js');
+await copyModule('services/runtime-test-hooks.js', 'services/runtime-test-hooks.js');
+await writeFile(
+  join(tempDir, 'app', 'color-utils.js'),
+  'export const resolveColorToHex = (value) => value || "#94a3b8";\n',
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'app', 'feature-utils.js'),
+  [
+    'export const getFeatureCaption = (feature) => feature?.label || feature?.id || "Feature";',
+    'export const normalizeStringArray = (value) => Array.isArray(value) ? value : (value ? [String(value)] : []);',
+    'export const resolveDisplayProteinId = () => "";'
+  ].join('\n'),
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'app', 'pairwise-match-popup.js'),
+  [
+    'export const PAIRWISE_MATCH_SELECTOR = "path[data-gbdraw-pairwise-match-id]";',
+    'export const buildPairwiseMatchHoverRows = () => [];',
+    'export const buildPairwiseMatchPayload = () => null;'
+  ].join('\n'),
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'app', 'feature-sequence-fasta.js'),
+  'export const buildFeatureSequenceFastas = () => ({ nucleotideFasta: "", aminoAcidFasta: "" });\n',
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'services', 'svg-serialization.js'),
+  'export const serializeCleanSvg = () => "<svg></svg>";\n',
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'services', 'feature-override-identity.js'),
+  'export const getFeatureOverride = () => null;\n',
+  'utf8'
+);
+await writeFile(
+  join(tempDir, 'app', 'legend', 'utils.js'),
+  'export const COMPARISON_LEGEND_SELECTOR = "[data-gbdraw-role=comparison-legend]";\n',
+  'utf8'
+);
+
+let nextTimerId = 1;
+const timers = new Map();
+let nextFrameId = 1;
+const frames = new Map();
+const runTimersAtDelay = (delay) => {
+  [...timers.entries()]
+    .filter(([, timer]) => timer.delay === delay)
+    .forEach(([id, timer]) => {
+      timers.delete(id);
+      timer.callback();
+    });
+};
+const flushFrames = () => {
+  const pending = [...frames.entries()];
+  frames.clear();
+  pending.forEach(([, callback]) => callback());
+};
+
+globalThis.window = {
+  innerWidth: 1440,
+  innerHeight: 1000,
+  setTimeout(callback, delay) {
+    const id = nextTimerId++;
+    timers.set(id, { callback, delay });
+    return id;
+  },
+  clearTimeout(id) {
+    timers.delete(id);
+  },
+  requestAnimationFrame(callback) {
+    const id = nextFrameId++;
+    frames.set(id, callback);
+    return id;
+  },
+  cancelAnimationFrame(id) {
+    frames.delete(id);
+  },
+  matchMedia: () => ({ matches: false })
+};
+globalThis.requestAnimationFrame = window.requestAnimationFrame;
+globalThis.cancelAnimationFrame = window.cancelAnimationFrame;
+globalThis.CSS = { escape: (value) => String(value) };
+
+class ListenerTarget {
+  constructor() {
+    this.listeners = new Map();
+    this.listenerAdds = new Map();
+    this.listenerRemoves = new Map();
+  }
+
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type).add(listener);
+    this.listenerAdds.set(type, Number(this.listenerAdds.get(type) || 0) + 1);
+  }
+
+  removeEventListener(type, listener) {
+    this.listeners.get(type)?.delete(listener);
+    this.listenerRemoves.set(type, Number(this.listenerRemoves.get(type) || 0) + 1);
+  }
+
+  dispatch(type, event = {}) {
+    for (const listener of this.listeners.get(type) || []) listener({ target: this, ...event });
+  }
+}
+
+const wrapper = new ListenerTarget();
+wrapper.style = {};
+const canvas = { style: {} };
+const uiState = {
+  zoom: ref(1),
+  layoutRepositionMode: ref(false),
+  isPanning: ref(false),
+  panStart: { x: 0, y: 0, panX: 0, panY: 0 },
+  canvasPan: { x: 0, y: 0 },
+  canvasContainerRef: ref(canvas),
+  svgContainer: ref(wrapper)
+};
+const { createPanZoom } = await import(pathToFileURL(join(tempDir, 'app', 'ui.js')));
+const panZoom = createPanZoom(uiState);
+const interactionChanges = [];
+panZoom.previewTransformInteraction.subscribe((change) => interactionChanges.push(change));
+
+const wheelEvent = { deltaY: -100, clientX: 500, clientY: 400 };
+panZoom.handleWheel(wheelEvent);
+panZoom.handleWheel(wheelEvent);
+panZoom.handleWheel(wheelEvent);
+assert.equal(panZoom.previewTransformInteraction.isActive(), true);
+assert.equal(interactionChanges.filter((change) => change.active).length, 1);
+assert.equal(wrapper.listenerAdds.get('transitionend'), 1);
+assert.equal(wrapper.listeners.get('transitionend').size, 1);
+assert.equal([...timers.values()].filter((timer) => timer.delay === 220).length, 1);
+assert.equal([...timers.values()].filter((timer) => timer.delay === 260).length, 1);
+wrapper.dispatch('transitionend', { propertyName: 'opacity' });
+wrapper.dispatch('transitionend', { target: canvas, propertyName: 'transform' });
+assert.equal(panZoom.previewTransformInteraction.isActive(), true);
+runTimersAtDelay(220);
+assert.equal(panZoom.previewTransformInteraction.isActive(), true);
+wrapper.dispatch('transitionend', { propertyName: 'transform' });
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+assert.equal(wrapper.listeners.get('transitionend').size, 0);
+assert.equal(interactionChanges.filter((change) => !change.active).length, 1);
+completeCase('repeated wheel uses one source, timer pair, and transition listener');
+
+panZoom.handleWheel({ ...wheelEvent, deltaY: 100 });
+runTimersAtDelay(260);
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+assert.equal(wrapper.listenerAdds.get('transitionend'), 2);
+assert.equal(wrapper.listenerRemoves.get('transitionend'), 2);
+completeCase('wheel fallback ends a clamped or missing-transition window');
+
+const backgroundTarget = {
+  tagName: 'rect',
+  closest: () => null
+};
+panZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 100,
+  clientY: 120,
+  target: backgroundTarget
+});
+assert.equal(uiState.isPanning.value, true);
+assert.equal(panZoom.previewTransformInteraction.isActive(), true);
+assert.equal(canvas.style.cursor, 'grabbing');
+panZoom.doPan({ clientX: 130, clientY: 150 });
+flushFrames();
+assert.equal(wrapper.style.transform, 'translate(30px, 30px) scale(1.2)');
+panZoom.endPan({ clientX: 130, clientY: 150 });
+assert.equal(uiState.isPanning.value, false);
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+assert.equal(canvas.style.cursor, 'grab');
+assert.equal(wrapper.style.transition, 'transform 0.2s');
+completeCase('pan updates the wrapper transform and restores the existing transition');
+
+const changesBeforePanThenWheel = interactionChanges.length;
+panZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 130,
+  clientY: 150,
+  target: backgroundTarget
+});
+panZoom.handleWheel(wheelEvent);
+panZoom.endPan({ clientX: 130, clientY: 150 });
+assert.equal(panZoom.previewTransformInteraction.isActive(), true);
+assert.equal(
+  interactionChanges.slice(changesBeforePanThenWheel).filter((change) => change.active).length,
+  1
+);
+runTimersAtDelay(220);
+wrapper.dispatch('transitionend', { propertyName: 'transform' });
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+completeCase('pan then wheel keeps wheel active after pan ends');
+
+const changesBeforeWheelThenPan = interactionChanges.length;
+panZoom.handleWheel(wheelEvent);
+panZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 130,
+  clientY: 150,
+  target: backgroundTarget
+});
+runTimersAtDelay(260);
+assert.equal(panZoom.previewTransformInteraction.isActive(), true);
+assert.equal(
+  interactionChanges.slice(changesBeforeWheelThenPan).filter((change) => !change.active).length,
+  0
+);
+panZoom.endPan({ clientX: 130, clientY: 150 });
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+completeCase('wheel then pan keeps pan active after wheel ends');
+
+panZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 130,
+  clientY: 150,
+  target: backgroundTarget
+});
+panZoom.endPan({ type: 'pointercancel', clientX: 130, clientY: 150 });
+assert.equal(uiState.isPanning.value, false);
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+completeCase('pointercancel routes to complete pan cleanup');
+
+panZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 130,
+  clientY: 150,
+  target: backgroundTarget
+});
+panZoom.endPan({ type: 'lostpointercapture', clientX: 130, clientY: 150 });
+assert.equal(uiState.isPanning.value, false);
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+completeCase('lostpointercapture routes to complete pan cleanup');
+
+panZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 130,
+  clientY: 150,
+  target: backgroundTarget
+});
+panZoom.handleWheel(wheelEvent);
+panZoom.cancelPreviewTransformInteraction({ reconcile: false });
+assert.equal(uiState.isPanning.value, false);
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+assert.equal(timers.size, 0);
+assert.equal(wrapper.listeners.get('transitionend').size, 0);
+completeCase('explicit canonical cancel empties every active source and resource');
+
+panZoom.handleWheel(wheelEvent);
+panZoom.resetPreviewViewport();
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+assert.equal(timers.size, 0);
+completeCase('reset cancels the canonical interaction without reconciliation');
+
+panZoom.handleWheel(wheelEvent);
+panZoom.disposePanZoom();
+assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+assert.equal(timers.size, 0);
+assert.equal(wrapper.listeners.get('transitionend').size, 0);
+completeCase('pan/zoom dispose removes sources, timers, listeners, and subscriptions');
+
+class FakeStyle {
+  constructor() {
+    this.values = Object.create(null);
+    this.writeCount = 0;
+  }
+
+  get opacity() { return this.values.opacity || ''; }
+  set opacity(value) { this.values.opacity = String(value); this.writeCount += 1; }
+  get filter() { return this.values.filter || ''; }
+  set filter(value) { this.values.filter = String(value); this.writeCount += 1; }
+  get cursor() { return this.values.cursor || ''; }
+  set cursor(value) { this.values.cursor = String(value); this.writeCount += 1; }
+  removeProperty(name) { delete this.values[name]; this.writeCount += 1; }
+}
+
+class FakeElement {
+  constructor(kind, attributes = {}) {
+    this.kind = kind;
+    this.attributes = { ...attributes };
+    this.id = attributes.id || '';
+    this.style = new FakeStyle();
+    this.attributeMutationCount = 0;
+  }
+
+  getAttribute(name) {
+    return Object.hasOwn(this.attributes, name) ? this.attributes[name] : null;
+  }
+
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+    this.attributeMutationCount += 1;
+  }
+
+  removeAttribute(name) {
+    if (Object.hasOwn(this.attributes, name)) {
+      delete this.attributes[name];
+      this.attributeMutationCount += 1;
+    }
+  }
+
+  hasAttribute(name) {
+    return Object.hasOwn(this.attributes, name);
+  }
+
+  matches(selector) {
+    if (this.kind === 'feature') {
+      return selector.includes('data-gbdraw-feature-id') || selector.includes('path[id^="f"]');
+    }
+    if (this.kind === 'match') return selector.includes('data-gbdraw-pairwise-match-id');
+    return false;
+  }
+
+  closest(selector) {
+    if (selector === 'g[id]' || selector === 'svg' || selector.includes('button')) return null;
+    return this.matches(selector) ? this : null;
+  }
+}
+
+class FakeSvg extends ListenerTarget {
+  constructor(elements) {
+    super();
+    this.elements = elements;
+    this.queryCounts = new Map();
+  }
+
+  contains(element) {
+    return element === this || this.elements.includes(element);
+  }
+
+  querySelectorAll(selector) {
+    this.queryCounts.set(selector, Number(this.queryCounts.get(selector) || 0) + 1);
+    if (selector === '[data-orthogroup-id]') {
+      return this.elements.filter((element) => element.hasAttribute('data-orthogroup-id'));
+    }
+    if (selector.includes('data-gbdraw-pairwise-match-id')) {
+      return this.elements.filter((element) => element.kind === 'match');
+    }
+    return this.elements.filter((element) => element.kind === 'feature');
+  }
+
+  getElementById(id) {
+    return this.elements.find((element) => element.id === id) || null;
+  }
+}
+
+const featureOne = new FakeElement('feature', {
+  id: 'f1',
+  'data-gbdraw-feature-id': 'f1',
+  'data-gbdraw-feature-part': 'block',
+  fill: '#123456',
+  'data-orthogroup-id': 'OG1'
+});
+const featureTwo = new FakeElement('feature', {
+  id: 'f2',
+  'data-gbdraw-feature-id': 'f2',
+  'data-gbdraw-feature-part': 'block',
+  fill: '#654321',
+  'data-orthogroup-id': 'OG1'
+});
+const match = new FakeElement('match', {
+  id: 'm1',
+  'data-gbdraw-pairwise-match-id': 'm1',
+  'data-orthogroup-id': 'OG1'
+});
+const unrelatedPath = new FakeElement('generic', {
+  id: 'axis-path',
+  'data-orthogroup-id': 'OG2'
+});
+const svg = new FakeSvg([featureOne, featureTwo, match, unrelatedPath]);
+globalThis.document = {
+  elementsFromPoint: () => [featureOne],
+  createElement: () => { throw new Error('Hover summary should stay disabled in this Contract.'); },
+  body: { appendChild: () => {} }
+};
+
+const featureInteractionWrapper = new ListenerTarget();
+featureInteractionWrapper.style = {};
+const featureInteractionCanvas = { style: {} };
+const featureInteractionState = {
+  zoom: ref(1),
+  layoutRepositionMode: ref(false),
+  isPanning: ref(false),
+  panStart: { x: 0, y: 0, panX: 0, panY: 0 },
+  canvasPan: { x: 0, y: 0 },
+  canvasContainerRef: ref(featureInteractionCanvas),
+  svgContainer: ref(featureInteractionWrapper)
+};
+const featurePanZoom = createPanZoom(featureInteractionState);
+
+const featureMap = new Map([
+  ['f1', { id: 'f1', rendered_svg_id: 'f1', label: 'One', orthogroupId: 'OG1', start: 0, end: 10 }],
+  ['f2', { id: 'f2', rendered_svg_id: 'f2', label: 'Two', orthogroupId: 'OG1', start: 10, end: 20 }]
+]);
+let selectedFeatureId = '';
+const featureSelection = {
+  consumeSuppressNextClick: () => false,
+  getSelectableFeatureTarget: (eventLike, root) => (
+    eventLike?.target?.kind === 'feature' && root.contains(eventLike.target)
+      ? eventLike.target
+      : null
+  ),
+  toggleFeatureSelection(featureId) {
+    selectedFeatureId = featureId;
+  },
+  markPlainFeatureClick() {}
+};
+const state = {
+  results: ref([{ content: '<svg></svg>' }]),
+  selectedResultIndex: ref(0),
+  isPanning: ref(false),
+  orthogroups: ref([]),
+  collinearGroups: ref([]),
+  orthogroupNameOverrides: {},
+  orthogroupDescriptionOverrides: {},
+  extractedFeatures: ref([...featureMap.values()]),
+  biologicalFeatures: ref([]),
+  featuresBySvgId: ref(featureMap),
+  featureColorOverrides: {},
+  featureVisibilityOverrides: {},
+  svgContainer: ref({ querySelector: (selector) => selector === 'svg' ? svg : null }),
+  clickedFeature: ref(null),
+  clickedFeaturePos: { x: 0, y: 0 },
+  clickedPairwiseMatch: ref(null),
+  clickedPairwiseMatchPos: { x: 0, y: 0 },
+  matchSequenceRegistry: null,
+  selectedAnnotation: ref(null),
+  featurePopupSize: { width: 0, height: 0 },
+  featureSelectionDrag: { active: false },
+  skipCaptureBaseConfig: ref(false),
+  adv: { rich_feature_popup: false }
+};
+const { createFeatureSvgActions } = await import(
+  pathToFileURL(join(tempDir, 'app', 'feature-editor', 'svg-actions.js'))
+);
+const featureActions = createFeatureSvgActions({
+  state,
+  getFeatureColor: () => '#123456',
+  getEffectiveLegendCaption: () => '',
+  featureSelection,
+  previewTransformInteraction: featurePanZoom.previewTransformInteraction
+});
+assert.equal(featureActions.attachSvgFeatureHandlers({ root: svg }), true);
+assert.equal(featureActions.attachSvgFeatureHandlers({ root: svg }), false);
+for (const type of ['mouseover', 'mousemove', 'mouseout', 'click', 'keydown']) {
+  assert.equal(svg.listeners.get(type).size, 1, type);
+}
+completeCase('delegated Feature listeners install once per SVG root');
+
+const eventAtFeature = {
+  target: featureOne,
+  relatedTarget: null,
+  clientX: 500,
+  clientY: 400,
+  stopPropagation() {},
+  preventDefault() {}
+};
+featurePanZoom.startPan({
+  button: 0,
+  shiftKey: false,
+  clientX: 500,
+  clientY: 400,
+  target: backgroundTarget
+});
+assert.equal([...svg.queryCounts.values()].reduce((total, count) => total + count, 0), 0);
+assert.equal(
+  [featureOne, featureTwo, match, unrelatedPath]
+    .reduce((total, element) => total + element.style.writeCount, 0),
+  0
+);
+featurePanZoom.cancelPreviewTransformInteraction({ reconcile: false });
+completeCase('absent-hover gesture start performs no scan or presentation mutation');
+
+assert.equal(featureActions.preparePairwiseInteractionAffordances({ root: svg }), true);
+assert.equal(match.style.cursor, 'pointer');
+assert.equal(featureOne.style.cursor, '');
+completeCase('pairwise keyboard affordance remains separate from Feature cursor ownership');
+
+svg.dispatch('mouseover', eventAtFeature);
+assert.equal(metrics.filter((metric) => metric.name === 'featureDomFullScanCount').length, 1);
+assert.equal(featureOne.style.opacity, '0.7');
+assert.equal(featureTwo.style.opacity, '0.7');
+assert.equal(match.style.opacity, '0.7');
+assert.equal(featureOne.style.cursor, '');
+assert.equal(featureTwo.style.cursor, '');
+assert.equal(unrelatedPath.style.opacity, '');
+completeCase('ordinary Feature hover builds one cold index and tracks only its fan-out');
+
+const queryCountBeforeCleanup = [...svg.queryCounts.values()]
+  .reduce((total, count) => total + count, 0);
+featurePanZoom.startPan({ ...eventAtFeature, button: 0, shiftKey: false, target: backgroundTarget });
+featurePanZoom.handleWheel(wheelEvent);
+assert.equal(metrics.filter((metric) => metric.name === 'previewTransformHoverCleanupCount').length, 2);
+const styleWritesAfterCleanup = [featureOne, featureTwo, match]
+  .reduce((total, element) => total + element.style.writeCount, 0);
+const attributeWritesAfterCleanup = [featureOne, featureTwo, match]
+  .reduce((total, element) => total + element.attributeMutationCount, 0);
+const queryCountAfterCleanup = [...svg.queryCounts.values()]
+  .reduce((total, count) => total + count, 0);
+assert.equal(queryCountAfterCleanup, queryCountBeforeCleanup);
+assert.equal(unrelatedPath.style.writeCount, 0);
+completeCase('existing-hover gesture clear uses tracked elements with zero scan delta');
+
+for (let index = 0; index < 20; index += 1) {
+  svg.dispatch('mouseover', { ...eventAtFeature, target: index % 2 ? featureOne : featureTwo });
+  svg.dispatch('mouseout', { ...eventAtFeature, target: featureOne, relatedTarget: featureTwo });
+  svg.dispatch('mousemove', { ...eventAtFeature, target: featureTwo });
+}
+assert.equal(
+  [featureOne, featureTwo, match].reduce((total, element) => total + element.style.writeCount, 0),
+  styleWritesAfterCleanup
+);
+assert.equal(
+  [featureOne, featureTwo, match].reduce((total, element) => total + element.attributeMutationCount, 0),
+  attributeWritesAfterCleanup
+);
+assert.equal(
+  [...svg.queryCounts.values()].reduce((total, count) => total + count, 0),
+  queryCountAfterCleanup
+);
+assert.equal(metrics.filter((metric) => metric.name === 'previewTransformHoverCleanupCount').length, 2);
+assert.equal(unrelatedPath.style.writeCount, 0);
+completeCase('active delegated hover events cause zero scan, style, and attribute deltas');
+
+featurePanZoom.endPan(eventAtFeature);
+assert.equal(featurePanZoom.previewTransformInteraction.isActive(), true);
+runTimersAtDelay(220);
+featureInteractionWrapper.dispatch('transitionend', { propertyName: 'transform' });
+assert.equal(featurePanZoom.previewTransformInteraction.isActive(), false);
+flushFrames();
+assert.equal(featureOne.style.opacity, '0.7');
+assert.equal(metrics.filter((metric) => metric.name === 'previewTransformHoverReconcileCount').length, 1);
+assert.equal(metrics.filter((metric) => metric.name === 'featureDomFullScanCount').length, 1);
+svg.dispatch('mouseout', eventAtFeature);
+assert.equal(featureOne.style.opacity, '');
+completeCase('ordinary Feature hover resumes after the final source settles');
+
+svg.dispatch('click', eventAtFeature);
+assert.equal(state.clickedFeature.value?.id, 'f1');
+svg.dispatch('click', { ...eventAtFeature, ctrlKey: true });
+assert.equal(selectedFeatureId, 'f1');
+completeCase('Feature click and modifier selection remain available after settle');
+
+featurePanZoom.startPan({ ...eventAtFeature, button: 0, shiftKey: false, target: backgroundTarget });
+featurePanZoom.endPan(eventAtFeature);
+assert.equal(frames.size, 1);
+const replacementFeature = new FakeElement('feature', {
+  id: 'f1',
+  'data-gbdraw-feature-id': 'f1',
+  'data-gbdraw-feature-part': 'block'
+});
+const replacementSvg = new FakeSvg([replacementFeature]);
+assert.equal(featureActions.attachSvgFeatureHandlers({ root: replacementSvg }), true);
+assert.equal(frames.size, 0);
+for (const listeners of svg.listeners.values()) assert.equal(listeners.size, 0);
+for (const type of ['mouseover', 'mousemove', 'mouseout', 'click', 'keydown']) {
+  assert.equal(replacementSvg.listeners.get(type).size, 1, type);
+}
+completeCase('SVG root replacement cancels reconciliation and removes old listeners');
+
+featureActions.dispose();
+for (const listeners of replacementSvg.listeners.values()) assert.equal(listeners.size, 0);
+const cleanupCountBeforeDisposedInteraction = metrics
+  .filter((metric) => metric.name === 'previewTransformHoverCleanupCount')
+  .length;
+featurePanZoom.startPan({ ...eventAtFeature, button: 0, shiftKey: false, target: backgroundTarget });
+featurePanZoom.cancelPreviewTransformInteraction({ reconcile: false });
+assert.equal(
+  metrics.filter((metric) => metric.name === 'previewTransformHoverCleanupCount').length,
+  cleanupCountBeforeDisposedInteraction
+);
+featurePanZoom.disposePanZoom();
+completeCase('Feature action dispose removes delegated listeners and lifecycle subscription');
+
+const featureDomSource = await readFile(
+  join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'feature-dom.js'),
+  'utf8'
+);
+assert.doesNotMatch(featureDomSource, /markCursor|style\.cursor\s*=\s*['"]pointer['"]/);
+const indexHtml = await readFile(join(repoRoot, 'gbdraw', 'web', 'index.html'), 'utf8');
+const cursorRule = indexHtml.match(
+  /\.gbdraw-preview-surface\s+:is\(([\s\S]*?)\)\s*\{\s*cursor:\s*pointer;\s*\}/
+);
+assert.equal(Boolean(cursorRule), true);
+const cssFeatureSelector = cursorRule[1]
+  .split(',')
+  .map((selector) => selector.trim())
+  .join(', ');
+const { FEATURE_SELECTOR } = await import(pathToFileURL(join(tempDir, 'app', 'feature-dom.js')));
+assert.equal(cssFeatureSelector, FEATURE_SELECTOR);
+for (const excludedSelector of [
+  'data-gbdraw-pairwise-match-id',
+  'data-match-kind',
+  'data-orthogroup-id',
+  'legend',
+  'text',
+  'circle',
+  'line'
+]) {
+  assert.equal(cursorRule[1].includes(excludedSelector), false, excludedSelector);
+}
+completeCase('declarative Feature cursor exactly matches the production Feature selector');
+
+const svgActionsSource = await readFile(
+  join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'feature-editor', 'svg-actions.js'),
+  'utf8'
+);
+const trackedClearSource = svgActionsSource.match(
+  /const clearTrackedHoverStyles = \(\) => \{[\s\S]*?const clearActiveMatchHover = \(\) => \{[\s\S]*?\n\s*\};/
+)?.[0] || '';
+assert.match(trackedClearSource, /activeHoverElements/);
+assert.doesNotMatch(
+  trackedClearSource,
+  /ensureFeaturePaths|ensureFeatureLookup|ensureFeatureOrthogroupIndex|ensureComparisonIndexes|querySelectorAll|cursor/
+);
+completeCase('gesture-start clear source has no ensure, scan, or cursor call path');
+
+const appSetupSource = await readFile(
+  join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'app-setup.js'),
+  'utf8'
+);
+assert.match(
+  appSetupSource,
+  /installDelegatedInteractions\(context\)\s*\{\s*cancelPreviewTransformInteraction\(\{ reconcile: false \}\);\s*featureActions\.attachSvgFeatureHandlers/
+);
+completeCase('preview replacement cancels the canonical lifecycle before rebinding');
+
+assert.match(indexHtml, /transition:\s*isPanning\s*\?\s*'none'\s*:\s*'transform 0\.2s'/);
+assert.match(indexHtml, /@pointercancel="endPan"/);
+assert.match(indexHtml, /@lostpointercapture="endPan"/);
+completeCase('template preserves transition and routes interrupted pan cleanup');
+
+delete globalThis.__GBDRAW_TEST_HOOKS__;
+console.log(JSON.stringify({
+  status: 'preview transform interaction tests passed',
+  assertionCount,
+  cases: caseNames
+}, null, 2));

--- a/tests/web/responsiveness-guardrail.test.mjs
+++ b/tests/web/responsiveness-guardrail.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  aggregateResponsivenessSamples,
+  evaluateResponsivenessGuardrail,
+  median
+} = require('./helpers/responsiveness-guardrail.cjs');
+
+assert.equal(median([9, 1, 5]), 5);
+assert.equal(median([8, 2, 4, 6]), 5);
+assert.throws(() => median([]), /at least one/);
+assert.throws(() => median([1, Number.NaN]), /finite/);
+
+const aggregate = aggregateResponsivenessSamples([
+  {
+    longTasks: { totalDurationMs: 20, longestDurationMs: 12 },
+    raf: { p95Ms: 22 },
+    heartbeat: { maximumGapMs: 55 }
+  },
+  {
+    longTasks: { totalDurationMs: 10, longestDurationMs: 8 },
+    raf: { p95Ms: 18 },
+    heartbeat: { maximumGapMs: 65 }
+  },
+  {
+    longTasks: { totalDurationMs: 30, longestDurationMs: 16 },
+    raf: { p95Ms: 20 },
+    heartbeat: { maximumGapMs: 60 }
+  }
+]);
+assert.deepEqual(aggregate, {
+  repetitions: 3,
+  medianLongTaskTotalMs: 20,
+  medianLongestLongTaskMs: 12,
+  medianRafP95Ms: 20,
+  maximumHeartbeatGapMs: 65
+});
+assert.deepEqual(evaluateResponsivenessGuardrail(aggregate, {
+  maximumMedianLongTaskTotalMs: 25,
+  maximumMedianLongestLongTaskMs: 15
+}), []);
+assert.deepEqual(evaluateResponsivenessGuardrail(aggregate, {
+  maximumMedianLongTaskTotalMs: 19,
+  maximumMedianLongestLongTaskMs: 11
+}), [
+  'median Long Task total 20 ms exceeded 19 ms',
+  'median longest Long Task 12 ms exceeded 11 ms'
+]);
+
+console.log(JSON.stringify({
+  status: 'responsiveness guardrail aggregate tests passed',
+  assertions: 8
+}));


### PR DESCRIPTION
## Plain-language summary

Large preview pan and wheel gestures now pause delegated Feature and comparison hover work while the preview transform is active. One shared lifecycle prevents overlapping inputs from ending each other early, then restores ordinary hover and click behavior after the gesture settles. This PR does not change diagram generation or scientific output, and its corrected performance test uses a controlled synthetic workload instead of claiming to reproduce native operating-system input.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `5a7c384bff7894e9af2ee611825cea0bd6b3d7a9`.
- Original production head: `a6555e023e28adde10325d02ccb7f989b152d220`.
- Final head and test-only commit: `e137251dec35bb30538f8a2811930b1a793b4d1d`.

## User-visible impact

Panning and repeated wheel zooming over a large preview no longer trigger application-owned Feature/match hover scans and style mutations during the active transform window. Existing hover is cleared once at gesture start, and hover, Feature popup, and click behavior resume after the final pan/wheel source settles. The production `transform 0.2s ease` behavior and Feature-only pointer cursor semantics are preserved.

## Production changes

- Make `createPanZoom` the sole owner of a shared pan/wheel transform-interaction source set, bounded wheel quiet/fallback timers, transition completion, and lifecycle cleanup.
- Let delegated Feature interaction subscribe to that owner, stop before target/index work during transforms, clear only tracked hover state on start, and reconcile the remembered pointer after settle.
- Replace per-Feature inline cursor assignment with the equivalent Feature-selector CSS rule scoped to the preview surface.

No production code changed after `a6555e023e28adde10325d02ccb7f989b152d220`; the final commit changes only the performance config and Web tests.

## Corrected test architecture

### Structural Contract

The exact fixture still runs cold/warm pan and wheel cases with hard assertions for scan suppression, active Feature/match mutation suppression, lifecycle ownership, timers/listeners/frames cleanup, Worker inactivity, preserved Result identity, and post-settle Feature hover/popup behavior. These are structural assertions, not timing assertions.

### Responsiveness guardrail

The dedicated serial performance profile adds a low-overhead Chromium hard gate. During the measured interval it observes Long Tasks, native `requestAnimationFrame`, a bounded 50 ms heartbeat, and input/dispatch timestamps; it does not replace global timers, animation frames, event targets, query APIs, or scan the full SVG. The pure median aggregation and threshold evaluation are independently covered by deterministic tests.

### Controlled workload

The primary workload is a warm controlled browser-timer synthetic wheel stress workload: 30 `WheelEvent`s, 15 zoom-in plus 15 zoom-out, nominal 80 ms spacing, followed by a fixed 500 ms settle. Each of three committed repetitions uses a fresh browser context and retains every sample. This schedule is intentionally not described as environment-equivalent, native-equivalent, or representative of exact OS delivery.

### Native headless

Playwright native wheel input remains diagnostic/report-only. Event delivery, coalescing, quiet-window splitting, and browser/process lifetime can dominate absolute headless timing, so no native headless absolute threshold is used.

### Headed Edge

Headed Microsoft Edge 152.0.4191.53 on Windows 10.0.26200 remains supporting evidence. The prescribed paired batch did not reproduce the original freeze: warm wheel Long Task totals were `[0, 0, 0]` ms for both revisions; warm pan was baseline `[0, 53, 63]` ms and PR `[72, 70, 72]` ms, an approximately one-frame and visually equivalent difference; median maximum rAF gap improved from 129 to 89 ms and input gap from 195 to 169 ms.

## Calibration and falsification

Ten alternating paired Chromium repetitions per revision produced these Long Task distributions:

- Baseline total: `[3510, 2414, 3478, 2428, 2373, 2372, 2511, 2499, 3055, 2275]` ms; median 2463.5 ms, minimum 2275 ms.
- Candidate total: `[50, 50, 0, 0, 0, 0, 0, 0, 101, 0]` ms; median 0 ms, maximum 101 ms.
- Baseline longest: `[906, 940, 948, 930, 933, 916, 977, 910, 935, 891]` ms; median 931.5 ms, minimum 891 ms.
- Candidate longest: `[50, 50, 0, 0, 0, 0, 0, 0, 51, 0]` ms; median 0 ms, maximum 51 ms.

The thresholds are the rounded-up geometric separation between candidate worst and baseline best: 500 ms for median total Long Task time and 250 ms for median longest Long Task. Both are about five times the candidate maxima and remain below the baseline minima.

The final candidate guardrail passed with total/longest samples `[0, 0, 0]` / `[0, 0, 0]` ms and 30/30 delivered events in every repetition. Running the committed harness against the exact historical baseline failed only the intended timing assertions: total samples `[2977, 2505, 3361]` ms and longest samples `[905, 964, 959]` ms, with medians 2977 and 959 ms against the 500/250 ms limits. Fixture loading, setup, and structural behavior passed.

The retained controlled Edge evidence likewise separates the revisions: median total Long Task time 2966 to 103 ms and median longest Long Task 922 to 53 ms.

## Verification

- `node --test tests/web/preview-transform-interaction.test.mjs` — 24 Contract cases / 119 assertions passed.
- Pure responsiveness aggregate/helper test — 8 assertions passed.
- `node --test --test-concurrency=1 tests/web/*.test.mjs` — 480/480 passed.
- Architecture, Product Impact fixture, and PR-language contract selection — 218/218 passed.
- Exact structural Contract, Chromium 149.0.7827.55 — 4/4 passed.
- Exact structural Contract, Microsoft Edge 152.0.4191.53 — 4/4 passed.
- Corrected dedicated Chromium performance profile — 13/13 passed, including the hard guardrail and report-only native diagnostic.
- Existing default Chromium Playwright suite — 122 passed, 2 dedicated-performance cases skipped by design.
- Edge native headless diagnostic — 1/1 passed; 30/30 delivered, coalescing ratio 1, one quiet window, and no page or console errors; report-only.
- `python -m pytest tests/ -v -m "not slow"` — 3008 passed, 17 skipped, 11 deselected.
- Reference-output comparison — 16/16 passed and scientific output is unchanged.
- `ruff check gbdraw/` and JavaScript syntax checks — passed.
- Clean archive build — source distribution and wheel built successfully.
- Web policy checker — Gate `PASS`, Review `REQUIRED`, no blocking violations; architecture authority unchanged and no dependency, vendor, binary runtime, workflow, or guard-file changes.
- `git diff --check` — passed.

## Risk and review notes

- Review is required because the complete production PR has 285 net added lines and the report-only inventories identify `wheelFallbackTimerId` and `handleWheelTransitionEnd`. There are no new production modules or exports, no first-party import cycles, and no registered architecture authority change.
- Active Feature/match mutation and scan work is eliminated during the transform interval. Reconciliation suppression did not remove the observed long stalls and is not the primary stall cause.
- Large-SVG raster, paint, and compositing cost remains; this PR does not claim that all pan or zoom jank is fixed.
- The first ordinary Feature hover still performs one lazy index build and is a separate future task.
- A fresh automated headed Edge batch was retained rather than filtered: warm pan totals were baseline `[104, 89, 84]` ms and PR `[93, 100, 425]` ms; native wheel delivery varied between 17 and 30 events and split across quiet windows on both revisions. The outliers tracked native delivery loss/splitting rather than a repeatable PR-only effect, which is why native timing stays report-only and the fixed-cadence controlled workload is the hard gate.

## Rollback

Revert the production commit and this test-only commit to restore the previous delegated-hover behavior and its earlier coverage. No stored data, session schema, generated artifact, or dependency migration is involved.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: no registered Product Impact concern triggered
- Affected concern(s), if known: N/A
- Affected journey/checkpoint effects: N/A
- Authority and decision references: N/A
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: Existing pan/zoom, hover, click, cursor, transition, generation, Worker, Result, and scientific-output behavior is preserved; only redundant hover work during transforms is suspended. Residual browser rendering cost is documented above.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

N/A

### ARCHITECTURE_EXCEPTION

N/A

### PROMOTION

N/A
