### PR TITLE
perf(web): remove full pairwise payload work from hover

### DIFF
--- a/gbdraw/web/js/app/feature-editor/svg-actions.js
+++ b/gbdraw/web/js/app/feature-editor/svg-actions.js
@@ -2,7 +2,7 @@ import { resolveColorToHex } from '../color-utils.js';
 import { getFeatureCaption, normalizeStringArray, resolveDisplayProteinId } from '../feature-utils.js';
 import {
   PAIRWISE_MATCH_SELECTOR,
-  buildPairwiseMatchHoverRows,
+  buildPairwiseMatchHoverSummary,
   buildPairwiseMatchPayload
 } from '../pairwise-match-popup.js';
 import { buildFeatureSequenceFastas } from '../feature-sequence-fasta.js';
@@ -531,49 +531,49 @@ export const createFeatureSvgActions = ({
     hoverSummaryState.timer = window.setTimeout(show, 180);
   };
 
-  const renderMatchHoverSummary = (payload, eventLike) => {
-    if (!payload || !hoverSummaryIsAllowed()) {
+  const renderMatchHoverSummary = (summary, eventLike) => {
+    if (!summary || !hoverSummaryIsAllowed()) {
       hideHoverSummary();
       return;
     }
     const element = ensureHoverSummaryElement();
-    const color = resolveColorToHex(payload.fill || '#94a3b8') || '#94a3b8';
+    const color = resolveColorToHex(summary.fill || '#94a3b8') || '#94a3b8';
 
     element.replaceChildren();
     const title = createHoverSummaryElement('div', 'feature-hover-summary-title');
     const swatch = createHoverSummaryElement('div', 'feature-hover-summary-swatch');
     swatch.style.backgroundColor = color;
     const titleTextWrap = createHoverSummaryElement('div', 'feature-hover-summary-text');
-    titleTextWrap.appendChild(createHoverSummaryElement('div', 'feature-hover-summary-heading', payload.title));
-    titleTextWrap.appendChild(createHoverSummaryElement('div', 'feature-hover-summary-subtitle', payload.subtitle || payload.id || ''));
+    titleTextWrap.appendChild(createHoverSummaryElement('div', 'feature-hover-summary-heading', summary.title));
+    titleTextWrap.appendChild(createHoverSummaryElement('div', 'feature-hover-summary-subtitle', summary.subtitle || summary.id || ''));
     title.appendChild(swatch);
     title.appendChild(titleTextWrap);
     element.appendChild(title);
 
-    buildPairwiseMatchHoverRows(payload).forEach((row) => {
+    summary.rows.forEach((row) => {
       addHoverSummaryRow(element, row.label, row.value, { clamp: row.label === 'Query' || row.label === 'Subject' });
     });
 
     element.hidden = false;
     hoverSummaryState.visible = true;
-    hoverSummaryState.activeSvgId = String(payload.id || '').trim();
+    hoverSummaryState.activeSvgId = String(summary.id || '').trim();
     scheduleHoverSummaryPosition(eventLike);
     positionHoverSummary(eventLike);
   };
 
-  const scheduleMatchHoverSummary = (payload, eventLike) => {
+  const scheduleMatchHoverSummary = (summary, eventLike) => {
     if (hoverSummaryState.timer) {
       window.clearTimeout(hoverSummaryState.timer);
       hoverSummaryState.timer = null;
     }
-    if (!payload || !hoverSummaryIsAllowed()) {
+    if (!summary || !hoverSummaryIsAllowed()) {
       hideHoverSummary();
       return;
     }
     scheduleHoverSummaryPosition(eventLike);
     const show = () => {
       hoverSummaryState.timer = null;
-      renderMatchHoverSummary(payload, eventLike);
+      renderMatchHoverSummary(summary, eventLike);
     };
     if (hoverSummaryState.visible) {
       show();
@@ -661,6 +661,14 @@ export const createFeatureSvgActions = ({
     orthogroupNameOverrides,
     orthogroupDescriptionOverrides,
     resolveSequenceSource: matchSequenceRegistry?.resolve
+  });
+
+  const buildMatchHoverSummary = (matchElement) => buildPairwiseMatchHoverSummary(matchElement, {
+    orthogroups: () => [
+      ...(Array.isArray(orthogroups?.value) ? orthogroups.value : []),
+      ...(Array.isArray(collinearGroups?.value) ? collinearGroups.value : [])
+    ],
+    orthogroupNameOverrides
   });
 
   const openPairwiseMatchPopup = (matchElement, eventLike, featureLookup) => {
@@ -975,7 +983,7 @@ export const createFeatureSvgActions = ({
         }
         handlerState.activeMatchHoverElement = matchEl;
         handlerState.activeMatchHoverKey = matchKey;
-        scheduleMatchHoverSummary(buildMatchPayload(matchEl, ensureFeatureLookup()), eventLike);
+        scheduleMatchHoverSummary(buildMatchHoverSummary(matchEl), eventLike);
         return true;
       };
 

--- a/gbdraw/web/js/app/pairwise-match-popup.js
+++ b/gbdraw/web/js/app/pairwise-match-popup.js
@@ -211,15 +211,17 @@ const getOrthogroupById = (orthogroups, orthogroupId, groupScope = '') => {
   const requestedScope = normalizeText(groupScope)
     ? normalizeGroupMetadataScope(groupScope)
     : '';
-  const matches = (Array.isArray(orthogroups) ? orthogroups : [])
-    .filter((entry) => {
-      const status = orthogroupIdStatus(entry);
-      const scopeStatus = groupScopeStatus(entry);
-      return status.valid
-        && scopeStatus.valid
-        && status.value === id
-        && (!requestedScope || scopeStatus.value === requestedScope);
-    });
+  const matches = [];
+  for (const entry of Array.isArray(orthogroups) ? orthogroups : []) {
+    const status = orthogroupIdStatus(entry);
+    const scopeStatus = groupScopeStatus(entry);
+    if (
+      status.valid
+      && scopeStatus.valid
+      && status.value === id
+      && (!requestedScope || scopeStatus.value === requestedScope)
+    ) matches.push(entry);
+  }
   return matches.length === 1 ? matches[0] : null;
 };
 
@@ -243,26 +245,6 @@ const getFeatureLookupValues = (featureLookup) => {
   if (Array.isArray(featureLookup)) return featureLookup;
   if (typeof featureLookup === 'object') return Object.values(featureLookup);
   return [];
-};
-
-const uniqueFeatureValues = (...sources) => {
-  const seen = new Set();
-  const features = [];
-  sources.flatMap(getFeatureLookupValues).forEach((feature) => {
-    if (!feature || seen.has(feature)) return;
-    seen.add(feature);
-    features.push(feature);
-  });
-  return features;
-};
-
-const renderedFeatureForId = (renderedSvgId, featureLookup) => {
-  const id = normalizeText(renderedSvgId);
-  if (!id) return null;
-  const candidates = uniqueFeatureValues(featureLookup)
-    .map((feature) => ({ feature, identity: renderedFeatureIdentity(feature) }))
-    .filter(({ identity }) => identity.usable && identity.renderedId.value === id);
-  return candidates.length === 1 ? candidates[0] : null;
 };
 
 const matchEndpointReferences = (element, role) => {
@@ -299,139 +281,53 @@ const matchEndpointReferences = (element, role) => {
   };
 };
 
-const matchEndpointAgrees = (reference, featureLookup) => {
-  const endpoint = renderedFeatureForId(reference.renderedId.value, featureLookup);
-  return Boolean(endpoint && identityMatches(
-    reference,
-    endpoint.identity,
-    { includeRendered: true }
-  ));
-};
-
-const verifiedMatchFeatureLookup = (element, featureLookup) => {
-  const rejected = new Set();
-  for (const role of ['query', 'subject']) {
-    const endpoint = matchEndpointReferences(element, role);
-    if (!endpoint.constrained) continue;
-    const renderedIds = splitMetadataValues(attr(element, `data-${role}-feature-svg-id`));
-    if (!endpoint.valid) {
-      renderedIds.forEach((renderedId) => rejected.add(renderedId));
-      continue;
-    }
-    endpoint.references.forEach((reference) => {
-      if (!matchEndpointAgrees(reference, featureLookup)) {
-        rejected.add(reference.renderedId.value);
-      }
-    });
-  }
-  if (rejected.size === 0) return featureLookup;
-  let entries = [];
-  if (typeof featureLookup?.entries === 'function') {
-    entries = Array.from(featureLookup.entries());
-  } else if (featureLookup && typeof featureLookup === 'object' && !Array.isArray(featureLookup)) {
-    entries = Object.entries(featureLookup);
-  } else if (Array.isArray(featureLookup)) {
-    entries = featureLookup.map((feature) => [featureRenderedSvgId(feature), feature]);
-  }
-  return new Map(entries.filter(([key, feature]) => {
-    const renderedId = renderedFeatureIdentity(feature).renderedId.value;
-    return !rejected.has(normalizeText(key)) && !rejected.has(renderedId);
-  }));
-};
-
-const getRenderedFeatureForMember = (member, feature, featureLookup) => {
-  if (!feature || !featureLookup) return null;
-  const memberIdentity = featureIdentity(member);
-  let sourceIdentity = featureIdentity(feature);
-  if (!sourceIdentity.usable) {
-    sourceIdentity = featureIdentity(feature, { allowLegacySvgStable: true });
-  }
-  if (
-    !memberIdentity.usable ||
-    !sourceIdentity.usable ||
-    !identityMatches(memberIdentity, sourceIdentity)
-  ) return null;
-
-  const memberRendered = textAliasStatus(member, RENDERED_FEATURE_ID_KEYS);
-  const sourceRendered = textAliasStatus(feature, RENDERED_FEATURE_ID_KEYS);
-  if (!memberRendered.valid || !sourceRendered.valid) return null;
-  if (
-    memberRendered.supplied &&
-    sourceRendered.supplied &&
-    memberRendered.value !== sourceRendered.value
-  ) return null;
-  let renderedSvgId = memberRendered.value || sourceRendered.value;
-  if (!renderedSvgId) {
-    const legacyRendered = textAliasStatus(feature, ['svg_id', 'svgId']);
-    if (!legacyRendered.valid) return null;
-    renderedSvgId = legacyRendered.value;
-  }
-  const endpoint = renderedFeatureForId(renderedSvgId, featureLookup);
-  if (
-    !endpoint ||
-    !identityMatches(memberIdentity, endpoint.identity, { includeRendered: true }) ||
-    !identityMatches(sourceIdentity, endpoint.identity)
-  ) return null;
-  return endpoint.feature;
-};
-
-const getFeatureForMember = (member, featureLookup, sourceFeatures = []) => {
-  const identity = featureIdentity(member);
-  if (!identity.usable) return null;
-  const source = Array.isArray(sourceFeatures) && sourceFeatures.length > 0
-    ? sourceFeatures
-    : uniqueFeatureValues(featureLookup);
-  const sourceIsBiological = Array.isArray(sourceFeatures) && sourceFeatures.length > 0;
-  const candidates = source.filter((feature) => {
-    const candidateIdentity = sourceIsBiological
-      ? featureIdentity(feature, { allowLegacySvgStable: true })
-      : renderedFeatureIdentity(feature);
-    if (!identityMatches(identity, candidateIdentity)) return false;
-    if (!identity.renderedId.supplied && !candidateIdentity.renderedId.supplied) return true;
-    return Boolean(getRenderedFeatureForMember(member, feature, featureLookup));
-  });
-  return candidates.length === 1 ? candidates[0] : null;
-};
-
-const getGroupMemberForFeatureSvgId = (group, featureSvgId, featureLookup = null) => {
-  const endpoint = renderedFeatureForId(featureSvgId, featureLookup);
-  if (!endpoint) return null;
-  const members = Array.isArray(group?.members) ? group.members : [];
-  const matches = members.filter((member) => (
-    identityMatches(featureIdentity(member), endpoint.identity, { includeRendered: true })
-  ));
-  return matches.length === 1 ? matches[0] : null;
-};
-
-const groupHasFeatureSvgId = (group, featureSvgId, featureLookup = null) => {
-  const ids = splitMetadataValues(featureSvgId);
-  if (ids.length === 0) return false;
-  return ids.some((id) => Boolean(getGroupMemberForFeatureSvgId(group, id, featureLookup)));
-};
-
-const getOrthogroupForMatch = (
-  orthogroups,
-  {
+const readPairwiseMatchDescriptor = (element) => {
+  const matchKind = normalizeMatchKind(attr(element, 'data-match-kind'), element);
+  const orthogroupId = attr(element, 'data-orthogroup-id');
+  const collinearityBlockId = attr(element, 'data-collinearity-block-id');
+  const groupScope = firstText(
+    attr(element, 'data-collinear-group-scope'),
+    attr(element, 'data-group-scope')
+  );
+  const queryFeatureSvgId = attr(element, 'data-query-feature-svg-id');
+  const subjectFeatureSvgId = attr(element, 'data-subject-feature-svg-id');
+  const queryStart = attr(element, 'data-qstart');
+  const queryEnd = attr(element, 'data-qend');
+  const subjectStart = attr(element, 'data-sstart');
+  const subjectEnd = attr(element, 'data-send');
+  const matchId = firstText(
+    attr(element, 'data-gbdraw-match-id'),
+    attr(element, 'data-gbdraw-pairwise-match-id'),
+    collinearityBlockId,
+    orthogroupId
+  );
+  return {
+    matchKind,
+    matchId,
     orthogroupId,
+    orthogroupIds: uniqueMetadataValues(orthogroupId),
+    collinearityBlockId,
+    groupScope,
+    normalizedGroupScope: normalizeGroupMetadataScope(groupScope),
     queryFeatureSvgId,
     subjectFeatureSvgId,
-    featureLookup,
-    groupScope
-  } = {}
-) => {
-  const requestedId = normalizeText(orthogroupId);
-  const direct = getOrthogroupById(orthogroups, orthogroupId, groupScope);
-  if (direct) return direct;
-  if (requestedId) return null;
-  const groups = Array.isArray(orthogroups) ? orthogroups : [];
-  const matches = groups.filter((group) => {
-    const status = orthogroupIdStatus(group);
-    return status.valid && status.value && (
-      groupHasFeatureSvgId(group, queryFeatureSvgId, featureLookup) ||
-      groupHasFeatureSvgId(group, subjectFeatureSvgId, featureLookup)
-    );
-  });
-  return matches.length === 1 ? matches[0] : null;
+    queryRecordId: attr(element, 'data-query-record-id'),
+    subjectRecordId: attr(element, 'data-subject-record-id'),
+    queryInterval: intervalText(queryStart, queryEnd),
+    subjectInterval: intervalText(subjectStart, subjectEnd),
+    identity: attr(element, 'data-identity'),
+    orientation: firstText(
+      attr(element, 'data-collinearity-orientation'),
+      attr(element, 'data-orientation')
+    ),
+    title: MATCH_KIND_TITLES[matchKind] || MATCH_KIND_TITLES.pairwise,
+    subtitle: firstText(collinearityBlockId, orthogroupId, matchId),
+    fill: firstText(attr(element, 'fill'), element?.style?.fill, '#94a3b8'),
+    endpoints: {
+      query: matchEndpointReferences(element, 'query'),
+      subject: matchEndpointReferences(element, 'subject')
+    }
+  };
 };
 
 const featureOrthogroupIdStatus = (feature) => {
@@ -465,11 +361,13 @@ const featureProduct = (feature) => firstText(
   qualifierFirstValue(feature, 'note')
 );
 
-const featureToOrthogroupMember = (feature) => {
+const featureToOrthogroupMember = (feature, resolvedIdentity = null) => {
   if (!feature) return null;
   const member = feature?.orthogroupMember || feature?.orthogroup_member || {};
-  let identity = featureIdentity(feature);
-  if (!identity.usable) identity = featureIdentity(feature, { allowLegacySvgStable: true });
+  let identity = resolvedIdentity || featureIdentity(feature);
+  if (!resolvedIdentity && !identity.usable) {
+    identity = featureIdentity(feature, { allowLegacySvgStable: true });
+  }
   return {
     recordIndex: identity.recordIndex.value,
     recordKey: firstText(member?.recordKey, member?.record_key, feature?.recordKey, feature?.record_key),
@@ -502,26 +400,325 @@ const featureToOrthogroupMember = (feature) => {
   };
 };
 
-const buildFallbackOrthogroup = ({
+const addBucketValue = (buckets, key, value) => {
+  if (!key) return;
+  if (!buckets.has(key)) buckets.set(key, []);
+  buckets.get(key).push(value);
+};
+
+const identityIndexKeys = (identity) => {
+  if (!identity?.usable) return [];
+  const recordIndex = identity.recordIndex.supplied ? identity.recordIndex.value : null;
+  const keys = [];
+  if (identity.recordKey.supplied && identity.biologicalId.supplied) {
+    keys.push(`canonical:${identity.recordKey.value}\u001f${identity.biologicalId.value}`);
+  }
+  if (recordIndex !== null && identity.sourceIndex.supplied) {
+    keys.push(`source:${recordIndex}\u001f${identity.sourceIndex.value}`);
+  }
+  if (recordIndex !== null && identity.stableId.supplied) {
+    keys.push(`stable:${recordIndex}\u001f${identity.stableId.value}`);
+  }
+  return keys;
+};
+
+const createPairwisePayloadContext = ({
+  featureLookup = new Map(),
+  sourceFeatures = [],
+  orthogroups = [],
+  descriptor = null
+} = {}) => {
+  const identityCache = new WeakMap();
+  const cachedIdentity = (source, mode) => {
+    if (!source || (typeof source !== 'object' && typeof source !== 'function')) {
+      if (mode === 'rendered') return renderedFeatureIdentity(source);
+      return featureIdentity(source, { allowLegacySvgStable: mode === 'legacy' });
+    }
+    let modes = identityCache.get(source);
+    if (!modes) {
+      modes = new Map();
+      identityCache.set(source, modes);
+    }
+    if (!modes.has(mode)) {
+      modes.set(
+        mode,
+        mode === 'rendered'
+          ? renderedFeatureIdentity(source)
+          : featureIdentity(source, { allowLegacySvgStable: mode === 'legacy' })
+      );
+    }
+    return modes.get(mode);
+  };
+
+  const renderedRecords = [];
+  const renderedByObject = new WeakMap();
+  const renderedById = new Map();
+  const featuresByOrthogroupId = new Map();
+  const featureOrthogroupStatuses = new WeakMap();
+  const seenRenderedFeatures = new Set();
+  for (const feature of getFeatureLookupValues(featureLookup)) {
+    if (!feature) continue;
+    const groupStatus = featureOrthogroupIdStatus(feature);
+    featureOrthogroupStatuses.set(feature, groupStatus);
+    if (groupStatus.valid && groupStatus.value) {
+      addBucketValue(featuresByOrthogroupId, groupStatus.value, feature);
+    }
+    if (seenRenderedFeatures.has(feature)) continue;
+    seenRenderedFeatures.add(feature);
+    const identity = cachedIdentity(feature, 'rendered');
+    const record = { feature, identity };
+    renderedRecords.push(record);
+    renderedByObject.set(feature, record);
+    if (identity.usable && identity.renderedId.value) {
+      addBucketValue(renderedById, identity.renderedId.value, record);
+    }
+  }
+
+  const sourceIsBiological = Array.isArray(sourceFeatures) && sourceFeatures.length > 0;
+  const sourceByObject = new WeakMap();
+  const sourceByIdentity = new Map();
+  const sourceValues = sourceIsBiological
+    ? sourceFeatures
+    : renderedRecords.map((record) => record.feature);
+  for (const feature of sourceValues) {
+    if (!feature) continue;
+    const standardIdentity = cachedIdentity(feature, 'standard');
+    const legacyIdentity = sourceIsBiological
+      ? cachedIdentity(feature, 'legacy')
+      : null;
+    const candidateIdentity = sourceIsBiological
+      ? legacyIdentity
+      : renderedByObject.get(feature)?.identity;
+    const record = {
+      feature,
+      candidateIdentity,
+      sourceIdentity: standardIdentity.usable ? standardIdentity : legacyIdentity,
+      sourceRendered: textAliasStatus(feature, RENDERED_FEATURE_ID_KEYS),
+      legacyRendered: textAliasStatus(feature, ['svg_id', 'svgId'])
+    };
+    if (!sourceByObject.has(feature)) sourceByObject.set(feature, record);
+    identityIndexKeys(candidateIdentity).forEach((key) => {
+      addBucketValue(sourceByIdentity, key, record);
+    });
+  }
+
+  const rejectedRenderedIds = new Set();
+  const rawRenderedRecordForId = (renderedSvgId) => {
+    const candidates = renderedById.get(normalizeText(renderedSvgId)) || [];
+    return candidates.length === 1 ? candidates[0] : null;
+  };
+  for (const role of ['query', 'subject']) {
+    const endpoint = descriptor?.endpoints?.[role];
+    if (!endpoint?.constrained) continue;
+    const renderedIds = splitMetadataValues(descriptor[`${role}FeatureSvgId`]);
+    if (!endpoint.valid) {
+      renderedIds.forEach((renderedId) => rejectedRenderedIds.add(renderedId));
+      continue;
+    }
+    endpoint.references.forEach((reference) => {
+      const endpointRecord = rawRenderedRecordForId(reference.renderedId.value);
+      if (!endpointRecord || !identityMatches(
+        reference,
+        endpointRecord.identity,
+        { includeRendered: true }
+      )) rejectedRenderedIds.add(reference.renderedId.value);
+    });
+  }
+
+  const renderedRecordForId = (renderedSvgId) => {
+    const id = normalizeText(renderedSvgId);
+    if (!id || rejectedRenderedIds.has(id)) return null;
+    return rawRenderedRecordForId(id);
+  };
+  const featureForLookupId = (renderedSvgId) => {
+    const id = normalizeText(renderedSvgId);
+    if (!id || rejectedRenderedIds.has(id)) return null;
+    const feature = featureLookup?.get?.(id) || null;
+    const record = feature ? renderedByObject.get(feature) : null;
+    return record && rejectedRenderedIds.has(record.identity.renderedId.value)
+      ? null
+      : feature;
+  };
+
+  const groupMemberIndexes = new WeakMap();
+  const memberIndexForGroup = (group) => {
+    if (!group || typeof group !== 'object') return { records: [], byIdentity: new Map() };
+    const cached = groupMemberIndexes.get(group);
+    if (cached) return cached;
+    const index = { records: [], byIdentity: new Map() };
+    for (const member of Array.isArray(group.members) ? group.members : []) {
+      const record = { member, identity: cachedIdentity(member, 'standard') };
+      index.records.push(record);
+      identityIndexKeys(record.identity).forEach((key) => {
+        addBucketValue(index.byIdentity, key, record);
+      });
+    }
+    groupMemberIndexes.set(group, index);
+    return index;
+  };
+  const groupMemberForFeatureId = (group, featureSvgId) => {
+    const endpoint = renderedRecordForId(featureSvgId);
+    if (!endpoint) return null;
+    const memberIndex = memberIndexForGroup(group);
+    const seen = new Set();
+    const candidates = [];
+    identityIndexKeys(endpoint.identity).forEach((key) => {
+      for (const record of memberIndex.byIdentity.get(key) || []) {
+        if (seen.has(record)) continue;
+        seen.add(record);
+        candidates.push(record);
+      }
+    });
+    const matches = candidates.filter(({ identity }) => (
+      identityMatches(identity, endpoint.identity, { includeRendered: true })
+    ));
+    return matches.length === 1 ? matches[0].member : null;
+  };
+  const groupHasFeatureIds = (group, featureSvgIds) => (
+    splitMetadataValues(featureSvgIds)
+      .some((featureSvgId) => Boolean(groupMemberForFeatureId(group, featureSvgId)))
+  );
+
+  const groupsById = new Map();
+  const groupsByScopedId = new Map();
+  const implicitGroupMatches = [];
+  for (const group of Array.isArray(orthogroups) ? orthogroups : []) {
+    const idStatus = orthogroupIdStatus(group);
+    const scopeStatus = groupScopeStatus(group);
+    if (!idStatus.valid || !idStatus.value) continue;
+    if (scopeStatus.valid) {
+      addBucketValue(groupsById, idStatus.value, group);
+      addBucketValue(
+        groupsByScopedId,
+        `${idStatus.value}\u001f${scopeStatus.value}`,
+        group
+      );
+    }
+    if (
+      descriptor
+      && !normalizeText(descriptor.orthogroupId)
+      && descriptor.matchKind !== 'collinear'
+      && (
+        groupHasFeatureIds(group, descriptor.queryFeatureSvgId)
+        || groupHasFeatureIds(group, descriptor.subjectFeatureSvgId)
+      )
+    ) implicitGroupMatches.push(group);
+  }
+
+  const orthogroupById = (orthogroupId, groupScope = '') => {
+    const id = normalizeText(orthogroupId);
+    if (!id) return null;
+    const requestedScope = normalizeText(groupScope)
+      ? normalizeGroupMetadataScope(groupScope)
+      : '';
+    const candidates = requestedScope
+      ? groupsByScopedId.get(`${id}\u001f${requestedScope}`) || []
+      : groupsById.get(id) || [];
+    return candidates.length === 1 ? candidates[0] : null;
+  };
+  const orthogroupForMatch = () => {
+    const direct = orthogroupById(descriptor?.orthogroupId, descriptor?.groupScope);
+    if (direct) return direct;
+    if (normalizeText(descriptor?.orthogroupId)) return null;
+    return implicitGroupMatches.length === 1 ? implicitGroupMatches[0] : null;
+  };
+
+  const renderedFeatureForMember = (member, feature) => {
+    if (!feature) return null;
+    const memberIdentity = cachedIdentity(member, 'standard');
+    const sourceRecord = sourceByObject.get(feature);
+    const sourceIdentity = sourceRecord?.sourceIdentity;
+    if (
+      !memberIdentity.usable
+      || !sourceIdentity?.usable
+      || !identityMatches(memberIdentity, sourceIdentity)
+    ) return null;
+    const memberRendered = memberIdentity.renderedId;
+    const sourceRendered = sourceRecord.sourceRendered;
+    if (!memberRendered.valid || !sourceRendered.valid) return null;
+    if (
+      memberRendered.supplied
+      && sourceRendered.supplied
+      && memberRendered.value !== sourceRendered.value
+    ) return null;
+    let renderedSvgId = memberRendered.value || sourceRendered.value;
+    if (!renderedSvgId) {
+      if (!sourceRecord.legacyRendered.valid) return null;
+      renderedSvgId = sourceRecord.legacyRendered.value;
+    }
+    const endpoint = renderedRecordForId(renderedSvgId);
+    if (
+      !endpoint
+      || !identityMatches(memberIdentity, endpoint.identity, { includeRendered: true })
+      || !identityMatches(sourceIdentity, endpoint.identity)
+    ) return null;
+    return endpoint.feature;
+  };
+  const featureForMember = (member) => {
+    const memberIdentity = cachedIdentity(member, 'standard');
+    const candidateKey = identityIndexKeys(memberIdentity)[0];
+    if (!candidateKey) return null;
+    const matches = (sourceByIdentity.get(candidateKey) || []).filter((record) => {
+      if (!identityMatches(memberIdentity, record.candidateIdentity)) return false;
+      if (!memberIdentity.renderedId.supplied && !record.candidateIdentity.renderedId.supplied) {
+        return true;
+      }
+      return Boolean(renderedFeatureForMember(member, record.feature));
+    });
+    return matches.length === 1 ? matches[0].feature : null;
+  };
+
+  const identityForFeature = (feature) => {
+    const standard = cachedIdentity(feature, 'standard');
+    return standard.usable ? standard : cachedIdentity(feature, 'legacy');
+  };
+  const orthogroupStatusForFeature = (feature) => (
+    featureOrthogroupStatuses.get(feature) || featureOrthogroupIdStatus(feature)
+  );
+  const fallbackFeaturesForOrthogroup = (orthogroupId, queryFeature, subjectFeature) => {
+    const id = normalizeText(orthogroupId);
+    const matching = featuresByOrthogroupId.get(id) || [];
+    if (matching.length) return matching;
+    return [queryFeature, subjectFeature].filter((feature) => {
+      if (!feature) return false;
+      const status = orthogroupStatusForFeature(feature);
+      return status.valid && (!status.supplied || status.value === id);
+    });
+  };
+
+  return {
+    fallbackFeaturesForOrthogroup,
+    featureForLookupId,
+    featureForMember,
+    groupHasFeatureIds,
+    groupMemberForFeatureId,
+    groupMemberRecords: (group) => memberIndexForGroup(group).records,
+    identityForFeature,
+    orthogroupById,
+    orthogroupForMatch,
+    renderedFeatureForMember
+  };
+};
+
+const buildFallbackOrthogroupWithContext = ({
   orthogroupId,
   queryFeature,
   subjectFeature,
-  featureLookup
+  context
 }) => {
   const id = normalizeText(orthogroupId);
   if (!id) return null;
-  const features = getFeatureLookupValues(featureLookup);
-  const matchingFeatures = features.filter((feature) => featureOrthogroupId(feature) === id);
-  const fallbackFeatures = matchingFeatures.length
-    ? matchingFeatures
-    : [queryFeature, subjectFeature].filter((feature) => {
-        if (!feature) return false;
-        const status = featureOrthogroupIdStatus(feature);
-        return status.valid && (!status.supplied || status.value === id);
-      });
+  const fallbackFeatures = context.fallbackFeaturesForOrthogroup(
+    id,
+    queryFeature,
+    subjectFeature
+  );
   if (!fallbackFeatures.length) return null;
   const members = fallbackFeatures
-    .map(featureToOrthogroupMember)
+    .map((feature) => featureToOrthogroupMember(
+      feature,
+      context.identityForFeature(feature)
+    ))
     .filter(Boolean);
   const firstFeature = fallbackFeatures[0] || {};
   const recordCoverageFallback = new Set(
@@ -537,6 +734,46 @@ const buildFallbackOrthogroup = ({
     members
   };
 };
+
+const getRenderedFeatureForMember = (member, feature, featureLookup) => (
+  createPairwisePayloadContext({ featureLookup, sourceFeatures: [feature] })
+    .renderedFeatureForMember(member, feature)
+);
+
+const getFeatureForMember = (member, featureLookup, sourceFeatures = []) => (
+  createPairwisePayloadContext({ featureLookup, sourceFeatures }).featureForMember(member)
+);
+
+const getGroupMemberForFeatureSvgId = (group, featureSvgId, featureLookup = null) => (
+  createPairwisePayloadContext({ featureLookup, orthogroups: [group] })
+    .groupMemberForFeatureId(group, featureSvgId)
+);
+
+const getOrthogroupForMatch = (orthogroups, options = {}) => (
+  createPairwisePayloadContext({
+    featureLookup: options.featureLookup,
+    orthogroups,
+    descriptor: {
+      matchKind: 'pairwise',
+      orthogroupId: options.orthogroupId,
+      groupScope: options.groupScope,
+      queryFeatureSvgId: options.queryFeatureSvgId,
+      subjectFeatureSvgId: options.subjectFeatureSvgId
+    }
+  }).orthogroupForMatch()
+);
+
+const buildFallbackOrthogroup = ({
+  orthogroupId,
+  queryFeature,
+  subjectFeature,
+  featureLookup
+}) => buildFallbackOrthogroupWithContext({
+  orthogroupId,
+  queryFeature,
+  subjectFeature,
+  context: createPairwisePayloadContext({ featureLookup })
+});
 
 const overrideValue = (overrides, key) => {
   const normalizedKey = normalizeText(key);
@@ -618,14 +855,16 @@ const buildMemberFeaturePayload = (member, feature, nucleotideSequence, aminoAci
   };
 };
 
-const memberFastaText = (member, feature, nucleotideSequence, aminoAcidSequence, sequenceKind) => {
+const buildMemberFastas = (member, feature, nucleotideSequence, aminoAcidSequence) => {
   const fastaFeature = buildMemberFeaturePayload(member, feature, nucleotideSequence, aminoAcidSequence);
   const fastas = buildFeatureSequenceFastas(fastaFeature, {
     nucleotideSequence,
     aminoAcidSequence
   });
-  const text = sequenceKindLabel(sequenceKind) === 'aa' ? fastas.aminoAcidFasta : fastas.nucleotideFasta;
-  return text ? `${text}\n` : '';
+  return {
+    ntFasta: fastas.nucleotideFasta ? `${fastas.nucleotideFasta}\n` : '',
+    aaFasta: fastas.aminoAcidFasta ? `${fastas.aminoAcidFasta}\n` : ''
+  };
 };
 
 const orthogroupSequenceFilename = (orthogroupId, displayName, sequenceKind) => {
@@ -644,14 +883,19 @@ const orthogroupMemberSequenceFilename = (member, orthogroupId, sequenceKind) =>
   return `${makeSafeFilename(`${id}_${memberId}_${sequenceKindLabel(sequenceKind)}`)}.${sequenceExtension(sequenceKind)}`;
 };
 
-const buildOrthogroupMemberRows = (group, featureLookup, orthogroupId, sourceFeatures = []) => {
-  const members = Array.isArray(group?.members) ? group.members : [];
-  return members
-    .map((member) => {
-      const feature = getFeatureForMember(member, featureLookup, sourceFeatures);
-      const renderedFeature = getRenderedFeatureForMember(member, feature, featureLookup);
+const buildOrthogroupMemberRows = (group, context, orthogroupId) => (
+  context.groupMemberRecords(group)
+    .map(({ member }) => {
+      const feature = context.featureForMember(member);
+      const renderedFeature = context.renderedFeatureForMember(member, feature);
       const nucleotideSequence = memberSequence(member, feature, 'nt');
       const aminoAcidSequence = memberSequence(member, feature, 'aa');
+      const fastas = buildMemberFastas(
+        member,
+        feature,
+        nucleotideSequence,
+        aminoAcidSequence
+      );
       return {
         feature: renderedFeature || feature,
         canOpen: Boolean(renderedFeature),
@@ -662,19 +906,19 @@ const buildOrthogroupMemberRows = (group, featureLookup, orthogroupId, sourceFea
         confidence: firstText(member?.confidence, member?.memberConfidence, member?.member_confidence),
         assignmentReason: firstText(member?.assignmentReason, member?.assignment_reason),
         productOrNote: firstText(member?.product, member?.note),
-        ntFasta: memberFastaText(member, feature, nucleotideSequence, aminoAcidSequence, 'nt'),
-        aaFasta: memberFastaText(member, feature, nucleotideSequence, aminoAcidSequence, 'aa'),
+        ntFasta: fastas.ntFasta,
+        aaFasta: fastas.aaFasta,
         ntFilename: orthogroupMemberSequenceFilename(member, orthogroupId, 'nt'),
         aaFilename: orthogroupMemberSequenceFilename(member, orthogroupId, 'aa')
       };
     })
-    .filter((row) => row.record || row.coordinates || row.proteinId || row.role || row.confidence || row.assignmentReason || row.productOrNote || row.ntFasta || row.aaFasta);
-};
+    .filter((row) => row.record || row.coordinates || row.proteinId || row.role || row.confidence || row.assignmentReason || row.productOrNote || row.ntFasta || row.aaFasta)
+);
 
 const resolveFeatureSectionProteinIds = ({
   feature,
   featureSvgIds,
-  featureLookup,
+  context,
   group,
   fallbackProteinIds,
   locusId,
@@ -688,12 +932,15 @@ const resolveFeatureSectionProteinIds = ({
 
   const ids = splitMetadataValues(featureSvgIds);
   ids.forEach((featureSvgId) => {
-    const candidateFeature = featureLookup?.get?.(featureSvgId) || null;
-    const member = getGroupMemberForFeatureSvgId(group, featureSvgId, featureLookup);
+    const candidateFeature = context.featureForLookupId(featureSvgId);
+    const member = context.groupMemberForFeatureId(group, featureSvgId);
     addFeatureProteinId(candidateFeature, member);
   });
   if (feature) {
-    addFeatureProteinId(feature, ids.length === 1 ? getGroupMemberForFeatureSvgId(group, ids[0], featureLookup) : null);
+    addFeatureProteinId(
+      feature,
+      ids.length === 1 ? context.groupMemberForFeatureId(group, ids[0]) : null
+    );
   }
   if (values.length === 0) {
     splitMetadataValues(locusId).forEach((value) => addUniqueDisplayText(values, value));
@@ -753,7 +1000,7 @@ const featureRowSubLabel = (primaryLabel, ...values) => {
 
 const buildFeatureListRows = ({
   featureSvgIds,
-  featureLookup,
+  context,
   group,
   recordId,
   interval,
@@ -770,8 +1017,8 @@ const buildFeatureListRows = ({
 
   return Array.from({ length: count }, (_unused, index) => {
     const svgId = featureIds[index] || '';
-    const feature = svgId ? featureLookup?.get?.(svgId) || null : null;
-    const member = svgId ? getGroupMemberForFeatureSvgId(group, svgId, featureLookup) : null;
+    const feature = svgId ? context.featureForLookupId(svgId) : null;
+    const member = svgId ? context.groupMemberForFeatureId(group, svgId) : null;
     const fallbackProteinId = firstNonInternalDisplayText(
       locusIds[index],
       displayNames[index],
@@ -873,13 +1120,13 @@ const orthogroupMemberSectionExtras = (memberRows, orthogroupId, displayName) =>
 const resolveBlockMemberLabels = ({
   group,
   featureSvgIds,
-  featureLookup
+  context
 }) => {
   if (!group) return '';
   const values = [];
   uniqueMetadataValues(featureSvgIds).forEach((featureSvgId) => {
-    const feature = featureLookup?.get?.(featureSvgId) || null;
-    const member = group ? getGroupMemberForFeatureSvgId(group, featureSvgId, featureLookup) : null;
+    const feature = context.featureForLookupId(featureSvgId);
+    const member = group ? context.groupMemberForFeatureId(group, featureSvgId) : null;
     if (!member) return;
     addUniqueDisplayText(values, resolveDisplayProteinId(feature, member, ''));
   });
@@ -913,16 +1160,14 @@ const buildOrthogroupDetailRows = ({
 
 const buildBlockOrthogroups = ({
   orthogroupIds,
-  orthogroups,
-  featureLookup,
-  sourceFeatures,
+  context,
   queryFeatureSvgId,
   subjectFeatureSvgId,
   orthogroupNameOverrides,
   orthogroupDescriptionOverrides,
   groupScope
 }) => orthogroupIds.map((orthogroupId) => {
-  const group = getOrthogroupById(orthogroups, orthogroupId, groupScope);
+  const group = context.orthogroupById(orthogroupId, groupScope);
   const normalizedGroupScope = normalizeGroupMetadataScope(groupScopeValue(group) || groupScope);
   const displayName = firstText(
     overrideValue(orthogroupNameOverrides, orthogroupId),
@@ -953,15 +1198,15 @@ const buildBlockOrthogroups = ({
     group?.relatedEdgeCount,
     Array.isArray(group?.relatedEdges) ? String(group.relatedEdges.length) : ''
   );
-  const memberRows = buildOrthogroupMemberRows(group, featureLookup, orthogroupId, sourceFeatures);
+  const memberRows = buildOrthogroupMemberRows(group, context, orthogroupId);
   return {
     id: orthogroupId,
     displayName,
     description,
     memberCount,
     recordCoverage,
-    queryMember: resolveBlockMemberLabels({ group, featureSvgIds: queryFeatureSvgId, featureLookup }),
-    subjectMember: resolveBlockMemberLabels({ group, featureSvgIds: subjectFeatureSvgId, featureLookup }),
+    queryMember: resolveBlockMemberLabels({ group, featureSvgIds: queryFeatureSvgId, context }),
+    subjectMember: resolveBlockMemberLabels({ group, featureSvgIds: subjectFeatureSvgId, context }),
     detailRows: buildOrthogroupDetailRows({
       orthogroupId,
       idLabel,
@@ -987,13 +1232,13 @@ const buildFeatureRows = ({
   locusId,
   displayName,
   featureSvgIds,
-  featureLookup,
+  context,
   group
 }) => {
   const rows = [];
   const featureRows = buildFeatureListRows({
     featureSvgIds,
-    featureLookup,
+    context,
     group,
     recordId,
     interval,
@@ -1004,7 +1249,7 @@ const buildFeatureRows = ({
   const displayProteinIds = resolveFeatureSectionProteinIds({
     feature,
     featureSvgIds,
-    featureLookup,
+    context,
     group,
     fallbackProteinIds: proteinId,
     locusId,
@@ -1105,37 +1350,42 @@ export const buildMatchPopupPayload = (
   } = {}
 ) => {
   if (!element) return null;
-  const matchKind = normalizeMatchKind(attr(element, 'data-match-kind'), element);
-  const orthogroupId = attr(element, 'data-orthogroup-id');
-  const orthogroupIds = uniqueMetadataValues(orthogroupId);
-  const collinearityBlockId = attr(element, 'data-collinearity-block-id');
-  const groupScope = firstText(attr(element, 'data-collinear-group-scope'), attr(element, 'data-group-scope'));
-  const normalizedGroupScope = normalizeGroupMetadataScope(groupScope);
-  const queryFeatureSvgId = attr(element, 'data-query-feature-svg-id');
-  const subjectFeatureSvgId = attr(element, 'data-subject-feature-svg-id');
-  const matchFeatureLookup = verifiedMatchFeatureLookup(element, featureLookup);
-  const queryFeature = matchFeatureLookup.get?.(queryFeatureSvgId) || null;
-  const subjectFeature = matchFeatureLookup.get?.(subjectFeatureSvgId) || null;
+  const descriptor = readPairwiseMatchDescriptor(element);
+  const {
+    matchKind,
+    matchId,
+    orthogroupId,
+    orthogroupIds,
+    collinearityBlockId,
+    groupScope,
+    normalizedGroupScope,
+    queryFeatureSvgId,
+    subjectFeatureSvgId,
+    queryInterval: qInterval,
+    subjectInterval: sInterval,
+    title,
+    subtitle
+  } = descriptor;
+  const context = createPairwisePayloadContext({
+    featureLookup,
+    sourceFeatures,
+    orthogroups,
+    descriptor
+  });
+  const queryFeature = context.featureForLookupId(queryFeatureSvgId);
+  const subjectFeature = context.featureForLookupId(subjectFeatureSvgId);
   const group = matchKind === 'collinear'
     ? null
-    : getOrthogroupForMatch(orthogroups, {
-      orthogroupId,
-      queryFeatureSvgId,
-      subjectFeatureSvgId,
-      featureLookup: matchFeatureLookup,
-      groupScope
-    }) || buildFallbackOrthogroup({
+    : context.orthogroupForMatch() || buildFallbackOrthogroupWithContext({
       orthogroupId,
       queryFeature,
       subjectFeature,
-      featureLookup: matchFeatureLookup
+      context
     });
   const blockOrthogroups = matchKind === 'collinear'
     ? buildBlockOrthogroups({
       orthogroupIds,
-      orthogroups,
-      featureLookup: matchFeatureLookup,
-      sourceFeatures,
+      context,
       queryFeatureSvgId,
       subjectFeatureSvgId,
       orthogroupNameOverrides,
@@ -1155,26 +1405,13 @@ export const buildMatchPopupPayload = (
     overrideValue(orthogroupDescriptionOverrides, orthogroupId),
     group?.description
   );
-  const qInterval = intervalText(attr(element, 'data-qstart'), attr(element, 'data-qend'));
-  const sInterval = intervalText(attr(element, 'data-sstart'), attr(element, 'data-send'));
-  const title = MATCH_KIND_TITLES[matchKind] || MATCH_KIND_TITLES.pairwise;
-  const matchId = firstText(
-    attr(element, 'data-gbdraw-match-id'),
-    attr(element, 'data-gbdraw-pairwise-match-id'),
-    collinearityBlockId,
-    orthogroupId
-  );
-  const subtitle = firstText(collinearityBlockId, orthogroupId, matchId);
 
   const summaryRows = [];
-  addRow(summaryRows, 'Query record', attr(element, 'data-query-record-id'));
-  addRow(summaryRows, 'Subject record', attr(element, 'data-subject-record-id'));
+  addRow(summaryRows, 'Query record', descriptor.queryRecordId);
+  addRow(summaryRows, 'Subject record', descriptor.subjectRecordId);
   addRow(summaryRows, 'Query interval', qInterval);
   addRow(summaryRows, 'Subject interval', sInterval);
-  addRow(summaryRows, 'Orientation', firstText(
-    attr(element, 'data-collinearity-orientation'),
-    attr(element, 'data-orientation')
-  ));
+  addRow(summaryRows, 'Orientation', descriptor.orientation);
   if (matchKind === 'homology') {
     addRow(summaryRows, 'Ring label', attr(element, 'data-track-label'));
     const rawSourceIndex = integerAttr(element, 'data-source-index');
@@ -1184,7 +1421,7 @@ export const buildMatchPopupPayload = (
   }
 
   const alignmentRows = [];
-  addRow(alignmentRows, 'Identity', attr(element, 'data-identity'));
+  addRow(alignmentRows, 'Identity', descriptor.identity);
   addRow(alignmentRows, 'Alignment length', attr(element, 'data-alignment-length'));
   addRow(alignmentRows, 'E-value', attr(element, 'data-evalue'));
   addRow(alignmentRows, 'Bit score', attr(element, 'data-bitscore'));
@@ -1209,7 +1446,7 @@ export const buildMatchPopupPayload = (
   addRow(blockRows, 'Orientation', attr(element, 'data-collinearity-orientation'));
   addRow(blockRows, 'Color mode', attr(element, 'data-collinearity-color-mode'));
   if (matchKind === 'collinear') {
-    addRow(blockRows, 'Average identity', attr(element, 'data-identity'));
+    addRow(blockRows, 'Average identity', descriptor.identity);
     addRow(blockRows, 'Aligned length', attr(element, 'data-alignment-length'));
   }
   addRow(blockRows, 'Block score', attr(element, 'data-collinearity-block-score'));
@@ -1236,12 +1473,7 @@ export const buildMatchPopupPayload = (
       Array.isArray(group?.relatedEdges) ? String(group.relatedEdges.length) : ''
     ));
   }
-  const orthogroupMemberRows = buildOrthogroupMemberRows(
-    group,
-    matchFeatureLookup,
-    orthogroupId,
-    sourceFeatures
-  );
+  const orthogroupMemberRows = buildOrthogroupMemberRows(group, context, orthogroupId);
 
   if (matchKind === 'orthogroup') {
     const summarySection = section(
@@ -1258,7 +1490,7 @@ export const buildMatchPopupPayload = (
       collinearityBlockId,
       queryFeatureSvgId,
       subjectFeatureSvgId,
-      fill: firstText(element.getAttribute('fill'), element.style?.fill, '#94a3b8'),
+      fill: descriptor.fill,
       sections: summarySection.rows.length > 0 || summarySection.memberRows.length > 0
         ? [summarySection]
         : []
@@ -1298,25 +1530,25 @@ export const buildMatchPopupPayload = (
   if (matchKind !== 'homology') sections.push(buildFeatureRows({
     title: 'Query',
     feature: queryFeature,
-    recordId: attr(element, 'data-query-record-id'),
+    recordId: descriptor.queryRecordId,
     interval: qInterval,
     proteinId: attr(element, 'data-query-protein-id'),
     locusId: attr(element, 'data-query-locus-id'),
     displayName: attr(element, 'data-query-display-name'),
     featureSvgIds: queryFeatureSvgId,
-    featureLookup: matchFeatureLookup,
+    context,
     group
   }));
   if (matchKind !== 'homology') sections.push(buildFeatureRows({
     title: 'Subject',
     feature: subjectFeature,
-    recordId: attr(element, 'data-subject-record-id'),
+    recordId: descriptor.subjectRecordId,
     interval: sInterval,
     proteinId: attr(element, 'data-subject-protein-id'),
     locusId: attr(element, 'data-subject-locus-id'),
     displayName: attr(element, 'data-subject-display-name'),
     featureSvgIds: subjectFeatureSvgId,
-    featureLookup: matchFeatureLookup,
+    context,
     group
   }));
 
@@ -1339,7 +1571,7 @@ export const buildMatchPopupPayload = (
     subjectFeatureSvgId,
     blockOrthogroupCount: blockOrthogroups.length || (matchKind === 'collinear' ? orthogroupIds.length : 0),
     blockOrthogroups,
-    fill: firstText(element.getAttribute('fill'), element.style?.fill, '#94a3b8'),
+    fill: descriptor.fill,
     sequenceTitle: matchKind === 'collinear' ? 'Collinear block spans' : 'Matched sequences',
     sequenceNote: matchKind === 'collinear'
       ? 'Block envelopes may include intergenic sequence and genes that are not anchors.'
@@ -1356,42 +1588,121 @@ export const buildMatchPopupPayload = (
 export const buildPairwiseMatchPayload = (element, options = {}) =>
   buildMatchPopupPayload(element, options);
 
-export const buildPairwiseMatchHoverRows = (payload) => {
+const formatPairwiseMatchHoverRows = ({
+  matchKind,
+  identity,
+  queryInterval,
+  subjectInterval,
+  orthogroupId,
+  displayName,
+  memberCount,
+  groupScope,
+  blockOrthogroupCount,
+  collinearityBlockId
+} = {}) => {
   const rows = [];
   const addFirst = (label, value) => addRow(rows, label, value);
-  if (!payload) return rows;
-  const summary = payload.sections.find((entry) => entry.title === 'Summary');
-  const findValue = (sectionEntry, label) =>
-    sectionEntry?.rows.find((row) => row.label === label)?.value || '';
-  if (payload.matchKind === 'orthogroup') {
-    addFirst('Kind', payload.matchKind);
-    addFirst(
-      'Similarity group',
-      findValue(summary, 'Similarity group ID') || payload.orthogroupId
-    );
-    addFirst('Display name', findValue(summary, 'Display name'));
-    addFirst('Members', findValue(summary, 'Members'));
+  if (!matchKind) return rows;
+  if (matchKind === 'orthogroup') {
+    addFirst('Kind', matchKind);
+    addFirst('Similarity group', orthogroupId);
+    addFirst('Display name', displayName);
+    addFirst('Members', memberCount);
     return rows.slice(0, 6);
   }
+  addFirst('Kind', matchKind);
+  addFirst('Identity', identity);
+  addFirst('Query', queryInterval);
+  addFirst('Subject', subjectInterval);
+  if (matchKind === 'collinear') {
+    addFirst(
+      groupScope === 'adjacent_local'
+        ? 'Collinear groups'
+        : 'Similarity groups',
+      String(blockOrthogroupCount ?? '')
+    );
+  } else {
+    addFirst('Similarity group', orthogroupId);
+  }
+  addFirst('Block', collinearityBlockId);
+  return rows.slice(0, 6);
+};
+
+export const buildPairwiseMatchHoverSummary = (
+  element,
+  {
+    orthogroups = [],
+    orthogroupNameOverrides = null
+  } = {}
+) => {
+  if (!element) return null;
+  const descriptor = readPairwiseMatchDescriptor(element);
+  const groupValues = descriptor.matchKind === 'orthogroup'
+    ? (typeof orthogroups === 'function' ? orthogroups() : orthogroups)
+    : [];
+  const group = descriptor.matchKind === 'orthogroup'
+    ? getOrthogroupById(
+      groupValues,
+      descriptor.orthogroupId,
+      descriptor.groupScope
+    )
+    : null;
+  const displayName = descriptor.matchKind === 'orthogroup'
+    ? firstText(
+      overrideValue(orthogroupNameOverrides, descriptor.orthogroupId),
+      group?.displayName,
+      group?.display_name,
+      group?.name
+    )
+    : '';
+  const memberCount = descriptor.matchKind === 'orthogroup'
+    ? firstText(group?.member_count, group?.memberCount)
+    : '';
+  return {
+    id: descriptor.matchId,
+    title: descriptor.matchKind === 'orthogroup'
+      ? orthogroupTitle(descriptor.orthogroupId, displayName)
+      : descriptor.title,
+    subtitle: descriptor.matchKind === 'orthogroup' ? '' : descriptor.subtitle,
+    fill: descriptor.fill,
+    rows: formatPairwiseMatchHoverRows({
+      matchKind: descriptor.matchKind,
+      identity: descriptor.identity,
+      queryInterval: descriptor.queryInterval,
+      subjectInterval: descriptor.subjectInterval,
+      orthogroupId: descriptor.orthogroupId,
+      displayName,
+      memberCount,
+      groupScope: descriptor.normalizedGroupScope,
+      blockOrthogroupCount: descriptor.orthogroupIds.length,
+      collinearityBlockId: descriptor.collinearityBlockId
+    })
+  };
+};
+
+export const buildPairwiseMatchHoverRows = (payload) => {
+  if (!payload) return [];
+  const summary = payload.sections.find((entry) => entry.title === 'Summary');
   const alignment = payload.sections.find((entry) => entry.title === 'Alignment');
   const block = payload.sections.find((entry) => entry.title === 'Collinearity');
   const orthogroup = payload.sections.find(
     (entry) => entry.title === 'Similarity group'
   );
-  addFirst('Kind', payload.matchKind);
-  addFirst('Identity', findValue(alignment, 'Identity') || findValue(block, 'Average identity'));
-  addFirst('Query', findValue(summary, 'Query interval'));
-  addFirst('Subject', findValue(summary, 'Subject interval'));
-  if (payload.matchKind === 'collinear') {
-    addFirst(
-      payload.groupScope === 'adjacent_local'
-        ? 'Collinear groups'
-        : 'Similarity groups',
-      String(payload.blockOrthogroupCount ?? '')
-    );
-  } else {
-    addFirst('Similarity group', findValue(orthogroup, 'Similarity group ID'));
-  }
-  addFirst('Block', findValue(block, 'Block ID'));
-  return rows.slice(0, 6);
+  const findValue = (sectionEntry, label) => (
+    sectionEntry?.rows.find((row) => row.label === label)?.value || ''
+  );
+  return formatPairwiseMatchHoverRows({
+    matchKind: payload.matchKind,
+    identity: findValue(alignment, 'Identity') || findValue(block, 'Average identity'),
+    queryInterval: findValue(summary, 'Query interval'),
+    subjectInterval: findValue(summary, 'Subject interval'),
+    orthogroupId: payload.matchKind === 'orthogroup'
+      ? findValue(summary, 'Similarity group ID') || payload.orthogroupId
+      : findValue(orthogroup, 'Similarity group ID'),
+    displayName: findValue(summary, 'Display name'),
+    memberCount: findValue(summary, 'Members'),
+    groupScope: payload.groupScope,
+    blockOrthogroupCount: payload.blockOrthogroupCount,
+    collinearityBlockId: findValue(block, 'Block ID')
+  });
 };

--- a/tests/web/pairwise-payload-performance.test.mjs
+++ b/tests/web/pairwise-payload-performance.test.mjs
@@ -1,0 +1,799 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { gunzipSync } from 'node:zlib';
+
+const repoRoot = new URL('../..', import.meta.url);
+const tempRoot = await mkdtemp(join(tmpdir(), 'gbdraw-pairwise-payload-'));
+
+const modulePaths = [
+  'gbdraw/web/js/app/pairwise-match-popup.js',
+  'gbdraw/web/js/app/feature-utils.js',
+  'gbdraw/web/js/app/feature-sequence-fasta.js',
+  'gbdraw/web/js/app/match-sequences.js',
+  'gbdraw/web/js/app/conservation-series.js',
+  'gbdraw/web/js/app/color-utils.js',
+  'gbdraw/web/js/app/losat-normalization.js',
+  'gbdraw/web/js/services/file-content-cache.js',
+  'gbdraw/web/js/services/feature-catalog.js',
+  'gbdraw/web/js/services/feature-identity.js',
+  'gbdraw/web/js/services/orthogroup-feature-metadata.js',
+  'gbdraw/web/js/services/runtime-test-hooks.js'
+];
+
+await writeFile(join(tempRoot, 'package.json'), '{"type":"module"}\n', 'utf8');
+for (const relativePath of modulePaths) {
+  const target = join(tempRoot, relativePath);
+  await mkdir(dirname(target), { recursive: true });
+  const source = relativePath.endsWith('/file-content-cache.js')
+    ? 'export const readFileText = (file) => file.text();\n'
+    : await readFile(new URL(relativePath, repoRoot), 'utf8');
+  await writeFile(target, source, 'utf8');
+}
+
+const popupPath = join(tempRoot, 'gbdraw/web/js/app/pairwise-match-popup.js');
+const instrumentedPopupPath = join(
+  tempRoot,
+  'gbdraw/web/js/app/pairwise-match-popup-instrumented.js'
+);
+const popupSource = await readFile(popupPath, 'utf8');
+const instrumentedPopupSource = popupSource
+  .replace(
+    "import { buildFeatureSequenceFastas } from './feature-sequence-fasta.js';",
+    "import { buildFeatureSequenceFastas as buildFeatureSequenceFastasBase } from './feature-sequence-fasta.js';"
+  )
+  .replace(
+    "import { buildMatchSequenceBundle } from './match-sequences.js';",
+    "import { buildMatchSequenceBundle as buildMatchSequenceBundleBase } from './match-sequences.js';"
+  )
+  .replace(
+    '  featureIdentity,\n  identityMatches,\n  renderedFeatureIdentity,',
+    '  featureIdentity as featureIdentityBase,\n  identityMatches,\n  renderedFeatureIdentity as renderedFeatureIdentityBase,'
+  )
+  .replace(
+    'export const PAIRWISE_MATCH_SELECTOR = [',
+    `const pairwiseMetrics = () => globalThis.__GBDRAW_PAIRWISE_TEST_METRICS__;
+const buildFeatureSequenceFastas = (...args) => {
+  if (pairwiseMetrics()) pairwiseMetrics().fastaCalls += 1;
+  return buildFeatureSequenceFastasBase(...args);
+};
+const buildMatchSequenceBundle = (...args) => {
+  if (pairwiseMetrics()) pairwiseMetrics().sequenceBundleCalls += 1;
+  return buildMatchSequenceBundleBase(...args);
+};
+const featureIdentity = (source, options = {}) => {
+  if (pairwiseMetrics()) pairwiseMetrics().identityCalls.push({
+    source,
+    mode: options.allowLegacySvgStable ? 'legacy' : 'standard'
+  });
+  return featureIdentityBase(source, options);
+};
+const renderedFeatureIdentity = (source) => {
+  if (pairwiseMetrics()) pairwiseMetrics().identityCalls.push({ source, mode: 'rendered' });
+  return renderedFeatureIdentityBase(source);
+};
+
+export const PAIRWISE_MATCH_SELECTOR = [`
+  )
+  .replace(
+    'const createPairwisePayloadContext = ({',
+    `const createPairwisePayloadContext = (options = {}) => {
+  if (pairwiseMetrics()) pairwiseMetrics().contextCreations += 1;
+  return createPairwisePayloadContextImplementation(options);
+};
+
+const createPairwisePayloadContextImplementation = ({`
+  );
+assert.notEqual(instrumentedPopupSource, popupSource, 'pairwise instrumentation was not applied');
+await writeFile(instrumentedPopupPath, instrumentedPopupSource, 'utf8');
+
+const popupModule = await import(pathToFileURL(join(
+  tempRoot,
+  'gbdraw/web/js/app/pairwise-match-popup.js'
+)));
+const instrumentedPopupModule = await import(pathToFileURL(instrumentedPopupPath));
+const { admitFeatureCatalog } = await import(pathToFileURL(join(
+  tempRoot,
+  'gbdraw/web/js/services/feature-catalog.js'
+)));
+const { createSequenceSourceRegistry } = await import(pathToFileURL(join(
+  tempRoot,
+  'gbdraw/web/js/app/match-sequences.js'
+)));
+
+const elementFrom = (attributes) => ({
+  style: { fill: attributes.fill || '' },
+  getAttribute: (name) => attributes[name] || ''
+});
+
+const sha256 = (value) => createHash('sha256')
+  .update(JSON.stringify(value))
+  .digest('hex');
+
+const sortedCanonical = (value, featureTokens = new WeakMap()) => {
+  if (value === null || typeof value !== 'object') return value;
+  const token = featureTokens.get(value);
+  if (token) return { __featureReference: token };
+  if (Array.isArray(value)) {
+    return value.map((entry) => sortedCanonical(entry, featureTokens));
+  }
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, sortedCanonical(value[key], featureTokens)])
+  );
+};
+
+const makeSyntheticState = () => {
+  const renderedQuery = {
+    fileIdx: 0,
+    sourceFeatureIndex: 3,
+    stable_feature_id: 'stable-query',
+    svg_id: 'rendered-query',
+    record_id: 'query-record',
+    start: 9,
+    end: 18,
+    strand: '+',
+    protein_id: 'QUERY.1',
+    product: 'query enzyme',
+    nucleotide_sequence: 'ATGAAATAA',
+    amino_acid_sequence: 'MK'
+  };
+  const renderedSubject = {
+    fileIdx: 1,
+    sourceFeatureIndex: 7,
+    stable_feature_id: 'stable-subject',
+    svg_id: 'rendered-subject',
+    record_id: 'subject-record',
+    start: 29,
+    end: 38,
+    strand: '-',
+    protein_id: 'SUBJECT.1',
+    product: 'subject enzyme'
+  };
+  const sourceQuery = { ...renderedQuery, svg_id: 'stable-query' };
+  const sourceSubject = { ...renderedSubject, svg_id: 'stable-subject' };
+  const queryMember = {
+    recordIndex: 0,
+    featureIndex: 3,
+    stableFeatureSvgId: 'stable-query',
+    renderedFeatureSvgId: 'rendered-query',
+    recordId: 'query-record',
+    start: 9,
+    end: 18,
+    strand: '+',
+    proteinId: 'QUERY.1',
+    role: 'anchor',
+    confidence: 'high',
+    product: 'query enzyme',
+    nucleotideSequence: 'ATGAAATAA',
+    aminoAcidSequence: 'MK'
+  };
+  const subjectMember = {
+    recordIndex: 1,
+    featureIndex: 7,
+    stableFeatureSvgId: 'stable-subject',
+    renderedFeatureSvgId: 'rendered-subject',
+    recordId: 'subject-record',
+    start: 29,
+    end: 38,
+    strand: '-',
+    proteinId: 'SUBJECT.1',
+    role: 'member',
+    confidence: 'medium',
+    product: 'subject enzyme'
+  };
+  const globalGroup = {
+    id: 'og-main',
+    name: 'Main enzymes',
+    description: 'Synthetic similarity group',
+    scope: 'global',
+    member_count: 2,
+    record_coverage_count: 2,
+    members: [queryMember, subjectMember]
+  };
+  const localGroup = {
+    ...globalGroup,
+    name: 'Local enzymes',
+    scope: 'cross_record',
+    presentationScope: 'adjacent_local',
+    collinearGroupScope: 'adjacent_local',
+    groupKind: 'collinear_gene_group'
+  };
+  return {
+    renderedQuery,
+    renderedSubject,
+    sourceQuery,
+    sourceSubject,
+    queryMember,
+    subjectMember,
+    globalGroup,
+    localGroup,
+    featureLookup: new Map([
+      ['rendered-query', renderedQuery],
+      ['rendered-subject', renderedSubject]
+    ]),
+    sourceFeatures: [sourceQuery, sourceSubject]
+  };
+};
+
+const commonAttributes = {
+  'data-gbdraw-pairwise-match-id': 'match-synthetic',
+  'data-query-record-id': 'query-record',
+  'data-subject-record-id': 'subject-record',
+  'data-query-record-index': '0',
+  'data-subject-record-index': '1',
+  'data-query-feature-index': '3',
+  'data-subject-feature-index': '7',
+  'data-query-feature-svg-id': 'rendered-query',
+  'data-subject-feature-svg-id': 'rendered-subject',
+  'data-query-stable-feature-svg-id': 'stable-query',
+  'data-subject-stable-feature-svg-id': 'stable-subject',
+  'data-query-protein-id': 'QUERY.1',
+  'data-subject-protein-id': 'SUBJECT.1',
+  'data-query-locus-id': 'query-locus',
+  'data-subject-locus-id': 'subject-locus',
+  'data-query-display-name': 'query gene',
+  'data-subject-display-name': 'subject gene',
+  'data-qstart': '10',
+  'data-qend': '18',
+  'data-sstart': '30',
+  'data-send': '38',
+  'data-identity': '88.5',
+  'data-alignment-length': '9',
+  'data-evalue': '1e-10',
+  'data-bitscore': '42',
+  fill: '#123456'
+};
+
+const buildSyntheticCases = () => {
+  const state = makeSyntheticState();
+  const sources = createSequenceSourceRegistry([
+    {
+      key: 'linear:record:0',
+      recordId: 'query-record',
+      aliases: [],
+      sequence: 'AAAAAAAAAATGAAATAACCCCC',
+      origin: 'linear-record',
+      recordIndex: 0
+    },
+    {
+      key: 'linear:record:1',
+      recordId: 'subject-record',
+      aliases: [],
+      sequence: 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCATGAAATAAGGGG',
+      origin: 'linear-record',
+      recordIndex: 1
+    }
+  ]);
+  const fullOptions = {
+    featureLookup: state.featureLookup,
+    sourceFeatures: state.sourceFeatures,
+    orthogroups: [state.globalGroup, state.localGroup],
+    resolveSequenceSource: sources.resolve
+  };
+  const duplicateRendered = {
+    ...state.renderedQuery,
+    svg_id: 'rendered-query'
+  };
+  return {
+    ordinary: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'pairwise',
+        'data-orthogroup-id': 'og-main'
+      }),
+      options: fullOptions,
+      featureReferences: [state.renderedQuery, state.renderedSubject]
+    },
+    orthogroup: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'orthogroup',
+        'data-orthogroup-id': 'og-main'
+      }),
+      options: fullOptions,
+      featureReferences: [state.renderedQuery, state.renderedSubject]
+    },
+    collinear: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'collinear',
+        'data-orthogroup-id': 'og-main',
+        'data-collinearity-block-id': 'block-synthetic',
+        'data-collinear-group-scope': 'adjacent_local',
+        'data-collinearity-block-kind': 'cluster',
+        'data-collinearity-orientation': 'plus',
+        'data-collinearity-color-mode': 'orientation_identity',
+        'data-collinearity-block-score': '42',
+        'data-collinearity-anchor-index': '1',
+        'data-collinearity-anchor-count': '1'
+      }),
+      options: fullOptions,
+      featureReferences: [state.renderedQuery, state.renderedSubject]
+    },
+    homologyUnavailable: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'homology',
+        'data-source-index': '4',
+        'data-reference-side': 'query',
+        'data-track-label': 'Comparison ring',
+        'data-reference-record-id': 'query-record'
+      }),
+      options: { resolveSequenceSource: () => null },
+      featureReferences: []
+    },
+    ambiguousFeature: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'pairwise'
+      }),
+      options: {
+        featureLookup: new Map([
+          ['rendered-query', state.renderedQuery],
+          ['duplicate-key', duplicateRendered],
+          ['rendered-subject', state.renderedSubject]
+        ]),
+        sourceFeatures: state.sourceFeatures
+      },
+      featureReferences: [state.renderedSubject]
+    },
+    conflictingEndpoint: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'pairwise',
+        'data-query-stable-feature-svg-id': 'wrong-stable-id'
+      }),
+      options: fullOptions,
+      featureReferences: [state.renderedSubject]
+    },
+    duplicateGroup: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'orthogroup',
+        'data-orthogroup-id': 'og-duplicate'
+      }),
+      options: {
+        featureLookup: new Map(),
+        sourceFeatures: [],
+        orthogroups: [
+          { id: 'og-duplicate', scope: 'global', members: [] },
+          { orthogroupId: 'og-duplicate', scope: 'global', members: [] }
+        ]
+      },
+      featureReferences: []
+    },
+    scopedGroup: {
+      element: elementFrom({
+        ...commonAttributes,
+        'data-match-kind': 'orthogroup',
+        'data-orthogroup-id': 'og-main',
+        'data-group-scope': 'adjacent_local'
+      }),
+      options: fullOptions,
+      featureReferences: [state.renderedQuery, state.renderedSubject]
+    }
+  };
+};
+
+const SYNTHETIC_BASELINES_GZIP = 'H4sIAAAAAAAAA+1cX2/bNhD/KoL2sqGxZzfb0AXoAMdrt6xputnpwzAHBi3RtjaZ1CQqndf2u+9ISiKpP7bi2onTEX1oLB3J493x7nenk967NPYDguK1e/bejdA6pMjnf85C6v31JmZLuohpGg1pSph71jsp30jcsz9uTlyPhmFAMIoDtj7nFBcwi+ueuPMgDOGvL/pPT7/59ju4IEaNPRphuLwI6QyFcDXg5CvEvGUnWRO2xCzw4LK48iog/G6EgvhdkGC4TIvlxTJ00VmhgMCNv1Mcr19ixNIYj28X4m6MiY9j7HfETSBKsMcCSjjn792YvpN/hGiGOae/cSonxh4IBohvUZhyTsXgTnb544miH6ezP2HC6ohE3qgbI9cICMPxrdh+Pqbf63b7z2rnr6E+BepToAb5s4CFWFCvVlyZfIbK1i58TIBwrU3x7Fn3W2O5QRgsyAronBCTBVtqtN8bhC868rrGPO70ewbNecCcBHavU33z1GC4WE8MXOHVDMcDlJlb/6S48hIlDAH9D7+9fTH6vdt3hEIcTP5dr/CEvH414fovqAPgHq2wMo6poJ9K+ilC3TlCxYAhjdbX+B9Y0R0JbU3YkMqDwXDifPnk685XE/ZrTBkOiHPx44SNaIg5EZkHIFQP/h4kSS65GKOEEjHAT0F1XzsERk6IbkMTJnUNk8PU2aYmTP4z92Ya0oRJtTtfcp7Gb89/eTG8VkMz4mxwscMrVhbpFStEqvN11u91gCuTg8H1T4PB4How0IQM47cImbDunCghj3JzRC2VierUmI1QGkSF3EdC7NLteIi8iTD8YHGKuXvKFZXdVtotTh3XBHdY0ntwHzidZj9GeA4eRI7O/eUZN3WX7CxFUie/fHeF6CJpQm/iK7Cg3A0p5UbSJIWfy8bC1czjlJwWXKfiyImTppTQJOnCtPYqa2W8d5F135R1k/gUy40CrJwPXYTFeF2IJT+uifHmpOpjx8EqCEUYdESAAm+hOb88UulO8scgiUK0dsReSgEnZ1Onfy1OU6KRPjXuSw/mePQWx2iBTTo9VJQ4FZPkSsi3VdFt4ShbODNJAmggTXKftsAEm/4N+POlBK6kMhXhnU/jX3hdCfidHkxTBN7ijABXiKOA8vEX3F6owyN+Kzv61CMIxnSZ8aLNDxHC2HXSBF3YOmo2vVFrzHKZb76MPIQQdEoV8zTafJslQiGfFgZ8KbZszKjLuvXZEMLSLVrAqjuaccvgmpNlxpx7EWnOFZ9iGrROfGenVzLpnA/dqHWvpZm14WmVWRs7MQx7D65RM29jHTDwkhQqJp7dv7ORb4DZNWauCWWrmastbzb0kty2mLop/xbGbgjOxPpSYvxaguFMgP2cp8QPhW15dDWDjMwv8Ekpu5JY7YMU23PdVXwQETt5Ll3Ch4TFiPjPnxgApjJbxmU+n6mVfEYp/foZBVLIWFaRvbzMjLJlFtkBhcQBziDlLYJYNuM7lyd8fpBdy3y2iTcJfvU5pwIGZvxS4Jaw/HQ+cZXSLmWmdfY9XIoQ4drLPMiIao6Nb5kfGUgQAVPDHS8Vd0nqhZgywFzF2bxoRn9FFkzT2MOvhHuRqftZhl25bwHpxUyEBe6EUlIIWAE/gSJby30f9rFB9tl8U3Pe6Wmvc7oH+Y8L3yQ1cNpSA03QUfm6Zi30NS2cbtDCzUe1kQzjalu7znzFay4v7Dv59UQ6a85FU7lEYzKd5T5HlVryK79mZRlHqITzueTIc1R23KKKo7xaUc3RPWCbAkV+FraXTGoqJSfNQL0OpXPZqlpTqULWvuTVorilrbLX8pYtqNiCytEXVHJrtyWV+yipFNK2RZUDFFXy+vvNbvFVC6zZts5KPLcLr1o8uWvQ27cUeRAtYmWrp0z92qdMAMpw4sVBlCG4cR5KnaS6Kx8zgEoVKQ1zPj7RjnhmGWYSKCVxGo9aKtnMq6Ee8VisvIxnMr1XuzUrFea2MuCi4McBwYRYOYtzyfGiCUS8JY0nbBksljvjCrkp/r8fpKsNGCOTM6jqnlGHqY1jhR1cCZ8GPYqT9XiRh7TI+8Qf0mw/DYUowR8jCJF2LvyjELp0sjVaGeZuVZ7RbL6CXCsgNrZIiEBnpIWbOyaQ/yfyQFtTXult2Tmhoq9tnWguCLzR6kNanSLkVdqGDguLUixKsSjFohSLUixK+UxQSiWoX6WczqFzJ6zz87pT7xuBsjYsJPWdiQIPmXGuDIz0eFEqdngQoxmOW0fzEyPU0thZUV8POtqTommQP5IwmiSlQJ2gbUMl9re1U0oJ1DVL6nPJY6RJHMKCKfWhhjIfZUdPydvZlh7b0vPoW3pKgcT29NieHtvTY3t6bE+P7elp29Mj8SEmtzikEU6cFeJVMEC+Ppb1LXAlvHCTjXJA2MK7JA5bIuagGPP6gSMTsaTrVluEVNVpJrEoiG3XNqFqVbMOn8qFWj/TVGXMh+oZGm7MfcpoflMycyM2DeZGF+u3RDtyR/4SXs5ztZJsS8gAZAKycOQPRTekqwhUAmfbieG+Ob1wFTC7j//RhpjWWyBJJwn8CmZuIN0iws/klcFWKGlfKGSOwkQLh2bwahWMek3BSCULhwMErRDAOI8fQeJo97tlZHBAWajzcuDY3CoYa6e3iK3vUCKCaZJGURhg35nTGMIsiOz8cjC+duQi3fvuza167vzOz5nXFg7ojo26hce/16DLJYfgzC5SmiYvVXp91MGx+Q31/21w/EziTPXV9F71saJb/+ywsIQiodnaM+1WnqT1qk/S3PqHY43L1T8gq6vHbCla5DWRnd8lzYLHltJzXbW5rvRcKc7Vl5tJGoYtyslmibhSUnbblJNLZTaTrG0Z+cELx9uLaU0lXlsN3lgNLse12gcdtihsi8K7FYUfQbpzjLXPI8h8jrck2SycY0lxHtVriPKVCDIPA4D7ZPGC+BENOMyzCY5NcGyCYxMcm+DYBOfxJjg1oc3mODbH2WOOYxtfbOPLPpM/2/hyDFmmzSZ3zib9NIKIixj+6YG/VFMwslNGuHMOoi08NX4cJgdpXK59DrL1mxZKkof7wIS2xiE/LKFvhZ9wXnrwH9pSj/GbSvYFw4f71NL/5XVC7fTZFwrv94VCXfRH/krh4b7BdKC30o/4C07lHR/BJ5yaldDwDaeP/wF0wn24KmQAAA==';
+const SYNTHETIC_BASELINES = SYNTHETIC_BASELINES_GZIP
+  ? JSON.parse(gunzipSync(Buffer.from(SYNTHETIC_BASELINES_GZIP, 'base64')).toString('utf8'))
+  : {};
+
+test('compact pairwise payloads and hover rows match the accepted semantic baselines', () => {
+  const captured = {};
+  for (const [name, fixture] of Object.entries(buildSyntheticCases())) {
+    const payload = popupModule.buildPairwiseMatchPayload(fixture.element, fixture.options);
+    const featureTokens = new WeakMap(
+      fixture.featureReferences.map((feature, index) => [feature, `${name}:${index}`])
+    );
+    const canonicalPayload = sortedCanonical(payload, featureTokens);
+    const hoverRows = popupModule.buildPairwiseMatchHoverRows(payload);
+    captured[name] = { payload: canonicalPayload, hoverRows };
+    for (const reference of fixture.featureReferences) {
+      const exposed = payload.sections
+        .flatMap((entry) => entry.featureRows || [])
+        .some((row) => row.feature === reference)
+        || (payload.blockOrthogroups || [])
+          .flatMap((group) => group.memberRows || [])
+          .some((row) => row.feature === reference)
+        || payload.sections
+          .flatMap((entry) => entry.memberRows || [])
+          .some((row) => row.feature === reference);
+      assert.equal(exposed, true, `${name} lost a canonical Feature object reference`);
+    }
+  }
+  assert.deepStrictEqual(captured, SYNTHETIC_BASELINES);
+});
+
+const expectedHoverSummary = (payload) => ({
+  id: payload.id,
+  title: payload.title,
+  subtitle: payload.subtitle,
+  fill: payload.fill,
+  rows: popupModule.buildPairwiseMatchHoverRows(payload)
+});
+
+test('lightweight hover summaries match accepted compact payload-derived rows', () => {
+  const fixtures = buildSyntheticCases();
+  for (const [name, fixture] of Object.entries(fixtures)) {
+    if (name === 'orthogroup') continue;
+    const payload = popupModule.buildPairwiseMatchPayload(fixture.element, fixture.options);
+    assert.deepStrictEqual(
+      popupModule.buildPairwiseMatchHoverSummary(fixture.element, fixture.options),
+      expectedHoverSummary(payload),
+      `${name} hover summary changed`
+    );
+  }
+
+  const state = makeSyntheticState();
+  const orthogroupElement = elementFrom({
+    ...commonAttributes,
+    'data-match-kind': 'orthogroup',
+    'data-orthogroup-id': 'og-main',
+    'data-group-scope': 'global'
+  });
+  const orthogroupOptions = {
+    featureLookup: state.featureLookup,
+    sourceFeatures: state.sourceFeatures,
+    orthogroups: [state.globalGroup]
+  };
+  const orthogroupPayload = popupModule.buildPairwiseMatchPayload(
+    orthogroupElement,
+    orthogroupOptions
+  );
+  assert.deepStrictEqual(
+    popupModule.buildPairwiseMatchHoverSummary(orthogroupElement, orthogroupOptions),
+    expectedHoverSummary(orthogroupPayload)
+  );
+});
+
+const createPairwiseMetrics = () => ({
+  contextCreations: 0,
+  fastaCalls: 0,
+  sequenceBundleCalls: 0,
+  identityCalls: []
+});
+
+const throwingCollection = (message) => new Proxy([], {
+  get() {
+    throw new Error(message);
+  }
+});
+
+test('hover cannot touch full payload, Feature, source, member, FASTA, or sequence work', () => {
+  const metrics = createPairwiseMetrics();
+  globalThis.__GBDRAW_PAIRWISE_TEST_METRICS__ = metrics;
+  const pairwiseElement = elementFrom({
+    ...commonAttributes,
+    'data-match-kind': 'pairwise',
+    'data-orthogroup-id': 'og-main'
+  });
+  const pairwiseSummary = instrumentedPopupModule.buildPairwiseMatchHoverSummary(
+    pairwiseElement,
+    {
+      featureLookup: throwingCollection('hover traversed rendered Features'),
+      sourceFeatures: throwingCollection('hover traversed source Features'),
+      orthogroups: () => {
+        throw new Error('ordinary hover traversed orthogroups');
+      }
+    }
+  );
+  assert.deepStrictEqual(Object.keys(pairwiseSummary), ['id', 'title', 'subtitle', 'fill', 'rows']);
+
+  const members = throwingCollection('orthogroup hover expanded members');
+  const orthogroupElement = elementFrom({
+    ...commonAttributes,
+    'data-match-kind': 'orthogroup',
+    'data-orthogroup-id': 'og-main',
+    'data-group-scope': 'global'
+  });
+  const orthogroupSummary = instrumentedPopupModule.buildPairwiseMatchHoverSummary(
+    orthogroupElement,
+    {
+      orthogroups: [{
+        id: 'og-main',
+        scope: 'global',
+        name: 'Main enzymes',
+        member_count: 2,
+        members
+      }]
+    }
+  );
+  assert.equal(orthogroupSummary.rows.at(-1).value, '2');
+  assert.equal(metrics.contextCreations, 0);
+  assert.equal(metrics.fastaCalls, 0);
+  assert.equal(metrics.sequenceBundleCalls, 0);
+  delete globalThis.__GBDRAW_PAIRWISE_TEST_METRICS__;
+});
+
+const countedArray = (values, onTraversal) => new Proxy(values, {
+  get(target, property, receiver) {
+    if (property === Symbol.iterator) {
+      return function iterator() {
+        onTraversal();
+        return target[Symbol.iterator]();
+      };
+    }
+    return Reflect.get(target, property, receiver);
+  }
+});
+
+test('one full payload request traverses each input once and builds one FASTA pair per member', () => {
+  const state = makeSyntheticState();
+  const traversalCounts = {
+    rendered: 0,
+    source: 0,
+    orthogroup: 0,
+    members: 0
+  };
+  class CountedFeatureMap extends Map {
+    values() {
+      traversalCounts.rendered += 1;
+      return super.values();
+    }
+  }
+  const featureLookup = new CountedFeatureMap(state.featureLookup);
+  const sourceFeatures = countedArray(state.sourceFeatures, () => {
+    traversalCounts.source += 1;
+  });
+  const group = {
+    ...state.globalGroup,
+    members: countedArray([state.queryMember, state.subjectMember], () => {
+      traversalCounts.members += 1;
+    })
+  };
+  const orthogroups = countedArray([group], () => {
+    traversalCounts.orthogroup += 1;
+  });
+  const sequenceRegistry = createSequenceSourceRegistry([
+    {
+      key: 'linear:record:0',
+      recordId: 'query-record',
+      aliases: [],
+      sequence: 'AAAAAAAAAATGAAATAACCCCC',
+      origin: 'linear-record',
+      recordIndex: 0
+    },
+    {
+      key: 'linear:record:1',
+      recordId: 'subject-record',
+      aliases: [],
+      sequence: 'CCCCCCCCCCCCCCCCCCCCCCCCCCCCCATGAAATAAGGGG',
+      origin: 'linear-record',
+      recordIndex: 1
+    }
+  ]);
+  const element = elementFrom({
+    ...commonAttributes,
+    'data-match-kind': 'pairwise',
+    'data-orthogroup-id': 'og-main',
+    'data-group-scope': 'global'
+  });
+  const metrics = createPairwiseMetrics();
+  globalThis.__GBDRAW_PAIRWISE_TEST_METRICS__ = metrics;
+  const payload = instrumentedPopupModule.buildPairwiseMatchPayload(element, {
+    featureLookup,
+    sourceFeatures,
+    orthogroups,
+    resolveSequenceSource: sequenceRegistry.resolve
+  });
+  delete globalThis.__GBDRAW_PAIRWISE_TEST_METRICS__;
+
+  assert.deepStrictEqual(traversalCounts, {
+    rendered: 1,
+    source: 1,
+    orthogroup: 1,
+    members: 1
+  });
+  assert.equal(metrics.contextCreations, 1);
+  assert.equal(metrics.sequenceBundleCalls, 1);
+  const memberRows = payload.sections
+    .find((entry) => entry.title === 'Similarity group')
+    .memberRows;
+  const resolvedMemberCount = memberRows.filter((row) => row.feature).length;
+  assert.equal(resolvedMemberCount, 2);
+  assert.equal(metrics.fastaCalls, resolvedMemberCount);
+
+  const identityCounts = new Map();
+  metrics.identityCalls.forEach(({ source, mode }) => {
+    if (!identityCounts.has(source)) identityCounts.set(source, new Map());
+    const modes = identityCounts.get(source);
+    modes.set(mode, (modes.get(mode) || 0) + 1);
+  });
+  identityCounts.forEach((modes) => {
+    modes.forEach((count, mode) => {
+      assert.ok(count <= 1, `identity mode ${mode} normalized one object ${count} times`);
+    });
+  });
+});
+
+test('source contracts keep heavy work out of hover and migrated inner loops', async () => {
+  const svgActionsSource = await readFile(new URL(
+    'gbdraw/web/js/app/feature-editor/svg-actions.js',
+    repoRoot
+  ), 'utf8');
+  const activateStart = svgActionsSource.indexOf('const activateMatchHover =');
+  const activateEnd = svgActionsSource.indexOf('handlerState.beginPreviewTransformInteraction', activateStart);
+  const activateSource = svgActionsSource.slice(activateStart, activateEnd);
+  assert.match(activateSource, /buildMatchHoverSummary\(matchEl\)/);
+  assert.doesNotMatch(activateSource, /buildMatchPayload|ensureFeatureLookup/);
+
+  const payloadStart = popupSource.indexOf('export const buildMatchPopupPayload =');
+  const payloadEnd = popupSource.indexOf('// Compatibility export retained', payloadStart);
+  const payloadSource = popupSource.slice(payloadStart, payloadEnd);
+  assert.equal(
+    (payloadSource.match(/createPairwisePayloadContext\s*\(/g) || []).length,
+    1,
+    'the full payload must create exactly one request context'
+  );
+  assert.doesNotMatch(popupSource, /memberFastaText\s*\(/);
+  assert.doesNotMatch(popupSource, /globalThis|MutationObserver|requestIdleCallback/);
+
+  for (const [startMarker, endMarker] of [
+    ['const buildOrthogroupMemberRows =', 'const resolveFeatureSectionProteinIds ='],
+    ['const buildBlockOrthogroups =', 'const buildFeatureRows =']
+  ]) {
+    const start = popupSource.indexOf(startMarker);
+    const end = popupSource.indexOf(endMarker, start);
+    const innerLoopSource = popupSource.slice(start, end);
+    assert.doesNotMatch(
+      innerLoopSource,
+      /getFeatureLookupValues|sourceFeatures|orthogroups\.filter|featureLookup\.values/
+    );
+  }
+});
+
+const decodeXml = (value) => String(value || '')
+  .replaceAll('&quot;', '"')
+  .replaceAll('&apos;', "'")
+  .replaceAll('&lt;', '<')
+  .replaceAll('&gt;', '>')
+  .replaceAll('&amp;', '&')
+  .replace(/&#(\d+);/g, (_match, decimal) => String.fromCodePoint(Number(decimal)))
+  .replace(/&#x([\da-f]+);/gi, (_match, hexadecimal) => String.fromCodePoint(Number.parseInt(hexadecimal, 16)));
+
+const pairwiseElementsFromSvg = (svg) => Array.from(
+  svg.matchAll(/<path\b(?=[^>]*data-gbdraw-pairwise-match-id=)[^>]*>/g),
+  (match) => {
+    const attributes = {};
+    for (const attribute of match[0].matchAll(/([\w:-]+)="([^"]*)"/g)) {
+      attributes[attribute[1]] = decodeXml(attribute[2]);
+    }
+    return { attributes, element: elementFrom(attributes) };
+  }
+);
+
+const exactFixturePath = new URL(
+  'gbdraw/web/gallery/sessions/hepatoplasmataceae_collinear.gbdraw-session.json.gz',
+  repoRoot
+);
+const exactSession = JSON.parse(gunzipSync(await readFile(exactFixturePath)).toString('utf8'));
+const exactAdmission = admitFeatureCatalog(
+  exactSession.editorState.featureCatalog,
+  exactSession.results,
+  { mode: exactSession.renderRequest.mode }
+);
+const exactState = exactAdmission.featureState;
+const exactFeatureLookup = new Map(
+  exactState.extractedFeatures.map((feature) => [feature.svg_id, feature])
+);
+const exactSequenceRegistry = createSequenceSourceRegistry(exactState.sequenceSources);
+const exactOptions = {
+  featureLookup: exactFeatureLookup,
+  sourceFeatures: exactState.biologicalFeatures,
+  orthogroups: [...exactState.orthogroups, ...exactState.collinearGroups],
+  resolveSequenceSource: exactSequenceRegistry.resolve
+};
+const exactFeatureTokens = new WeakMap([
+  ...exactState.extractedFeatures.map((feature) => [feature, `rendered:${feature.svg_id}`]),
+  ...exactState.biologicalFeatures.map((feature) => [
+    feature,
+    `source:${feature.recordKey}:${feature.biologicalFeatureId}`
+  ])
+]);
+const exactElements = pairwiseElementsFromSvg(exactSession.results[0].content);
+const exactFirst = exactElements[0];
+const exactLater = exactElements.find((entry) => (
+  entry.attributes['data-collinearity-block-id']
+  && entry.attributes['data-collinearity-block-id']
+    !== exactFirst.attributes['data-collinearity-block-id']
+));
+
+const EXACT_BASELINES = {
+  first: {
+    target: {
+      matchId: 'comparison1_match1',
+      blockId: 'block_0024',
+      orthogroupIds: 'og_34;og_35;og_36;og_37;og_38;og_39;og_40;og_41;og_42;og_43;og_44;og_45;og_46;og_47;og_48'
+    },
+    digest: '7f55fa2faa8ee3a3fb798334b9b4ac74954e55ffafc5d15e3b7cf57c43f7093f',
+    hoverRows: [
+      { label: 'Kind', value: 'collinear' },
+      { label: 'Identity', value: '43.9684414414' },
+      { label: 'Query', value: '61879..78669' },
+      { label: 'Subject', value: '19161..35565' },
+      { label: 'Similarity groups', value: '15' },
+      { label: 'Block', value: 'block_0024' }
+    ],
+    sectionTitles: ['Summary', 'Similarity groups covered', 'Collinearity', 'Query', 'Subject'],
+    blockOrthogroupCount: 15,
+    memberRowCounts: Array(15).fill(5),
+    featureRowCount: 30,
+    exposedFeatureCount: 105,
+    sequenceAvailability: [true, true],
+    combinedSequenceLength: 33898
+  },
+  laterDistinctBlock: {
+    target: {
+      matchId: 'comparison1_match2',
+      blockId: 'block_0155',
+      orthogroupIds: 'og_274;og_275;og_276;og_277;og_278;og_279;og_280;og_281;og_282;og_283;og_284;og_285;og_286;og_287;og_288;og_289;og_290;og_291;og_292;og_293'
+    },
+    digest: '08e079f6f37ce48da62331aed504303e2e6239094c77e4f32f227ea55d02d8c6',
+    hoverRows: [
+      { label: 'Kind', value: 'collinear' },
+      { label: 'Identity', value: '64.1326369725' },
+      { label: 'Query', value: '484749..494272' },
+      { label: 'Subject', value: '586163..595833' },
+      { label: 'Similarity groups', value: '20' },
+      { label: 'Block', value: 'block_0155' }
+    ],
+    sectionTitles: ['Summary', 'Similarity groups covered', 'Collinearity', 'Query', 'Subject'],
+    blockOrthogroupCount: 20,
+    memberRowCounts: Array(20).fill(5),
+    featureRowCount: 40,
+    exposedFeatureCount: 140,
+    sequenceAvailability: [true, true],
+    combinedSequenceLength: 19668
+  }
+};
+
+test('exact large-fixture payloads retain canonical digests, structure, and Feature references', () => {
+  assert.ok(exactFirst, 'the exact fixture has no first pairwise target');
+  assert.ok(exactLater, 'the exact fixture has no later distinct-block target');
+  const captured = {};
+  for (const [name, target] of [['first', exactFirst], ['laterDistinctBlock', exactLater]]) {
+    const payload = popupModule.buildPairwiseMatchPayload(target.element, exactOptions);
+    assert.deepStrictEqual(
+      popupModule.buildPairwiseMatchHoverSummary(target.element, exactOptions),
+      expectedHoverSummary(payload),
+      `${name} exact-fixture hover summary changed`
+    );
+    const canonical = sortedCanonical(payload, exactFeatureTokens);
+    const featureRows = payload.sections.flatMap((entry) => entry.featureRows || []);
+    const memberRows = [
+      ...payload.sections.flatMap((entry) => entry.memberRows || []),
+      ...payload.blockOrthogroups.flatMap((group) => group.memberRows || [])
+    ];
+    const exposedFeatures = [...featureRows, ...memberRows]
+      .map((row) => row.feature)
+      .filter(Boolean);
+    exposedFeatures.forEach((feature) => {
+      assert.ok(exactFeatureTokens.has(feature), `${name} exposed a non-canonical Feature object`);
+    });
+    captured[name] = {
+      target: {
+        matchId: target.attributes['data-gbdraw-pairwise-match-id'],
+        blockId: target.attributes['data-collinearity-block-id'],
+        orthogroupIds: target.attributes['data-orthogroup-id']
+      },
+      digest: sha256(canonical),
+      hoverRows: popupModule.buildPairwiseMatchHoverRows(payload),
+      sectionTitles: payload.sections.map((entry) => entry.title),
+      blockOrthogroupCount: payload.blockOrthogroupCount,
+      memberRowCounts: payload.blockOrthogroups.map((group) => group.memberRows.length),
+      featureRowCount: featureRows.length,
+      exposedFeatureCount: exposedFeatures.length,
+      sequenceAvailability: payload.sequenceBundle.entries.map((entry) => entry.available),
+      combinedSequenceLength: payload.sequenceBundle.combinedFasta.length
+    };
+  }
+  assert.deepStrictEqual(captured, EXACT_BASELINES);
+});

--- a/tests/web/preview-transform-interaction.test.mjs
+++ b/tests/web/preview-transform-interaction.test.mjs
@@ -67,7 +67,7 @@ await writeFile(
   join(tempDir, 'app', 'pairwise-match-popup.js'),
   [
     'export const PAIRWISE_MATCH_SELECTOR = "path[data-gbdraw-pairwise-match-id]";',
-    'export const buildPairwiseMatchHoverRows = () => [];',
+    'export const buildPairwiseMatchHoverSummary = (element) => ({ id: element.getAttribute("data-gbdraw-pairwise-match-id"), title: "Pairwise match", subtitle: "", fill: "#94a3b8", rows: [] });',
     'export const buildPairwiseMatchPayload = () => null;'
   ].join('\n'),
   'utf8'


### PR DESCRIPTION
## Plain-language summary

Hovering a pairwise match now builds only the small summary shown beside the cursor, instead of constructing the full popup payload. Clicking still builds the complete payload on demand, with the same popup text, sequences, actions, keyboard behavior, and scientific output. This removes repeated full-feature scans and sequence extraction from a high-frequency path while preserving the existing interaction contract.

## Change class

- [x] STANDARD
- [ ] GOVERNANCE
- [ ] ARCHITECTURE_EXCEPTION
- [ ] PROMOTION

## Purpose

- Applicable baseline: `dev` at `e4f855ab659162074ffc9b4b1162187f74852612`; candidate `b68e9e15ac10807cebd19f990809bf3eb790965c` (tree `5bbd06339099191ccc86d4399113e6dd011dc7d5`). Required checks come from the current trusted `dev` CI profile. Focused contracts are `tests/web/pairwise-payload-performance.test.mjs`, `tests/test_pairwise_match_popup.py`, and the Chromium/Edge evidence for the exact large fixture SHA `2afba7111520b9dd7b00dffd351a1f4a21d4e0d9bfbaebc25ba7b5a937288577`.

The large comparison preview made pairwise-match hover expensive because hover called the same full payload builder as click. That path repeatedly resolved feature catalogs, reconstructed orthogroups, and extracted FASTA text even though the hover card needs only labels and match statistics.

## User-visible impact

Pairwise-match hover is substantially more responsive on large diagrams. The hover card, click popup, popup selection actions, keyboard behavior, nucleotide and amino-acid sequences, saved-session behavior, standalone interaction, worker requests/results, and generated scientific SVGs remain semantically unchanged.

## Changes

- Add `buildPairwiseMatchHoverSummary` as the narrow hover projection and route hover through it.
- Keep `buildPairwiseMatchPayload` as the full click-only projection.
- Build a request-local pairwise payload context once per click, indexing exact feature identities and orthogroups for reuse across endpoint resolution, fallback reconstruction, member rendering, and actions.
- Preserve ambiguous identities by accepting an indexed feature only when the existing identity agreement rules identify one exact feature; ambiguous candidates continue down the established fallback path.
- Compute both member FASTA strings in one `buildMemberFastas` call after the member feature has been resolved.
- Add deterministic parity, negative hot-path, traversal-count, fixture-digest, and performance-contract coverage.

Call graphs after this change:

```text
mouseover -> buildPairwiseMatchHoverSummary -> descriptor + orthogroup labels -> hover rows
click     -> buildPairwiseMatchPayload -> request-local context -> full members/actions/sequences -> popup
```

No module, global cache, persistent cache, worker, watcher, timer, schema, output format, user-visible string, or compatibility path was added. The existing 180 ms hover delay remains unchanged.

## Verification

- Session 03 result: `PERFORMANCE_ACCEPTED` for the exact candidate head/tree and fixture above.
- Required acceptance gates passed in Chromium and Microsoft Edge: aggregate ratio `<= 0.50`, paired-median ratio `<= 0.50`, and candidate maximum/p95 no worse than its paired baseline. The earlier absolute gates—at least 90% reduction, median `<= 500 ms`, and maximum/p95 `<= 1000 ms`—were superseded by these later task-authoritative gates and were not used for the decision; the candidate observations also satisfy them. Absolute candidate measurements are reported below as observations, not replacement gates.

| Browser | Profile | Baseline aggregate (ms) | Candidate aggregate (ms) | Aggregate ratio | Paired-median ratio | Candidate max <= baseline max |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Chromium | H1 | 6308.7 | 296.3 | 0.0470 | 0.0479 | 311.4 <= 6725.0 |
| Chromium | H2 | 9764.9 | 241.2 | 0.0247 | 0.0248 | 242.5 <= 10365.2 |
| Chromium | P1 | 6163.2 | 172.8 | 0.0280 | 0.0279 | 190.4 <= 6829.6 |
| Chromium | P2 | 9554.6 | 114.2 | 0.0120 | 0.0121 | 128.1 <= 10425.9 |
| Edge | H1 | 6613.6 | 331.2 | 0.0501 | 0.0501 | 342.6 <= 23019.5 |
| Edge | H2 | 10142.6 | 299.9 | 0.0296 | 0.0294 | 308.6 <= 11298.0 |
| Edge | P1 | 6426.7 | 246.9 | 0.0384 | 0.0387 | 302.1 <= 15674.2 |
| Edge | P2 | 9951.9 | 205.1 | 0.0206 | 0.0206 | 213.3 <= 10223.9 |

- Exact large-fixture popup payload digests stayed stable (`7f55…` first run, `08e079…` warm run); hover-summary digests also stayed stable. Edge was verified from the installed Microsoft Edge binary (`Edg/152.0.4191.53`).
- Deterministic Web CI inventory: 349/349 passed under Node 20.20.2.
- Pairwise payload performance/parity tests: 6/6 passed.
- Preview transform interaction unit suite: 119 assertions across 24 cases passed.
- Python fast suite: 3008 passed, 17 skipped, 11 deselected.
- Reference SVG comparison: 16/16 passed without updating references.
- Architecture ratchet suites: 137/137, 17/17, and 36/36 passed; PR-language fixtures also passed.
- `ruff check gbdraw/`, changed-module JavaScript syntax checks, `git diff --check`, browser wheel preparation, and `python -m build` passed.
- Chromium functional coverage passed after one unrelated layout assertion was rerun serially without concurrent CPU-heavy validation; the pairwise popup case and exact v2 raw-match metadata case passed directly.
- Chromium performance coverage passed: 12/13 cases passed in the full run, and the sole calibrated responsiveness case passed on its final isolated candidate run (Long Task total median 378 ms, limit 500 ms; longest median 58 ms, limit 250 ms). Two preceding candidate samples exceeded only the total-duration guard while a separate CPU-heavy benchmark shared the host; the unchanged exact `origin/dev` test was also measured and passed (250 ms and 51 ms), so the variance is recorded rather than hidden.

## Risk and review notes

- Gate result and any blocker: Web change-budget gate `PASS`; no blocking violations and no unresolved local validation blocker.
- Review result and why it is `CLEAR` or `REQUIRED`: `REQUIRED` because two production Web files change and the pairwise payload builder is substantially reorganized, even though authority, behavior, schemas, and outputs do not change.
- Architecture impact: **This is not architecture-bearing**. The same modules retain ownership of pairwise payload projection and feature-editor event routing; the change narrows the hover call path and removes the superseded full-payload call from hover.
- Architecture baseline and changed-scope conclusion, if architecture-bearing: N/A. No semantic owner, canonical path, compatibility namespace, or dependency direction changed; `OE`, `PE`, and `CB` are therefore N/A for this standard non-architecture-bearing refactor.
- `architecture-change` label, if relevant: N/A.

Design review:

- SOLID: hover and click now depend on projections sized to their responsibilities; request-scoped lookup behavior is encapsulated behind one context.
- KISS: two existing production modules remain the only owners, with no cache lifecycle or new asynchronous mechanism.
- DRY: descriptor parsing, identity rules, fallback semantics, and member FASTA construction have single internal owners reused by the projections.
- YAGNI: no speculative cross-request cache, worker protocol, new schema, or broader feature-search refactor was added.

Non-goals: changing pairwise semantics, popup copy, selection actions, keyboard handling, saved-session or standalone formats, Python rendering, scientific SVG geometry, or unrelated preview-transform behavior.

Residual risk is limited to identity-edge cases inside the reorganized full click projection. Exact parity fixtures, ambiguous-identity fallback tests, traversal-count tests, browser popup coverage, and stable payload digests bound that risk.

## Rollback

Revert commit `b68e9e15ac10807cebd19f990809bf3eb790965c`. It is one focused commit with no migration, persisted state, schema, generated reference update, or external cleanup requirement.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concern(s), if known: None
- Affected journey/checkpoint effects: None; hover and click outcomes are preserved.
- Authority and decision references: N/A
- Decision Pack or evidence reference, if required: N/A
- Behavior contracts and residual risk: Existing pairwise hover/popup, sequence, action, keyboard, session, standalone, worker, and SVG contracts remain unchanged; focused parity evidence is listed above.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

N/A for this `STANDARD` change.
