### PR TITLE
Fix linear ribbon gaps and include six completed Web fixes

### DIFF
--- a/docs/CLI_Reference.md
+++ b/docs/CLI_Reference.md
@@ -1309,10 +1309,10 @@ non-annotation slot in the complete stack. Unknown IDs, non-drawing slots, and
 annotation-to-annotation anchor chains are rejected.
 
 `--comparison_height` sets the minimum clear corridor between neighboring
-records. Comparison endpoints attach to the outer edges of their measured
-exclusion bands. Taller occupancy moves record axes apart without placing links
-through track stacks; other row or definition constraints can make the corridor
-larger than the configured minimum.
+records. Comparison endpoints follow the painted feature lanes and other tracks,
+with a 4 px clearance. Feature labels reserve row space but do not shorten the
+links. Taller occupancy moves record axes apart; other row or definition
+constraints can make the corridor larger than the configured minimum.
 
 When a logical depth track has no file for one displayed record, keep that
 record's position with `''`, `-`, `none`, or `null`. The group must still

--- a/docs/RELEASE_NOTES_0.14.0b0.md
+++ b/docs/RELEASE_NOTES_0.14.0b0.md
@@ -328,10 +328,10 @@ controlled by `--feature_height`. Feature-slot `spacing` is clearance to the
 adjacent outer track. Missing Depth data produces no paint, reserve, axis, or
 ticks; logical identity remains independent of record-local geometry.
 
-Comparison links now begin and end at the outer edges of the records' painted
-exclusion bands without an additional endpoint pad. `--comparison_height`
-remains a minimum corridor; record spacing expands around taller occupancy while
-keeping links outside the track stacks. Geometry metadata schema v2 reports
+Comparison links begin and end 4 px outside the painted feature lanes and other
+tracks. Feature labels reserve row space without shortening the links.
+`--comparison_height` remains a minimum corridor; record spacing expands around
+taller occupancy while keeping links outside the track stacks. Geometry metadata schema v2 reports
 record-specific paint, reserve, comparison-exclusion, and canvas bands.
 
 Row spacing now composes body, comparison, and definition constraints with an

--- a/docs/images/h-cli-13/cli_export.interactive.svg
+++ b/docs/images/h-cli-13/cli_export.interactive.svg
@@ -50,6 +50,7 @@
   stroke-width: 1.5;
   paint-order: stroke fill markers;
 }
+.gbdraw-interactive-pairwise-match.gbdraw-interactive-pairwise-match--pending,
 .gbdraw-interactive-pairwise-match.gbdraw-interactive-pairwise-match--selected {
   opacity: 1;
   filter: url(#gbdraw-interactive-feature-glow);
@@ -58,6 +59,10 @@
   stroke-width: 2.5;
   paint-order: stroke fill markers;
   outline: none;
+}
+.gbdraw-interactive-pairwise-match:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 .gbdraw-interactive-annotation {
   cursor: pointer;
@@ -1954,8 +1959,9 @@
   var matchElementsById = new Map();
   var ambiguousMatchElementIds = new Set();
   var selectedMatchElements = [];
+  var pendingMatchElement = null;
   var comparisonElementsByCollinearityBlockId = new Map();
-  Array.prototype.slice.call(svg.querySelectorAll(MATCH_SELECTOR)).forEach(function (element) {
+  Array.prototype.slice.call(svg.querySelectorAll(MATCH_SELECTOR)).forEach(function (element, index) {
     var matchId = getElementMatchId(element);
     if (matchId &amp;&amp; !ambiguousMatchElementIds.has(matchId)) {
       if (matchElementsById.has(matchId)) {
@@ -1973,6 +1979,9 @@
       comparisonElementsByCollinearityBlockId.get(blockId).push(element);
     }
     setClassToken(element, 'gbdraw-interactive-pairwise-match', true);
+    element.setAttribute('role', 'button');
+    element.setAttribute('tabindex', '0');
+    element.setAttribute('aria-label', 'Pairwise match ' + (index + 1));
   });
 
   function setClassToken(element, token, enabled) {
@@ -2107,6 +2116,19 @@
     selectedMatchElements.forEach(function (element) {
       setClassToken(element, 'gbdraw-interactive-pairwise-match--selected', true);
     });
+  }
+
+  function clearPendingMatch() {
+    if (!pendingMatchElement) return;
+    setClassToken(pendingMatchElement, 'gbdraw-interactive-pairwise-match--pending', false);
+    pendingMatchElement = null;
+  }
+
+  function setPendingMatch(element) {
+    if (pendingMatchElement === element) return;
+    clearPendingMatch();
+    pendingMatchElement = element;
+    setClassToken(element, 'gbdraw-interactive-pairwise-match--pending', true);
   }
 
   function clearActiveFeatureHover() {
@@ -4526,9 +4548,129 @@
     });
   }
 
-  function copyButton(value, label) {
-    var index = copyValues.push(String(value == null ? '' : value)) - 1;
-    return '&lt;button type="button" class="gfi-copy" data-copy-index="' + index + '"&gt;' + escapeHtml(label || 'Copy') + '&lt;/button&gt;';
+  function memberCopyFeedbackIdentity(memberOrRow) {
+    var recordKey = consistentTextIdentity(memberOrRow, ['recordKey', 'record_key']);
+    var biologicalId = consistentTextIdentity(
+      memberOrRow,
+      ['biologicalFeatureId', 'biological_feature_id']
+    );
+    if (
+      recordKey.valid
+      &amp;&amp; biologicalId.valid
+      &amp;&amp; recordKey.value
+      &amp;&amp; biologicalId.value
+    ) {
+      return JSON.stringify(['canonical', recordKey.value, biologicalId.value]);
+    }
+    var recordIndex = memberRecordIndex(memberOrRow);
+    var stableId = memberFeatureSvgId(memberOrRow);
+    var sourceIndex = nonnegativeIntegerIdentity(memberOrRow, [
+      'featureIndex', 'feature_index', 'sourceFeatureIndex', 'source_feature_index'
+    ]);
+    if (Number.isInteger(recordIndex) &amp;&amp; (stableId || Number.isInteger(sourceIndex.value))) {
+      return JSON.stringify([
+        'source',
+        recordIndex,
+        stableId,
+        Number.isInteger(sourceIndex.value) ? sourceIndex.value : null
+      ]);
+    }
+    return JSON.stringify([
+      'display',
+      firstDisplayText(memberOrRow &amp;&amp; (memberOrRow.record || memberOrRow.recordId || memberOrRow.record_id)),
+      firstDisplayText(memberOrRow &amp;&amp; memberOrRow.coordinates, memberLocationText(memberOrRow)),
+      firstNonInternalDisplayText(
+        memberOrRow &amp;&amp; (memberOrRow.proteinId || memberOrRow.protein_id),
+        memberOrRow &amp;&amp; displayProteinId(null, memberOrRow, '')
+      )
+    ]);
+  }
+
+  function sequenceCopyFeedbackKey(context, orthogroupId, action, memberOrRow, sequenceKind) {
+    return JSON.stringify([
+      'orthogroup-sequence',
+      String(context || ''),
+      String(orthogroupId || '').trim(),
+      action,
+      memberOrRow ? memberCopyFeedbackIdentity(memberOrRow) : '',
+      sequenceKindLabel(sequenceKind)
+    ]);
+  }
+
+  function copyFeedbackLabel(status) {
+    if (status === 'success') return 'Copied!';
+    if (status === 'manual') return 'Copy manually';
+    if (status === 'failure') return 'Copy failed';
+    return '';
+  }
+
+  function updateCopyFeedbackButtons(feedbackKey) {
+    if (!popup || !popup.querySelectorAll || !feedbackKey) return;
+    var feedback = copyFeedbackByKey.get(feedbackKey);
+    Array.prototype.slice.call(
+      popup.querySelectorAll('[data-copy-feedback-key]')
+    ).forEach(function (button) {
+      if (button.getAttribute('data-copy-feedback-key') !== feedbackKey) return;
+      button.textContent = feedback
+        ? copyFeedbackLabel(feedback.status)
+        : String(button.getAttribute('data-copy-label') || 'Copy');
+    });
+  }
+
+  function beginCopyFeedback(feedbackKey) {
+    var previousTimer = copyFeedbackTimers.get(feedbackKey);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackTimers.delete(feedbackKey);
+    copyFeedbackByKey.delete(feedbackKey);
+    nextCopyOperationId += 1;
+    copyOperationIds.set(feedbackKey, nextCopyOperationId);
+    updateCopyFeedbackButtons(feedbackKey);
+    return nextCopyOperationId;
+  }
+
+  function finishCopyFeedback(feedbackKey, operationId, status) {
+    if (!feedbackKey || copyOperationIds.get(feedbackKey) !== operationId) return;
+    var previousTimer = copyFeedbackTimers.get(feedbackKey);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackByKey.set(feedbackKey, { operationId: operationId, status: status });
+    updateCopyFeedbackButtons(feedbackKey);
+    var timer = window.setTimeout(function () {
+      var current = copyFeedbackByKey.get(feedbackKey);
+      if (
+        copyOperationIds.get(feedbackKey) !== operationId
+        || !current
+        || current.operationId !== operationId
+      ) return;
+      copyFeedbackByKey.delete(feedbackKey);
+      copyFeedbackTimers.delete(feedbackKey);
+      copyOperationIds.delete(feedbackKey);
+      updateCopyFeedbackButtons(feedbackKey);
+    }, COPY_FEEDBACK_DURATION_MS);
+    copyFeedbackTimers.set(feedbackKey, timer);
+  }
+
+  function clearCopyFeedback() {
+    copyFeedbackTimers.forEach(function (timer) {
+      window.clearTimeout(timer);
+    });
+    copyFeedbackTimers.clear();
+    copyFeedbackByKey.clear();
+    copyOperationIds.clear();
+  }
+
+  function copyButton(value, label, feedbackKey) {
+    var originalLabel = String(label || 'Copy');
+    var key = String(feedbackKey || '');
+    var feedback = key ? copyFeedbackByKey.get(key) : null;
+    var index = copyValues.push({
+      feedbackKey: key,
+      text: String(value == null ? '' : value)
+    }) - 1;
+    var feedbackAttributes = key
+      ? ' data-copy-feedback-key="' + escapeHtml(key) + '" data-copy-label="' + escapeHtml(originalLabel) + '" aria-live="polite" aria-atomic="true"'
+      : '';
+    return '&lt;button type="button" class="gfi-copy" data-copy-index="' + index + '"' + feedbackAttributes + '&gt;' +
+      escapeHtml(feedback ? copyFeedbackLabel(feedback.status) : originalLabel) + '&lt;/button&gt;';
   }
 
   function downloadButton(filename, text, label) {
@@ -4550,18 +4692,32 @@
       if (!text) return;
       var count = groupFastaCount(rows, sequenceKind);
       var suffix = count &gt; 1 ? ' (' + count + ')' : '';
-      html.push(copyButton(text, 'Copy ' + sequenceKind + suffix));
+      var feedbackKey = sequenceCopyFeedbackKey(
+        options &amp;&amp; options.feedbackContext,
+        orthogroupId,
+        'group',
+        null,
+        sequenceKind
+      );
+      html.push(copyButton(text, 'Copy ' + sequenceKind + suffix, feedbackKey));
       html.push(downloadButton(groupSequenceFilename(orthogroupId, displayName, sequenceKind), text, 'DL ' + sequenceKind + suffix));
     });
     return html.join('');
   }
 
-  function renderMemberSequenceActions(memberOrRow, orthogroupId) {
+  function renderMemberSequenceActions(memberOrRow, orthogroupId, feedbackContext) {
     var html = [];
     ['nt', 'aa'].forEach(function (sequenceKind) {
       var text = String(memberFasta(memberOrRow, sequenceKind) || '').trim();
       if (!text) return;
-      html.push(copyButton(text, 'Copy ' + sequenceKind));
+      var feedbackKey = sequenceCopyFeedbackKey(
+        feedbackContext,
+        orthogroupId,
+        'member',
+        memberOrRow,
+        sequenceKind
+      );
+      html.push(copyButton(text, 'Copy ' + sequenceKind, feedbackKey));
       html.push(downloadButton(memberSequenceFilename(memberOrRow, sequenceKind, orthogroupId), text, 'DL ' + sequenceKind));
     });
     return html.length ? '&lt;div class="gfi-seq-actions"&gt;' + html.join('') + '&lt;/div&gt;' : '';
@@ -4569,6 +4725,11 @@
 
   var copyValues = [];
   var downloadValues = [];
+  var COPY_FEEDBACK_DURATION_MS = 1500;
+  var copyFeedbackByKey = new Map();
+  var copyFeedbackTimers = new Map();
+  var copyOperationIds = new Map();
+  var nextCopyOperationId = 0;
 
   function renderRows(rows) {
     if (!rows.length) {
@@ -4625,10 +4786,11 @@
     ).join('\n');
     var sequenceActions = renderGroupSequenceActions(rows, {
       orthogroupId: orthogroupId,
-      displayName: displayName
+      displayName: displayName,
+      feedbackContext: 'feature-orthogroup'
     });
     var body = rows.map(function (row) {
-      var sequenceActions = renderMemberSequenceActions(row, orthogroupId);
+      var sequenceActions = renderMemberSequenceActions(row, orthogroupId, 'feature-orthogroup');
       return '&lt;tr&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.record) + '&lt;/td&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.coordinates) + '&lt;/td&gt;' +
@@ -5363,7 +5525,7 @@
       '&lt;tbody&gt;' + body + '&lt;/tbody&gt;&lt;/table&gt;&lt;/div&gt;';
   }
 
-  function renderMatchMemberTable(section, rows) {
+  function renderMatchMemberTable(section, rows, feedbackContext) {
     if (!rows.length) return '';
     var orthogroupId = String(section &amp;&amp; (section.id || section.orthogroupId || section.orthogroup_id) || rows[0] &amp;&amp; (rows[0].orthogroupId || rows[0].orthogroup_id) || '').trim();
     var displayName = String(section &amp;&amp; (section.displayName || section.display_name || section.name) || rows[0] &amp;&amp; (rows[0].displayName || rows[0].display_name) || '').trim();
@@ -5379,7 +5541,7 @@
       ).join('\n');
     }
     var body = rows.map(function (row) {
-      var sequenceActions = renderMemberSequenceActions(row, orthogroupId);
+      var sequenceActions = renderMemberSequenceActions(row, orthogroupId, feedbackContext);
       return '&lt;tr&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.record) + '&lt;/td&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.coordinates) + '&lt;/td&gt;' +
@@ -5390,7 +5552,8 @@
     }).join('');
     var sequenceActions = renderGroupSequenceActions(rows, {
       orthogroupId: orthogroupId,
-      displayName: displayName
+      displayName: displayName,
+      feedbackContext: feedbackContext
     });
     return '&lt;div class="gfi-table-wrap"&gt;&lt;table class="gfi-table gfi-og-members-table"&gt;' +
       '&lt;thead&gt;&lt;tr&gt;&lt;th&gt;Record&lt;/th&gt;&lt;th&gt;Coordinates (+/-)&lt;/th&gt;&lt;th&gt;Protein ID&lt;/th&gt;&lt;th&gt;Product / note&lt;/th&gt;&lt;th&gt;Seq&lt;/th&gt;&lt;/tr&gt;&lt;/thead&gt;' +
@@ -5441,7 +5604,11 @@
         ? '&lt;div class="gfi-block gfi-block--selected-og"&gt;' +
           '&lt;div class="gfi-block-title"&gt;' + escapeHtml('Selected similarity group') + '&lt;/div&gt;' +
           renderRows(selectedBlockOrthogroup.detailRows) +
-          renderMatchMemberTable(selectedBlockOrthogroup, selectedBlockOrthogroup.memberRows) +
+          renderMatchMemberTable(
+            selectedBlockOrthogroup,
+            selectedBlockOrthogroup.memberRows,
+            'selected-orthogroup:' + selectedBlockOrthogroup.id
+          ) +
           '&lt;/div&gt;'
         : '';
       return '&lt;div class="gfi-block"&gt;' +
@@ -5449,7 +5616,16 @@
         (rows.length &amp;&amp; !featureRows.length ? renderRows(rows) : '') +
         renderMatchFeatureTable(featureRows) +
         renderMatchBlockOrthogroupTable(blockOrthogroups, selectedBlockOrthogroupId) +
-        renderMatchMemberTable(section, memberRows) +
+        renderMatchMemberTable(
+          section,
+          memberRows,
+          'match-section:' + firstDisplayText(
+            section &amp;&amp; section.id,
+            section &amp;&amp; section.title,
+            match &amp;&amp; match.id,
+            selectedBlockOrthogroupId
+          )
+        ) +
         selectedHtml +
         '&lt;/div&gt;';
     }).join('') || '&lt;div class="gfi-empty"&gt;No match details available.&lt;/div&gt;';
@@ -5491,6 +5667,7 @@
   function closePopup() {
     stopPopupResize();
     stopPopupDrag();
+    clearCopyFeedback();
     updateActivePopupViewportMetrics = null;
     if (popup &amp;&amp; popup.parentNode) {
       popup.parentNode.removeChild(popup);
@@ -6194,8 +6371,10 @@
       var copyTarget = closestFromTarget(rootEvent.target, '[data-copy-index]');
       if (copyTarget) {
         var index = Number(copyTarget.getAttribute('data-copy-index'));
-        var value = Number.isFinite(index) ? copyValues[index] || '' : '';
-        Promise.resolve(copyText(value, copyTarget)).catch(function () {});
+        var copyPayload = Number.isFinite(index) ? copyValues[index] || null : null;
+        var value = copyPayload ? copyPayload.text : '';
+        var feedbackKey = copyPayload ? copyPayload.feedbackKey : '';
+        Promise.resolve(copyText(value, copyTarget, feedbackKey)).catch(function () {});
         return;
       }
       var downloadTarget = closestFromTarget(rootEvent.target, '[data-download-index]');
@@ -6241,18 +6420,34 @@
     syncStandaloneOverlayOrder();
   }
 
-  async function copyText(value, button) {
+  async function copyText(value, button, feedbackKey) {
     var text = String(value == null ? '' : value);
-    if (navigator.clipboard &amp;&amp; navigator.clipboard.writeText) {
+    var operationId = feedbackKey ? beginCopyFeedback(feedbackKey) : 0;
+    var clipboard = null;
+    try {
+      clipboard = navigator.clipboard;
+    } catch (error) {
+      clipboard = null;
+    }
+    if (clipboard &amp;&amp; clipboard.writeText) {
       try {
-        await navigator.clipboard.writeText(text);
-        if (button) button.textContent = 'Copied';
-        return;
+        await clipboard.writeText(text);
+        if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'success');
+        else if (button) button.textContent = 'Copied';
+        return 'copied';
       } catch (error) {
         // Fall back to a prompt below when clipboard permission is unavailable.
       }
     }
-    window.prompt('Copy text', text);
+    try {
+      if (typeof window.prompt !== 'function') throw new Error('Manual copy is unavailable.');
+      window.prompt('Copy text', text);
+      if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'manual');
+      return 'manual';
+    } catch (error) {
+      if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'failure');
+      return 'failed';
+    }
   }
 
   function closestFeature(node) {
@@ -6393,6 +6588,41 @@
     closeHoverPopup();
   });
 
+  svg.addEventListener('pointerdown', function (event) {
+    if (event.button !== 0 || event.isPrimary === false) return;
+    var matchElement = closestMatch(event.target);
+    if (!matchElement) {
+      clearPendingMatch();
+      return;
+    }
+    setPendingMatch(matchElement);
+  });
+
+  svg.addEventListener('pointerout', function (event) {
+    if (!pendingMatchElement) return;
+    var matchElement = closestMatch(event.target);
+    if (matchElement !== pendingMatchElement) return;
+    if (closestMatch(event.relatedTarget) === matchElement) return;
+    clearPendingMatch();
+  });
+
+  window.addEventListener('pointerup', clearPendingMatch, true);
+  window.addEventListener('pointercancel', clearPendingMatch, true);
+  window.addEventListener('blur', clearPendingMatch);
+
+  function activateMatch(matchElement, event) {
+    var matchId = getElementMatchId(matchElement);
+    var match = matchesById.get(matchId);
+    if (!match) return false;
+    clearPendingMatch();
+    event.preventDefault();
+    event.stopPropagation();
+    closeHoverPopup();
+    openPopup(match, event, 'match');
+    setSelectedMatch(matchId);
+    return true;
+  }
+
   svg.addEventListener('click', function (event) {
     if (popup &amp;&amp; popup.contains(event.target)) return;
     if (closestSearchControls(event.target)) return;
@@ -6420,14 +6650,7 @@
         closePopup();
         return;
       }
-      var matchId = getElementMatchId(matchElement);
-      var match = matchesById.get(matchId);
-      if (!match) return;
-      event.preventDefault();
-      event.stopPropagation();
-      closeHoverPopup();
-      openPopup(match, event, 'match');
-      setSelectedMatch(matchId);
+      activateMatch(matchElement, event);
       return;
     }
     var svgId = getElementFeatureId(featureElement);
@@ -6441,6 +6664,13 @@
     event.stopPropagation();
     closeHoverPopup();
     openPopup(feature, event, 'feature');
+  });
+
+  svg.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter' &amp;&amp; event.key !== ' ') return;
+    var matchElement = closestMatch(event.target);
+    if (!matchElement) return;
+    activateMatch(matchElement, event);
   });
 
   document.addEventListener('keydown', function (event) {

--- a/docs/images/t-py-08/interactive_human_mitochondrion.interactive.svg
+++ b/docs/images/t-py-08/interactive_human_mitochondrion.interactive.svg
@@ -50,6 +50,7 @@
   stroke-width: 1.5;
   paint-order: stroke fill markers;
 }
+.gbdraw-interactive-pairwise-match.gbdraw-interactive-pairwise-match--pending,
 .gbdraw-interactive-pairwise-match.gbdraw-interactive-pairwise-match--selected {
   opacity: 1;
   filter: url(#gbdraw-interactive-feature-glow);
@@ -58,6 +59,10 @@
   stroke-width: 2.5;
   paint-order: stroke fill markers;
   outline: none;
+}
+.gbdraw-interactive-pairwise-match:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 .gbdraw-interactive-annotation {
   cursor: pointer;
@@ -1954,8 +1959,9 @@
   var matchElementsById = new Map();
   var ambiguousMatchElementIds = new Set();
   var selectedMatchElements = [];
+  var pendingMatchElement = null;
   var comparisonElementsByCollinearityBlockId = new Map();
-  Array.prototype.slice.call(svg.querySelectorAll(MATCH_SELECTOR)).forEach(function (element) {
+  Array.prototype.slice.call(svg.querySelectorAll(MATCH_SELECTOR)).forEach(function (element, index) {
     var matchId = getElementMatchId(element);
     if (matchId &amp;&amp; !ambiguousMatchElementIds.has(matchId)) {
       if (matchElementsById.has(matchId)) {
@@ -1973,6 +1979,9 @@
       comparisonElementsByCollinearityBlockId.get(blockId).push(element);
     }
     setClassToken(element, 'gbdraw-interactive-pairwise-match', true);
+    element.setAttribute('role', 'button');
+    element.setAttribute('tabindex', '0');
+    element.setAttribute('aria-label', 'Pairwise match ' + (index + 1));
   });
 
   function setClassToken(element, token, enabled) {
@@ -2107,6 +2116,19 @@
     selectedMatchElements.forEach(function (element) {
       setClassToken(element, 'gbdraw-interactive-pairwise-match--selected', true);
     });
+  }
+
+  function clearPendingMatch() {
+    if (!pendingMatchElement) return;
+    setClassToken(pendingMatchElement, 'gbdraw-interactive-pairwise-match--pending', false);
+    pendingMatchElement = null;
+  }
+
+  function setPendingMatch(element) {
+    if (pendingMatchElement === element) return;
+    clearPendingMatch();
+    pendingMatchElement = element;
+    setClassToken(element, 'gbdraw-interactive-pairwise-match--pending', true);
   }
 
   function clearActiveFeatureHover() {
@@ -4526,9 +4548,129 @@
     });
   }
 
-  function copyButton(value, label) {
-    var index = copyValues.push(String(value == null ? '' : value)) - 1;
-    return '&lt;button type="button" class="gfi-copy" data-copy-index="' + index + '"&gt;' + escapeHtml(label || 'Copy') + '&lt;/button&gt;';
+  function memberCopyFeedbackIdentity(memberOrRow) {
+    var recordKey = consistentTextIdentity(memberOrRow, ['recordKey', 'record_key']);
+    var biologicalId = consistentTextIdentity(
+      memberOrRow,
+      ['biologicalFeatureId', 'biological_feature_id']
+    );
+    if (
+      recordKey.valid
+      &amp;&amp; biologicalId.valid
+      &amp;&amp; recordKey.value
+      &amp;&amp; biologicalId.value
+    ) {
+      return JSON.stringify(['canonical', recordKey.value, biologicalId.value]);
+    }
+    var recordIndex = memberRecordIndex(memberOrRow);
+    var stableId = memberFeatureSvgId(memberOrRow);
+    var sourceIndex = nonnegativeIntegerIdentity(memberOrRow, [
+      'featureIndex', 'feature_index', 'sourceFeatureIndex', 'source_feature_index'
+    ]);
+    if (Number.isInteger(recordIndex) &amp;&amp; (stableId || Number.isInteger(sourceIndex.value))) {
+      return JSON.stringify([
+        'source',
+        recordIndex,
+        stableId,
+        Number.isInteger(sourceIndex.value) ? sourceIndex.value : null
+      ]);
+    }
+    return JSON.stringify([
+      'display',
+      firstDisplayText(memberOrRow &amp;&amp; (memberOrRow.record || memberOrRow.recordId || memberOrRow.record_id)),
+      firstDisplayText(memberOrRow &amp;&amp; memberOrRow.coordinates, memberLocationText(memberOrRow)),
+      firstNonInternalDisplayText(
+        memberOrRow &amp;&amp; (memberOrRow.proteinId || memberOrRow.protein_id),
+        memberOrRow &amp;&amp; displayProteinId(null, memberOrRow, '')
+      )
+    ]);
+  }
+
+  function sequenceCopyFeedbackKey(context, orthogroupId, action, memberOrRow, sequenceKind) {
+    return JSON.stringify([
+      'orthogroup-sequence',
+      String(context || ''),
+      String(orthogroupId || '').trim(),
+      action,
+      memberOrRow ? memberCopyFeedbackIdentity(memberOrRow) : '',
+      sequenceKindLabel(sequenceKind)
+    ]);
+  }
+
+  function copyFeedbackLabel(status) {
+    if (status === 'success') return 'Copied!';
+    if (status === 'manual') return 'Copy manually';
+    if (status === 'failure') return 'Copy failed';
+    return '';
+  }
+
+  function updateCopyFeedbackButtons(feedbackKey) {
+    if (!popup || !popup.querySelectorAll || !feedbackKey) return;
+    var feedback = copyFeedbackByKey.get(feedbackKey);
+    Array.prototype.slice.call(
+      popup.querySelectorAll('[data-copy-feedback-key]')
+    ).forEach(function (button) {
+      if (button.getAttribute('data-copy-feedback-key') !== feedbackKey) return;
+      button.textContent = feedback
+        ? copyFeedbackLabel(feedback.status)
+        : String(button.getAttribute('data-copy-label') || 'Copy');
+    });
+  }
+
+  function beginCopyFeedback(feedbackKey) {
+    var previousTimer = copyFeedbackTimers.get(feedbackKey);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackTimers.delete(feedbackKey);
+    copyFeedbackByKey.delete(feedbackKey);
+    nextCopyOperationId += 1;
+    copyOperationIds.set(feedbackKey, nextCopyOperationId);
+    updateCopyFeedbackButtons(feedbackKey);
+    return nextCopyOperationId;
+  }
+
+  function finishCopyFeedback(feedbackKey, operationId, status) {
+    if (!feedbackKey || copyOperationIds.get(feedbackKey) !== operationId) return;
+    var previousTimer = copyFeedbackTimers.get(feedbackKey);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackByKey.set(feedbackKey, { operationId: operationId, status: status });
+    updateCopyFeedbackButtons(feedbackKey);
+    var timer = window.setTimeout(function () {
+      var current = copyFeedbackByKey.get(feedbackKey);
+      if (
+        copyOperationIds.get(feedbackKey) !== operationId
+        || !current
+        || current.operationId !== operationId
+      ) return;
+      copyFeedbackByKey.delete(feedbackKey);
+      copyFeedbackTimers.delete(feedbackKey);
+      copyOperationIds.delete(feedbackKey);
+      updateCopyFeedbackButtons(feedbackKey);
+    }, COPY_FEEDBACK_DURATION_MS);
+    copyFeedbackTimers.set(feedbackKey, timer);
+  }
+
+  function clearCopyFeedback() {
+    copyFeedbackTimers.forEach(function (timer) {
+      window.clearTimeout(timer);
+    });
+    copyFeedbackTimers.clear();
+    copyFeedbackByKey.clear();
+    copyOperationIds.clear();
+  }
+
+  function copyButton(value, label, feedbackKey) {
+    var originalLabel = String(label || 'Copy');
+    var key = String(feedbackKey || '');
+    var feedback = key ? copyFeedbackByKey.get(key) : null;
+    var index = copyValues.push({
+      feedbackKey: key,
+      text: String(value == null ? '' : value)
+    }) - 1;
+    var feedbackAttributes = key
+      ? ' data-copy-feedback-key="' + escapeHtml(key) + '" data-copy-label="' + escapeHtml(originalLabel) + '" aria-live="polite" aria-atomic="true"'
+      : '';
+    return '&lt;button type="button" class="gfi-copy" data-copy-index="' + index + '"' + feedbackAttributes + '&gt;' +
+      escapeHtml(feedback ? copyFeedbackLabel(feedback.status) : originalLabel) + '&lt;/button&gt;';
   }
 
   function downloadButton(filename, text, label) {
@@ -4550,18 +4692,32 @@
       if (!text) return;
       var count = groupFastaCount(rows, sequenceKind);
       var suffix = count &gt; 1 ? ' (' + count + ')' : '';
-      html.push(copyButton(text, 'Copy ' + sequenceKind + suffix));
+      var feedbackKey = sequenceCopyFeedbackKey(
+        options &amp;&amp; options.feedbackContext,
+        orthogroupId,
+        'group',
+        null,
+        sequenceKind
+      );
+      html.push(copyButton(text, 'Copy ' + sequenceKind + suffix, feedbackKey));
       html.push(downloadButton(groupSequenceFilename(orthogroupId, displayName, sequenceKind), text, 'DL ' + sequenceKind + suffix));
     });
     return html.join('');
   }
 
-  function renderMemberSequenceActions(memberOrRow, orthogroupId) {
+  function renderMemberSequenceActions(memberOrRow, orthogroupId, feedbackContext) {
     var html = [];
     ['nt', 'aa'].forEach(function (sequenceKind) {
       var text = String(memberFasta(memberOrRow, sequenceKind) || '').trim();
       if (!text) return;
-      html.push(copyButton(text, 'Copy ' + sequenceKind));
+      var feedbackKey = sequenceCopyFeedbackKey(
+        feedbackContext,
+        orthogroupId,
+        'member',
+        memberOrRow,
+        sequenceKind
+      );
+      html.push(copyButton(text, 'Copy ' + sequenceKind, feedbackKey));
       html.push(downloadButton(memberSequenceFilename(memberOrRow, sequenceKind, orthogroupId), text, 'DL ' + sequenceKind));
     });
     return html.length ? '&lt;div class="gfi-seq-actions"&gt;' + html.join('') + '&lt;/div&gt;' : '';
@@ -4569,6 +4725,11 @@
 
   var copyValues = [];
   var downloadValues = [];
+  var COPY_FEEDBACK_DURATION_MS = 1500;
+  var copyFeedbackByKey = new Map();
+  var copyFeedbackTimers = new Map();
+  var copyOperationIds = new Map();
+  var nextCopyOperationId = 0;
 
   function renderRows(rows) {
     if (!rows.length) {
@@ -4625,10 +4786,11 @@
     ).join('\n');
     var sequenceActions = renderGroupSequenceActions(rows, {
       orthogroupId: orthogroupId,
-      displayName: displayName
+      displayName: displayName,
+      feedbackContext: 'feature-orthogroup'
     });
     var body = rows.map(function (row) {
-      var sequenceActions = renderMemberSequenceActions(row, orthogroupId);
+      var sequenceActions = renderMemberSequenceActions(row, orthogroupId, 'feature-orthogroup');
       return '&lt;tr&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.record) + '&lt;/td&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.coordinates) + '&lt;/td&gt;' +
@@ -5363,7 +5525,7 @@
       '&lt;tbody&gt;' + body + '&lt;/tbody&gt;&lt;/table&gt;&lt;/div&gt;';
   }
 
-  function renderMatchMemberTable(section, rows) {
+  function renderMatchMemberTable(section, rows, feedbackContext) {
     if (!rows.length) return '';
     var orthogroupId = String(section &amp;&amp; (section.id || section.orthogroupId || section.orthogroup_id) || rows[0] &amp;&amp; (rows[0].orthogroupId || rows[0].orthogroup_id) || '').trim();
     var displayName = String(section &amp;&amp; (section.displayName || section.display_name || section.name) || rows[0] &amp;&amp; (rows[0].displayName || rows[0].display_name) || '').trim();
@@ -5379,7 +5541,7 @@
       ).join('\n');
     }
     var body = rows.map(function (row) {
-      var sequenceActions = renderMemberSequenceActions(row, orthogroupId);
+      var sequenceActions = renderMemberSequenceActions(row, orthogroupId, feedbackContext);
       return '&lt;tr&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.record) + '&lt;/td&gt;' +
         '&lt;td class="gfi-mono"&gt;' + escapeHtml(row.coordinates) + '&lt;/td&gt;' +
@@ -5390,7 +5552,8 @@
     }).join('');
     var sequenceActions = renderGroupSequenceActions(rows, {
       orthogroupId: orthogroupId,
-      displayName: displayName
+      displayName: displayName,
+      feedbackContext: feedbackContext
     });
     return '&lt;div class="gfi-table-wrap"&gt;&lt;table class="gfi-table gfi-og-members-table"&gt;' +
       '&lt;thead&gt;&lt;tr&gt;&lt;th&gt;Record&lt;/th&gt;&lt;th&gt;Coordinates (+/-)&lt;/th&gt;&lt;th&gt;Protein ID&lt;/th&gt;&lt;th&gt;Product / note&lt;/th&gt;&lt;th&gt;Seq&lt;/th&gt;&lt;/tr&gt;&lt;/thead&gt;' +
@@ -5441,7 +5604,11 @@
         ? '&lt;div class="gfi-block gfi-block--selected-og"&gt;' +
           '&lt;div class="gfi-block-title"&gt;' + escapeHtml('Selected similarity group') + '&lt;/div&gt;' +
           renderRows(selectedBlockOrthogroup.detailRows) +
-          renderMatchMemberTable(selectedBlockOrthogroup, selectedBlockOrthogroup.memberRows) +
+          renderMatchMemberTable(
+            selectedBlockOrthogroup,
+            selectedBlockOrthogroup.memberRows,
+            'selected-orthogroup:' + selectedBlockOrthogroup.id
+          ) +
           '&lt;/div&gt;'
         : '';
       return '&lt;div class="gfi-block"&gt;' +
@@ -5449,7 +5616,16 @@
         (rows.length &amp;&amp; !featureRows.length ? renderRows(rows) : '') +
         renderMatchFeatureTable(featureRows) +
         renderMatchBlockOrthogroupTable(blockOrthogroups, selectedBlockOrthogroupId) +
-        renderMatchMemberTable(section, memberRows) +
+        renderMatchMemberTable(
+          section,
+          memberRows,
+          'match-section:' + firstDisplayText(
+            section &amp;&amp; section.id,
+            section &amp;&amp; section.title,
+            match &amp;&amp; match.id,
+            selectedBlockOrthogroupId
+          )
+        ) +
         selectedHtml +
         '&lt;/div&gt;';
     }).join('') || '&lt;div class="gfi-empty"&gt;No match details available.&lt;/div&gt;';
@@ -5491,6 +5667,7 @@
   function closePopup() {
     stopPopupResize();
     stopPopupDrag();
+    clearCopyFeedback();
     updateActivePopupViewportMetrics = null;
     if (popup &amp;&amp; popup.parentNode) {
       popup.parentNode.removeChild(popup);
@@ -6194,8 +6371,10 @@
       var copyTarget = closestFromTarget(rootEvent.target, '[data-copy-index]');
       if (copyTarget) {
         var index = Number(copyTarget.getAttribute('data-copy-index'));
-        var value = Number.isFinite(index) ? copyValues[index] || '' : '';
-        Promise.resolve(copyText(value, copyTarget)).catch(function () {});
+        var copyPayload = Number.isFinite(index) ? copyValues[index] || null : null;
+        var value = copyPayload ? copyPayload.text : '';
+        var feedbackKey = copyPayload ? copyPayload.feedbackKey : '';
+        Promise.resolve(copyText(value, copyTarget, feedbackKey)).catch(function () {});
         return;
       }
       var downloadTarget = closestFromTarget(rootEvent.target, '[data-download-index]');
@@ -6241,18 +6420,34 @@
     syncStandaloneOverlayOrder();
   }
 
-  async function copyText(value, button) {
+  async function copyText(value, button, feedbackKey) {
     var text = String(value == null ? '' : value);
-    if (navigator.clipboard &amp;&amp; navigator.clipboard.writeText) {
+    var operationId = feedbackKey ? beginCopyFeedback(feedbackKey) : 0;
+    var clipboard = null;
+    try {
+      clipboard = navigator.clipboard;
+    } catch (error) {
+      clipboard = null;
+    }
+    if (clipboard &amp;&amp; clipboard.writeText) {
       try {
-        await navigator.clipboard.writeText(text);
-        if (button) button.textContent = 'Copied';
-        return;
+        await clipboard.writeText(text);
+        if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'success');
+        else if (button) button.textContent = 'Copied';
+        return 'copied';
       } catch (error) {
         // Fall back to a prompt below when clipboard permission is unavailable.
       }
     }
-    window.prompt('Copy text', text);
+    try {
+      if (typeof window.prompt !== 'function') throw new Error('Manual copy is unavailable.');
+      window.prompt('Copy text', text);
+      if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'manual');
+      return 'manual';
+    } catch (error) {
+      if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'failure');
+      return 'failed';
+    }
   }
 
   function closestFeature(node) {
@@ -6393,6 +6588,41 @@
     closeHoverPopup();
   });
 
+  svg.addEventListener('pointerdown', function (event) {
+    if (event.button !== 0 || event.isPrimary === false) return;
+    var matchElement = closestMatch(event.target);
+    if (!matchElement) {
+      clearPendingMatch();
+      return;
+    }
+    setPendingMatch(matchElement);
+  });
+
+  svg.addEventListener('pointerout', function (event) {
+    if (!pendingMatchElement) return;
+    var matchElement = closestMatch(event.target);
+    if (matchElement !== pendingMatchElement) return;
+    if (closestMatch(event.relatedTarget) === matchElement) return;
+    clearPendingMatch();
+  });
+
+  window.addEventListener('pointerup', clearPendingMatch, true);
+  window.addEventListener('pointercancel', clearPendingMatch, true);
+  window.addEventListener('blur', clearPendingMatch);
+
+  function activateMatch(matchElement, event) {
+    var matchId = getElementMatchId(matchElement);
+    var match = matchesById.get(matchId);
+    if (!match) return false;
+    clearPendingMatch();
+    event.preventDefault();
+    event.stopPropagation();
+    closeHoverPopup();
+    openPopup(match, event, 'match');
+    setSelectedMatch(matchId);
+    return true;
+  }
+
   svg.addEventListener('click', function (event) {
     if (popup &amp;&amp; popup.contains(event.target)) return;
     if (closestSearchControls(event.target)) return;
@@ -6420,14 +6650,7 @@
         closePopup();
         return;
       }
-      var matchId = getElementMatchId(matchElement);
-      var match = matchesById.get(matchId);
-      if (!match) return;
-      event.preventDefault();
-      event.stopPropagation();
-      closeHoverPopup();
-      openPopup(match, event, 'match');
-      setSelectedMatch(matchId);
+      activateMatch(matchElement, event);
       return;
     }
     var svgId = getElementFeatureId(featureElement);
@@ -6441,6 +6664,13 @@
     event.stopPropagation();
     closeHoverPopup();
     openPopup(feature, event, 'feature');
+  });
+
+  svg.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter' &amp;&amp; event.key !== ' ') return;
+    var matchElement = closestMatch(event.target);
+    if (!matchElement) return;
+    activateMatch(matchElement, event);
   });
 
   document.addEventListener('keydown', function (event) {

--- a/gbdraw/analysis/collinearity.py
+++ b/gbdraw/analysis/collinearity.py
@@ -1167,6 +1167,7 @@ def _filter_hit_tables_by_search_scope(
     scope: CollinearitySearchScope | str,
     comparison_pairs: Sequence[tuple[int, int]] | None = None,
 ) -> dict[tuple[int, int], DataFrame]:
+    """Keep local semantic evidence and scope only cross-record evidence."""
     normalized_scope = normalize_collinearity_search_scope(str(scope))
     if normalized_scope == "all":
         return dict(hit_tables)
@@ -1181,8 +1182,8 @@ def _filter_hit_tables_by_search_scope(
     return {
         (query_index, subject_index): hits
         for (query_index, subject_index), hits in hit_tables.items()
-        if query_index != subject_index
-        and (min(query_index, subject_index), max(query_index, subject_index)) in allowed_pairs
+        if query_index == subject_index
+        or (min(query_index, subject_index), max(query_index, subject_index)) in allowed_pairs
     }
 
 
@@ -1265,7 +1266,7 @@ def build_orthogroup_collinearity_blocks_from_hits(
         if len(set(normalized_pairs)) != len(normalized_pairs):
             raise ValidationError("comparison_pairs must not contain duplicates.")
         normalized_comparison_pairs = tuple(normalized_pairs)
-    directional_tables = _filter_hit_tables_by_search_scope(
+    semantic_hit_tables = _filter_hit_tables_by_search_scope(
         directional_tables,
         record_count=record_count,
         scope=normalized_search_scope,
@@ -1275,35 +1276,34 @@ def build_orthogroup_collinearity_blocks_from_hits(
             else None
         ),
     )
+    geometry_hit_tables = {
+        pair: hits
+        for pair, hits in semantic_hit_tables.items()
+        if pair[0] != pair[1]
+    }
+    edge_selection = select_rbh_orthogroup_edges_from_directional_hits(
+        semantic_hit_tables,
+        extraction.protein_map,
+        record_count=record_count,
+        orthogroup_membership_mode=normalized_membership_mode,
+        orthogroup_member_max_hits=int(orthogroup_member_max_hits),
+        max_related_edges_per_orthogroup=resolved_max_paralog_links,
+    )
+    orthogroups = edge_selection.orthogroups
     if normalized_edge_mode == "rbh":
-        edge_selection = select_rbh_orthogroup_edges_from_directional_hits(
-            directional_tables,
-            extraction.protein_map,
-            record_count=record_count,
-            orthogroup_membership_mode=normalized_membership_mode,
-            orthogroup_member_max_hits=int(orthogroup_member_max_hits),
-            max_related_edges_per_orthogroup=resolved_max_paralog_links,
-        )
-        orthogroups = edge_selection.orthogroups
-        comparison_edges_by_pair = {
-            pair: edge_selection.all_edges_by_pair.get(pair, _empty_hits())
-            for pair in normalized_comparison_pairs
+        edge_tables = {
+            pair: edges
+            for pair, edges in edge_selection.all_edges_by_pair.items()
+            if pair in geometry_hit_tables or pair[::-1] in geometry_hit_tables
         }
     else:
-        edge_tables = _select_orthogroup_edges(directional_tables, edge_mode=normalized_edge_mode)
-        seed_selection = select_rbh_orthogroup_edges_from_directional_hits(
-            directional_tables,
-            extraction.protein_map,
-            record_count=record_count,
-            orthogroup_membership_mode=normalized_membership_mode,
-            orthogroup_member_max_hits=int(orthogroup_member_max_hits),
-            max_related_edges_per_orthogroup=resolved_max_paralog_links,
+        edge_tables = _select_orthogroup_edges(
+            geometry_hit_tables, edge_mode=normalized_edge_mode,
         )
-        orthogroups = seed_selection.orthogroups
-        comparison_edges_by_pair = {
-            pair: edge_tables.get(pair, _empty_hits())
-            for pair in normalized_comparison_pairs
-        }
+    comparison_edges_by_pair = {
+        pair: edge_tables.get(pair, _empty_hits())
+        for pair in normalized_comparison_pairs
+    }
     anchors = orthogroup_edges_to_lossless_collinearity_anchors(
         comparison_edges_by_pair,
         extraction.protein_map,

--- a/gbdraw/diagrams/linear/assemble.py
+++ b/gbdraw/diagrams/linear/assemble.py
@@ -2383,6 +2383,30 @@ def assemble_linear_diagram(
             ),
             px_per_bp=sequence_width / max(1, len(record.seq)),
         )
+    # Row spacing reserves labels, but ribbon endpoints attach to track paint.
+    # Resolve this after both layout paths have fixed every slot and record.
+    for record_index, placement in record_placements.items():
+        plan = record_vertical_plans[record_index]
+        attachment_band = plan.axis_band
+        for slot in plan.slots:
+            band = slot.paint_band
+            if band is None:
+                continue
+            if slot.renderer == "features":
+                band = record_feature_lane_geometries[
+                    record_index
+                ].occupied_band.translate(slot.origin_y)
+            attachment_band = attachment_band.union(band)
+        record_placements[record_index] = replace(
+            placement,
+            comparison_top_y=(
+                placement.axis_y + attachment_band.top_y - comparison_endpoint_gap_px
+            ),
+            comparison_bottom_y=(
+                placement.axis_y + attachment_band.bottom_y + comparison_endpoint_gap_px
+            ),
+        )
+
     canvas: Drawing = canvas_config.create_svg_canvas()
     primary_target_start = len(getattr(canvas, "elements", []))
     if length_bar_group is not None:

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -782,8 +782,10 @@
         .hosted-build-label {
             white-space: nowrap;
         }
-        .right-drawer {
+        .result-pane {
             --right-drawer-width: min(100vw, 360px);
+        }
+        .right-drawer {
             width: var(--right-drawer-width);
             transform: translateX(0);
             visibility: visible;
@@ -795,7 +797,6 @@
             pointer-events: none;
         }
         .drawer-toggle {
-            --right-drawer-width: min(100vw, 360px);
             transform: translateY(-50%);
         }
         .drawer-toggle[aria-expanded="true"] {
@@ -803,6 +804,13 @@
                 calc(-1 * var(--right-drawer-width)),
                 -50%
             );
+        }
+        .preview-controls.preview-controls--drawer-open {
+            left: 0;
+            right: var(--right-drawer-width);
+            transform: none;
+            justify-content: center;
+            flex-wrap: wrap;
         }
         @media (max-width: 760px) {
             .feature-popup-grid {
@@ -4675,7 +4683,8 @@
                          :style="featureSelectionMarqueeStyle"></div>
 
                     <!-- Zoom and Canvas controls -->
-                    <div class="preview-controls absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-20">
+                    <div class="preview-controls absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-20"
+                         :class="{ 'preview-controls--drawer-open': showRightDrawer }">
                         <!-- Reset preview layout button -->
                         <button v-if="svgContent" @click="resetLayout"
                                 class="flex items-center gap-2 px-3 py-2 bg-white shadow rounded-lg border border-slate-200 hover:bg-slate-100 text-slate-600 text-sm"

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -4908,15 +4908,17 @@
                             </div>
                             <div class="grid grid-cols-2 gap-2 mb-3">
                                 <button type="button"
-                                        @click="copyOrthogroupSequences(clickedOrthogroupDetail.id, 'nt')"
+                                        @click="copyOrthogroupSequences(clickedOrthogroupDetail.id, 'nt', 'feature-popup')"
                                         :disabled="!clickedOrthogroupDetail.ntSequenceCount"
                                         :class="[
                                           'px-2 py-1.5 rounded-md text-xs flex items-center justify-center gap-1',
                                           clickedOrthogroupDetail.ntSequenceCount ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                         ]"
-                                        title="Copy all member nucleotide FASTA">
-                                    <i class="ph ph-copy"></i>
-                                    <span>Copy nt</span>
+                                        title="Copy all member nucleotide FASTA"
+                                        aria-live="polite"
+                                        aria-atomic="true">
+                                    <i class="ph ph-copy" aria-hidden="true"></i>
+                                    <span>{{ orthogroupCopyFeedbackLabel(clickedOrthogroupDetail.id, 'nt', 'Copy nt', null, 'feature-popup') }}</span>
                                 </button>
                                 <button type="button"
                                         @click="downloadOrthogroupSequences(clickedOrthogroupDetail.id, 'nt')"
@@ -4930,15 +4932,17 @@
                                     <span>Download nt</span>
                                 </button>
                                 <button type="button"
-                                        @click="copyOrthogroupSequences(clickedOrthogroupDetail.id, 'aa')"
+                                        @click="copyOrthogroupSequences(clickedOrthogroupDetail.id, 'aa', 'feature-popup')"
                                         :disabled="!clickedOrthogroupDetail.aaSequenceCount"
                                         :class="[
                                           'px-2 py-1.5 rounded-md text-xs flex items-center justify-center gap-1',
                                           clickedOrthogroupDetail.aaSequenceCount ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                         ]"
-                                        title="Copy all member amino-acid FASTA">
-                                    <i class="ph ph-copy"></i>
-                                    <span>Copy aa</span>
+                                        title="Copy all member amino-acid FASTA"
+                                        aria-live="polite"
+                                        aria-atomic="true">
+                                    <i class="ph ph-copy" aria-hidden="true"></i>
+                                    <span>{{ orthogroupCopyFeedbackLabel(clickedOrthogroupDetail.id, 'aa', 'Copy aa', null, 'feature-popup') }}</span>
                                 </button>
                                 <button type="button"
                                         @click="downloadOrthogroupSequences(clickedOrthogroupDetail.id, 'aa')"
@@ -4991,14 +4995,16 @@
                                                 <td class="px-2 py-1 whitespace-nowrap">
                                                     <div class="grid grid-cols-2 gap-1 w-24">
                                                         <button type="button"
-                                                                @click="copyOrthogroupMemberSequence(member, 'nt', clickedOrthogroupDetail.id)"
+                                                                @click="copyOrthogroupMemberSequence(member, 'nt', clickedOrthogroupDetail.id, 'feature-popup')"
                                                                 :disabled="!hasOrthogroupMemberSequence(member, 'nt')"
                                                                 :class="[
                                                                   'h-6 rounded text-[10px] flex items-center justify-center gap-0.5',
                                                                   hasOrthogroupMemberSequence(member, 'nt') ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                                                 ]"
-                                                                title="Copy nucleotide FASTA">
-                                                            <i class="ph ph-copy"></i><span>nt</span>
+                                                                title="Copy nucleotide FASTA"
+                                                                aria-live="polite"
+                                                                aria-atomic="true">
+                                                            <i class="ph ph-copy" aria-hidden="true"></i><span>{{ orthogroupCopyFeedbackLabel(clickedOrthogroupDetail.id, 'nt', 'nt', member, 'feature-popup') }}</span>
                                                         </button>
                                                         <button type="button"
                                                                 @click="downloadOrthogroupMemberSequence(member, 'nt', clickedOrthogroupDetail.id)"
@@ -5011,14 +5017,16 @@
                                                             <i class="ph ph-download-simple"></i><span>nt</span>
                                                         </button>
                                                         <button type="button"
-                                                                @click="copyOrthogroupMemberSequence(member, 'aa', clickedOrthogroupDetail.id)"
+                                                                @click="copyOrthogroupMemberSequence(member, 'aa', clickedOrthogroupDetail.id, 'feature-popup')"
                                                                 :disabled="!hasOrthogroupMemberSequence(member, 'aa')"
                                                                 :class="[
                                                                   'h-6 rounded text-[10px] flex items-center justify-center gap-0.5',
                                                                   hasOrthogroupMemberSequence(member, 'aa') ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                                                 ]"
-                                                                title="Copy amino-acid FASTA">
-                                                            <i class="ph ph-copy"></i><span>aa</span>
+                                                                title="Copy amino-acid FASTA"
+                                                                aria-live="polite"
+                                                                aria-atomic="true">
+                                                            <i class="ph ph-copy" aria-hidden="true"></i><span>{{ orthogroupCopyFeedbackLabel(clickedOrthogroupDetail.id, 'aa', 'aa', member, 'feature-popup') }}</span>
                                                         </button>
                                                         <button type="button"
                                                                 @click="downloadOrthogroupMemberSequence(member, 'aa', clickedOrthogroupDetail.id)"
@@ -6272,9 +6280,11 @@
                                                   'px-2 py-1.5 rounded text-xs flex items-center justify-center gap-1',
                                                   hasOrthogroupSequence(selectedOrthogroup, 'nt') ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                                 ]"
-                                                title="Copy all member nucleotide FASTA">
-                                            <i class="ph ph-copy"></i>
-                                            <span>Copy nt</span>
+                                                title="Copy all member nucleotide FASTA"
+                                                aria-live="polite"
+                                                aria-atomic="true">
+                                            <i class="ph ph-copy" aria-hidden="true"></i>
+                                            <span>{{ orthogroupCopyFeedbackLabel(selectedOrthogroup, 'nt', 'Copy nt') }}</span>
                                         </button>
                                         <button type="button"
                                                 @click="downloadOrthogroupSequences(selectedOrthogroup, 'nt')"
@@ -6294,9 +6304,11 @@
                                                   'px-2 py-1.5 rounded text-xs flex items-center justify-center gap-1',
                                                   hasOrthogroupSequence(selectedOrthogroup, 'aa') ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                                 ]"
-                                                title="Copy all member amino-acid FASTA">
-                                            <i class="ph ph-copy"></i>
-                                            <span>Copy aa</span>
+                                                title="Copy all member amino-acid FASTA"
+                                                aria-live="polite"
+                                                aria-atomic="true">
+                                            <i class="ph ph-copy" aria-hidden="true"></i>
+                                            <span>{{ orthogroupCopyFeedbackLabel(selectedOrthogroup, 'aa', 'Copy aa') }}</span>
                                         </button>
                                         <button type="button"
                                                 @click="downloadOrthogroupSequences(selectedOrthogroup, 'aa')"
@@ -6344,8 +6356,10 @@
                                                                       'h-6 rounded text-[10px] flex items-center justify-center gap-0.5',
                                                                       hasOrthogroupMemberSequence(member, 'nt') ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                                                     ]"
-                                                                    title="Copy nucleotide FASTA">
-                                                                <i class="ph ph-copy"></i><span>nt</span>
+                                                                    title="Copy nucleotide FASTA"
+                                                                    aria-live="polite"
+                                                                    aria-atomic="true">
+                                                                <i class="ph ph-copy" aria-hidden="true"></i><span>{{ orthogroupCopyFeedbackLabel(selectedOrthogroup, 'nt', 'nt', member) }}</span>
                                                             </button>
                                                             <button type="button"
                                                                     @click="downloadOrthogroupMemberSequence(member, 'nt', selectedOrthogroup)"
@@ -6364,8 +6378,10 @@
                                                                       'h-6 rounded text-[10px] flex items-center justify-center gap-0.5',
                                                                       hasOrthogroupMemberSequence(member, 'aa') ? 'bg-slate-100 hover:bg-slate-200 text-slate-700' : 'bg-slate-100 text-slate-300 cursor-not-allowed'
                                                                     ]"
-                                                                    title="Copy amino-acid FASTA">
-                                                                <i class="ph ph-copy"></i><span>aa</span>
+                                                                    title="Copy amino-acid FASTA"
+                                                                    aria-live="polite"
+                                                                    aria-atomic="true">
+                                                                <i class="ph ph-copy" aria-hidden="true"></i><span>{{ orthogroupCopyFeedbackLabel(selectedOrthogroup, 'aa', 'aa', member) }}</span>
                                                             </button>
                                                             <button type="button"
                                                                     @click="downloadOrthogroupMemberSequence(member, 'aa', selectedOrthogroup)"

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -686,6 +686,7 @@
             stroke-opacity: 1 !important;
             stroke-width: 3px !important;
         }
+        .gbdraw-match-pending,
         .gbdraw-match-selected {
             opacity: 1 !important;
             filter: drop-shadow(0 0 5px rgba(245, 158, 11, 0.82));
@@ -694,6 +695,15 @@
             stroke-width: 2.5px !important;
             paint-order: stroke fill markers;
             outline: none;
+        }
+        .gbdraw-preview-surface :is(
+            path[data-gbdraw-match-id],
+            path[data-gbdraw-pairwise-match-id],
+            path[data-match-kind],
+            path[data-pairwise-match-style]
+        ):focus-visible {
+            outline: 2px solid #2563eb;
+            outline-offset: 2px;
         }
         .gbdraw-feature-selected {
             opacity: 1 !important;

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -5937,31 +5937,50 @@
 
                         <div class="space-y-2">
                             <div class="flex items-center justify-between gap-2">
-                                <div class="text-xs font-bold uppercase tracking-wider text-slate-500">Command</div>
-                                <div class="flex flex-wrap items-center justify-end gap-2">
-                                    <button v-if="runInfoHasCliHelperFiles"
-                                            type="button"
-                                            @click="downloadCliHelperFiles"
-                                            class="px-3 py-1.5 rounded border border-emerald-200 bg-emerald-50 hover:bg-emerald-100 text-emerald-700 text-xs font-semibold flex items-center gap-1"
-                                            title="Download browser-generated files referenced by this command">
-                                        <i class="ph ph-download-simple"></i>
-                                        <span>Download CLI Files</span>
-                                    </button>
-                                    <button type="button"
-                                            @click="copyRunCommand"
-                                            class="px-3 py-1.5 rounded border border-slate-200 bg-slate-50 hover:bg-slate-100 text-slate-700 text-xs font-semibold flex items-center gap-1"
-                                            title="Copy command">
-                                        <i class="ph ph-copy"></i>
-                                        <span>{{ runInfoCopyStatus || 'Copy' }}</span>
-                                    </button>
-                                </div>
+                                <div class="text-xs font-bold uppercase tracking-wider text-slate-500">Source recipe</div>
+                                <button v-if="lastRunInfo.sourceRecipe?.available !== false"
+                                        type="button"
+                                        @click="copyRunCommand"
+                                        class="px-3 py-1.5 rounded border border-slate-200 bg-slate-50 hover:bg-slate-100 text-slate-700 text-xs font-semibold flex items-center gap-1"
+                                        title="Copy command">
+                                    <i class="ph ph-copy"></i>
+                                    <span>{{ runInfoCopyStatus || 'Copy' }}</span>
+                                </button>
                             </div>
-                            <pre class="h-28 overflow-auto custom-scrollbar rounded border border-slate-200 bg-slate-950 text-slate-100 p-3 text-xs leading-relaxed whitespace-pre font-mono">{{ lastRunInfo.command }}</pre>
+                            <pre v-if="lastRunInfo.sourceRecipe?.available !== false"
+                                 class="h-28 overflow-auto custom-scrollbar rounded border border-slate-200 bg-slate-950 text-slate-100 p-3 text-xs leading-relaxed whitespace-pre font-mono">{{ lastRunInfo.sourceRecipe?.command || lastRunInfo.command }}</pre>
+                            <div v-else
+                                 class="rounded border border-amber-200 bg-amber-50 p-3 text-xs leading-relaxed text-amber-800">
+                                {{ lastRunInfo.sourceRecipe?.unavailableReason || 'Source recipe unavailable.' }}
+                            </div>
                         </div>
 
-                        <div v-if="lastRunInfo.sessionCommand" class="space-y-2">
-                            <div class="text-xs font-bold uppercase tracking-wider text-slate-500">Session command</div>
-                            <pre class="overflow-auto custom-scrollbar rounded border border-slate-200 bg-slate-50 text-slate-700 p-3 text-xs leading-relaxed whitespace-pre font-mono">{{ lastRunInfo.sessionCommand }}</pre>
+                        <div v-if="lastRunInfo.exactReplay?.command || lastRunInfo.sessionCommand" class="space-y-2">
+                            <div class="flex items-center justify-between gap-2">
+                                <div class="text-xs font-bold uppercase tracking-wider text-slate-500">Exact replay</div>
+                                <button type="button"
+                                        @click="copyExactReplayCommand"
+                                        class="px-3 py-1.5 rounded border border-slate-200 bg-slate-50 hover:bg-slate-100 text-slate-700 text-xs font-semibold flex items-center gap-1"
+                                        title="Copy exact replay command">
+                                    <i class="ph ph-copy"></i>
+                                    <span>{{ exactReplayCopyStatus || 'Copy' }}</span>
+                                </button>
+                            </div>
+                            <pre class="overflow-auto custom-scrollbar rounded border border-slate-200 bg-slate-50 text-slate-700 p-3 text-xs leading-relaxed whitespace-pre font-mono">{{ lastRunInfo.exactReplay?.command || lastRunInfo.sessionCommand }}</pre>
+                        </div>
+
+                        <div v-if="runInfoHasCliHelperFiles" class="space-y-2 rounded border border-emerald-200 bg-emerald-50 p-3">
+                            <div class="flex items-center justify-between gap-2">
+                                <div class="text-xs font-bold uppercase tracking-wider text-emerald-800">Reproducibility files</div>
+                                <button type="button"
+                                        @click="downloadCliHelperFiles"
+                                        class="px-3 py-1.5 rounded border border-emerald-200 bg-white hover:bg-emerald-100 text-emerald-700 text-xs font-semibold flex items-center gap-1"
+                                        title="Download Source recipe helpers and the Exact replay file">
+                                    <i class="ph ph-download-simple"></i>
+                                    <span>Download reproducibility files</span>
+                                </button>
+                            </div>
+                            <p class="text-xs leading-relaxed text-emerald-800">{{ lastRunInfo.downloadBundle?.description }}</p>
                         </div>
 
                         <div class="space-y-1 text-xs text-slate-500 leading-relaxed">

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1151,10 +1151,11 @@
                     <button @click="saveSessionWithTitle" class="app-config-button text-[11px] font-bold text-slate-600 hover:text-blue-700 px-1 py-0.5 rounded border border-blue-200 bg-blue-50 flex items-center gap-0.5" title="Save Session" aria-label="Save Session">
                         <i class="ph ph-archive"></i> Save Session
                     </button>
-                    <button data-history-managed @click="$refs.sessionInput.click()" class="app-config-button text-[11px] font-bold text-slate-600 hover:text-blue-700 px-1 py-0.5 rounded border border-blue-200 bg-blue-50 flex items-center gap-0.5" title="Load Session" aria-label="Load Session">
+                    <button data-history-managed @click="$refs.sessionInput.click()" :disabled="sessionImportPending" :aria-busy="sessionImportPending" class="app-config-button text-[11px] font-bold text-slate-600 hover:text-blue-700 px-1 py-0.5 rounded border border-blue-200 bg-blue-50 flex items-center gap-0.5 disabled:opacity-40 disabled:cursor-not-allowed" title="Load Session" aria-label="Load Session">
                         <i class="ph ph-archive-tray"></i> Load Session
                     </button>
                     <input data-history-managed type="file" ref="sessionInput" accept=".json,.gz,application/json,application/gzip" class="hidden" @change="importSession">
+                    <span v-if="sessionImportPending" data-session-import-status role="status" aria-live="polite" class="text-[10px] font-semibold text-blue-700 whitespace-nowrap">Loading session…</span>
                 </div>
                 <div class="app-session-actions flex items-center gap-1 min-w-0">
                     <span class="app-session-label text-[10px] uppercase tracking-wide text-slate-400 font-semibold">Session</span>

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -2328,29 +2328,40 @@ export const createAppSetup = () => {
   const resetAllLabelTextOverridesWithHistory = undoableAction('Reset label edits', resetAllLabelTextOverrides);
   const loadLabelOverrideTableWithHistory = undoableAction('Load label edits', loadLabelOverrideTable);
   const runInfoCopyStatus = ref('');
+  const exactReplayCopyStatus = ref('');
 
   const runInfoElapsedText = (info) => formatElapsedMs(info?.elapsedMs);
   const runInfoReproducibilityText = (info) => reproducibilityLabel(info?.reproducibility?.level);
   const runInfoHasCliHelperFiles = computed(() =>
     Array.isArray(lastRunInfo.value?.helperFiles) && lastRunInfo.value.helperFiles.length > 0
   );
-  const copyRunCommand = async () => {
-    const command = String(lastRunInfo.value?.command || '');
+  const copyRunInfoCommand = async (commandValue, status, description) => {
+    const command = String(commandValue || '');
     if (!command) return;
     try {
       await copyTextToClipboard(command);
-      runInfoCopyStatus.value = 'Copied';
+      status.value = 'Copied';
       setTimeout(() => {
-        if (runInfoCopyStatus.value === 'Copied') runInfoCopyStatus.value = '';
+        if (status.value === 'Copied') status.value = '';
       }, 1600);
     } catch (error) {
-      console.warn('Failed to copy run command:', error);
-      runInfoCopyStatus.value = 'Copy failed';
+      console.warn(`Failed to copy ${description}:`, error);
+      status.value = 'Copy failed';
       setTimeout(() => {
-        if (runInfoCopyStatus.value === 'Copy failed') runInfoCopyStatus.value = '';
+        if (status.value === 'Copy failed') status.value = '';
       }, 2200);
     }
   };
+  const copyRunCommand = () => copyRunInfoCommand(
+    lastRunInfo.value?.sourceRecipe?.command || lastRunInfo.value?.command,
+    runInfoCopyStatus,
+    'source recipe'
+  );
+  const copyExactReplayCommand = () => copyRunInfoCommand(
+    lastRunInfo.value?.exactReplay?.command || lastRunInfo.value?.sessionCommand,
+    exactReplayCopyStatus,
+    'exact replay command'
+  );
 
   async function prepareLinearRecordCatalog(loadComparison = false) {
     if (mode.value !== 'linear') return { catalog: null, error: '' };
@@ -3306,6 +3317,7 @@ export const createAppSetup = () => {
     resultPanelTab,
     lastRunInfo,
     runInfoCopyStatus,
+    exactReplayCopyStatus,
     svgContent,
     zoom,
     layoutRepositionMode,
@@ -3870,6 +3882,7 @@ export const createAppSetup = () => {
     downloadPNG,
     downloadPDF,
     copyRunCommand,
+    copyExactReplayCommand,
     downloadCliHelperFiles,
     runInfoElapsedText,
     runInfoReproducibilityText,

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -3595,6 +3595,7 @@ export const createAppSetup = () => {
     getOrthogroupSequenceCount: orthogroupActions.getOrthogroupSequenceCount,
     hasOrthogroupSequence: orthogroupActions.hasOrthogroupSequence,
     hasOrthogroupMemberSequence: orthogroupActions.hasOrthogroupMemberSequence,
+    orthogroupCopyFeedbackLabel: orthogroupActions.orthogroupCopyFeedbackLabel,
     copyOrthogroupSequences: orthogroupActions.copyOrthogroupSequences,
     downloadOrthogroupSequences: orthogroupActions.downloadOrthogroupSequences,
     copyOrthogroupMemberSequence: orthogroupActions.copyOrthogroupMemberSequence,

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -51,7 +51,7 @@ import { createPreviewFeatureSearch } from './feature-search/preview-actions.js'
 import { createSvgStyles } from './svg-styles.js';
 import { createLegendManager } from './legend.js';
 import { createPaletteLoader } from './palettes.js';
-import { createRunAnalysis } from './run-analysis.js';
+import { afterPaint, createRunAnalysis } from './run-analysis.js';
 import { normalizeUserFacingError } from '../services/error-normalization.js';
 import { formatElapsedMs, reproducibilityLabel } from './run-info.js';
 import { createLegendLayout } from './legend-layout.js';
@@ -2061,47 +2061,72 @@ export const createAppSetup = () => {
     preparePaletteDefinitions: paletteLoader.loadPaletteAsset
   });
 
+  const sessionImportPending = ref(false);
   let nextSessionPreviewToken = 1;
   const importSession = async (event) => {
-    const result = await importSessionFromFile(event, {
-      beforePreviewMount: ({ results: importedResults, resultIndex }) => {
-        const selectedResult = importedResults[resultIndex] || null;
-        if (!selectedResult) return null;
-        const token = `session-load:${nextSessionPreviewToken++}`;
-        return previewRuntime.registerReadinessExpectation({
-          result: selectedResult,
-          resultIndex,
-          artifactIdentity: token,
-          generationToken: token,
-          catalogState: state.featureCatalog?.value || null,
-          phase: 'session-load',
-          bindingOptions: { isIncrementalEdit: true },
-          isCurrent: () => (
-            results.value[resultIndex] === selectedResult
-            && Number(selectedResultIndex.value) === resultIndex
-          )
-        });
-      },
-      rollbackState: createSessionImportRollbackState({
-        depthTrackUiCounts,
-        depthTracks: adv.depth_tracks,
-        featureListScrollTop,
-        featureListScrollRef,
-        selectedPairwiseBlockOrthogroupId
-      })
-    });
-    if (result?.status === 'ok' || result?.status === 'legacy') {
-      historySnapshots.clearGeneratedArtifactIdentity({
-        retainedBytes: result?.status === 'ok'
-          ? Number(result.decompressedCharacters || 0) * 2
-          : 0
-      });
-      await nextTick();
-      recordSessionLifecycleEvent('history-baseline-start');
-      await history.initializeIntentBaseline('Loaded session');
-      recordSessionLifecycleEvent('history-baseline-end');
+    const input = event?.target;
+    const file = input?.files?.[0];
+    if (!file) return { status: 'skipped' };
+    if (sessionImportPending.value) {
+      input.value = '';
+      return { status: 'busy' };
     }
-    return result;
+
+    const importEvent = {
+      target: {
+        files: [file],
+        value: input.value
+      }
+    };
+    sessionImportPending.value = true;
+    recordSessionLifecycleEvent('session-import-pending-published');
+    try {
+      await nextTick();
+      await afterPaint();
+      recordSessionLifecycleEvent('session-import-paint-opportunity-completed');
+      const result = await importSessionFromFile(importEvent, {
+        beforePreviewMount: ({ results: importedResults, resultIndex }) => {
+          const selectedResult = importedResults[resultIndex] || null;
+          if (!selectedResult) return null;
+          const token = `session-load:${nextSessionPreviewToken++}`;
+          return previewRuntime.registerReadinessExpectation({
+            result: selectedResult,
+            resultIndex,
+            artifactIdentity: token,
+            generationToken: token,
+            catalogState: state.featureCatalog?.value || null,
+            phase: 'session-load',
+            bindingOptions: { isIncrementalEdit: true },
+            isCurrent: () => (
+              results.value[resultIndex] === selectedResult
+              && Number(selectedResultIndex.value) === resultIndex
+            )
+          });
+        },
+        rollbackState: createSessionImportRollbackState({
+          depthTrackUiCounts,
+          depthTracks: adv.depth_tracks,
+          featureListScrollTop,
+          featureListScrollRef,
+          selectedPairwiseBlockOrthogroupId
+        })
+      });
+      if (result?.status === 'ok' || result?.status === 'legacy') {
+        historySnapshots.clearGeneratedArtifactIdentity({
+          retainedBytes: result?.status === 'ok'
+            ? Number(result.decompressedCharacters || 0) * 2
+            : 0
+        });
+        await nextTick();
+        recordSessionLifecycleEvent('history-baseline-start');
+        await history.initializeIntentBaseline('Loaded session');
+        recordSessionLifecycleEvent('history-baseline-end');
+      }
+      return result;
+    } finally {
+      sessionImportPending.value = false;
+      input.value = '';
+    }
   };
 
   const {
@@ -3261,6 +3286,7 @@ export const createAppSetup = () => {
   return {
     processing,
     processingStatus,
+    sessionImportPending,
     generationCancelRequested,
     errorLog,
     errorDisplay,

--- a/gbdraw/web/js/app/feature-editor/svg-actions.js
+++ b/gbdraw/web/js/app/feature-editor/svg-actions.js
@@ -649,25 +649,25 @@ export const createFeatureSvgActions = ({
     }
   };
 
+  const groupsForMatch = (matchElement) => (
+    matchElement.getAttribute('data-match-kind') === 'collinear'
+      ? collinearGroups?.value || []
+      : orthogroups?.value || []
+  );
+
   const buildMatchPayload = (matchElement, featureLookup) => buildPairwiseMatchPayload(matchElement, {
     featureLookup,
     sourceFeatures: Array.isArray(biologicalFeatures?.value) && biologicalFeatures.value.length > 0
       ? biologicalFeatures.value
       : (Array.isArray(extractedFeatures.value) ? extractedFeatures.value : []),
-    orthogroups: [
-      ...(Array.isArray(orthogroups?.value) ? orthogroups.value : []),
-      ...(Array.isArray(collinearGroups?.value) ? collinearGroups.value : [])
-    ],
+    orthogroups: groupsForMatch(matchElement),
     orthogroupNameOverrides,
     orthogroupDescriptionOverrides,
     resolveSequenceSource: matchSequenceRegistry?.resolve
   });
 
   const buildMatchHoverSummary = (matchElement) => buildPairwiseMatchHoverSummary(matchElement, {
-    orthogroups: () => [
-      ...(Array.isArray(orthogroups?.value) ? orthogroups.value : []),
-      ...(Array.isArray(collinearGroups?.value) ? collinearGroups.value : [])
-    ],
+    orthogroups: () => groupsForMatch(matchElement),
     orthogroupNameOverrides
   });
 

--- a/gbdraw/web/js/app/feature-editor/svg-actions.js
+++ b/gbdraw/web/js/app/feature-editor/svg-actions.js
@@ -781,6 +781,7 @@ export const createFeatureSvgActions = ({
       activeHoverKey: '',
       activeMatchHoverElement: null,
       activeMatchHoverKey: '',
+      pendingMatchElement: null,
       activeHoverElements: new Set(),
       transformPointer: null,
       reconcileHoverAfterTransform: false,
@@ -946,6 +947,19 @@ export const createFeatureSvgActions = ({
         handlerState.activeMatchHoverKey = '';
       };
 
+      const clearPendingMatch = () => {
+        if (!handlerState.pendingMatchElement) return;
+        handlerState.pendingMatchElement.classList.remove('gbdraw-match-pending');
+        handlerState.pendingMatchElement = null;
+      };
+
+      const setPendingMatch = (matchElement) => {
+        if (handlerState.pendingMatchElement === matchElement) return;
+        clearPendingMatch();
+        handlerState.pendingMatchElement = matchElement;
+        matchElement.classList.add('gbdraw-match-pending');
+      };
+
       const rememberTransformPointer = (eventLike) => {
         if (!Number.isFinite(eventLike?.clientX) || !Number.isFinite(eventLike?.clientY)) return;
         handlerState.transformPointer = {
@@ -1090,6 +1104,7 @@ export const createFeatureSvgActions = ({
       };
 
       const handleClick = (e) => {
+        clearPendingMatch();
         if (featureSelection?.consumeSuppressNextClick?.()) {
           e.preventDefault();
           e.stopPropagation();
@@ -1167,8 +1182,24 @@ export const createFeatureSvgActions = ({
       };
 
       const handlePointerDown = (e) => {
+        if (e.button === 0 && e.isPrimary !== false) {
+          const matchEl = getPairwiseMatchClickTarget(e, svg);
+          if (matchEl) {
+            setPendingMatch(matchEl);
+            return;
+          }
+        }
+        clearPendingMatch();
         if (!featureSelection?.startMarqueePointer?.(e, svg)) return;
         e.stopPropagation();
+      };
+
+      const handlePointerOut = (e) => {
+        if (!handlerState.pendingMatchElement) return;
+        const matchEl = getPairwiseMatchTarget(e.target, svg);
+        if (matchEl !== handlerState.pendingMatchElement) return;
+        if (getPairwiseMatchTarget(e.relatedTarget, svg) === matchEl) return;
+        clearPendingMatch();
       };
 
       const handlePointerMove = (e) => {
@@ -1179,6 +1210,7 @@ export const createFeatureSvgActions = ({
       };
 
       const handlePointerUp = (e) => {
+        clearPendingMatch();
         if (!featureSelection?.commitMarqueePointer?.(e)) return;
         e.preventDefault();
         e.stopPropagation();
@@ -1186,6 +1218,7 @@ export const createFeatureSvgActions = ({
       };
 
       const handlePointerCancel = () => {
+        clearPendingMatch();
         featureSelection?.cancelMarqueePointer?.();
       };
 
@@ -1195,9 +1228,13 @@ export const createFeatureSvgActions = ({
       svg.addEventListener('click', handleClick);
       svg.addEventListener('keydown', handleKeyDown);
       svg.addEventListener('pointerdown', handlePointerDown, true);
+      svg.addEventListener('pointerout', handlePointerOut, true);
       svg.addEventListener('pointermove', handlePointerMove, true);
       svg.addEventListener('pointerup', handlePointerUp, true);
       svg.addEventListener('pointercancel', handlePointerCancel, true);
+      window.addEventListener?.('pointerup', clearPendingMatch, true);
+      window.addEventListener?.('pointercancel', clearPendingMatch, true);
+      window.addEventListener?.('blur', clearPendingMatch);
       handlerState.cleanup = () => {
         svg.removeEventListener('mouseover', handleMouseOver);
         svg.removeEventListener('mousemove', handleMouseMove);
@@ -1205,15 +1242,20 @@ export const createFeatureSvgActions = ({
         svg.removeEventListener('click', handleClick);
         svg.removeEventListener('keydown', handleKeyDown);
         svg.removeEventListener('pointerdown', handlePointerDown, true);
+        svg.removeEventListener('pointerout', handlePointerOut, true);
         svg.removeEventListener('pointermove', handlePointerMove, true);
         svg.removeEventListener('pointerup', handlePointerUp, true);
         svg.removeEventListener('pointercancel', handlePointerCancel, true);
+        window.removeEventListener?.('pointerup', clearPendingMatch, true);
+        window.removeEventListener?.('pointercancel', clearPendingMatch, true);
+        window.removeEventListener?.('blur', clearPendingMatch);
         if (handlerState.hoverReconcileFrame !== null) {
           window.cancelAnimationFrame(handlerState.hoverReconcileFrame);
           handlerState.hoverReconcileFrame = null;
         }
         handlerState.reconcileHoverAfterTransform = false;
         handlerState.transformPointer = null;
+        clearPendingMatch();
         clearActiveFeatureHover();
         clearActiveMatchHover();
         hideHoverSummary();

--- a/gbdraw/web/js/app/orthogroups.js
+++ b/gbdraw/web/js/app/orthogroups.js
@@ -28,7 +28,13 @@ import {
 
 export { resolveUniqueOrthogroupMemberForFeature } from '../services/feature-identity.js';
 
-const { computed } = window.Vue;
+const { computed, reactive, watch } = window.Vue;
+
+const COPY_FEEDBACK_DURATION_MS = 1500;
+const COPY_FEEDBACK_LABELS = Object.freeze({
+  success: 'Copied!',
+  failure: 'Copy failed'
+});
 
 const normalizeText = (value) => String(value ?? '').trim();
 const normalizeLower = (value) => normalizeText(value).toLowerCase();
@@ -36,6 +42,27 @@ const normalizeLower = (value) => normalizeText(value).toLowerCase();
 const memberStableFeatureId = (member) => {
   const status = textAliasStatus(member, STABLE_FEATURE_ID_KEYS);
   return status.valid ? status.value : '';
+};
+
+const memberCopyFeedbackIdentity = (member) => {
+  const identity = featureIdentity(member);
+  if (identity.usable) {
+    return JSON.stringify([
+      identity.recordIndex.supplied ? identity.recordIndex.value : null,
+      identity.recordKey.supplied ? identity.recordKey.value : '',
+      identity.biologicalId.supplied ? identity.biologicalId.value : '',
+      identity.sourceIndex.supplied ? identity.sourceIndex.value : null,
+      identity.stableId.supplied ? identity.stableId.value : ''
+    ]);
+  }
+  return JSON.stringify([
+    normalizeText(member?.recordId ?? member?.record_id),
+    memberStableFeatureId(member),
+    normalizeText(member?.start),
+    normalizeText(member?.end),
+    normalizeText(member?.strand),
+    normalizeText(resolveDisplayProteinId(member?.sequenceFeature, member, ''))
+  ]);
 };
 
 const normalizeSequence = (value) => String(value ?? '').replace(/\s+/g, '').toUpperCase();
@@ -245,11 +272,103 @@ export const createOrthogroupEditor = ({ state, runAnalysis }) => {
     orthogroupSearch,
     orthogroupSortMode,
     selectedOrthogroupAlignmentFeature,
+    clickedFeature,
+    showRightDrawer,
+    rightDrawerTab,
     svgContainer,
     linearSeqs,
     extractedFeatures,
     biologicalFeatures
   } = state;
+
+  const copyFeedbackByKey = reactive({});
+  const copyFeedbackTimers = new Map();
+  const copyOperationIds = new Map();
+  let nextCopyOperationId = 0;
+
+  const orthogroupCopyFeedbackKey = (
+    groupOrId,
+    sequenceKind,
+    member = null,
+    context = 'drawer'
+  ) => {
+    const group = typeof groupOrId === 'string' ? getOrthogroupById(groupOrId) : groupOrId;
+    const groupId = group ? orthogroupIdValue(group) : normalizeText(groupOrId);
+    return JSON.stringify([
+      normalizeText(context),
+      member ? 'member' : 'group',
+      groupId,
+      member ? memberCopyFeedbackIdentity(member) : '',
+      sequenceKindLabel(sequenceKind)
+    ]);
+  };
+
+  const updateCopyFeedback = (key, operationId, status) => {
+    if (copyOperationIds.get(key) !== operationId) return;
+    const previousTimer = copyFeedbackTimers.get(key);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackByKey[key] = { operationId, status };
+    const timer = window.setTimeout(() => {
+      if (
+        copyOperationIds.get(key) !== operationId ||
+        copyFeedbackByKey[key]?.operationId !== operationId
+      ) return;
+      delete copyFeedbackByKey[key];
+      copyFeedbackTimers.delete(key);
+      copyOperationIds.delete(key);
+    }, COPY_FEEDBACK_DURATION_MS);
+    copyFeedbackTimers.set(key, timer);
+  };
+
+  const beginCopyFeedback = (key) => {
+    const previousTimer = copyFeedbackTimers.get(key);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackTimers.delete(key);
+    delete copyFeedbackByKey[key];
+    nextCopyOperationId += 1;
+    copyOperationIds.set(key, nextCopyOperationId);
+    return nextCopyOperationId;
+  };
+
+  const clearCopyFeedback = () => {
+    copyFeedbackTimers.forEach((timer) => window.clearTimeout(timer));
+    copyFeedbackTimers.clear();
+    copyOperationIds.clear();
+    Object.keys(copyFeedbackByKey).forEach((key) => delete copyFeedbackByKey[key]);
+  };
+
+  const copyWithFeedback = async (text, key) => {
+    if (!text) return false;
+    const operationId = beginCopyFeedback(key);
+    try {
+      await copyTextToClipboard(text);
+      updateCopyFeedback(key, operationId, 'success');
+      return true;
+    } catch {
+      updateCopyFeedback(key, operationId, 'failure');
+      return false;
+    }
+  };
+
+  const orthogroupCopyFeedbackLabel = (
+    groupOrId,
+    sequenceKind,
+    originalLabel,
+    member = null,
+    context = 'drawer'
+  ) => {
+    const key = orthogroupCopyFeedbackKey(groupOrId, sequenceKind, member, context);
+    const status = copyFeedbackByKey[key]?.status;
+    return COPY_FEEDBACK_LABELS[status] || String(originalLabel || 'Copy');
+  };
+
+  if (typeof watch === 'function') {
+    watch(
+      [orthogroups, selectedOrthogroupId, clickedFeature, showRightDrawer, rightDrawerTab].filter(Boolean),
+      clearCopyFeedback,
+      { flush: 'sync' }
+    );
+  }
 
   const resolvableOrthogroupEntries = () => uniqueOrthogroupEntries(orthogroups.value);
 
@@ -503,10 +622,14 @@ export const createOrthogroupEditor = ({ state, runAnalysis }) => {
     return `${stem}.${sequenceExtension(sequenceKind)}`;
   };
 
-  const copyOrthogroupSequences = async (groupOrId = selectedOrthogroup.value, sequenceKind = 'nt') => {
+  const copyOrthogroupSequences = async (
+    groupOrId = selectedOrthogroup.value,
+    sequenceKind = 'nt',
+    context = 'drawer'
+  ) => {
     const text = buildOrthogroupFasta(groupOrId, sequenceKind);
-    if (!text) return;
-    await copyTextToClipboard(text);
+    const key = orthogroupCopyFeedbackKey(groupOrId, sequenceKind, null, context);
+    return copyWithFeedback(text, key);
   };
 
   const downloadOrthogroupSequences = (groupOrId = selectedOrthogroup.value, sequenceKind = 'nt') => {
@@ -519,10 +642,15 @@ export const createOrthogroupEditor = ({ state, runAnalysis }) => {
     );
   };
 
-  const copyOrthogroupMemberSequence = async (member, sequenceKind = 'nt', groupOrId = selectedOrthogroup.value) => {
+  const copyOrthogroupMemberSequence = async (
+    member,
+    sequenceKind = 'nt',
+    groupOrId = selectedOrthogroup.value,
+    context = 'drawer'
+  ) => {
     const text = buildOrthogroupMemberFasta(member, sequenceKind, groupOrId);
-    if (!text) return;
-    await copyTextToClipboard(text);
+    const key = orthogroupCopyFeedbackKey(groupOrId, sequenceKind, member, context);
+    return copyWithFeedback(text, key);
   };
 
   const downloadOrthogroupMemberSequence = (member, sequenceKind = 'nt', groupOrId = selectedOrthogroup.value) => {
@@ -644,6 +772,7 @@ export const createOrthogroupEditor = ({ state, runAnalysis }) => {
     getOrthogroupSequenceCount,
     hasOrthogroupSequence,
     hasOrthogroupMemberSequence,
+    orthogroupCopyFeedbackLabel,
     copyOrthogroupSequences,
     downloadOrthogroupSequences,
     copyOrthogroupMemberSequence,

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -44,7 +44,7 @@ import { encodeAnnotationTable } from './annotations/table-codec.js';
 import {
   normalizeCollinearSearchScope
 } from './losat-normalization.js';
-import { buildRunInfo } from './run-info.js';
+import { buildRunInfo, buildSourceRecipe } from './run-info.js';
 import {
   buildPairwiseLosatJobSpecs,
   resolveLinearComparisonPlan
@@ -1180,13 +1180,22 @@ export const createRunAnalysis = ({
 
   const downloadCliHelperFiles = () => {
     if (!latestCliHelperFiles.length) {
-      alert('No CLI helper files are available for the latest run.');
+      alert('No reproducibility files are available for the latest run.');
       return;
     }
     const materializedFiles = latestCliHelperFiles.map((file) => ({
       name: file.name,
       data: typeof file.buildData === 'function' ? file.buildData() : file.data
     }));
+    const archiveNames = new Set();
+    materializedFiles.forEach((file) => {
+      const name = String(file.name || '');
+      const key = name.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+      if (!name || archiveNames.has(key)) {
+        throw new Error('Reproducibility bundle filenames must be unique before ZIP creation.');
+      }
+      archiveNames.add(key);
+    });
     const totalChars = materializedFiles.reduce(
       (sum, file) => sum + String(file.data ?? '').length,
       0
@@ -4413,13 +4422,30 @@ export const createRunAnalysis = ({
       let candidateRunInfo = null;
       let candidateCliHelpers = null;
       if (!isReflow && manualRunStartedAt !== null) {
+        const generatedFileNameHints = new Map();
+        generatedCliFileMap.forEach((file) => {
+          const slot = String(file?.slot || '').trim();
+          const name = String(file?.name || '').trim();
+          if (slot && name && !generatedFileNameHints.has(slot)) {
+            generatedFileNameHints.set(slot, name);
+          }
+        });
+        const sourceRecipe = buildSourceRecipe({ ...canonical, generatedFileNameHints });
         candidateRunInfo = buildRunInfo({
           mode: mode.value,
-          args: ['--session', canonicalReplayPath],
+          sourceRecipe,
+          exactReplayArgs: ['--session', canonicalReplayPath],
           fileMetadata: runInfoFileMap,
           elapsedMs: getNow() - manualRunStartedAt,
           resultCount: candidateCommit.results.length,
           startedAtIso: manualRunStartedAtIso
+        });
+        sourceRecipe.generatedFiles.forEach((file) => {
+          recordGeneratedCliFile(
+            file.path,
+            file.data instanceof Uint8Array ? textDecoder.decode(file.data) : file.data,
+            { name: file.name, slot: file.slot }
+          );
         });
         if (structuredLosatTelemetry) {
           candidateRunInfo.losatTelemetry = cloneJsonData(structuredLosatTelemetry);

--- a/gbdraw/web/js/app/run-info.js
+++ b/gbdraw/web/js/app/run-info.js
@@ -1,6 +1,36 @@
+import {
+  buildCircularTrackSlotSpec,
+  parseCircularTrackSlotSpec
+} from './circular-track-slots.js';
+import {
+  buildLinearTrackSlotSpec,
+  parseLinearTrackSlotSpec
+} from './linear-track-slots.js';
+import { encodeAnnotationTable } from './annotations/table-codec.js';
+import { base64ToBytes } from '../services/byte-utils.js';
+
 const SAFE_SHELL_TOKEN_RE = /^[A-Za-z0-9_@%+=:,./-]+$/;
 
+const SOURCE_PROVENANCE_UNAVAILABLE =
+  'Source recipe unavailable: this session does not contain sufficient source-file provenance.';
+
+class SourceRecipeUnavailable extends Error {}
+
 const normalizePath = (value) => String(value ?? '').trim();
+
+const isPlainObject = (value) => Boolean(
+  value && typeof value === 'object' && !Array.isArray(value)
+);
+
+const visibleBasename = (value) => {
+  const name = String(value || '')
+    .replace(/\\/g, '/')
+    .split('/')
+    .pop()
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .trim();
+  return name && name !== '.' && name !== '..' ? name : '';
+};
 
 const fallbackNameFromPath = (path) => {
   const name = normalizePath(path).split('/').filter(Boolean).pop();
@@ -42,6 +72,62 @@ const normalizeFileMetadata = (fileMetadata) => {
   return map;
 };
 
+const filenameCollisionKey = (name) => String(name || '')
+  .replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+
+const suffixedFilename = (name, suffix) => {
+  const dot = name.lastIndexOf('.');
+  return dot > 0
+    ? `${name.slice(0, dot)}-${suffix}${name.slice(dot)}`
+    : `${name}-${suffix}`;
+};
+
+const allocateVisibleFilenames = ({ sourceMetadata, exactMetadata, sourceAvailable }) => {
+  const source = new Map(Array.from(sourceMetadata, ([path, entry]) => [path, { ...entry }]));
+  const exact = new Map(Array.from(exactMetadata, ([path, entry]) => [path, { ...entry }]));
+  const used = new Map();
+  const reserveFixed = (namespace, path, entry) => {
+    const name = visibleBasename(entry.name);
+    if (!name) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: an uploaded input has no safe visible filename.'
+      );
+    }
+    const key = filenameCollisionKey(name);
+    const owner = `${namespace}:${path}`;
+    if (used.has(key) && used.get(key) !== owner) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: multiple uploaded inputs use the visible filename "${name}".`
+      );
+    }
+    entry.name = name;
+    used.set(key, owner);
+  };
+  const reserveGenerated = (namespace, path, entry, index) => {
+    const base = visibleBasename(entry.name) || visibleBasename(path) || `helper-${index}`;
+    let name = base;
+    let suffix = 2;
+    while (used.has(filenameCollisionKey(name))) {
+      name = suffixedFilename(base, suffix);
+      suffix += 1;
+    }
+    entry.name = name;
+    used.set(filenameCollisionKey(name), `${namespace}:${path}`);
+  };
+
+  const namespaces = sourceAvailable ? [['source', source], ['exact', exact]] : [['exact', exact]];
+  namespaces.forEach(([namespace, metadata]) => metadata.forEach((entry, path) => {
+    if (entry.kind !== 'generated') reserveFixed(namespace, path, entry);
+  }));
+  let generatedIndex = 0;
+  namespaces.forEach(([namespace, metadata]) => metadata.forEach((entry, path) => {
+    if (entry.kind !== 'generated') return;
+    generatedIndex += 1;
+    reserveGenerated(namespace, path, entry, generatedIndex);
+  }));
+  return { source, exact };
+};
+
 const formatHelperFileList = (files) => {
   const names = Array.from(new Set((Array.isArray(files) ? files : [])
     .map((file) => String(file?.name || fallbackNameFromPath(file?.path)).trim())
@@ -49,6 +135,1323 @@ const formatHelperFileList = (files) => {
   if (names.length === 0) return 'generated helper files';
   if (names.length <= 3) return names.join(', ');
   return `${names.slice(0, 3).join(', ')}, and ${names.length - 3} more`;
+};
+
+const selectorText = (selector) => {
+  if (!isPlainObject(selector)) return '';
+  if (selector.kind === 'recordId') return String(selector.value || '').trim();
+  if (selector.kind === 'recordIndex') {
+    const index = Number(selector.index);
+    return Number.isInteger(index) && index >= 0 ? `#${index + 1}` : '';
+  }
+  return '';
+};
+
+const tsvCell = (value) => {
+  const text = String(value ?? '');
+  return /[\t\r\n"]/.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+};
+
+const tsv = (columns, rows) => `${[
+  columns.join('\t'),
+  ...rows.map((row) => columns.map((column) => tsvCell(row[column])).join('\t'))
+].join('\n')}\n`;
+
+const collectBindingNameHints = (value, hints) => {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => collectBindingNameHints(entry, hints));
+    return;
+  }
+  if (!isPlainObject(value)) return;
+  const resourceId = String(value.resourceId || '').trim();
+  const name = visibleBasename(value.name);
+  if (resourceId && name && !hints.has(resourceId)) hints.set(resourceId, name);
+  Object.values(value).forEach((entry) => collectBindingNameHints(entry, hints));
+};
+
+const originalResourceNameHints = (webFiles) => {
+  const hints = new Map();
+  const stored = isPlainObject(webFiles?.resourceOriginalNames)
+    ? webFiles.resourceOriginalNames
+    : {};
+  Object.entries(stored).forEach(([resourceId, name]) => {
+    const visible = visibleBasename(name);
+    if (resourceId && visible) hints.set(resourceId, visible);
+  });
+  collectBindingNameHints(webFiles?.bindings, hints);
+  return hints;
+};
+
+const normalizeNameHints = (hints) => new Map(
+  hints instanceof Map
+    ? hints
+    : (isPlainObject(hints) ? Object.entries(hints) : [])
+);
+
+const resourceBytes = (descriptor) => {
+  if (!isPlainObject(descriptor)) return null;
+  if (descriptor.encoding === 'base64' && typeof descriptor.data === 'string') {
+    return base64ToBytes(descriptor.data);
+  }
+  if (descriptor.encoding === 'utf8' && typeof descriptor.data === 'string') {
+    return new TextEncoder().encode(descriptor.data);
+  }
+  return null;
+};
+
+const createRecipeFiles = (resources, webFiles, generatedFileNameHints) => {
+  const descriptors = isPlainObject(resources) ? resources : {};
+  const originalNames = originalResourceNameHints(webFiles);
+  const generatedNames = normalizeNameHints(generatedFileNameHints);
+  const fileMetadata = new Map();
+  const generatedFiles = [];
+  const pathsByResourceId = new Map();
+  const visibleNameOwners = new Map();
+  const recordCountCache = new Map();
+  let generatedIndex = 0;
+
+  const reserveName = (name, owner) => {
+    const collisionKey = name.replace(/[A-Z]/g, (letter) => letter.toLowerCase());
+    const existing = visibleNameOwners.get(collisionKey);
+    if (existing && existing !== owner) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: multiple required files use the visible filename "${name}".`
+      );
+    }
+    visibleNameOwners.set(collisionKey, owner);
+  };
+
+  const resourcePath = (resourceIdRaw, {
+    source = false,
+    fallback = 'helper.tsv',
+    slot = '',
+    nameHintSlot = ''
+  } = {}) => {
+    const resourceId = String(resourceIdRaw || '').trim();
+    const descriptor = descriptors[resourceId];
+    if (!resourceId || !isPlainObject(descriptor)) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: canonical resource "${resourceId || '(missing)'}" is unavailable.`
+      );
+    }
+    if (pathsByResourceId.has(resourceId)) return pathsByResourceId.get(resourceId);
+
+    const originalName = originalNames.get(resourceId) || '';
+    if (source && !originalName) throw new SourceRecipeUnavailable(SOURCE_PROVENANCE_UNAVAILABLE);
+    const generated = !originalName;
+    const name = originalName || visibleBasename(
+      generatedNames.get(resourceId) || generatedNames.get(nameHintSlot) || fallback
+    );
+    if (!name) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: a generated helper has no trustworthy visible filename.'
+      );
+    }
+    if (!generated) reserveName(name, resourceId);
+    const path = `/run-info-resource-${resourceId}`;
+    const resolvedSlot = generated
+      ? (slot || `generatedFiles.source_recipe.${resourceId}`)
+      : `resources.${resourceId}`;
+    fileMetadata.set(path, {
+      path,
+      name,
+      slot: resolvedSlot,
+      kind: generated ? 'generated' : 'uploaded',
+      resourceId
+    });
+    if (generated) {
+      const data = resourceBytes(descriptor);
+      if (!data) {
+        throw new SourceRecipeUnavailable(
+          `Source recipe unavailable: generated helper file "${name}" cannot be materialized.`
+        );
+      }
+      generatedFiles.push({ path, name, slot: resolvedSlot, data });
+    }
+    pathsByResourceId.set(resourceId, path);
+    return path;
+  };
+
+  const generatedTextPath = (nameRaw, data, slot) => {
+    generatedIndex += 1;
+    const name = visibleBasename(nameRaw) || `helper-${generatedIndex}.tsv`;
+    const path = `/run-info-generated-${generatedIndex}`;
+    const resolvedSlot = slot || `generatedFiles.source_recipe.helper_${generatedIndex}`;
+    fileMetadata.set(path, { path, name, slot: resolvedSlot, kind: 'generated' });
+    generatedFiles.push({
+      path,
+      name,
+      slot: resolvedSlot,
+      ...(typeof data === 'function'
+        ? { buildData: data }
+        : { data: String(data ?? '') })
+    });
+    return path;
+  };
+
+  const visibleName = (path) => fileMetadata.get(path)?.name || fallbackNameFromPath(path);
+  const resourceRecordCount = (resourceIdRaw, kind) => {
+    const resourceId = String(resourceIdRaw || '').trim();
+    const cacheKey = `${resourceId}:${kind}`;
+    if (recordCountCache.has(cacheKey)) return recordCountCache.get(cacheKey);
+    const bytes = resourceBytes(descriptors[resourceId]);
+    let count = 0;
+    if (bytes) {
+      const text = new TextDecoder().decode(bytes);
+      count = kind === 'genbank'
+        ? (text.match(/^LOCUS\s+/gm) || []).length
+        : (text.match(/^>/gm) || []).length;
+    }
+    recordCountCache.set(cacheKey, count);
+    return count;
+  };
+  return {
+    resourcePath,
+    generatedTextPath,
+    visibleName,
+    resourceRecordCount,
+    fileMetadata,
+    generatedFiles
+  };
+};
+
+const DIAGRAM_OPTION_FIELDS = new Set([
+  'configOverrides', 'tracks', 'output', 'colors', 'selectedFeaturesSet', 'featureShapes',
+  'dinucleotide', 'window', 'step', 'depthWindow', 'depthStep', 'depthTracks',
+  'plotTitle', 'plotTitleFontSize', 'evalue', 'bitscore', 'identity', 'alignmentLength',
+  'featureVisibilityTableFile', 'labelWhitelistFile', 'qualifierPriorityFile',
+  'qualifierPriorityTable', 'labelOverrideFile', 'annotations', 'pairwiseMatchStyle',
+  'keepFullDefinitionWithPlotTitle', 'species', 'strain', 'conservationBlastFiles',
+  'conservationFastaFiles', 'conservationReference', 'conservationLabels',
+  'conservationColors', 'conservationRingWidth', 'conservationRingGap'
+]);
+
+const coverObject = (coverage, value, path, projected, metadata = []) => {
+  if (!isPlainObject(value)) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: semantic field "${path}" is malformed.`
+    );
+  }
+  const projectedKeys = new Set(projected);
+  const metadataKeys = new Set(metadata);
+  Object.keys(value).forEach((key) => {
+    const fieldPath = path ? `${path}.${key}` : key;
+    if (projectedKeys.has(key)) coverage.consumedPaths.add(fieldPath);
+    else if (metadataKeys.has(key)) coverage.metadataPaths.add(fieldPath);
+    else {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: semantic field "${fieldPath}" has no current CLI projection.`
+      );
+    }
+  });
+};
+
+const coverResourceRef = (coverage, value, path) => {
+  if (value === null || value === undefined) return;
+  coverObject(coverage, value, path, ['resourceId', 'representation']);
+};
+
+const coverTrackScalar = (coverage, value, path) => {
+  if (isPlainObject(value)) coverObject(coverage, value, path, ['value', 'unit']);
+};
+
+const coverTrackSlots = (coverage, tracks, mode) => {
+  coverObject(coverage, tracks, 'diagramOptions.tracks', [
+    'circularTrackSlots', 'circularTrackAxisIndex', 'linearTrackSlots',
+    'linearTrackAxisIndex', 'centerReservedRadius'
+  ]);
+  const slots = mode === 'circular' ? tracks.circularTrackSlots : tracks.linearTrackSlots;
+  if (!Array.isArray(slots)) return;
+  slots.forEach((slot, index) => {
+    if (typeof slot === 'string') return;
+    const path = `diagramOptions.tracks.${mode}TrackSlots[${index}]`;
+    const scalarFields = mode === 'circular' ? ['radius', 'width'] : ['height', 'spacing'];
+    coverObject(coverage, slot, path, [
+      'kind', 'id', 'renderer', 'enabled', 'side', ...scalarFields,
+      ...(mode === 'circular' ? ['innerGapPx', 'outerGapPx'] : []),
+      'z', 'params'
+    ]);
+    scalarFields.forEach((field) => coverTrackScalar(coverage, slot[field], `${path}.${field}`));
+    const params = slot.params;
+    if (!isPlainObject(params)) return;
+    coverObject(coverage, params, `${path}.params`, [
+      'track_index', 'nt', 'positive_color', 'negative_color', 'tick_label_layout',
+      'preset', 'lane_direction', 'source_index', 'set_id', 'marks', 'lane_gap_px',
+      'padding_px', 'overflow', 'show_labels', 'anchor_slot', 'layer', 'cover_anchor',
+      'legend_label'
+    ]);
+  });
+};
+
+const validateSchema6SemanticCoverage = (request) => {
+  const coverage = { schema: 6, consumedPaths: new Set(), metadataPaths: new Set() };
+  coverObject(coverage, request, '', [
+    'mode', 'grouping', 'records', 'diagramOptions', 'layout', 'comparisons', 'output'
+  ], ['schema']);
+  const supportedGroupings = request.mode === 'circular' ? ['single', 'grid'] : ['single'];
+  if (!supportedGroupings.includes(request.grouping) || Array.isArray(request.output)) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: batch or multiple-output semantics have no single current CLI projection.'
+    );
+  }
+
+  (Array.isArray(request.records) ? request.records : []).forEach((record, index) => {
+    const path = `records[${index}]`;
+    coverObject(coverage, record, path, [
+      'cardinality', 'source', 'selector', 'region', 'presentation'
+    ], ['recordKey']);
+    if (!['all', 'exactly_one'].includes(record.cardinality)) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: record cardinality "${String(record.cardinality || 'missing')}" has no current CLI projection.`
+      );
+    }
+    coverObject(
+      coverage,
+      record.source,
+      `${path}.source`,
+      record.source?.kind === 'gffFasta'
+        ? ['kind', 'gffResourceId', 'fastaResourceId']
+        : ['kind', 'resourceId']
+    );
+    if (record.selector) {
+      if (!['recordId', 'recordIndex'].includes(record.selector.kind)) {
+        throw new SourceRecipeUnavailable(
+          `Source recipe unavailable: record selector "${String(record.selector.kind || 'unknown')}" has no current CLI projection.`
+        );
+      }
+      coverObject(
+        coverage,
+        record.selector,
+        `${path}.selector`,
+        record.selector.kind === 'recordIndex' ? ['kind', 'index'] : ['kind', 'value']
+      );
+    }
+    if (record.region) {
+      coverObject(coverage, record.region, `${path}.region`, [
+        'selector', 'start', 'end', 'reverseComplement'
+      ]);
+      if (record.region.selector) {
+        if (!['recordId', 'recordIndex'].includes(record.region.selector.kind)) {
+          throw new SourceRecipeUnavailable(
+            `Source recipe unavailable: region selector "${String(record.region.selector.kind || 'unknown')}" has no current CLI projection.`
+          );
+        }
+        coverObject(
+          coverage,
+          record.region.selector,
+          `${path}.region.selector`,
+          record.region.selector.kind === 'recordIndex' ? ['kind', 'index'] : ['kind', 'value']
+        );
+      }
+    }
+    coverObject(coverage, record.presentation, `${path}.presentation`, [
+      'label', 'subtitle', 'reverseComplement', 'gridRow', 'gridColumn'
+    ]);
+    ['gridRow', 'gridColumn'].forEach((field) => {
+      const value = record.presentation[field];
+      if (value !== null && value !== undefined && value !== '' && gridCoordinate(value) === '') {
+        throw new SourceRecipeUnavailable(
+          `Source recipe unavailable: record placement "${path}.presentation.${field}" is invalid.`
+        );
+      }
+    });
+  });
+
+  const options = request.diagramOptions;
+  coverObject(coverage, options, 'diagramOptions', DIAGRAM_OPTION_FIELDS);
+  coverObject(coverage, options.configOverrides || {}, 'diagramOptions.configOverrides', Object.keys(
+    options.configOverrides || {}
+  ));
+  coverTrackSlots(coverage, options.tracks || {}, request.mode);
+  coverObject(coverage, options.output || {}, 'diagramOptions.output', ['legend', 'plotTitlePosition']);
+  coverObject(coverage, options.colors || {}, 'diagramOptions.colors', [
+    'colorTable', 'colorTableFile', 'defaultColors', 'defaultColorsPalette', 'defaultColorsFile'
+  ]);
+  ['colorTable', 'colorTableFile', 'defaultColors', 'defaultColorsFile'].forEach((field) => (
+    coverResourceRef(coverage, options.colors?.[field], `diagramOptions.colors.${field}`)
+  ));
+  coverObject(coverage, options.featureShapes || {}, 'diagramOptions.featureShapes', Object.keys(
+    options.featureShapes || {}
+  ));
+  [
+    'featureVisibilityTableFile', 'labelWhitelistFile', 'qualifierPriorityFile',
+    'qualifierPriorityTable', 'labelOverrideFile'
+  ].forEach((field) => coverResourceRef(coverage, options[field], `diagramOptions.${field}`));
+  (Array.isArray(options.depthTracks) ? options.depthTracks : []).forEach((track, index) => {
+    const path = `diagramOptions.depthTracks[${index}]`;
+    coverObject(coverage, track, path, [
+      'source', 'label', 'color', 'height', 'largeTickInterval', 'smallTickInterval',
+      'tickFontSize'
+    ]);
+    const refs = Array.isArray(track.source) ? track.source : [track.source];
+    refs.forEach((ref, refIndex) => coverResourceRef(
+      coverage, ref, `${path}.source${Array.isArray(track.source) ? `[${refIndex}]` : ''}`
+    ));
+  });
+  ['conservationBlastFiles', 'conservationFastaFiles'].forEach((field) => {
+    (Array.isArray(options[field]) ? options[field] : []).forEach((ref, index) => (
+      coverResourceRef(coverage, ref, `diagramOptions.${field}[${index}]`)
+    ));
+  });
+  if (options.annotations !== undefined) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: canonical annotation semantics have no fully lossless current CLI projection.'
+    );
+  }
+
+  const layoutFields = request.mode === 'linear'
+    ? ['recordGapPx']
+    : [
+        'multiRecordSizeMode', 'multiRecordMinRadiusRatio', 'multiRecordColumnGapRatio',
+        'multiRecordRowGapRatio', 'multiRecordPositions'
+      ];
+  coverObject(coverage, request.layout || {}, 'layout', layoutFields);
+  (Array.isArray(request.comparisons) ? request.comparisons : []).forEach((comparison, index) => {
+    const path = `comparisons[${index}]`;
+    if (comparison?.kind !== 'nucleotideBlast') {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: comparison "${String(comparison?.kind || 'unknown')}" has no lossless current CLI projection.`
+      );
+    }
+    coverObject(coverage, comparison, path, [
+      'kind', 'resourceId', 'queryRecordIndex', 'subjectRecordIndex'
+    ]);
+  });
+  coverObject(coverage, request.output, 'output', [
+    'prefix', 'formats', 'overwrite', 'interactiveMetadataPolicy'
+  ]);
+  if (request.output?.interactiveMetadataPolicy !== 'auto') {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: the interactive metadata policy has no current CLI projection.'
+    );
+  }
+  return {
+    schema: coverage.schema,
+    consumedPaths: Array.from(coverage.consumedPaths).sort(),
+    metadataPaths: Array.from(coverage.metadataPaths).sort()
+  };
+};
+
+const sourceSpec = (record) => {
+  const source = isPlainObject(record?.source) ? record.source : {};
+  if (source.kind === 'genbank') {
+    return { kind: 'genbank', ids: [String(source.resourceId || '').trim()] };
+  }
+  if (source.kind === 'gffFasta') {
+    return {
+      kind: 'gffFasta',
+      ids: [
+        String(source.gffResourceId || '').trim(),
+        String(source.fastaResourceId || '').trim()
+      ]
+    };
+  }
+  throw new SourceRecipeUnavailable(
+    `Source recipe unavailable: source kind "${String(source.kind || 'unknown')}" has no CLI recipe.`
+  );
+};
+
+const circularLayoutRows = (request, records) => {
+  const positions = Array.isArray(request.layout?.multiRecordPositions)
+    ? request.layout.multiRecordPositions
+    : [];
+  if (positions.length === 0) return [];
+  const rows = Array(records.length).fill(null);
+  positions.forEach((position) => {
+    const text = String(position || '').trim();
+    const separator = text.lastIndexOf('@');
+    const selector = separator > 0 ? text.slice(0, separator) : '';
+    const row = Number(separator > 0 ? text.slice(separator + 1) : NaN);
+    let recordIndex = -1;
+    const indexMatch = selector.match(/^#(\d+)$/);
+    if (indexMatch) {
+      const index = Number(indexMatch[1]) - 1;
+      if (Number.isInteger(index) && index >= 0 && index < records.length) recordIndex = index;
+    } else {
+      const matches = records
+        .map((record, index) => (
+          [selectorText(record?.selector), selectorText(record?.region?.selector)].includes(selector)
+            ? index
+            : -1
+        ))
+        .filter((index) => index >= 0);
+      if (matches.length === 1) [recordIndex] = matches;
+    }
+    if (
+      recordIndex < 0 ||
+      !Number.isInteger(row) ||
+      row < 1 ||
+      rows[recordIndex] !== null
+    ) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: circular record placement cannot be projected into a records table.'
+      );
+    }
+    rows[recordIndex] = row;
+  });
+  if (rows.some((row) => row === null)) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: circular record placement is incomplete for a records table.'
+    );
+  }
+  return rows;
+};
+
+const gridCoordinate = (value) => {
+  if (value === null || value === undefined || value === '') return '';
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : '';
+};
+
+const appendInputArgs = (args, request, files) => {
+  const records = Array.isArray(request.records) ? request.records : [];
+  if (records.length === 0) {
+    throw new SourceRecipeUnavailable('Source recipe unavailable: the committed render has no source records.');
+  }
+  const specs = records.map(sourceSpec);
+  if (new Set(specs.map((spec) => spec.kind)).size !== 1) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: the committed render mixes source kinds that the CLI cannot combine.'
+    );
+  }
+  const inputKind = specs[0].kind;
+  const sourcePaths = specs.map((spec, recordIndex) => spec.ids.map((resourceId, partIndex) => (
+    files.resourcePath(resourceId, {
+      source: true,
+      fallback: inputKind === 'genbank'
+        ? `record-${recordIndex + 1}.gbk`
+        : (partIndex === 0 ? `record-${recordIndex + 1}.gff3` : `record-${recordIndex + 1}.fasta`)
+    })
+  )));
+  const sourceKeys = sourcePaths.map((paths) => paths.join('\0'));
+  const hasDuplicateSources = new Set(sourceKeys).size !== sourceKeys.length;
+  const recordNeedsTable = records.some((record) => (
+    gridCoordinate(record.presentation?.gridColumn) !== ''
+    || (request.mode === 'circular' && (
+      Boolean(record.region)
+      || Boolean(record.presentation?.label)
+      || Boolean(record.presentation?.subtitle)
+      || Boolean(record.presentation?.reverseComplement)
+      || gridCoordinate(record.presentation?.gridRow) !== ''
+    ))
+  ));
+  const circularSelectorNeedsTable = request.mode === 'circular' && records.some((record, index) => (
+    Boolean(record.region?.selector || record.selector)
+    && files.resourceRecordCount(
+      specs[index].ids.at(-1),
+      inputKind === 'genbank' ? 'genbank' : 'fasta'
+    ) !== 1
+  ));
+  const recordsTableRequired = hasDuplicateSources || circularSelectorNeedsTable || recordNeedsTable;
+  if (
+    request.schema === 6
+    && recordsTableRequired
+    && records.some((record) => record.cardinality !== 'exactly_one')
+  ) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: this record cardinality cannot be preserved by a CLI records table.'
+    );
+  }
+
+  if (request.schema === 6 && !recordsTableRequired) {
+    const loadComparison = request.mode === 'linear'
+      && Array.isArray(request.comparisons)
+      && request.comparisons.length > 0;
+    const effectiveCardinality = request.mode === 'circular'
+      ? 'all'
+      : ((inputKind === 'gffFasta' || records.length > 1) && loadComparison ? 'first' : 'all');
+    records.forEach((record, index) => {
+      const canonicalCardinality = String(record.cardinality || '');
+      const cliCardinality = (record.region?.selector || record.selector)
+        ? 'exactly_one'
+        : effectiveCardinality;
+      if (
+        canonicalCardinality !== cliCardinality
+        && files.resourceRecordCount(
+          specs[index].ids.at(-1),
+          inputKind === 'genbank' ? 'genbank' : 'fasta'
+        ) !== 1
+      ) {
+        throw new SourceRecipeUnavailable(
+          `Source recipe unavailable: record cardinality "${canonicalCardinality || 'missing'}" cannot be preserved by the current CLI.`
+        );
+      }
+    });
+  }
+
+  if (recordsTableRequired) {
+    const layoutRows = request.mode === 'circular'
+      ? circularLayoutRows(request, records)
+      : [];
+    const columns = inputKind === 'genbank'
+      ? ['gbk', 'record_label', 'record_subtitle', 'record_id', 'region', 'reverse_complement', 'order', 'row', 'column']
+      : ['gff', 'fasta', 'record_label', 'record_subtitle', 'record_id', 'region', 'reverse_complement', 'order', 'row', 'column'];
+    const rows = records.map((record, index) => {
+      const region = isPlainObject(record.region) ? record.region : null;
+      const selector = selectorText(region?.selector || record.selector);
+      const row = {
+        gbk: inputKind === 'genbank' ? files.visibleName(sourcePaths[index][0]) : '',
+        gff: inputKind === 'gffFasta' ? files.visibleName(sourcePaths[index][0]) : '',
+        fasta: inputKind === 'gffFasta' ? files.visibleName(sourcePaths[index][1]) : '',
+        record_label: String(record.presentation?.label || ''),
+        record_subtitle: String(record.presentation?.subtitle || ''),
+        record_id: selector,
+        region: region
+          ? `${Number(region.start)}-${Number(region.end)}${region.reverseComplement ? ':rc' : ''}`
+          : '',
+        reverse_complement: region ? '0' : (record.presentation?.reverseComplement ? '1' : '0'),
+        order: index + 1,
+        row: gridCoordinate(record.presentation?.gridRow) || layoutRows[index] || '',
+        column: gridCoordinate(record.presentation?.gridColumn)
+      };
+      return row;
+    });
+    const tablePath = files.generatedTextPath(
+      'records.tsv',
+      tsv(columns, rows),
+      'generatedFiles.source_recipe.records_table'
+    );
+    args.push('--records_table', tablePath);
+    return true;
+  }
+
+  if (inputKind === 'genbank') {
+    args.push('--gbk', ...sourcePaths.map(([gbk]) => gbk));
+  } else {
+    args.push('--gff', ...sourcePaths.map(([gff]) => gff));
+    args.push('--fasta', ...sourcePaths.map(([, fasta]) => fasta));
+  }
+
+  if (request.mode !== 'linear') return false;
+  const selectors = records.map((record) => selectorText(record.selector));
+  if (selectors.some(Boolean)) args.push(...selectors.flatMap((value) => ['--record_id', value]));
+  const labels = records.map((record) => String(record.presentation?.label || ''));
+  if (labels.some(Boolean)) args.push(...labels.flatMap((value) => ['--record_label', value]));
+  const subtitles = records.map((record) => String(record.presentation?.subtitle || ''));
+  if (subtitles.some(Boolean)) args.push(...subtitles.flatMap((value) => ['--record_subtitle', value]));
+  const reverseFlags = records.map((record) => Boolean(record.presentation?.reverseComplement));
+  if (reverseFlags.some(Boolean)) {
+    args.push(...reverseFlags.flatMap((value) => ['--reverse_complement', value ? '1' : '0']));
+  }
+  records.forEach((record, index) => {
+    if (!isPlainObject(record.region)) return;
+    const selector = selectorText(record.region.selector) || `#${index + 1}`;
+    args.push(
+      '--region',
+      `${selector}:${Number(record.region.start)}-${Number(record.region.end)}` +
+        `${record.region.reverseComplement ? ':rc' : ''}`
+    );
+  });
+  const rows = records.map((record) => Number(record.presentation?.gridRow));
+  if (rows.some((row) => Number.isInteger(row) && row > 0)) {
+    rows.forEach((row, index) => {
+      if (Number.isInteger(row) && row > 0) args.push('--multi_record_position', `#${index + 1}@${row}`);
+    });
+  }
+  return false;
+};
+
+const appendOption = (args, option, value) => {
+  if (value === null || value === undefined || value === '') return;
+  args.push(option, String(value));
+};
+
+const appendBooleanOption = (args, value, enabledOption, disabledOption = '') => {
+  if (value === true && enabledOption) args.push(enabledOption);
+  else if (value === false && disabledOption) args.push(disabledOption);
+};
+
+const CONFIG_VALUE_OPTIONS = Object.freeze({
+  'objects.features.arrow_geometry.head_length_ratio': '--arrow_head_length_ratio',
+  'objects.features.arrow_geometry.shaft_width_ratio': '--arrow_shaft_width_ratio',
+  'objects.features.block_stroke_color': '--block_stroke_color',
+  'objects.features.line_stroke_color': '--line_stroke_color',
+  'labels.rendering': '--label_rendering',
+  'objects.gc_content.mode': '--gc_content_mode',
+  'objects.gc_content.min_percent': '--gc_content_min_percent',
+  'objects.gc_content.max_percent': '--gc_content_max_percent',
+  'objects.gc_content.large_tick_interval': '--gc_content_large_tick_interval',
+  'objects.gc_content.small_tick_interval': '--gc_content_small_tick_interval',
+  'objects.gc_content.tick_font_size': '--gc_content_tick_font_size',
+  'objects.depth.fill_color': '--depth_color',
+  'objects.depth.min_depth': '--depth_min',
+  'objects.depth.max_depth': '--depth_max',
+  'objects.depth.large_tick_interval': '--depth_large_tick_interval',
+  'objects.depth.small_tick_interval': '--depth_small_tick_interval',
+  'objects.depth.tick_font_size': '--depth_tick_font_size',
+  'objects.scale.interval': '--scale_interval'
+});
+
+const CIRCULAR_CONFIG_VALUE_OPTIONS = Object.freeze({
+  'objects.axis.circular.stroke_color': '--axis_stroke_color',
+  'objects.definition.circular.font_size': '--definition_font_size',
+  'canvas.circular.track_type': '--track_type',
+  'labels.spacing.circular': '--circular_label_spacing',
+  'labels.circular.placement': '--label_placement',
+  'objects.ticks.tick_labels.font_size': '--tick_label_font_size',
+  'labels.unified_adjustment.outer_labels.x_radius_offset': '--outer_label_x_radius_offset',
+  'labels.unified_adjustment.outer_labels.y_radius_offset': '--outer_label_y_radius_offset',
+  'labels.unified_adjustment.inner_labels.x_radius_offset': '--inner_label_x_radius_offset',
+  'labels.unified_adjustment.inner_labels.y_radius_offset': '--inner_label_y_radius_offset'
+});
+
+const LINEAR_CONFIG_VALUE_OPTIONS = Object.freeze({
+  'objects.axis.linear.stroke_color': '--axis_stroke_color',
+  'labels.spacing.linear': '--linear_label_spacing',
+  'labels.linear.placement': '--label_placement',
+  'labels.linear.rotation': '--label_rotation',
+  'canvas.linear.track_layout': '--track_layout',
+  'canvas.linear.track_axis_gap': '--track_axis_gap',
+  'canvas.linear.comparison_height': '--comparison_height',
+  'canvas.linear.default_gc_height': '--gc_height',
+  'canvas.linear.depth_height': '--depth_height',
+  'objects.scale.style': '--scale_style',
+  'objects.scale.stroke_color': '--scale_stroke_color',
+  'objects.scale.label_color': '--ruler_label_color',
+  'objects.scale.stroke_width': '--scale_stroke_width',
+  'objects.blast_match.style': '--pairwise_match_style'
+});
+
+const SHARED_LENGTH_OPTIONS = Object.freeze({
+  'objects.features.block_stroke_width': '--block_stroke_width',
+  'objects.features.line_stroke_width': '--line_stroke_width',
+  'objects.legends.color_rect_size': '--legend_box_size',
+  'objects.legends.font_size': '--legend_font_size'
+});
+
+const CIRCULAR_LENGTH_OPTIONS = Object.freeze({
+  'objects.axis.circular.stroke_width': '--axis_stroke_width',
+  'labels.font_size': '--label_font_size'
+});
+
+const LINEAR_LENGTH_OPTIONS = Object.freeze({
+  'objects.axis.linear.stroke_width': '--axis_stroke_width',
+  'objects.definition.linear.font_size': '--definition_font_size',
+  'canvas.linear.default_cds_height': '--feature_height',
+  'objects.scale.font_size': '--scale_font_size',
+  'objects.scale.ruler_label_font_size': '--ruler_label_font_size',
+  'labels.font_size.linear': '--label_font_size'
+});
+
+const appendConfigOverrides = (args, request) => {
+  const options = request.diagramOptions || {};
+  const overrides = isPlainObject(options.configOverrides) ? options.configOverrides : {};
+  const consumed = new Set();
+  const take = (path) => {
+    if (!Object.hasOwn(overrides, path)) return undefined;
+    consumed.add(path);
+    return overrides[path];
+  };
+
+  Object.entries({
+    ...CONFIG_VALUE_OPTIONS,
+    ...(request.mode === 'linear' ? LINEAR_CONFIG_VALUE_OPTIONS : CIRCULAR_CONFIG_VALUE_OPTIONS)
+  }).forEach(([path, option]) => appendOption(args, option, take(path)));
+
+  appendBooleanOption(args, take('canvas.show_gc'), '--gc', '--no-gc');
+  appendBooleanOption(args, take('canvas.show_skew'), '--skew', '--no-skew');
+  take('canvas.show_depth');
+  appendBooleanOption(args, take('canvas.strandedness'), '--separate_strands');
+  appendBooleanOption(args, take('canvas.resolve_overlaps'), '--resolve_overlaps');
+  appendBooleanOption(
+    args, take('objects.gc_content.show_axis'),
+    '--show_gc_content_axis', '--hide_gc_content_axis'
+  );
+  appendBooleanOption(
+    args, take('objects.gc_content.show_ticks'),
+    '--show_gc_content_ticks', '--hide_gc_content_ticks'
+  );
+  appendBooleanOption(args, take('objects.depth.normalize'), '--depth_log_scale', '--no_depth_log_scale');
+  appendBooleanOption(args, take('objects.depth.show_axis'), '--show_depth_axis', '--hide_depth_axis');
+  appendBooleanOption(args, take('objects.depth.show_ticks'), '--show_depth_ticks', '--hide_depth_ticks');
+  appendBooleanOption(args, take('objects.depth.share_axis'), '--share_depth_axis');
+  appendBooleanOption(args, take('objects.scale.show'), '', '--hide_scale');
+
+  const blacklist = take('labels.filtering.blacklist_keywords');
+  if (Array.isArray(blacklist) && blacklist.length > 0) {
+    appendOption(args, '--label_blacklist', blacklist.join(','));
+  } else if (blacklist !== undefined && !Array.isArray(blacklist)) {
+    throw new SourceRecipeUnavailable('Source recipe unavailable: the label blacklist is malformed.');
+  }
+
+  const scopePath = request.mode === 'linear' ? 'labels.linear.scope' : 'labels.circular.scope';
+  const scope = take(scopePath);
+  if (scope !== undefined) {
+    if (request.mode === 'linear') {
+      appendOption(args, '--show_labels', scope);
+    } else {
+      const value = { outer: 'out', both: 'both', none: 'none' }[String(scope)];
+      if (!value) throw new SourceRecipeUnavailable(`Source recipe unavailable: unsupported label scope "${scope}".`);
+      appendOption(args, '--labels', value);
+    }
+  }
+
+  if (request.mode === 'linear') {
+    appendBooleanOption(args, take('objects.definition.linear.show_replicon'), '--show_replicon');
+    appendBooleanOption(args, take('objects.definition.linear.show_accession'), '', '--hide_accession');
+    appendBooleanOption(args, take('objects.definition.linear.show_length'), '', '--hide_length');
+    appendBooleanOption(args, take('canvas.linear.align_center'), '--align_center');
+    appendBooleanOption(args, take('canvas.linear.keep_definition_left_aligned'), '--keep_definition_left_aligned');
+    appendBooleanOption(args, take('canvas.linear.ruler_on_axis'), '--ruler_on_axis');
+    appendBooleanOption(args, take('canvas.linear.normalize_length'), '--normalize_length');
+  }
+
+  const lengthOptions = {
+    ...SHARED_LENGTH_OPTIONS,
+    ...(request.mode === 'linear' ? LINEAR_LENGTH_OPTIONS : CIRCULAR_LENGTH_OPTIONS)
+  };
+  Object.entries(lengthOptions).forEach(([prefix, option]) => {
+    const shortValue = take(`${prefix}.short`);
+    const longValue = take(`${prefix}.long`);
+    if (shortValue === undefined && longValue === undefined) return;
+    if (shortValue === undefined || longValue === undefined || Number(shortValue) !== Number(longValue)) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: size-specific setting "${prefix}" cannot be expressed by the current CLI.`
+      );
+    }
+    appendOption(args, option, shortValue);
+  });
+
+  if (request.mode === 'circular') {
+    const definitionInterval = take('objects.definition.circular.interval');
+    if (definitionInterval !== undefined) {
+      const fontSize = overrides['objects.definition.circular.font_size'];
+      if (fontSize === undefined || Number(definitionInterval) !== Math.trunc(Number(fontSize) + 2)) {
+        throw new SourceRecipeUnavailable(
+          'Source recipe unavailable: the custom circular definition interval has no CLI option.'
+        );
+      }
+    }
+    const configuredTitleFontSize = take('objects.definition.circular.plot_title_font_size');
+    if (
+      configuredTitleFontSize !== undefined
+      && Number(configuredTitleFontSize) !== Number(options.plotTitleFontSize)
+    ) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: conflicting plot-title font settings cannot be expressed by the current CLI.'
+      );
+    }
+  } else {
+    ['name', 'subtitle', 'replicon', 'accession', 'length'].forEach((kind) => {
+      const prefix = `objects.definition.linear.line_styles.${kind}`;
+      const fields = [
+        ['font_size', 'size'],
+        ['font_weight', 'weight'],
+        ['fill', 'color']
+      ];
+      const values = fields
+        .map(([field, key]) => [key, take(`${prefix}.${field}`)])
+        .filter(([, value]) => value !== undefined);
+      if (values.length > 0) {
+        appendOption(
+          args,
+          '--definition_line_style',
+          `${kind}:${values.map(([key, value]) => `${key}=${value}`).join(',')}`
+        );
+      }
+    });
+  }
+
+  const unsupported = Object.keys(overrides).filter((path) => !consumed.has(path));
+  if (unsupported.length > 0) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: setting "${unsupported[0]}" has no current CLI projection.`
+    );
+  }
+};
+
+const referencedResourceId = (value) => String(value?.resourceId || '').trim();
+
+const appendResourceOptions = (args, options, files) => {
+  const colors = isPlainObject(options.colors) ? options.colors : {};
+  appendOption(args, '-p', colors.defaultColorsPalette);
+  const resourceOptions = [
+    ['-t', colors.colorTable || colors.colorTableFile, 'specific-colors.tsv'],
+    ['-d', colors.defaultColors || colors.defaultColorsFile, 'default-colors.tsv'],
+    ['--feature_visibility_table', options.featureVisibilityTableFile, 'feature-visibility.tsv'],
+    ['--label_whitelist', options.labelWhitelistFile, 'label-whitelist.tsv'],
+    ['--qualifier_priority', options.qualifierPriorityFile || options.qualifierPriorityTable, 'qualifier-priority.tsv'],
+    ['--label_table', options.labelOverrideFile, 'label-overrides.tsv']
+  ];
+  resourceOptions.forEach(([option, ref, fallback]) => {
+    const resourceId = referencedResourceId(ref);
+    if (resourceId) appendOption(args, option, files.resourcePath(resourceId, { fallback }));
+  });
+  if (Array.isArray(options.annotations?.sets) && options.annotations.sets.length > 0) {
+    appendOption(
+      args,
+      '--annotation_table',
+      files.generatedTextPath(
+        'annotations.tsv',
+        encodeAnnotationTable(options.annotations.sets),
+        'generatedFiles.source_recipe.annotation_table'
+      )
+    );
+  }
+};
+
+const appendDepthOptions = (args, options, files) => {
+  const tracks = Array.isArray(options.depthTracks) ? options.depthTracks : [];
+  tracks.forEach((track, trackIndex) => {
+    const refs = Array.isArray(track?.source) ? track.source : [track?.source];
+    const paths = refs.map((ref, recordIndex) => {
+      const resourceId = referencedResourceId(ref);
+      return resourceId
+        ? files.resourcePath(resourceId, {
+            fallback: `depth-${trackIndex + 1}-record-${recordIndex + 1}.tsv`
+          })
+        : '';
+    });
+    if (!paths.some(Boolean)) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: depth track ${trackIndex + 1} has no source file.`
+      );
+    }
+    args.push('--depth_track', ...paths);
+  });
+  const appendTrackValues = (option, field) => {
+    if (tracks.length === 0) return;
+    const values = tracks.map((track) => {
+      const value = track?.[field];
+      return value === null || value === undefined || value === '' ? 'auto' : String(value);
+    });
+    appendOption(args, option, values[0]);
+    if (values.length > 1) args.push(...values.slice(1));
+  };
+  appendTrackValues('--depth_track_label', 'label');
+  appendTrackValues('--depth_track_color', 'color');
+  if (options.mode === 'linear') appendTrackValues('--depth_track_height', 'height');
+  appendTrackValues('--depth_track_large_tick_interval', 'largeTickInterval');
+  appendTrackValues('--depth_track_small_tick_interval', 'smallTickInterval');
+  appendTrackValues('--depth_track_tick_font_size', 'tickFontSize');
+};
+
+const formatCanonicalTrackScalar = (value, { allowFactor = false } = {}) => {
+  if (!isPlainObject(value)) return value;
+  const numeric = Number(value.value);
+  const unit = String(value.unit || '').trim().toLowerCase();
+  if (!Number.isFinite(numeric) || (unit !== 'px' && !(allowFactor && unit === 'factor'))) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: a canonical track dimension cannot be represented by the current CLI.'
+    );
+  }
+  return unit === 'px' ? `${numeric}px` : String(numeric);
+};
+
+const TRACK_PARAM_KEYS = Object.freeze({
+  circular: {
+    features: new Set(['lane_direction', 'legend_label']),
+    ticks: new Set(['tick_label_layout', 'preset', 'legend_label']),
+    dinucleotide_content: new Set(['nt', 'legend_label']),
+    dinucleotide_skew: new Set(['nt', 'positive_color', 'negative_color', 'legend_label']),
+    depth: new Set(['track_index', 'legend_label']),
+    sequence_conservation: new Set(['track_index', 'source_index', 'legend_label']),
+    annotations: new Set([
+      'set_id', 'marks', 'lane_gap_px', 'padding_px', 'overflow', 'show_labels',
+      'anchor_slot', 'layer', 'cover_anchor', 'legend_label'
+    ]),
+    spacer: new Set(['legend_label'])
+  },
+  linear: {
+    features: new Set(['legend_label']),
+    dinucleotide_content: new Set(['nt', 'legend_label']),
+    dinucleotide_skew: new Set(['nt', 'positive_color', 'negative_color', 'legend_label']),
+    depth: new Set(['track_index', 'legend_label']),
+    annotations: new Set([
+      'set_id', 'marks', 'lane_gap_px', 'padding_px', 'overflow', 'show_labels',
+      'anchor_slot', 'layer', 'cover_anchor', 'legend_label'
+    ]),
+    spacer: new Set(['legend_label'])
+  }
+});
+
+const validateTrackParams = (mode, renderer, params) => {
+  if (!isPlainObject(params)) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: a canonical ${mode} track slot has malformed params.`
+    );
+  }
+  const allowed = TRACK_PARAM_KEYS[mode]?.[renderer];
+  if (!allowed) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: ${mode} track renderer "${renderer}" is not accepted by the current CLI.`
+    );
+  }
+  const unsupported = Object.keys(params).find((key) => !allowed.has(key));
+  if (unsupported) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: ${mode} track field "params.${unsupported}" cannot be projected losslessly.`
+    );
+  }
+};
+
+const validateStructuredTrackSlot = (slot, mode) => {
+  if (!isPlainObject(slot)) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: a canonical ${mode} track slot is malformed.`
+    );
+  }
+  if (slot.kind !== `${mode}TrackSlot`) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: a canonical ${mode} track slot has an invalid kind.`
+    );
+  }
+  const id = typeof slot.id === 'string' ? slot.id.trim() : '';
+  const renderer = typeof slot.renderer === 'string' ? slot.renderer.trim() : '';
+  const allowedSides = mode === 'circular'
+    ? new Set(['inside', 'outside', 'overlay'])
+    : new Set(['above', 'below', 'overlay']);
+  if (
+    !id || !renderer || typeof slot.enabled !== 'boolean' || !Number.isInteger(slot.z)
+    || (slot.side !== null && !allowedSides.has(slot.side))
+  ) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: a canonical ${mode} track slot has invalid identity fields.`
+    );
+  }
+  validateTrackParams(mode, renderer, slot.params);
+  return slot;
+};
+
+const trackSlotForRecipe = (slot, mode, options) => {
+  if (typeof slot === 'string') {
+    const text = slot.trim();
+    if (!text) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: a canonical ${mode} track slot cannot be empty.`
+      );
+    }
+    try {
+      const parsed = mode === 'circular'
+        ? parseCircularTrackSlotSpec(text)
+        : parseLinearTrackSlotSpec(text);
+      const atIndex = text.indexOf('@');
+      const canonicalHead = `${parsed.id}:${parsed.renderer}`;
+      if ((atIndex < 0 ? text : text.slice(0, atIndex)).trim() !== canonicalHead) {
+        throw new SourceRecipeUnavailable(
+          `Source recipe unavailable: a canonical ${mode} track slot would change identity in the current CLI projection.`
+        );
+      }
+      if (atIndex >= 0 && text.slice(atIndex + 1).split(',').some((entry) => {
+        const equalsIndex = entry.indexOf('=');
+        return equalsIndex <= 0 || !entry.slice(equalsIndex + 1).trim();
+      })) {
+        throw new SourceRecipeUnavailable(
+          `Source recipe unavailable: a canonical ${mode} track slot has a malformed option.`
+        );
+      }
+      validateTrackParams(mode, parsed.renderer, parsed.params || {});
+    } catch (error) {
+      if (error instanceof SourceRecipeUnavailable) throw error;
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: a canonical ${mode} track slot is not accepted by the current CLI.`
+      );
+    }
+    return text;
+  }
+
+  validateStructuredTrackSlot(slot, mode);
+  try {
+    if (mode === 'circular') {
+      return buildCircularTrackSlotSpec(
+        circularTrackSlotForRecipe(slot),
+        options.dinucleotide,
+        options.configOverrides?.['canvas.circular.track_type']
+      );
+    }
+    const parsed = parseLinearTrackSlotSpec(slot);
+    validateTrackParams('linear', parsed.renderer, parsed.params || {});
+    return buildLinearTrackSlotSpec(linearTrackSlotForRecipe(parsed), { includeEnabled: true });
+  } catch (error) {
+    if (error instanceof SourceRecipeUnavailable) throw error;
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: a canonical ${mode} track slot cannot be projected losslessly.`
+    );
+  }
+};
+
+const circularTrackSlotForRecipe = (slot) => ({
+  ...slot,
+  radius: formatCanonicalTrackScalar(slot?.radius, { allowFactor: true }),
+  width: formatCanonicalTrackScalar(slot?.width, { allowFactor: true })
+});
+
+const linearTrackSlotForRecipe = (slot) => ({
+  ...slot,
+  height: formatCanonicalTrackScalar(slot?.height),
+  spacing: formatCanonicalTrackScalar(slot?.spacing)
+});
+
+const appendTrackOptions = (args, request) => {
+  const options = request.diagramOptions || {};
+  const tracks = isPlainObject(options.tracks) ? options.tracks : {};
+  appendOption(args, '--center_reserved_radius', tracks.centerReservedRadius);
+  const field = request.mode === 'circular' ? 'circularTrackSlots' : 'linearTrackSlots';
+  const axisField = request.mode === 'circular' ? 'circularTrackAxisIndex' : 'linearTrackAxisIndex';
+  const slots = tracks[field];
+  if (slots === null || slots === undefined) {
+    if (tracks[axisField] !== null && tracks[axisField] !== undefined) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: ${request.mode} track axis placement has no explicit track slots.`
+      );
+    }
+    return;
+  }
+  if (!Array.isArray(slots)) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: canonical ${request.mode} track slots must be an array or null.`
+    );
+  }
+  if (slots.length === 0) {
+    throw new SourceRecipeUnavailable(
+      `Source recipe unavailable: an explicit empty ${request.mode} track list means no tracks, which the current CLI cannot express.`
+    );
+  }
+  const option = request.mode === 'circular' ? '--circular_track_slot' : '--linear_track_slot';
+  slots.forEach((slot) => appendOption(args, option, trackSlotForRecipe(slot, request.mode, options)));
+  appendOption(
+    args,
+    request.mode === 'circular' ? '--circular_track_axis_index' : '--linear_track_axis_index',
+    tracks[axisField]
+  );
+};
+
+const appendComparisonOptions = (args, request, files) => {
+  const options = request.diagramOptions || {};
+  if (request.mode === 'circular') {
+    const blasts = Array.isArray(options.conservationBlastFiles)
+      ? options.conservationBlastFiles
+      : [];
+    if (blasts.length === 0) return;
+    const fastas = Array.isArray(options.conservationFastaFiles)
+      ? options.conservationFastaFiles
+      : [];
+    const labels = Array.isArray(options.conservationLabels) ? options.conservationLabels : [];
+    const colors = Array.isArray(options.conservationColors) ? options.conservationColors : [];
+    args.push(
+      '--conservation_blast',
+      ...blasts.map((ref, index) => files.resourcePath(
+        referencedResourceId(ref),
+        {
+          fallback: `conservation-${index + 1}.tsv`,
+          slot: `generatedFiles.source_recipe.conservation_blasts[${index}]`,
+          nameHintSlot: `generatedFiles.circular_conservation_blasts[${index}]`
+        }
+      ))
+    );
+    if (fastas.some(Boolean)) {
+      args.push(
+        '--conservation_fasta',
+        ...fastas.map((ref, index) => {
+        const resourceId = referencedResourceId(ref);
+          return resourceId
+            ? files.resourcePath(resourceId, { fallback: `comparison-${index + 1}.fasta` })
+            : '';
+        })
+      );
+    }
+    if (labels.length > 0) args.push('--conservation_labels', ...labels.map(String));
+    if (colors.length > 0) args.push('--conservation_colors', ...colors.map(String));
+    appendOption(args, '--conservation_reference', options.conservationReference);
+    appendOption(args, '--conservation_ring_width', options.conservationRingWidth);
+    appendOption(args, '--conservation_ring_gap', options.conservationRingGap);
+    return;
+  }
+
+  const comparisons = Array.isArray(request.comparisons) ? request.comparisons : [];
+  if (comparisons.length === 0) return;
+  const recordCount = Array.isArray(request.records) ? request.records.length : 0;
+  if (comparisons.some((comparison) => (
+    !Number.isInteger(comparison?.queryRecordIndex)
+    || comparison.queryRecordIndex < 0
+    || comparison.queryRecordIndex >= recordCount
+    || !Number.isInteger(comparison?.subjectRecordIndex)
+    || comparison.subjectRecordIndex < 0
+    || comparison.subjectRecordIndex >= recordCount
+  ))) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: a comparison cannot be bound losslessly to its source records.'
+    );
+  }
+  if (comparisons.some((comparison) => comparison.kind !== 'nucleotideBlast')) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: this committed protein comparison has no lossless source CLI projection.'
+    );
+  }
+  const drawable = comparisons;
+  const adjacent = drawable.every((comparison, index) => (
+    Number(comparison.queryRecordIndex) === index
+    && Number(comparison.subjectRecordIndex) === index + 1
+  ));
+  if (adjacent) {
+    const paths = drawable.map((comparison, index) => files.resourcePath(
+      referencedResourceId(comparison),
+      {
+        fallback: `comparison-${index + 1}.tsv`,
+        slot: `generatedFiles.source_recipe.comparison_blasts[${index}]`,
+        nameHintSlot: `generatedFiles.losat_blasts[${index}]`
+      }
+    ));
+    if (paths.length > 0) args.push('-b', ...paths);
+    return;
+  }
+  const rows = drawable.map((comparison, index) => {
+    const path = files.resourcePath(referencedResourceId(comparison), {
+      fallback: `comparison-${index + 1}.tsv`,
+      slot: `generatedFiles.source_recipe.comparison_blasts[${index}]`,
+      nameHintSlot: `generatedFiles.losat_blasts[${index}]`
+    });
+    return {
+      blastPath: path,
+      query: `#${Number(comparison.queryRecordIndex) + 1}`,
+      subject: `#${Number(comparison.subjectRecordIndex) + 1}`
+    };
+  });
+  appendOption(
+    args,
+    '--comparisons_table',
+    files.generatedTextPath(
+      'comparisons.tsv',
+      (finalNameForPath) => tsv(
+        ['blast', 'query', 'subject'],
+        rows.map(({ blastPath, ...row }) => ({
+          ...row,
+          blast: finalNameForPath(blastPath)
+        }))
+      ),
+      'generatedFiles.source_recipe.comparisons_table'
+    )
+  );
+};
+
+const appendDiagramOptions = (args, request, files) => {
+  const options = request.diagramOptions || {};
+  if (Array.isArray(request.output) && request.output.length !== 1) {
+    throw new SourceRecipeUnavailable(
+      'Source recipe unavailable: per-record batch output names have no single current CLI projection.'
+    );
+  }
+  const output = Array.isArray(request.output) ? request.output[0] : request.output;
+  appendOption(args, '-o', output?.prefix);
+  if (Array.isArray(output?.formats) && output.formats.length > 0) {
+    appendOption(args, '-f', output.formats.join(','));
+  }
+  if (output?.overwrite === true) args.push('--overwrite');
+  appendOption(args, '-l', options.output?.legend);
+  if (request.mode === 'linear' || options.output?.plotTitlePosition !== 'none') {
+    appendOption(args, '--plot_title_position', options.output?.plotTitlePosition);
+  }
+  if (options.selectedFeaturesSet !== null && options.selectedFeaturesSet !== undefined) {
+    if (!Array.isArray(options.selectedFeaturesSet)) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: selected features must be an array or null.'
+      );
+    }
+    if (!options.selectedFeaturesSet.every((feature) => (
+      typeof feature === 'string' && feature.trim().length > 0
+    ))) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: selected features must contain only non-empty strings.'
+      );
+    }
+    if (options.selectedFeaturesSet.length > 0) {
+      args.push('-k', options.selectedFeaturesSet.join(','));
+    }
+  }
+  Object.entries(isPlainObject(options.featureShapes) ? options.featureShapes : {})
+    .forEach(([feature, shape]) => appendOption(args, '--feature_shape', `${feature}=${shape}`));
+  appendOption(args, '-n', options.dinucleotide);
+  appendOption(args, '-w', options.window);
+  appendOption(args, '-s', options.step);
+  appendOption(args, '--depth_window', options.depthWindow);
+  appendOption(args, '--depth_step', options.depthStep);
+  appendOption(args, '--plot_title', options.plotTitle);
+  appendOption(args, '--plot_title_font_size', options.plotTitleFontSize);
+  ['evalue', 'bitscore', 'identity'].forEach((field) => appendOption(args, `--${field}`, options[field]));
+  appendOption(args, '--alignment_length', options.alignmentLength);
+  if (request.mode === 'circular') {
+    appendOption(args, '--species', options.species);
+    appendOption(args, '--strain', options.strain);
+    appendBooleanOption(
+      args,
+      options.keepFullDefinitionWithPlotTitle,
+      '--keep_full_definition_with_plot_title'
+    );
+  } else if (Object.hasOwn(options, 'pairwiseMatchStyle')) {
+    const configured = options.configOverrides?.['objects.blast_match.style'];
+    if (configured === undefined) appendOption(args, '--pairwise_match_style', options.pairwiseMatchStyle);
+    else if (String(configured) !== String(options.pairwiseMatchStyle)) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: conflicting pairwise comparison styles cannot be expressed by the current CLI.'
+      );
+    }
+  }
+  appendResourceOptions(args, options, files);
+  appendDepthOptions(args, { ...options, mode: request.mode }, files);
+  appendTrackOptions(args, request);
+  appendComparisonOptions(args, request, files);
+};
+
+const appendLayoutOptions = (args, request, recordsTableUsed = false) => {
+  const layout = isPlainObject(request.layout) ? request.layout : {};
+  if (request.mode === 'linear') {
+    appendOption(args, '--linear_record_gap', layout.recordGapPx);
+    return;
+  }
+  if (Object.keys(layout).length === 0) return;
+  args.push('--multi_record_canvas');
+  appendOption(args, '--multi_record_size_mode', layout.multiRecordSizeMode);
+  appendOption(args, '--multi_record_min_radius_ratio', layout.multiRecordMinRadiusRatio);
+  appendOption(args, '--multi_record_column_gap_ratio', layout.multiRecordColumnGapRatio);
+  appendOption(args, '--multi_record_row_gap_ratio', layout.multiRecordRowGapRatio);
+  if (!recordsTableUsed && Array.isArray(layout.multiRecordPositions)) {
+    layout.multiRecordPositions.forEach((position) => appendOption(args, '--multi_record_position', position));
+  }
+};
+
+export const buildSourceRecipe = ({
+  renderRequest,
+  resources,
+  webFiles,
+  generatedFileNameHints
+} = {}) => {
+  const mode = String(renderRequest?.mode || '').trim();
+  const unavailable = (reason) => ({
+    available: false,
+    mode: mode === 'linear' ? 'linear' : 'circular',
+    args: [],
+    fileMetadata: new Map(),
+    generatedFiles: [],
+    semanticCoverage: null,
+    unavailableReason: String(reason || 'Source recipe unavailable.')
+  });
+  if (!isPlainObject(renderRequest) || !['circular', 'linear'].includes(mode)) {
+    return unavailable('Source recipe unavailable: the committed render request is missing or invalid.');
+  }
+  try {
+    const semanticCoverage = renderRequest.schema === 6
+      ? validateSchema6SemanticCoverage(renderRequest)
+      : { schema: renderRequest.schema, consumedPaths: [], metadataPaths: [] };
+    const files = createRecipeFiles(resources, webFiles, generatedFileNameHints);
+    const args = [];
+    const recordsTableUsed = appendInputArgs(args, renderRequest, files);
+    appendDiagramOptions(args, renderRequest, files);
+    appendConfigOverrides(args, renderRequest);
+    appendLayoutOptions(args, renderRequest, recordsTableUsed);
+    return {
+      available: true,
+      mode,
+      args,
+      fileMetadata: files.fileMetadata,
+      generatedFiles: files.generatedFiles,
+      semanticCoverage,
+      unavailableReason: ''
+    };
+  } catch (error) {
+    if (error instanceof SourceRecipeUnavailable) return unavailable(error.message);
+    console.warn('Failed to project the committed render into a source CLI recipe.', error);
+    return unavailable('Source recipe unavailable: the committed render cannot be represented safely by the current CLI.');
+  }
 };
 
 export const quoteShellArg = (value) => {
@@ -73,10 +1476,11 @@ export const formatElapsedMs = (elapsedMs) => {
 
 export const reproducibilityLabel = (level) => {
   const normalized = String(level || '').trim();
+  if (normalized === 'source-unavailable') return 'Source recipe unavailable';
   if (normalized === 'canonical-request') return 'Exact typed request';
-  if (normalized === 'exact-uploaded-files') return 'Ready to rerun';
-  if (normalized === 'requires-helper-files') return 'Raw CLI needs files';
-  if (normalized === 'session-recommended') return 'Raw CLI needs files';
+  if (normalized === 'exact-uploaded-files') return 'Source recipe ready';
+  if (normalized === 'requires-helper-files') return 'Source recipe needs helper files';
+  if (normalized === 'session-recommended') return 'Source recipe needs helper files';
   return 'Approximate command';
 };
 
@@ -87,16 +1491,7 @@ export const isCliInvocationSessionExportable = (invocation) => {
   return bindings.every((binding) => String(binding?.slot || '').startsWith('files.'));
 };
 
-export const buildRunInfo = ({
-  mode,
-  args,
-  fileMetadata,
-  elapsedMs,
-  resultCount,
-  startedAtIso,
-  generatedBy = 'gbdraw-web'
-} = {}) => {
-  const normalizedMode = String(mode || '').trim() === 'linear' ? 'linear' : 'circular';
+const projectInvocation = ({ mode, args, fileMetadata, generatedBy }) => {
   const metadata = normalizeFileMetadata(fileMetadata);
   const helperFiles = [];
   const unresolvedFileArgs = [];
@@ -104,29 +1499,20 @@ export const buildRunInfo = ({
     const token = String(arg ?? '');
     const meta = metadata.get(token);
     if (!meta) {
-      if (token.startsWith('/')) {
-        unresolvedFileArgs.push({ argIndex, path: token });
-      }
+      if (token.startsWith('/')) unresolvedFileArgs.push({ argIndex, path: token });
       return token;
     }
     const displayName = meta.name || fallbackNameFromPath(token);
     if (meta.kind === 'generated') {
-      helperFiles.push({
-        path: meta.path,
-        name: displayName,
-        slot: meta.slot || ''
-      });
+      helperFiles.push({ path: meta.path, name: displayName, slot: meta.slot || '' });
     }
     return displayName;
   });
-
-  const argsWithFormat = [...displayArgs];
   const bindingArgIndexesByName = new Map();
-  argsWithFormat.forEach((token, index) => {
+  displayArgs.forEach((token, index) => {
     if (!bindingArgIndexesByName.has(token)) bindingArgIndexesByName.set(token, []);
     bindingArgIndexesByName.get(token).push(index);
   });
-
   const fixedFileBindings = [];
   const seenBindingKeys = new Set();
   (Array.isArray(args) ? args : []).forEach((arg, originalIndex) => {
@@ -139,61 +1525,182 @@ export const buildRunInfo = ({
     const key = `${argIndex}:${meta.slot}`;
     if (seenBindingKeys.has(key)) return;
     seenBindingKeys.add(key);
-    fixedFileBindings.push({
-      argIndex,
-      slot: meta.slot,
-      name: displayName,
-      originalArgIndex: originalIndex
-    });
+    fixedFileBindings.push({ argIndex, slot: meta.slot, name: displayName, originalArgIndex: originalIndex });
   });
-
   const invocation = {
     schema: 1,
-    mode: normalizedMode,
-    args: argsWithFormat,
+    mode,
+    args: displayArgs,
     renderFormats: ['svg'],
     fileBindings: fixedFileBindings.map(({ originalArgIndex: _originalArgIndex, ...binding }) => binding),
     generatedBy,
-    sessionExportable: fixedFileBindings.every((binding) => String(binding.slot).startsWith('files.')) &&
-      unresolvedFileArgs.length === 0
+    sessionExportable: fixedFileBindings.every((binding) => String(binding.slot).startsWith('files.'))
+      && unresolvedFileArgs.length === 0
   };
+  const commandArgs = ['gbdraw', mode, ...displayArgs];
+  return {
+    command: buildShellCommand(commandArgs),
+    commandArgs,
+    invocation,
+    helperFiles,
+    unresolvedFileArgs
+  };
+};
 
-  const hasLosatHelpers = helperFiles.some((helper) => /losat|blast/i.test(`${helper.slot} ${helper.name}`));
-  const hasCanonicalRequest = helperFiles.some(
-    (helper) => helper.slot === 'generatedFiles.canonical_render_session'
+const finalizeGeneratedRecipeFiles = (generatedFiles, allocatedMetadata) => {
+  const finalNameForPath = (pathRaw) => {
+    const path = String(pathRaw || '').trim();
+    const name = allocatedMetadata.get(path)?.name;
+    if (!name) {
+      throw new SourceRecipeUnavailable(
+        'Source recipe unavailable: a generated helper dependency has no allocated filename.'
+      );
+    }
+    return name;
+  };
+  return (Array.isArray(generatedFiles) ? generatedFiles : []).map((file) => {
+    const path = String(file?.path || '').trim();
+    const slot = String(file?.slot || '').trim();
+    const name = finalNameForPath(path);
+    const data = typeof file?.buildData === 'function'
+      ? file.buildData(finalNameForPath)
+      : file?.data;
+    if (!(typeof data === 'string' || data instanceof Uint8Array)) {
+      throw new SourceRecipeUnavailable(
+        `Source recipe unavailable: generated helper file "${name}" cannot be materialized.`
+      );
+    }
+    return { path, name, slot, data };
+  });
+};
+
+export const buildRunInfo = ({
+  mode,
+  args,
+  sourceRecipe,
+  exactReplayArgs,
+  fileMetadata,
+  elapsedMs,
+  resultCount,
+  startedAtIso,
+  generatedBy = 'gbdraw-web'
+} = {}) => {
+  const normalizedMode = String(mode || '').trim() === 'linear' ? 'linear' : 'circular';
+  let sourceAvailable = sourceRecipe?.available !== false;
+  let sourceUnavailableReason = String(sourceRecipe?.unavailableReason || 'Source recipe unavailable.');
+  const sourceMetadata = normalizeFileMetadata(
+    sourceRecipe?.fileMetadata || fileMetadata
+  );
+  const allExactMetadata = normalizeFileMetadata(fileMetadata);
+  const exactPaths = new Set((Array.isArray(exactReplayArgs) ? exactReplayArgs : []).map(String));
+  const exactMetadata = new Map(
+    Array.from(allExactMetadata).filter(([path]) => exactPaths.has(path))
+  );
+  let allocatedMetadata;
+  let finalizedGeneratedFiles = [];
+  try {
+    allocatedMetadata = allocateVisibleFilenames({
+      sourceMetadata,
+      exactMetadata,
+      sourceAvailable
+    });
+    if (sourceAvailable) {
+      finalizedGeneratedFiles = finalizeGeneratedRecipeFiles(
+        sourceRecipe?.generatedFiles,
+        allocatedMetadata.source
+      );
+      if (Array.isArray(sourceRecipe?.generatedFiles)) {
+        sourceRecipe.generatedFiles.splice(
+          0,
+          sourceRecipe.generatedFiles.length,
+          ...finalizedGeneratedFiles
+        );
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof SourceRecipeUnavailable)) throw error;
+    sourceAvailable = false;
+    sourceUnavailableReason = error.message;
+    allocatedMetadata = allocateVisibleFilenames({
+      sourceMetadata: new Map(),
+      exactMetadata,
+      sourceAvailable: false
+    });
+  }
+  const source = sourceAvailable
+    ? projectInvocation({
+        mode: normalizedMode,
+        args: Array.isArray(sourceRecipe?.args) ? sourceRecipe.args : args,
+        fileMetadata: allocatedMetadata.source,
+        generatedBy
+      })
+    : {
+        command: '', commandArgs: [], helperFiles: [], unresolvedFileArgs: [], invocation: null
+      };
+  const exact = Array.isArray(exactReplayArgs)
+    ? projectInvocation({
+        mode: normalizedMode,
+        args: exactReplayArgs,
+        fileMetadata: allocatedMetadata.exact,
+        generatedBy
+      })
+    : null;
+  const recipeGeneratedHelpers = (Array.isArray(sourceRecipe?.generatedFiles)
+    ? finalizedGeneratedFiles
+    : [])
+    .map(({ path, name, slot }) => ({ path, name, slot }))
+    .filter((file) => file.path && file.name);
+  const sourceHelpers = Array.from(new Map(
+    [...source.helperFiles, ...recipeGeneratedHelpers]
+      .map((helper) => [`${helper.path}:${helper.slot}`, helper])
+  ).values());
+  const helperFiles = Array.from(new Map(
+    [...sourceHelpers, ...(exact?.helperFiles || [])]
+      .map((helper) => [`${helper.path}:${helper.slot}`, helper])
+  ).values());
+  const hasLosatHelpers = sourceHelpers.some(
+    (helper) => /losat|blast/i.test(`${helper.slot} ${helper.name}`)
   );
   const notes = [];
   let level = 'exact-uploaded-files';
-  if (hasCanonicalRequest) {
-    level = 'canonical-request';
-    notes.push(
-      'This command replays the exact typed request used for the render. ' +
-      'Use "Download CLI Files" to save its session file before running the command.'
-    );
-  } else if (helperFiles.length > 0) {
+  if (!sourceAvailable) {
+    level = 'source-unavailable';
+    notes.push(sourceUnavailableReason);
+    if (exact) notes.push('Exact replay remains available from the committed canonical session.');
+  } else if (sourceHelpers.length > 0) {
     level = hasLosatHelpers ? 'session-recommended' : 'requires-helper-files';
     notes.push(
-      `The plain command references browser-generated file(s): ${formatHelperFileList(helperFiles)}. ` +
-      'Use "Download CLI Files" to save those file(s) next to the uploaded inputs before running the command in a terminal.'
+      `The source recipe references browser-generated file(s): ${formatHelperFileList(sourceHelpers)}. ` +
+      'Use "Download reproducibility files" to save those file(s) next to the uploaded inputs before running the command in a terminal.'
     );
     notes.push(
       'If you save a .gbdraw-session.json.gz and load it back in the web app, the uploaded inputs, results, and LOSAT cache are restored from the compressed JSON; these TSV files do not need to be saved separately for session restore.'
     );
   }
-  if (unresolvedFileArgs.length > 0) {
+  if (source.unresolvedFileArgs.length > 0) {
     level = 'pseudo';
     notes.push('Some browser virtual paths could not be mapped to visible file names, so this command is only an approximation.');
-  } else if (fixedFileBindings.length === 0 && metadata.size > 0) {
-    level = 'pseudo';
   }
   if (notes.length === 0) {
-    notes.push('The command can be rerun with the uploaded file names shown here.');
+    notes.push('The source recipe can be rerun with the uploaded file names shown here.');
   }
-
-  const commandArgs = ['gbdraw', normalizedMode, ...argsWithFormat];
-  const sessionCommand = isCliInvocationSessionExportable(invocation)
-    ? buildShellCommand(['gbdraw', normalizedMode, '--session', 'session.gbdraw-session.json.gz'])
-    : '';
+  if (exact?.helperFiles.length > 0) {
+    notes.push(
+      `Exact replay references ${formatHelperFileList(exact.helperFiles)}, which is included in "Download reproducibility files".`
+    );
+  }
+  const bundleDescription = [
+    sourceAvailable
+      ? (
+          sourceHelpers.length > 0
+            ? `Source recipe helper files: ${formatHelperFileList(sourceHelpers)}.`
+            : 'The Source recipe uses only the original source files.'
+        )
+      : 'The Source recipe is unavailable.',
+    exact?.helperFiles.length > 0
+      ? `Exact replay file: ${formatHelperFileList(exact.helperFiles)}.`
+      : 'No Exact replay file is available.'
+  ].join(' ');
 
   return {
     schema: 1,
@@ -201,11 +1708,39 @@ export const buildRunInfo = ({
     startedAtIso: startedAtIso || new Date().toISOString(),
     elapsedMs: Number.isFinite(Number(elapsedMs)) ? Number(elapsedMs) : 0,
     resultCount: Number.isFinite(Number(resultCount)) ? Number(resultCount) : 0,
-    command: buildShellCommand(commandArgs),
-    commandArgs,
-    sessionCommand,
-    invocation,
+    command: source.command,
+    commandArgs: source.commandArgs,
+    sessionCommand: exact?.command || '',
+    invocation: source.invocation,
+    sourceRecipe: {
+      available: sourceAvailable,
+      command: source.command,
+      commandArgs: source.commandArgs,
+      invocation: source.invocation,
+      helperFiles: sourceHelpers,
+      reproducibility: {
+        status: !sourceAvailable
+          ? 'unavailable'
+          : (sourceHelpers.length > 0 ? 'requires-generated-helper-files' : 'ready-with-original-files')
+      },
+      unavailableReason: sourceAvailable
+        ? ''
+        : sourceUnavailableReason
+    },
+    exactReplay: {
+      available: Boolean(exact),
+      command: exact?.command || '',
+      commandArgs: exact?.commandArgs || [],
+      helperFiles: exact?.helperFiles || [],
+      reproducibility: { status: exact ? 'available' : 'unavailable' }
+    },
     helperFiles,
+    downloadBundle: {
+      available: helperFiles.length > 0,
+      sourceRecipeFiles: sourceHelpers,
+      exactReplayFiles: exact?.helperFiles || [],
+      description: bundleDescription
+    },
     reproducibility: {
       level,
       notes

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -2241,8 +2241,12 @@ const serializeFile = async (file) => {
   if (!file) return null;
   const source = getSessionResourceSource(file);
   if (source?.descriptor) {
-    setResourcePayloadOwner(source.descriptor, file);
-    return source.descriptor;
+    const visibleName = String(file.name || '').trim();
+    const descriptor = visibleName && visibleName !== source.descriptor.name
+      ? { ...source.descriptor, name: visibleName }
+      : source.descriptor;
+    setResourcePayloadOwner(descriptor, file);
+    return descriptor;
   }
   const cached = serializedFileDescriptors.get(file);
   if (cached) return cached;

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -3311,6 +3311,7 @@ const captureSessionImportSnapshot = () => ({
   features: buildFeatureStateData(),
   editorState: buildEditorStateData(),
   orthogroupState: buildOrthogroupStateData(),
+  collinearGroups: state.collinearGroups.value,
   runState: buildRunStateData(),
   losatCache: new Map(state.losatCache.value),
   losatDerivedCache: new Map(state.losatDerivedCache.value),
@@ -3364,6 +3365,7 @@ const restoreSessionImportSnapshot = async (snapshot) => {
     applyResultsData(snapshot.results, snapshot.ui);
     applyFeatureStateData(snapshot.features);
     applyOrthogroupStateData(snapshot.orthogroupState);
+    state.collinearGroups.value = snapshot.collinearGroups;
     applyEditorStateData(snapshot.editorState);
     applyRunStateData(snapshot.runState);
     state.errorLog.value = snapshot.errorLog;
@@ -3414,6 +3416,7 @@ const resetSessionBaseline = () => {
   state.legacyProteinDerivedEvidence.value = { schema: 1, entries: [] };
   state.losatCacheInfo.value = [];
   state.orthogroups.value = [];
+  state.collinearGroups.value = [];
   state.featureOrthogroupIndex.value = new Map();
   state.selectedOrthogroupId.value = '';
   state.selectedOrthogroupAlignmentFeature.value = '';
@@ -4187,6 +4190,7 @@ export const importSession = async (e, options = {}) => {
       : (data.features || {});
     applyFeatureStateData(features);
     if (currentSchemaSession && currentCatalogFeatureState) {
+      state.collinearGroups.value = currentCatalogFeatureState.collinearGroups;
       synchronizeRestoredFeatureSummaryStatus({ generationId: 'session-load' });
     }
     const catalogSequenceSources = currentSchemaSession

--- a/gbdraw/web/js/services/feature-catalog.js
+++ b/gbdraw/web/js/services/feature-catalog.js
@@ -370,11 +370,10 @@ const validateAndProjectCatalogItem = (item, result, resultIndex, context) => {
       [['recordKey', 'biologicalFeatureId']]
     );
     const expanded = expandOrthogroup(group, biologicalByKey, renderedByKey);
-    if (text(expanded.presentationScope) === 'adjacent_local') {
+    context.orthogroupProjection.addGroup(expanded);
+    context.orthogroups.push(expanded);
+    if (text(expanded.scope) === 'cross_record' && text(expanded.presentationScope)) {
       context.collinearGroups.push(expanded);
-    } else {
-      context.orthogroupProjection.addGroup(expanded);
-      context.orthogroups.push(expanded);
     }
   });
   context.scalarMetrics.orthogroupRecordCount += orthogroups.length;

--- a/gbdraw/web/js/services/standalone-interactivity-assets.js
+++ b/gbdraw/web/js/services/standalone-interactivity-assets.js
@@ -54,6 +54,7 @@ export const STANDALONE_INTERACTIVE_STYLE = `
   stroke-width: 1.5;
   paint-order: stroke fill markers;
 }
+.gbdraw-interactive-pairwise-match.gbdraw-interactive-pairwise-match--pending,
 .gbdraw-interactive-pairwise-match.gbdraw-interactive-pairwise-match--selected {
   opacity: 1;
   filter: url(#gbdraw-interactive-feature-glow);
@@ -62,6 +63,10 @@ export const STANDALONE_INTERACTIVE_STYLE = `
   stroke-width: 2.5;
   paint-order: stroke fill markers;
   outline: none;
+}
+.gbdraw-interactive-pairwise-match:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 .gbdraw-interactive-annotation {
   cursor: pointer;
@@ -1960,8 +1965,9 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
   var matchElementsById = new Map();
   var ambiguousMatchElementIds = new Set();
   var selectedMatchElements = [];
+  var pendingMatchElement = null;
   var comparisonElementsByCollinearityBlockId = new Map();
-  Array.prototype.slice.call(svg.querySelectorAll(MATCH_SELECTOR)).forEach(function (element) {
+  Array.prototype.slice.call(svg.querySelectorAll(MATCH_SELECTOR)).forEach(function (element, index) {
     var matchId = getElementMatchId(element);
     if (matchId && !ambiguousMatchElementIds.has(matchId)) {
       if (matchElementsById.has(matchId)) {
@@ -1979,6 +1985,9 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
       comparisonElementsByCollinearityBlockId.get(blockId).push(element);
     }
     setClassToken(element, 'gbdraw-interactive-pairwise-match', true);
+    element.setAttribute('role', 'button');
+    element.setAttribute('tabindex', '0');
+    element.setAttribute('aria-label', 'Pairwise match ' + (index + 1));
   });
 
   function setClassToken(element, token, enabled) {
@@ -2113,6 +2122,19 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     selectedMatchElements.forEach(function (element) {
       setClassToken(element, 'gbdraw-interactive-pairwise-match--selected', true);
     });
+  }
+
+  function clearPendingMatch() {
+    if (!pendingMatchElement) return;
+    setClassToken(pendingMatchElement, 'gbdraw-interactive-pairwise-match--pending', false);
+    pendingMatchElement = null;
+  }
+
+  function setPendingMatch(element) {
+    if (pendingMatchElement === element) return;
+    clearPendingMatch();
+    pendingMatchElement = element;
+    setClassToken(element, 'gbdraw-interactive-pairwise-match--pending', true);
   }
 
   function clearActiveFeatureHover() {
@@ -6399,6 +6421,41 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     closeHoverPopup();
   });
 
+  svg.addEventListener('pointerdown', function (event) {
+    if (event.button !== 0 || event.isPrimary === false) return;
+    var matchElement = closestMatch(event.target);
+    if (!matchElement) {
+      clearPendingMatch();
+      return;
+    }
+    setPendingMatch(matchElement);
+  });
+
+  svg.addEventListener('pointerout', function (event) {
+    if (!pendingMatchElement) return;
+    var matchElement = closestMatch(event.target);
+    if (matchElement !== pendingMatchElement) return;
+    if (closestMatch(event.relatedTarget) === matchElement) return;
+    clearPendingMatch();
+  });
+
+  window.addEventListener('pointerup', clearPendingMatch, true);
+  window.addEventListener('pointercancel', clearPendingMatch, true);
+  window.addEventListener('blur', clearPendingMatch);
+
+  function activateMatch(matchElement, event) {
+    var matchId = getElementMatchId(matchElement);
+    var match = matchesById.get(matchId);
+    if (!match) return false;
+    clearPendingMatch();
+    event.preventDefault();
+    event.stopPropagation();
+    closeHoverPopup();
+    openPopup(match, event, 'match');
+    setSelectedMatch(matchId);
+    return true;
+  }
+
   svg.addEventListener('click', function (event) {
     if (popup && popup.contains(event.target)) return;
     if (closestSearchControls(event.target)) return;
@@ -6426,14 +6483,7 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
         closePopup();
         return;
       }
-      var matchId = getElementMatchId(matchElement);
-      var match = matchesById.get(matchId);
-      if (!match) return;
-      event.preventDefault();
-      event.stopPropagation();
-      closeHoverPopup();
-      openPopup(match, event, 'match');
-      setSelectedMatch(matchId);
+      activateMatch(matchElement, event);
       return;
     }
     var svgId = getElementFeatureId(featureElement);
@@ -6447,6 +6497,13 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     event.stopPropagation();
     closeHoverPopup();
     openPopup(feature, event, 'feature');
+  });
+
+  svg.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    var matchElement = closestMatch(event.target);
+    if (!matchElement) return;
+    activateMatch(matchElement, event);
   });
 
   document.addEventListener('keydown', function (event) {

--- a/gbdraw/web/js/services/standalone-interactivity-assets.js
+++ b/gbdraw/web/js/services/standalone-interactivity-assets.js
@@ -4554,9 +4554,129 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     });
   }
 
-  function copyButton(value, label) {
-    var index = copyValues.push(String(value == null ? '' : value)) - 1;
-    return '<button type="button" class="gfi-copy" data-copy-index="' + index + '">' + escapeHtml(label || 'Copy') + '</button>';
+  function memberCopyFeedbackIdentity(memberOrRow) {
+    var recordKey = consistentTextIdentity(memberOrRow, ['recordKey', 'record_key']);
+    var biologicalId = consistentTextIdentity(
+      memberOrRow,
+      ['biologicalFeatureId', 'biological_feature_id']
+    );
+    if (
+      recordKey.valid
+      && biologicalId.valid
+      && recordKey.value
+      && biologicalId.value
+    ) {
+      return JSON.stringify(['canonical', recordKey.value, biologicalId.value]);
+    }
+    var recordIndex = memberRecordIndex(memberOrRow);
+    var stableId = memberFeatureSvgId(memberOrRow);
+    var sourceIndex = nonnegativeIntegerIdentity(memberOrRow, [
+      'featureIndex', 'feature_index', 'sourceFeatureIndex', 'source_feature_index'
+    ]);
+    if (Number.isInteger(recordIndex) && (stableId || Number.isInteger(sourceIndex.value))) {
+      return JSON.stringify([
+        'source',
+        recordIndex,
+        stableId,
+        Number.isInteger(sourceIndex.value) ? sourceIndex.value : null
+      ]);
+    }
+    return JSON.stringify([
+      'display',
+      firstDisplayText(memberOrRow && (memberOrRow.record || memberOrRow.recordId || memberOrRow.record_id)),
+      firstDisplayText(memberOrRow && memberOrRow.coordinates, memberLocationText(memberOrRow)),
+      firstNonInternalDisplayText(
+        memberOrRow && (memberOrRow.proteinId || memberOrRow.protein_id),
+        memberOrRow && displayProteinId(null, memberOrRow, '')
+      )
+    ]);
+  }
+
+  function sequenceCopyFeedbackKey(context, orthogroupId, action, memberOrRow, sequenceKind) {
+    return JSON.stringify([
+      'orthogroup-sequence',
+      String(context || ''),
+      String(orthogroupId || '').trim(),
+      action,
+      memberOrRow ? memberCopyFeedbackIdentity(memberOrRow) : '',
+      sequenceKindLabel(sequenceKind)
+    ]);
+  }
+
+  function copyFeedbackLabel(status) {
+    if (status === 'success') return 'Copied!';
+    if (status === 'manual') return 'Copy manually';
+    if (status === 'failure') return 'Copy failed';
+    return '';
+  }
+
+  function updateCopyFeedbackButtons(feedbackKey) {
+    if (!popup || !popup.querySelectorAll || !feedbackKey) return;
+    var feedback = copyFeedbackByKey.get(feedbackKey);
+    Array.prototype.slice.call(
+      popup.querySelectorAll('[data-copy-feedback-key]')
+    ).forEach(function (button) {
+      if (button.getAttribute('data-copy-feedback-key') !== feedbackKey) return;
+      button.textContent = feedback
+        ? copyFeedbackLabel(feedback.status)
+        : String(button.getAttribute('data-copy-label') || 'Copy');
+    });
+  }
+
+  function beginCopyFeedback(feedbackKey) {
+    var previousTimer = copyFeedbackTimers.get(feedbackKey);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackTimers.delete(feedbackKey);
+    copyFeedbackByKey.delete(feedbackKey);
+    nextCopyOperationId += 1;
+    copyOperationIds.set(feedbackKey, nextCopyOperationId);
+    updateCopyFeedbackButtons(feedbackKey);
+    return nextCopyOperationId;
+  }
+
+  function finishCopyFeedback(feedbackKey, operationId, status) {
+    if (!feedbackKey || copyOperationIds.get(feedbackKey) !== operationId) return;
+    var previousTimer = copyFeedbackTimers.get(feedbackKey);
+    if (previousTimer !== undefined) window.clearTimeout(previousTimer);
+    copyFeedbackByKey.set(feedbackKey, { operationId: operationId, status: status });
+    updateCopyFeedbackButtons(feedbackKey);
+    var timer = window.setTimeout(function () {
+      var current = copyFeedbackByKey.get(feedbackKey);
+      if (
+        copyOperationIds.get(feedbackKey) !== operationId
+        || !current
+        || current.operationId !== operationId
+      ) return;
+      copyFeedbackByKey.delete(feedbackKey);
+      copyFeedbackTimers.delete(feedbackKey);
+      copyOperationIds.delete(feedbackKey);
+      updateCopyFeedbackButtons(feedbackKey);
+    }, COPY_FEEDBACK_DURATION_MS);
+    copyFeedbackTimers.set(feedbackKey, timer);
+  }
+
+  function clearCopyFeedback() {
+    copyFeedbackTimers.forEach(function (timer) {
+      window.clearTimeout(timer);
+    });
+    copyFeedbackTimers.clear();
+    copyFeedbackByKey.clear();
+    copyOperationIds.clear();
+  }
+
+  function copyButton(value, label, feedbackKey) {
+    var originalLabel = String(label || 'Copy');
+    var key = String(feedbackKey || '');
+    var feedback = key ? copyFeedbackByKey.get(key) : null;
+    var index = copyValues.push({
+      feedbackKey: key,
+      text: String(value == null ? '' : value)
+    }) - 1;
+    var feedbackAttributes = key
+      ? ' data-copy-feedback-key="' + escapeHtml(key) + '" data-copy-label="' + escapeHtml(originalLabel) + '" aria-live="polite" aria-atomic="true"'
+      : '';
+    return '<button type="button" class="gfi-copy" data-copy-index="' + index + '"' + feedbackAttributes + '>' +
+      escapeHtml(feedback ? copyFeedbackLabel(feedback.status) : originalLabel) + '</button>';
   }
 
   function downloadButton(filename, text, label) {
@@ -4578,18 +4698,32 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
       if (!text) return;
       var count = groupFastaCount(rows, sequenceKind);
       var suffix = count > 1 ? ' (' + count + ')' : '';
-      html.push(copyButton(text, 'Copy ' + sequenceKind + suffix));
+      var feedbackKey = sequenceCopyFeedbackKey(
+        options && options.feedbackContext,
+        orthogroupId,
+        'group',
+        null,
+        sequenceKind
+      );
+      html.push(copyButton(text, 'Copy ' + sequenceKind + suffix, feedbackKey));
       html.push(downloadButton(groupSequenceFilename(orthogroupId, displayName, sequenceKind), text, 'DL ' + sequenceKind + suffix));
     });
     return html.join('');
   }
 
-  function renderMemberSequenceActions(memberOrRow, orthogroupId) {
+  function renderMemberSequenceActions(memberOrRow, orthogroupId, feedbackContext) {
     var html = [];
     ['nt', 'aa'].forEach(function (sequenceKind) {
       var text = String(memberFasta(memberOrRow, sequenceKind) || '').trim();
       if (!text) return;
-      html.push(copyButton(text, 'Copy ' + sequenceKind));
+      var feedbackKey = sequenceCopyFeedbackKey(
+        feedbackContext,
+        orthogroupId,
+        'member',
+        memberOrRow,
+        sequenceKind
+      );
+      html.push(copyButton(text, 'Copy ' + sequenceKind, feedbackKey));
       html.push(downloadButton(memberSequenceFilename(memberOrRow, sequenceKind, orthogroupId), text, 'DL ' + sequenceKind));
     });
     return html.length ? '<div class="gfi-seq-actions">' + html.join('') + '</div>' : '';
@@ -4597,6 +4731,11 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
 
   var copyValues = [];
   var downloadValues = [];
+  var COPY_FEEDBACK_DURATION_MS = 1500;
+  var copyFeedbackByKey = new Map();
+  var copyFeedbackTimers = new Map();
+  var copyOperationIds = new Map();
+  var nextCopyOperationId = 0;
 
   function renderRows(rows) {
     if (!rows.length) {
@@ -4653,10 +4792,11 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     ).join('\\n');
     var sequenceActions = renderGroupSequenceActions(rows, {
       orthogroupId: orthogroupId,
-      displayName: displayName
+      displayName: displayName,
+      feedbackContext: 'feature-orthogroup'
     });
     var body = rows.map(function (row) {
-      var sequenceActions = renderMemberSequenceActions(row, orthogroupId);
+      var sequenceActions = renderMemberSequenceActions(row, orthogroupId, 'feature-orthogroup');
       return '<tr>' +
         '<td class="gfi-mono">' + escapeHtml(row.record) + '</td>' +
         '<td class="gfi-mono">' + escapeHtml(row.coordinates) + '</td>' +
@@ -5391,7 +5531,7 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
       '<tbody>' + body + '</tbody></table></div>';
   }
 
-  function renderMatchMemberTable(section, rows) {
+  function renderMatchMemberTable(section, rows, feedbackContext) {
     if (!rows.length) return '';
     var orthogroupId = String(section && (section.id || section.orthogroupId || section.orthogroup_id) || rows[0] && (rows[0].orthogroupId || rows[0].orthogroup_id) || '').trim();
     var displayName = String(section && (section.displayName || section.display_name || section.name) || rows[0] && (rows[0].displayName || rows[0].display_name) || '').trim();
@@ -5407,7 +5547,7 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
       ).join('\\n');
     }
     var body = rows.map(function (row) {
-      var sequenceActions = renderMemberSequenceActions(row, orthogroupId);
+      var sequenceActions = renderMemberSequenceActions(row, orthogroupId, feedbackContext);
       return '<tr>' +
         '<td class="gfi-mono">' + escapeHtml(row.record) + '</td>' +
         '<td class="gfi-mono">' + escapeHtml(row.coordinates) + '</td>' +
@@ -5418,7 +5558,8 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     }).join('');
     var sequenceActions = renderGroupSequenceActions(rows, {
       orthogroupId: orthogroupId,
-      displayName: displayName
+      displayName: displayName,
+      feedbackContext: feedbackContext
     });
     return '<div class="gfi-table-wrap"><table class="gfi-table gfi-og-members-table">' +
       '<thead><tr><th>Record</th><th>Coordinates (+/-)</th><th>Protein ID</th><th>Product / note</th><th>Seq</th></tr></thead>' +
@@ -5469,7 +5610,11 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
         ? '<div class="gfi-block gfi-block--selected-og">' +
           '<div class="gfi-block-title">' + escapeHtml('Selected similarity group') + '</div>' +
           renderRows(selectedBlockOrthogroup.detailRows) +
-          renderMatchMemberTable(selectedBlockOrthogroup, selectedBlockOrthogroup.memberRows) +
+          renderMatchMemberTable(
+            selectedBlockOrthogroup,
+            selectedBlockOrthogroup.memberRows,
+            'selected-orthogroup:' + selectedBlockOrthogroup.id
+          ) +
           '</div>'
         : '';
       return '<div class="gfi-block">' +
@@ -5477,7 +5622,16 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
         (rows.length && !featureRows.length ? renderRows(rows) : '') +
         renderMatchFeatureTable(featureRows) +
         renderMatchBlockOrthogroupTable(blockOrthogroups, selectedBlockOrthogroupId) +
-        renderMatchMemberTable(section, memberRows) +
+        renderMatchMemberTable(
+          section,
+          memberRows,
+          'match-section:' + firstDisplayText(
+            section && section.id,
+            section && section.title,
+            match && match.id,
+            selectedBlockOrthogroupId
+          )
+        ) +
         selectedHtml +
         '</div>';
     }).join('') || '<div class="gfi-empty">No match details available.</div>';
@@ -5519,6 +5673,7 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
   function closePopup() {
     stopPopupResize();
     stopPopupDrag();
+    clearCopyFeedback();
     updateActivePopupViewportMetrics = null;
     if (popup && popup.parentNode) {
       popup.parentNode.removeChild(popup);
@@ -6222,8 +6377,10 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
       var copyTarget = closestFromTarget(rootEvent.target, '[data-copy-index]');
       if (copyTarget) {
         var index = Number(copyTarget.getAttribute('data-copy-index'));
-        var value = Number.isFinite(index) ? copyValues[index] || '' : '';
-        Promise.resolve(copyText(value, copyTarget)).catch(function () {});
+        var copyPayload = Number.isFinite(index) ? copyValues[index] || null : null;
+        var value = copyPayload ? copyPayload.text : '';
+        var feedbackKey = copyPayload ? copyPayload.feedbackKey : '';
+        Promise.resolve(copyText(value, copyTarget, feedbackKey)).catch(function () {});
         return;
       }
       var downloadTarget = closestFromTarget(rootEvent.target, '[data-download-index]');
@@ -6269,18 +6426,34 @@ export const STANDALONE_INTERACTIVE_SCRIPT = `
     syncStandaloneOverlayOrder();
   }
 
-  async function copyText(value, button) {
+  async function copyText(value, button, feedbackKey) {
     var text = String(value == null ? '' : value);
-    if (navigator.clipboard && navigator.clipboard.writeText) {
+    var operationId = feedbackKey ? beginCopyFeedback(feedbackKey) : 0;
+    var clipboard = null;
+    try {
+      clipboard = navigator.clipboard;
+    } catch (error) {
+      clipboard = null;
+    }
+    if (clipboard && clipboard.writeText) {
       try {
-        await navigator.clipboard.writeText(text);
-        if (button) button.textContent = 'Copied';
-        return;
+        await clipboard.writeText(text);
+        if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'success');
+        else if (button) button.textContent = 'Copied';
+        return 'copied';
       } catch (error) {
         // Fall back to a prompt below when clipboard permission is unavailable.
       }
     }
-    window.prompt('Copy text', text);
+    try {
+      if (typeof window.prompt !== 'function') throw new Error('Manual copy is unavailable.');
+      window.prompt('Copy text', text);
+      if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'manual');
+      return 'manual';
+    } catch (error) {
+      if (feedbackKey) finishCopyFeedback(feedbackKey, operationId, 'failure');
+      return 'failed';
+    }
   }
 
   function closestFeature(node) {

--- a/gbdraw/web/js/services/svg-serialization.js
+++ b/gbdraw/web/js/services/svg-serialization.js
@@ -7,6 +7,7 @@ const TRANSIENT_PREVIEW_CLASSES = Object.freeze([
   'gbdraw-feature-selected',
   'gbdraw-feature-selection-anchor',
   'gbdraw-feature-selection-candidate',
+  'gbdraw-match-pending',
   'gbdraw-match-selected',
   'feature-selection-marquee',
   'feature-selection-status'

--- a/tests/test_api_session.py
+++ b/tests/test_api_session.py
@@ -665,3 +665,121 @@ def test_python_depth_request_projects_in_web(tmp_path: Path) -> None:
         check=True,
         cwd=Path(__file__).parents[1],
     )
+
+
+def _record_local_collinear_session(tmp_path: Path, search_scope: str = "adjacent") -> Path:
+    """Render the Issue #460 evidence through typed, Web, and session boundaries."""
+    import xml.etree.ElementTree as ET
+    from dataclasses import replace
+
+    from tests.test_collinearity import _record_local_mixed_fixture
+    from gbdraw.analysis.collinearity import build_orthogroup_collinearity_blocks_from_hits
+    from gbdraw.api import render_request
+    from gbdraw.web_support.feature_catalog import build_feature_catalog_item
+    from gbdraw.web_support.request_render import render_canonical_web_request
+
+    records, extraction, hits = _record_local_mixed_fixture()
+    for record in records:
+        record.name = record.id
+        record.annotations["organism"] = "synthetic construct"
+    groups = build_orthogroup_collinearity_blocks_from_hits(
+        hits, extraction, records=records, search_scope=search_scope,
+    )
+    request = LinearDiagramRequest(
+        records=tuple(RecordInput(source=InMemoryRecordSource(record), record_key=record.id) for record in records),
+        options=LinearDiagramOptions(
+            orthogroups=groups.orthogroups,
+            collinearity_blocks=groups, collinearity_search_scope=search_scope,
+        ),
+        output=RenderOutputRequest(
+            output_directory=tmp_path / "typed", output_prefix="mixed",
+            formats=("svg", "interactive_svg"),
+        ),
+    )
+    typed = render_request(request, include_feature_catalog=True)
+    svg = (tmp_path / "typed" / "mixed.svg").read_text()
+    catalog_item = build_feature_catalog_item(
+        svg, typed.interactive_context, result_index=0, result_name="mixed.svg",
+    )
+    document = build_session_document(request)
+    with materialize_session(document, output_directory=tmp_path / "decoded") as materialized:
+        decoded = session_to_request(materialized)
+        assert decoded.options.collinearity_blocks == groups
+        assert decoded.options.orthogroups == groups.orthogroups
+        web = render_canonical_web_request(
+            document.to_dict()["renderRequest"], resource_paths=materialized.resource_paths,
+            output_directory=tmp_path / "web",
+        )
+    assert web["metadata"]["featureCatalog"]["items"] == [catalog_item]
+    semantic = {group["id"]: group for group in catalog_item["orthogroups"]}
+    assert set(semantic) == {"og_1", "og_2"}
+    assert semantic["og_1"]["scope"] == "cross_record"
+    assert semantic["og_2"]["scope"] == "record_local"
+    assert semantic["og_2"]["source_record_index"] == 0
+    biological = {
+        (feature["recordKey"], feature["biologicalFeatureId"]): feature
+        for feature in catalog_item["biologicalFeatures"]
+    }
+    for group_id, expected in (
+        ("og_1", {"a0": "anchor", "a1": "inparalog", "b0": "anchor"}),
+        ("og_2", {"a3": "local_paralog", "a4": "local_paralog"}),
+    ):
+        members = semantic[group_id]["members"]
+        assert {
+            biological[(member["recordKey"], member["biologicalFeatureId"])]["qualifiers"]["protein_id"][0]: member["role"]
+            for member in members
+        } == expected
+        if group_id == "og_2":
+            assert {biological[(m["recordKey"], m["biologicalFeatureId"])]["record_id"] for m in members} == {"record_a"}
+
+    def comparison_paths(source):
+        return [element for element in ET.fromstring(source).iter()
+                if element.tag.endswith("}path") and element.get("data-match-kind") == "collinear"]
+
+    paths = comparison_paths(svg)
+    assert len(groups.blocks) == len(paths) == 1
+    assert paths[0].get("data-orthogroup-id") == "og_1"
+    assert all(block.query_record_index != block.subject_record_index for block in groups.blocks)
+    geometry_only = build_orthogroup_collinearity_blocks_from_hits(
+        {pair: table for pair, table in hits.items() if pair[0] != pair[1]},
+        extraction, records=records, search_scope=search_scope,
+    )
+    baseline = render_request(replace(
+        request,
+        options=replace(request.options, orthogroups=geometry_only.orthogroups, collinearity_blocks=geometry_only),
+        output=replace(request.output, output_directory=tmp_path / "geometry", formats=("svg",)),
+    ))
+    assert [path.get("d") for path in paths] == [
+        path.get("d") for path in comparison_paths(baseline.output_paths[0].read_text())
+    ]
+    interactive_source = next(path for path in typed.output_paths if "interactive" in path.name).read_text()
+    interactive_root = ET.fromstring(interactive_source)
+    metadata = next(element for element in interactive_root.iter()
+                    if element.get("id") == "gbdraw-interactive-feature-metadata")
+    interactive = json.loads(metadata.text)
+    assert interactive["items"][0]["orthogroups"] == catalog_item["orthogroups"]
+    assert len(comparison_paths(interactive_source)) == 1
+    assert [path.get("d") for path in comparison_paths(web["results"][0]["content"])] == [paths[0].get("d")]
+
+    session_path = tmp_path / "mixed.gbdraw-session.json"
+    saved = save_session_document(session_path, request, adjunct={
+        "results": web["results"], "editorState": {"featureCatalog": web["metadata"]["featureCatalog"]},
+    })
+    reloaded = load_session_document(session_path)
+    assert reloaded.version == saved.version == CURRENT_SESSION_VERSION == 40
+    assert reloaded.to_dict()["editorState"]["featureCatalog"] == web["metadata"]["featureCatalog"]
+    with materialize_session(reloaded, output_directory=tmp_path / "reload") as materialized:
+        restored = session_to_request(materialized)
+        assert restored.options.collinearity_blocks == groups
+        rerendered = render_canonical_web_request(
+            reloaded.to_dict()["renderRequest"], resource_paths=materialized.resource_paths,
+            output_directory=tmp_path / "reload-web",
+        )
+    assert rerendered["metadata"]["featureCatalog"] == web["metadata"]["featureCatalog"]
+    assert [path.get("d") for path in comparison_paths(rerendered["results"][0]["content"])] == [paths[0].get("d")]
+    return session_path
+
+
+@pytest.mark.parametrize("search_scope", ["adjacent", "all"])
+def test_record_local_collinear_catalog_session_round_trip(tmp_path: Path, search_scope: str) -> None:
+    _record_local_collinear_session(tmp_path, search_scope)

--- a/tests/test_collinearity.py
+++ b/tests/test_collinearity.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import xml.etree.ElementTree as ET
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -147,6 +148,123 @@ def _hit_row(
         "evalue": 1e-30,
         "bitscore": bitscore,
     }
+
+
+def _record_local_mixed_fixture():
+    """Issue #460 evidence shared by analysis, catalog, session and browser checks."""
+    records = [
+        _record(record_id, [
+            _cds(start, start + 299, {
+                "locus_tag": [protein_id], "protein_id": [protein_id],
+                "translation": ["M" * 100],
+            })
+            for protein_id, start in features
+        ])
+        for record_id, features in (
+            ("record_a", [("a0", 100), ("a1", 700), ("a3", 1200), ("a4", 1600), ("a2", 2100)]),
+            ("record_b", [("b0", 120), ("b1", 900)]),
+        )
+    ]
+    for record in records:
+        record.seq = Seq("ATG" * 900)
+        record.annotations["molecule_type"] = "DNA"
+    hits = {
+        pair: pd.DataFrame.from_records(rows, columns=COMPARISON_COLUMNS)
+        for pair, rows in {
+            (0, 0): [
+                _hit_row("a0", "a1", 280), _hit_row("a1", "a0", 280),
+                _hit_row("a3", "a4", 300), _hit_row("a4", "a3", 300),
+            ],
+            (0, 1): [_hit_row("a0", "b0", 300)],
+            (1, 0): [_hit_row("b0", "a0", 300)],
+        }.items()
+    }
+    return records, extract_cds_proteins(records), hits
+
+
+@pytest.mark.parametrize("search_scope", ["adjacent", "all"])
+@pytest.mark.parametrize("edge_mode", ["rbh", "one_to_one", "all_hits"])
+def test_collinear_record_local_mixed_fixture(search_scope, edge_mode):
+    records, extraction, hits = _record_local_mixed_fixture()
+    result = collinearity_module.build_orthogroup_collinearity_blocks_from_hits(
+        hits, extraction, records=records, search_scope=search_scope, edge_mode=edge_mode,
+    )
+    groups = result.orthogroups
+    assert groups is not None
+    assert {
+        group_id: {member.protein_id for member in members}
+        for group_id, members in groups.orthogroups.items()
+    } == {"og_1": {"a0", "a1", "b0"}, "og_2": {"a3", "a4"}}
+    assert groups.scope_by_orthogroup_id == {"og_1": "cross_record", "og_2": "record_local"}
+    assert groups.source_record_index_by_orthogroup_id == {"og_2": 0}
+    assert {member.record_id for member in groups.orthogroups["og_2"]} == {"record_a"}
+    assert groups.member_by_protein_id["a1"].role == "inparalog"
+    assert {member.role for member in groups.orthogroups["og_2"]} == {"local_paralog"}
+    assert {"a2", "b1"}.isdisjoint(groups.member_by_protein_id)
+
+    # Removing only local evidence gives the pre-fix adjacent geometry baseline.
+    geometry_only = collinearity_module.build_orthogroup_collinearity_blocks_from_hits(
+        {pair: table for pair, table in hits.items() if pair[0] != pair[1]},
+        extraction, records=records, search_scope=search_scope, edge_mode=edge_mode,
+    )
+    assert len(result.blocks) == len(geometry_only.blocks) == 1
+    anchor = result.blocks[0].anchors[0]
+    assert anchor.query_orthogroup_member_count == 2
+    assert (replace(result.blocks[0], anchors=(
+        replace(anchor, query_orthogroup_member_count=1),
+    )),) == geometry_only.blocks
+    assert result.unblocked_anchors == geometry_only.unblocked_anchors == ()
+    assert {anchor.orthogroup_id for block in result.blocks for anchor in block.anchors} == {"og_1"}
+    comparisons = convert_collinearity_blocks_to_comparisons(result, records=records)
+    baseline = convert_collinearity_blocks_to_comparisons(geometry_only, records=records)
+    assert len(comparisons) == len(baseline) == 1
+    # Complete membership is semantic metadata, not a geometry coordinate.
+    assert comparisons[0]["query_orthogroup_member_count"].tolist() == ["2"]
+    assert comparisons[0]["subject_orthogroup_member_count"].tolist() == ["1"]
+    geometry_columns = comparisons[0].columns.difference([
+        "query_orthogroup_member_count", "subject_orthogroup_member_count",
+    ])
+    pd.testing.assert_frame_equal(
+        comparisons[0][geometry_columns], baseline[0][geometry_columns],
+    )
+
+
+@pytest.mark.parametrize("search_scope", ["adjacent", "all"])
+@pytest.mark.parametrize("edge_mode", ["one_to_one", "all_hits"])
+def test_collinear_scope_partitions_table_identity(monkeypatch, search_scope, edge_mode):
+    records, extraction, hits = _record_local_mixed_fixture()
+    records.append(_record("record_c", [_cds(0, 9, {"protein_id": ["c0"]})]))
+    extraction = extract_cds_proteins(records)
+    for pair, query, subject in (
+        ((1, 1), "b0", "b1"), ((2, 2), "c0", "c0"),
+        ((1, 2), "b0", "c0"), ((2, 1), "c0", "b0"),
+        ((0, 2), "a2", "c0"), ((2, 0), "c0", "a2"),
+    ):
+        hits[pair] = pd.DataFrame.from_records([_hit_row(query, subject)], columns=COMPARISON_COLUMNS)
+    captured = {}
+    infer = collinearity_module.select_rbh_orthogroup_edges_from_directional_hits
+    select_geometry = collinearity_module._select_orthogroup_edges
+
+    def capture_semantic(tables, *args, **kwargs):
+        captured["semantic"] = tables
+        return infer(tables, *args, **kwargs)
+
+    def capture_geometry(tables, **kwargs):
+        captured["geometry"] = tables
+        return select_geometry(tables, **kwargs)
+
+    monkeypatch.setattr(collinearity_module, "select_rbh_orthogroup_edges_from_directional_hits", capture_semantic)
+    monkeypatch.setattr(collinearity_module, "_select_orthogroup_edges", capture_geometry)
+    collinearity_module.build_orthogroup_collinearity_blocks_from_hits(
+        hits, extraction, records=records, search_scope=search_scope, edge_mode=edge_mode,
+    )
+    cross_pairs = {(0, 1), (1, 0), (1, 2), (2, 1)}
+    if search_scope == "all":
+        cross_pairs |= {(0, 2), (2, 0)}
+    assert set(captured["semantic"]) == cross_pairs | {(0, 0), (1, 1), (2, 2)}
+    assert set(captured["geometry"]) == cross_pairs
+    for tables in captured.values():
+        assert all(table is hits[pair] for pair, table in tables.items())
 
 
 def _first_fasta_id(fasta_text: str) -> str:

--- a/tests/test_gui_protein_comparison_capture_contracts.py
+++ b/tests/test_gui_protein_comparison_capture_contracts.py
@@ -912,8 +912,8 @@ def test_protein_popup_state_uses_catalog_commit_path() -> None:
 
     for fragment in (
         "collinearGroups,",
-        "...(Array.isArray(orthogroups?.value) ? orthogroups.value : []),",
-        "...(Array.isArray(collinearGroups?.value) ? collinearGroups.value : [])",
+        "orthogroups: groupsForMatch(matchElement),",
+        "orthogroups: () => groupsForMatch(matchElement),",
         "const payload = buildMatchPayload(matchElement, featureLookup);",
     ):
         assert fragment in svg_actions

--- a/tests/test_linear_multi_record_comparisons.py
+++ b/tests/test_linear_multi_record_comparisons.py
@@ -184,6 +184,122 @@ def test_comparison_ribbons_keep_four_pixel_clearance_from_painted_occupancy() -
     )
 
 
+@pytest.mark.parametrize("multi_record", [False, True])
+@pytest.mark.parametrize(
+    ("label_scope", "font_size", "rotation", "height", "reverse", "style"),
+    [
+        ("none", 18, 45, 60, False, "curve"),
+        ("first", 18, 45, 60, False, "curve"),
+        ("all", 18, 45, 60, False, "curve"),
+        ("all", 28, 70, 180, False, "ribbon"),
+        ("all", 12, 0, 100, True, "curve"),
+        ("all", 18, 45, 60, True, "ribbon"),
+    ],
+)
+def test_comparison_endpoints_follow_gene_tracks_with_labels(
+    multi_record, label_scope, font_size, rotation, height, reverse, style
+) -> None:
+    records = _records()[:3]
+    for record in records:
+        record.features.append(
+            SeqFeature(
+                FeatureLocation(10, 110, strand=1),
+                type="CDS",
+                qualifiers={"gene": ["long_biosynthetic_gene_label"]},
+            )
+        )
+    edges = [(0, 1), (1, 2)]
+    if reverse:
+        edges = [(subject, query) for query, subject in edges]
+    comparisons = [_comparison(*edge) for edge in edges]
+    if reverse:
+        for comparison in comparisons:
+            comparison.matches.loc[:, ["sstart", "send"]] = [110, 20]
+    canvas = assemble_linear_diagram_from_records(
+        records,
+        cfg=apply_config_overrides(
+            None,
+            {
+                "labels.linear.scope": label_scope,
+                "labels.linear.placement": "above_feature",
+                "labels.linear.rotation": rotation,
+                "labels.font_size.linear.short": font_size,
+                "objects.features.block_stroke_width.short": 2,
+                "objects.features.line_stroke_width.short": 2,
+                "canvas.show_gc": False,
+                "canvas.show_skew": False,
+                "canvas.linear.comparison_height": height,
+            },
+        ),
+        linear_comparisons=comparisons,
+        layout=(
+            LinearMultiRecordOptions(
+                multi_record_positions=("#1@1", "#2@2", "#3@3"),
+            )
+            if multi_record
+            else None
+        ),
+        pairwise_match_style=style,
+        legend="none",
+    )
+    root = ET.fromstring(canvas.tostring())
+    parents = {child: parent for parent in root.iter() for child in parent}
+    number = r"[-+0-9.eE]+"
+
+    def absolute_y(element, local_y):
+        while element is not None:
+            local_y += sum(
+                float(y)
+                for _x, y in re.findall(
+                    rf"translate\(\s*({number})[,\s]+({number})\s*\)",
+                    element.get("transform", ""),
+                )
+            )
+            element = parents.get(element)
+        return local_y
+
+    # Read painted glyph edges from the final SVG, independently of placement
+    # and footprint helpers. Both nested and composition translations count.
+    gene_bands = {}
+    for group in root.iter():
+        record_index = group.get("data-gbdraw-record-index")
+        features = [
+            element for element in group.iter()
+            if element.get("data-gbdraw-feature-id") is not None
+            and element.get("d") is not None
+        ]
+        if record_index is None or not features:
+            continue
+        values = [
+            absolute_y(feature, float(y))
+            for feature in features
+            for _x, y in re.findall(
+                rf"[ML]\s*({number})[,\s]+({number})", feature.get("d", "")
+            )
+        ]
+        half_stroke = max(float(f.get("stroke-width", "0")) for f in features) / 2
+        gene_bands[int(record_index)] = (
+            min(values) - half_stroke, max(values) + half_stroke
+        )
+    assert set(gene_bands) == {0, 1, 2}
+    paths = [p for p in root.iter() if p.get("data-pairwise-match-style")]
+    assert len(paths) == 2
+    for path, (query, subject) in zip(paths, edges, strict=True):
+        endpoints = re.findall(
+            rf"[ML]\s*({number})[,\s]+({number})", path.attrib["d"]
+        )
+        query_y = absolute_y(path, float(endpoints[0][1]))
+        subject_y = absolute_y(path, float(endpoints[1 if style == "curve" else 2][1]))
+        upper_y, lower_y = sorted((query_y, subject_y))
+        upper, lower = sorted((query, subject))
+        assert upper_y == pytest.approx(gene_bands[upper][1] + 4.0)
+        assert lower_y == pytest.approx(gene_bands[lower][0] - 4.0)
+        assert path.get("data-query-record-index") == str(query)
+        assert path.get("data-subject-record-index") == str(subject)
+        assert path.get("data-pairwise-match-style") == style
+    assert ("long_biosynthetic_gene_label" in canvas.tostring()) == (label_scope != "none")
+
+
 def test_reversed_explicit_endpoints_work_with_legacy_one_record_rows() -> None:
     canvas = assemble_linear_diagram_from_records(
         _records()[:2],

--- a/tests/web/depth-track-session.playwright.spec.js
+++ b/tests/web/depth-track-session.playwright.spec.js
@@ -19,6 +19,22 @@ const repeatRegionGenbankPath = join(repoRoot, 'tests/test_inputs/NC_001454.1.gb
 const sparseGenbankAPath = join(repoRoot, 'tests/test_inputs/BGC0000708.gbk');
 const sparseGenbankBPath = join(repoRoot, 'tests/test_inputs/BGC0000709.gbk');
 
+const storedZipEntryNames = (path) => {
+  const bytes = readFileSync(path);
+  const names = [];
+  let offset = 0;
+  while (offset + 30 <= bytes.length && bytes.readUInt32LE(offset) === 0x04034B50) {
+    const size = bytes.readUInt32LE(offset + 18);
+    const nameLength = bytes.readUInt16LE(offset + 26);
+    const extraLength = bytes.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    names.push(bytes.subarray(nameStart, nameStart + nameLength).toString('utf8'));
+    offset = dataStart + size;
+  }
+  return names;
+};
+
 test('diagram Worker startup leaves no main-thread Python runtime', { tag: '@pr-smoke' }, async ({ page }) => {
   test.setTimeout(180000);
   const genbank = readFileSync(hmmtDnaPath, 'utf8');
@@ -2342,7 +2358,8 @@ test('HmmtDNA middle overlap layout keeps feature, GC, and skew bands disjoint',
         showGc: window.__GBDRAW_APP__.form.show_gc,
         showSkew: window.__GBDRAW_APP__.form.show_skew
       },
-      reproducibilityLevel: window.__GBDRAW_APP__.lastRunInfo?.reproducibility?.level
+      reproducibilityLevel: window.__GBDRAW_APP__.lastRunInfo?.reproducibility?.level,
+      exactReplayCommand: window.__GBDRAW_APP__.lastRunInfo?.exactReplay?.command || ''
     };
   });
 
@@ -2352,8 +2369,86 @@ test('HmmtDNA middle overlap layout keeps feature, GC, and skew bands disjoint',
     showGc: true,
     showSkew: true
   });
-  expect(geometry.args).toEqual(['--session', 'out.gbdraw-session.json']);
-  expect(geometry.reproducibilityLevel).toBe('canonical-request');
+  expect(geometry.args).toContain('--gbk');
+  expect(geometry.args).toContain('HmmtDNA.gbk');
+  expect(geometry.args).toContain('--separate_strands');
+  expect(geometry.args).toContain('--resolve_overlaps');
+  expect(geometry.exactReplayCommand).toBe('gbdraw linear --session out.gbdraw-session.json');
+  expect(geometry.reproducibilityLevel).toBe('exact-uploaded-files');
+  await page.evaluate(() => { window.__GBDRAW_APP__.resultPanelTab = 'run-info'; });
+  await expect(page.locator('.run-info-panel').getByText('Source recipe', { exact: true })).toBeVisible();
+  await expect(page.locator('.run-info-panel').getByText('Exact replay', { exact: true })).toBeVisible();
+  await expect(
+    page.locator('.run-info-panel').getByText('Reproducibility files', { exact: true })
+  ).toBeVisible();
+  await expect(page.locator('.run-info-panel')).toContainText(
+    'The Source recipe uses only the original source files.'
+  );
+  await expect(page.locator('.run-info-panel')).toContainText('Exact replay file:');
+  await expect(page.locator('.run-info-panel')).not.toContainText('Source recipe helper files:');
+  const sourceCopy = page.locator('.run-info-panel').getByTitle('Copy command');
+  const replayCopy = page.locator('.run-info-panel').getByTitle('Copy exact replay command');
+  await sourceCopy.click();
+  await expect(sourceCopy).toContainText('Copied');
+  await replayCopy.click();
+  await expect(replayCopy).toContainText('Copied');
+  const expectedReproducibilityFiles = await page.evaluate(() => (
+    window.__GBDRAW_APP__.lastRunInfo.helperFiles.map(({ name }) => name).sort()
+  ));
+  const reproducibilityDownload = page.waitForEvent('download', { timeout: 60000 });
+  await page.locator('.run-info-panel').getByRole('button', {
+    name: 'Download reproducibility files'
+  }).click();
+  const downloadedBundle = await reproducibilityDownload;
+  const downloadedBundlePath = await downloadedBundle.path();
+  expect(downloadedBundlePath).toBeTruthy();
+  expect(storedZipEntryNames(downloadedBundlePath).sort()).toEqual(expectedReproducibilityFiles);
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    app.lastRunInfo = {
+      ...app.lastRunInfo,
+      sourceRecipe: {
+        ...app.lastRunInfo.sourceRecipe,
+        helperFiles: [{ name: 'browser-comparison.tsv' }]
+      },
+      downloadBundle: {
+        ...app.lastRunInfo.downloadBundle,
+        description:
+          'Source recipe helper files: browser-comparison.tsv. Exact replay file: out.gbdraw-session.json.'
+      }
+    };
+  });
+  await expect(page.locator('.run-info-panel')).toContainText(
+    'Source recipe helper files: browser-comparison.tsv.'
+  );
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    app.lastRunInfo = {
+      ...app.lastRunInfo,
+      command: '',
+      sourceRecipe: {
+        ...app.lastRunInfo.sourceRecipe,
+        available: false,
+        command: '',
+        commandArgs: [],
+        invocation: null,
+        helperFiles: [],
+        unavailableReason:
+          'Source recipe unavailable: multiple uploaded inputs use the visible filename "genome.gbk".'
+      },
+      downloadBundle: {
+        ...app.lastRunInfo.downloadBundle,
+        description: 'The Source recipe is unavailable. Exact replay file: out.gbdraw-session.json.'
+      }
+    };
+  });
+  await expect(page.locator('.run-info-panel')).toContainText(
+    'multiple uploaded inputs use the visible filename "genome.gbk"'
+  );
+  await expect(page.locator('.run-info-panel').getByTitle('Copy command')).toHaveCount(0);
+  await expect(page.locator('.run-info-panel').getByTitle('Copy exact replay command')).toBeVisible();
   for (const bands of [geometry.client, geometry.bbox]) {
     for (const band of Object.values(bands)) {
       expect(Number.isFinite(band.top)).toBe(true);
@@ -2450,13 +2545,28 @@ test('Linear sparse diagonal depth generates and survives a session round trip',
   });
   expect(firstResult.depthAFills).toContain('#112233');
   expect(firstResult.depthBFills).toContain('#445566');
-  expect(firstResult.depthArgs).toEqual([]);
+  expect(firstResult.depthArgs).toEqual([
+    ['sample-a.tsv', ''],
+    ['', 'sample-b.tsv']
+  ]);
+  const firstRecipe = await page.evaluate(() => ({
+    available: window.__GBDRAW_APP__.lastRunInfo?.sourceRecipe?.available,
+    args: window.__GBDRAW_APP__.lastRunInfo?.sourceRecipe?.invocation?.args || [],
+    exactReplay: window.__GBDRAW_APP__.lastRunInfo?.exactReplay?.command || ''
+  }));
+  expect(firstRecipe.available).toBe(true);
+  expect(firstRecipe.args).toContain('BGC0000711.gbk');
+  expect(firstRecipe.args).toContain('BGC0000713.gbk');
+  expect(firstRecipe.exactReplay).toContain('--session');
 
   const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
   await page.evaluate(async () => window.__GBDRAW_APP__.saveSessionWithTitle());
   const download = await downloadPromise;
   const savedSessionPath = await download.path();
   expect(savedSessionPath).toBeTruthy();
+  const savedSession = JSON.parse(gunzipSync(readFileSync(savedSessionPath)).toString('utf8'));
+  expect(savedSession.webFiles.bindings.linearSeqs[0].depth[0].name).toBe('sample-a.tsv');
+  expect(savedSession.webFiles.bindings.linearSeqs[1].depth[1].name).toBe('sample-b.tsv');
 
   await page.reload({ waitUntil: 'domcontentloaded' });
   await waitForAppShell(page, { waitForPalette: false });
@@ -2476,6 +2586,7 @@ test('Linear sparse diagonal depth generates and survives a session round trip',
     const app = window.__GBDRAW_APP__;
     return {
       sparseRows: app.linearSeqs.map((seq) => seq.depth.map(Boolean)),
+      depthNames: app.linearSeqs.map((seq) => seq.depth.map((file) => file?.name || '')),
       labels: app.adv.depth_tracks.map((track) => track.label),
       colors: app.adv.depth_tracks.map((track) => track.color.toLowerCase()),
       slotIds: app.adv.linear_track_slots.map((slot) => slot.id),
@@ -2487,6 +2598,7 @@ test('Linear sparse diagonal depth generates and survives a session round trip',
   });
   expect(restoredState).toEqual({
     sparseRows: [[true, false], [false, true]],
+    depthNames: [['sample-a.tsv', ''], ['', 'sample-b.tsv']],
     labels: ['Sample A', 'Sample B'],
     colors: ['#112233', '#445566'],
     slotIds: ['depth_a', 'depth_b', 'features'],
@@ -2504,7 +2616,13 @@ test('Linear sparse diagonal depth generates and survives a session round trip',
   expect(secondResult.groups).toEqual(firstResult.groups);
   expect(secondResult.depthAFills).toContain('#112233');
   expect(secondResult.depthBFills).toContain('#445566');
-  expect(secondResult.depthArgs).toEqual([]);
+  expect(secondResult.depthArgs).toEqual(firstResult.depthArgs);
+  const secondRecipe = await page.evaluate(() => ({
+    available: window.__GBDRAW_APP__.lastRunInfo?.sourceRecipe?.available,
+    args: window.__GBDRAW_APP__.lastRunInfo?.sourceRecipe?.invocation?.args || [],
+    exactReplay: window.__GBDRAW_APP__.lastRunInfo?.exactReplay?.command || ''
+  }));
+  expect(secondRecipe).toEqual(firstRecipe);
 });
 
 test('Circular sparse diagonal depth survives a session round trip and track removal', async ({ page }) => {
@@ -2593,7 +2711,10 @@ test('Circular sparse diagonal depth survives a session round trip and track rem
   });
   expect(firstResult.depthAFills).toContain('#112233');
   expect(firstResult.depthBFills).toContain('#445566');
-  expect(firstResult.depthArgs).toEqual([]);
+  expect(firstResult.depthArgs).toEqual([
+    ['sample-a.tsv', ''],
+    ['', 'sample-b.tsv']
+  ]);
 
   const downloadPromise = page.waitForEvent('download', { timeout: 60000 });
   await page.evaluate(async () => window.__GBDRAW_APP__.saveSessionWithTitle());
@@ -2641,7 +2762,7 @@ test('Circular sparse diagonal depth survives a session round trip and track rem
   expect(secondResult.groups).toEqual(firstResult.groups);
   expect(secondResult.depthAFills).toContain('#112233');
   expect(secondResult.depthBFills).toContain('#445566');
-  expect(secondResult.depthArgs).toEqual([]);
+  expect(secondResult.depthArgs).toEqual(firstResult.depthArgs);
 
   await page.evaluate(() => window.__GBDRAW_APP__.removeCircularDepthTrack(1));
   await page.waitForFunction(() => {

--- a/tests/web/feature-catalog.test.mjs
+++ b/tests/web/feature-catalog.test.mjs
@@ -208,24 +208,63 @@ test('orthogroup members do not select one of multiple rendered references', () 
   assert.equal(member.renderedFeatureSvgId, '');
 });
 
-test('catalog presentation scope partitions local collinear groups without changing core scope', () => {
-  const localCatalog = structuredClone(catalog);
-  Object.assign(localCatalog.items[0].orthogroups[0], {
-    scope: 'cross_record',
-    presentationScope: 'adjacent_local',
-    collinearGroupScope: 'adjacent_local',
-    groupKind: 'collinear_gene_group'
-  });
-
-  const state = featureStateFromCatalog(
-    validateFeatureCatalog(localCatalog, results)
-  );
-
-  assert.deepEqual(state.orthogroups, []);
-  assert.equal(state.collinearGroups.length, 1);
-  assert.equal(state.collinearGroups[0].scope, 'cross_record');
-  assert.equal(state.collinearGroups[0].presentationScope, 'adjacent_local');
-  assert.equal(state.collinearGroups[0].members[0].proteinId, 'public-protein');
+test('catalog dual-projects collinear groups into semantic and presentation catalogs without changing core scope', () => {
+  for (const [presentationScope, groupKind] of [
+    ['adjacent_local', 'collinear_gene_group'], ['global_collinear', 'orthogroup']
+  ]) {
+    const mixed = structuredClone(catalog);
+    const item = mixed.items[0];
+    const proteins = ['a0', 'a1', 'a3', 'a4', 'a2', 'b0', 'b1'];
+    item.recordKeys = ['record_a', 'record_b'];
+    item.sequenceSources = item.recordKeys.map((recordKey, recordIndex) => ({
+      ...catalog.items[0].sequenceSources[0], key: recordKey, recordIndex
+    }));
+    item.biologicalFeatures = proteins.map((id, index) => ({
+      ...structuredClone(catalog.items[0].biologicalFeatures[0]),
+      recordKey: id.startsWith('a') ? 'record_a' : 'record_b',
+      record_id: id.startsWith('a') ? 'record_a' : 'record_b',
+      record_idx: id.startsWith('a') ? 0 : 1,
+      sequenceSourceIndex: id.startsWith('a') ? 0 : 1,
+      biologicalFeatureId: id,
+      stableFeatureId: id,
+      sourceFeatureIndex: index,
+      qualifiers: { protein_id: [id] }
+    }));
+    item.features = item.biologicalFeatures.map((feature) => ({
+      recordKey: feature.recordKey, biologicalFeatureId: feature.biologicalFeatureId,
+      svgId: feature.stableFeatureId, fillColor: '#abcdef'
+    }));
+    const member = (id, role) => ({
+      recordKey: id.startsWith('a') ? 'record_a' : 'record_b',
+      biologicalFeatureId: id, role
+    });
+    item.orthogroups = [{
+      id: 'og_1', scope: 'cross_record', presentationScope,
+      collinearGroupScope: presentationScope, groupKind,
+      members: [member('a0', 'anchor'), member('a1', 'inparalog'), member('b0', 'anchor')]
+    }, {
+      id: 'og_2', scope: 'record_local', source_record_index: 0,
+      presentationScope, collinearGroupScope: presentationScope, groupKind,
+      members: [member('a3', 'local_paralog'), member('a4', 'local_paralog')]
+    }];
+    const state = featureStateFromCatalog(validateFeatureCatalog(mixed, results));
+    assert.deepEqual(state.orthogroups.map((group) => group.id), ['og_1', 'og_2']);
+    assert.deepEqual(state.collinearGroups.map((group) => group.id), ['og_1']);
+    assert.strictEqual(state.orthogroups[0], state.collinearGroups[0]);
+    assert.equal(state.orthogroups[0].scope, 'cross_record');
+    assert.equal(state.orthogroups[1].scope, 'record_local');
+    assert.equal(state.orthogroups[1].source_record_index, 0);
+    assert.equal(state.collinearGroups[0].presentationScope, presentationScope);
+    assert.deepEqual(state.orthogroups[0].members.map((member) => member.proteinId), ['a0', 'a1', 'b0']);
+    for (const features of [state.extractedFeatures, state.biologicalFeatures]) {
+      assert.deepEqual(features.map((feature) => feature.orthogroupId || null), [
+        'og_1', 'og_1', 'og_2', 'og_2', null, 'og_1', null
+      ]);
+      assert.equal(features[1].orthogroupMember.role, 'inparalog');
+      assert.equal(features[2].orthogroupMember.role, 'local_paralog');
+      assert.equal(features[3].orthogroupMember.role, 'local_paralog');
+    }
+  }
 });
 
 test('catalog result topology must match the logical Results exactly', () => {

--- a/tests/web/interactive-svg-search-performance.playwright.spec.js
+++ b/tests/web/interactive-svg-search-performance.playwright.spec.js
@@ -233,9 +233,71 @@ with open(sys.argv[1], 'w', encoding='utf-8') as handle:
     });
   });
   await page.goto(pathToFileURL(svgPath).href);
-  await page.locator('[data-gbdraw-pairwise-match-id="m1"]').click();
-  await expect(page.locator('[data-gbdraw-pairwise-match-id="m1"]'))
+  const firstMatch = page.locator('[data-gbdraw-pairwise-match-id="m1"]');
+  const secondMatch = page.locator('[data-gbdraw-pairwise-match-id="m2"]');
+  await expect(firstMatch).toHaveAttribute('role', 'button');
+  await expect(firstMatch).toHaveAttribute('tabindex', '0');
+
+  await firstMatch.hover();
+  await page.mouse.down();
+  const pendingStyle = await firstMatch.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      focused: element === document.activeElement,
+      focusVisible: element.matches(':focus-visible'),
+      outlineStyle: style.outlineStyle,
+      stroke: style.stroke
+    };
+  });
+  expect(pendingStyle).toEqual({
+    focused: true,
+    focusVisible: false,
+    outlineStyle: 'none',
+    stroke: 'rgb(245, 158, 11)'
+  });
+  await expect(firstMatch).toHaveClass(/gbdraw-interactive-pairwise-match--pending/);
+  await expect(firstMatch).not.toHaveClass(/gbdraw-interactive-pairwise-match--selected/);
+  await expect(page.locator('.gfi-title')).toHaveCount(0);
+  await firstMatch.dispatchEvent('pointercancel', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'mouse'
+  });
+  await expect(firstMatch).not.toHaveClass(/gbdraw-interactive-pairwise-match--pending/);
+  await page.mouse.move(1, 1);
+  await page.mouse.up();
+
+  await firstMatch.dispatchEvent('pointerdown', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 2,
+    pointerType: 'mouse'
+  });
+  await secondMatch.dispatchEvent('pointerdown', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 3,
+    pointerType: 'mouse'
+  });
+  await expect(firstMatch).not.toHaveClass(/gbdraw-interactive-pairwise-match--pending/);
+  await expect(secondMatch).toHaveClass(/gbdraw-interactive-pairwise-match--pending/);
+  await secondMatch.dispatchEvent('pointercancel', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 3,
+    pointerType: 'mouse'
+  });
+  await expect(secondMatch).not.toHaveClass(/gbdraw-interactive-pairwise-match--pending/);
+
+  await firstMatch.click();
+  await expect(firstMatch)
     .toHaveClass(/gbdraw-interactive-pairwise-match--selected/);
+  await expect(firstMatch).not.toHaveClass(/gbdraw-interactive-pairwise-match--pending/);
   await expect(page.locator('.gfi-title')).toHaveText('Pairwise match');
   const sectionTitles = await page.locator('.gfi-block-title').allTextContents();
   expect(sectionTitles).toEqual([
@@ -272,7 +334,7 @@ with open(sys.argv[1], 'w', encoding='utf-8') as handle:
   await page.locator('[data-close]').click();
   await expect(page.locator('[data-gbdraw-pairwise-match-id="m1"]'))
     .not.toHaveClass(/gbdraw-interactive-pairwise-match--selected/);
-  await page.locator('[data-gbdraw-pairwise-match-id="m2"]').click();
+  await secondMatch.click();
   const collinearTitles = await page.locator('.gfi-block-title').allTextContents();
   expect(collinearTitles).toEqual([
     'Collinear block spans',
@@ -296,6 +358,38 @@ with open(sys.argv[1], 'w', encoding='utf-8') as handle:
   await expect.poll(() => page.locator('[data-gbdraw-pairwise-match-id="m3"]')
     .evaluate((element) => getComputedStyle(element).outlineStyle))
     .toBe('none');
+
+  await page.locator('[data-close]').click();
+  await firstMatch.focus();
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.press('Tab');
+  await expect(firstMatch).toBeFocused();
+  const keyboardFocusStyle = await firstMatch.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      focusVisible: element.matches(':focus-visible'),
+      outlineColor: style.outlineColor,
+      outlineStyle: style.outlineStyle,
+      outlineWidth: style.outlineWidth
+    };
+  });
+  expect(keyboardFocusStyle).toEqual({
+    focusVisible: true,
+    outlineColor: 'rgb(37, 99, 235)',
+    outlineStyle: 'solid',
+    outlineWidth: '2px'
+  });
+  await firstMatch.press('Enter');
+  await expect(page.locator('.gfi-title')).toHaveText('Pairwise match');
+  await expect(firstMatch).toHaveClass(/gbdraw-interactive-pairwise-match--selected/);
+  await expect.poll(() => firstMatch.evaluate((element) => getComputedStyle(element).outlineStyle))
+    .toBe('solid');
+  await page.locator('[data-close]').click();
+
+  await secondMatch.focus();
+  await secondMatch.press('Space');
+  await expect(page.locator('.gfi-title')).toHaveText('Collinearity block');
+  await expect(secondMatch).toHaveClass(/gbdraw-interactive-pairwise-match--selected/);
 });
 
 test('standalone homology popup exports exact spans and keeps missing comparison optional', async ({ page }, testInfo) => {

--- a/tests/web/interactive-svg-v3.playwright.spec.js
+++ b/tests/web/interactive-svg-v3.playwright.spec.js
@@ -276,6 +276,7 @@ test('browser export embeds the exact selected schema-3 item and expands referen
     });
   });
   await page.goto(pathToFileURL(svgPath).href);
+  await page.clock.install();
 
   const expandedFeatures = await page.evaluate(
     () => window.__expandedCatalogFeatures
@@ -314,19 +315,152 @@ test('browser export embeds the exact selected schema-3 item and expands referen
   await expect(memberBlock.locator('tbody tr')).toHaveCount(2);
   await expect(memberBlock).toContainText('Visible protein');
   await expect(memberBlock).toContainText('Hidden override');
-  await memberBlock.locator('.gfi-block-actions').getByRole('button', {
-    name: 'Copy aa (2)'
-  }).click();
+  const groupCopyButtons = memberBlock.locator(
+    '.gfi-block-actions [data-copy-feedback-key]'
+  );
+  const groupNtCopy = groupCopyButtons.nth(0);
+  const groupAaCopy = groupCopyButtons.nth(1);
+  await expect(groupNtCopy).toHaveText('Copy nt (2)');
+  await expect(groupAaCopy).toHaveText('Copy aa (2)');
+  await groupAaCopy.click();
   await expect.poll(() => page.evaluate(() => window.__copiedText)).toContain('>VP_1');
   const copied = await page.evaluate(() => window.__copiedText);
   expect(copied).toContain('>HP_1');
   expect(copied).toContain('MHIDDEN');
-  await memberBlock.locator('.gfi-block-actions').getByRole('button', {
-    name: 'Copy nt (2)'
-  }).click();
+  await expect(groupAaCopy).toHaveText('Copied!');
+  await expect(groupAaCopy).toHaveAccessibleName('Copied!');
+  await expect(groupAaCopy).toHaveAttribute('aria-live', 'polite');
+  await expect(groupAaCopy).toHaveAttribute('aria-atomic', 'true');
+  await expect(groupNtCopy).toHaveText('Copy nt (2)');
+
+  await page.getByRole('button', { name: 'Qualifiers', exact: true }).click();
+  await page.getByRole('button', { name: 'Details', exact: true }).click();
+  await expect(groupAaCopy).toHaveText('Copied!');
+  await page.clock.fastForward(1500);
+  await expect(groupAaCopy).toHaveText('Copy aa (2)');
+
+  const firstMemberCopyButtons = memberBlock.locator(
+    'tbody tr'
+  ).first().locator('[data-copy-feedback-key]');
+  const secondMemberAaCopy = memberBlock.locator(
+    'tbody tr'
+  ).nth(1).locator('[data-copy-feedback-key]').nth(1);
+  const firstMemberAaCopy = firstMemberCopyButtons.nth(1);
+  await firstMemberAaCopy.click();
+  await expect(firstMemberAaCopy).toHaveText('Copied!');
+  await expect(secondMemberAaCopy).toHaveText('Copy aa');
+  expect(await page.evaluate(() => window.__copiedText)).toContain('>VP_1');
+  expect(await page.evaluate(() => window.__copiedText)).not.toContain('>HP_1');
+  await page.clock.fastForward(1500);
+  await expect(firstMemberAaCopy).toHaveText('Copy aa');
+
+  await groupNtCopy.click();
+  await expect(groupNtCopy).toHaveText('Copied!');
+  await expect(groupAaCopy).toHaveText('Copy aa (2)');
   const copiedNucleotide = await page.evaluate(() => window.__copiedText);
   expect(copiedNucleotide).toContain('ATGAAATAA');
   expect(copiedNucleotide).toContain('ATGCCCTAA');
+  await page.clock.fastForward(1500);
+
+  await page.evaluate(() => {
+    window.__manualCopy = null;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => { throw new Error('denied'); } }
+    });
+    window.prompt = (_title, value) => {
+      window.__manualCopy = String(value);
+      return null;
+    };
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText('Copy manually');
+  await expect(groupAaCopy).not.toHaveText('Copied!');
+  expect(await page.evaluate(() => window.__manualCopy)).toBe(copied);
+  await page.clock.fastForward(1500);
+  await expect(groupAaCopy).toHaveText('Copy aa (2)');
+
+  await page.evaluate(() => {
+    window.__manualCopy = null;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {}
+    });
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText('Copy manually');
+  expect(await page.evaluate(() => window.__manualCopy)).toBe(copied);
+  await page.clock.fastForward(1500);
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => { throw new Error('denied'); } }
+    });
+    window.prompt = () => { throw new Error('prompt failed'); };
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText('Copy failed');
+  await expect(groupAaCopy).not.toHaveText('Copied!');
+  await page.clock.fastForward(1500);
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (value) => { window.__copiedText = String(value); }
+      }
+    });
+  });
+  await groupAaCopy.click();
+  await page.clock.fastForward(1000);
+  await groupAaCopy.click();
+  await page.clock.fastForward(600);
+  await expect(groupAaCopy).toHaveText('Copied!');
+  await page.clock.fastForward(900);
+  await expect(groupAaCopy).toHaveText('Copy aa (2)');
+
+  await page.evaluate(() => {
+    window.__copyResolvers = [];
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (value) => {
+          window.__copiedText = String(value);
+          return new Promise((resolve, reject) => {
+            window.__copyResolvers.push({ reject, resolve });
+          });
+        }
+      }
+    });
+  });
+  await groupAaCopy.click();
+  await groupAaCopy.click();
+  await page.evaluate(() => window.__copyResolvers[1].resolve());
+  await expect(groupAaCopy).toHaveText('Copied!');
+  await page.evaluate(() => window.__copyResolvers[0].reject(new Error('stale denial')));
+  await expect(groupAaCopy).toHaveText('Copied!');
+  await page.clock.fastForward(1500);
+  await expect(groupAaCopy).toHaveText('Copy aa (2)');
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (value) => { window.__copiedText = String(value); }
+      }
+    });
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText('Copied!');
+  await page.locator('[data-close]').click();
+  await page.locator('[data-gbdraw-rendered-feature-id="rendered-visible"]').click();
+  const reopenedMemberBlock = page.locator('.gfi-block').filter({
+    hasText: 'Similarity-group members'
+  }).last();
+  await expect(reopenedMemberBlock.locator(
+    '.gfi-block-actions [data-copy-feedback-key]'
+  ).nth(1)).toHaveText('Copy aa (2)');
 
   await page.locator('[data-close]').click();
   await page.locator('[data-gbdraw-rendered-feature-id="rendered-collision"]').click();

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -157,7 +157,7 @@ const installDiagramRequestObserver = async (page) => {
   });
 };
 
-test('Similarity-group popup selects every OG match without a focus outline', async ({ page }) => {
+test('Pairwise pointer feedback commits selection and preserves keyboard focus', async ({ page }) => {
   await openApp(page, { waitForPalette: false });
 
   await page.evaluate(async () => {
@@ -194,22 +194,119 @@ test('Similarity-group popup selects every OG match without a focus outline', as
   const otherOgMatch = page.getByRole('button', { name: 'Pairwise match 3', exact: true });
   const pairwiseMatch = page.getByRole('button', { name: 'Pairwise match 4', exact: true });
   await expect(firstOgMatch).toBeVisible();
-  await firstOgMatch.press('Enter');
+
+  await firstOgMatch.dispatchEvent('pointerdown', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'mouse'
+  });
+  const pendingStyle = await firstOgMatch.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      outlineStyle: style.outlineStyle,
+      stroke: style.stroke
+    };
+  });
+  expect(pendingStyle).toEqual({
+    outlineStyle: 'none',
+    stroke: 'rgb(245, 158, 11)'
+  });
+  await expect(firstOgMatch).toHaveClass(/\bgbdraw-match-pending\b/);
+  await expect(firstOgMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);
+  await expect(page.getByRole('dialog', { name: 'Pairwise match details' })).toHaveCount(0);
+  await firstOgMatch.dispatchEvent('pointercancel', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'mouse'
+  });
+  await expect(firstOgMatch).not.toHaveClass(/\bgbdraw-match-pending\b/);
+
+  await firstOgMatch.dispatchEvent('pointerdown', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 2,
+    pointerType: 'mouse'
+  });
+  await otherOgMatch.dispatchEvent('pointerdown', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 3,
+    pointerType: 'mouse'
+  });
+  await expect(firstOgMatch).not.toHaveClass(/\bgbdraw-match-pending\b/);
+  await expect(otherOgMatch).toHaveClass(/\bgbdraw-match-pending\b/);
+  await otherOgMatch.dispatchEvent('pointerup', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 3,
+    pointerType: 'mouse'
+  });
+  await expect(otherOgMatch).not.toHaveClass(/\bgbdraw-match-pending\b/);
+  await otherOgMatch.dispatchEvent('pointerdown', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 4,
+    pointerType: 'mouse'
+  });
+  await otherOgMatch.dispatchEvent('pointercancel', {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 4,
+    pointerType: 'mouse'
+  });
+  await expect(otherOgMatch).not.toHaveClass(/\bgbdraw-match-pending\b/);
+
+  await firstOgMatch.dispatchEvent('click', { bubbles: true });
 
   await expect(page.getByRole('dialog', { name: 'Pairwise match details' })).toBeVisible();
   await expect(firstOgMatch).toHaveClass(/\bgbdraw-match-selected\b/);
   await expect(secondOgMatch).toHaveClass(/\bgbdraw-match-selected\b/);
   await expect(otherOgMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);
   await expect(pairwiseMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);
-  await expect.poll(() => firstOgMatch.evaluate((element) => getComputedStyle(element).outlineStyle))
-    .toBe('none');
 
   await page.getByRole('button', { name: 'Close match popup' }).click();
   await expect(page.getByRole('dialog', { name: 'Pairwise match details' })).toHaveCount(0);
   await expect(firstOgMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);
   await expect(secondOgMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);
 
-  await pairwiseMatch.press('Enter');
+  await firstOgMatch.focus();
+  await page.keyboard.press('Shift+Tab');
+  await page.keyboard.press('Tab');
+  await expect(firstOgMatch).toBeFocused();
+  const keyboardFocusStyle = await firstOgMatch.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      focusVisible: element.matches(':focus-visible'),
+      outlineColor: style.outlineColor,
+      outlineStyle: style.outlineStyle,
+      outlineWidth: style.outlineWidth
+    };
+  });
+  expect(keyboardFocusStyle).toEqual({
+    focusVisible: true,
+    outlineColor: 'rgb(37, 99, 235)',
+    outlineStyle: 'solid',
+    outlineWidth: '2px'
+  });
+  await firstOgMatch.press('Enter');
+  await expect(page.getByRole('dialog', { name: 'Pairwise match details' })).toBeVisible();
+  await expect(firstOgMatch).toHaveClass(/\bgbdraw-match-selected\b/);
+  await expect.poll(() => firstOgMatch.evaluate((element) => getComputedStyle(element).outlineStyle))
+    .toBe('solid');
+  await page.getByRole('button', { name: 'Close match popup' }).click();
+
+  await pairwiseMatch.focus();
+  await pairwiseMatch.press('Space');
+  await expect(page.getByRole('dialog', { name: 'Pairwise match details' })).toBeVisible();
   await expect(pairwiseMatch).toHaveClass(/\bgbdraw-match-selected\b/);
   await expect(firstOgMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);
   await expect(secondOgMatch).not.toHaveClass(/\bgbdraw-match-selected\b/);

--- a/tests/web/orthogroups-stable-identity.test.mjs
+++ b/tests/web/orthogroups-stable-identity.test.mjs
@@ -67,10 +67,44 @@ const orthogroupSource = (await readFile(
 );
 await writeFile(join(tempDir, 'app', 'orthogroups.js'), orthogroupSource, 'utf8');
 
+let copyFeedbackNow = 0;
+let nextCopyFeedbackTimerId = 1;
+const copyFeedbackTimers = new Map();
+const setCopyFeedbackTimeout = (callback, delay) => {
+  const timerId = nextCopyFeedbackTimerId;
+  nextCopyFeedbackTimerId += 1;
+  copyFeedbackTimers.set(timerId, {
+    callback,
+    dueAt: copyFeedbackNow + Number(delay || 0)
+  });
+  return timerId;
+};
+const clearCopyFeedbackTimeout = (timerId) => {
+  copyFeedbackTimers.delete(timerId);
+};
+const advanceCopyFeedbackTime = (duration) => {
+  const target = copyFeedbackNow + duration;
+  while (true) {
+    const next = Array.from(copyFeedbackTimers.entries())
+      .filter(([, timer]) => timer.dueAt <= target)
+      .sort((left, right) => left[1].dueAt - right[1].dueAt)[0];
+    if (!next) break;
+    const [timerId, timer] = next;
+    copyFeedbackTimers.delete(timerId);
+    copyFeedbackNow = timer.dueAt;
+    timer.callback();
+  }
+  copyFeedbackNow = target;
+};
+
 globalThis.window = {
   Vue: {
-    computed: (getter) => ({ get value() { return getter(); } })
-  }
+    computed: (getter) => ({ get value() { return getter(); } }),
+    reactive: (value) => value,
+    watch: () => () => {}
+  },
+  setTimeout: setCopyFeedbackTimeout,
+  clearTimeout: clearCopyFeedbackTimeout
 };
 globalThis.isSecureContext = true;
 let copiedText = '';
@@ -1246,6 +1280,7 @@ const state = {
   orthogroupSearch: ref(''),
   orthogroupSortMode: ref('id'),
   selectedOrthogroupAlignmentFeature: ref(''),
+  clickedFeature: ref(null),
   svgContainer: ref({ querySelector: () => svg }),
   linearSeqs: [
     { definition: 'record-a' },
@@ -1367,14 +1402,132 @@ assert.equal(duplicateSequenceMember.aminoAcidSequence, undefined);
 state.biologicalFeatures.value = originalBiologicalFeatures;
 assert.equal(editor.getOrthogroupSequenceCount(group, 'nt'), 3);
 await editor.copyOrthogroupSequences(group, 'nt');
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'nt', 'Copy nt'),
+  'Copied!'
+);
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa'),
+  'Copy aa'
+);
 assert.match(copiedText, /AAAA/);
 assert.match(copiedText, /CCCC/);
 assert.match(copiedText, /GGGG/);
+const copiedNucleotidePayload = copiedText;
 await editor.copyOrthogroupSequences(group, 'aa');
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa'),
+  'Copied!'
+);
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'nt', 'Copy nt'),
+  'Copied!'
+);
 assert.match(copiedText, />LOC_A\b/);
 assert.match(copiedText, />LOC_B\b/);
 assert.match(copiedText, />CAG34720\.1\b/);
 assert.doesNotMatch(copiedText, /h_[a-z2-7]{26}/);
+const copiedAminoAcidPayload = copiedText;
+
+await editor.copyOrthogroupMemberSequence(members[0], 'aa', group);
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'aa', members[0]),
+  'Copied!'
+);
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'aa', members[1]),
+  'aa'
+);
+assert.match(copiedText, /^>LOC_A\b/);
+
+const originalClipboardWriteText = navigator.clipboard.writeText;
+globalThis.document = {
+  createElement: () => ({
+    value: '',
+    setAttribute() {},
+    style: {},
+    select() {},
+    remove() {}
+  }),
+  body: { appendChild() {} },
+  execCommand: () => false
+};
+navigator.clipboard.writeText = async () => {
+  throw new Error('denied');
+};
+await editor.copyOrthogroupSequences(group, 'aa', 'failure-case');
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa', null, 'failure-case'),
+  'Copy failed'
+);
+assert.notEqual(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa', null, 'failure-case'),
+  'Copied!'
+);
+
+navigator.clipboard.writeText = undefined;
+globalThis.document.execCommand = () => true;
+await editor.copyOrthogroupSequences(group, 'aa', 'fallback-case');
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa', null, 'fallback-case'),
+  'Copied!'
+);
+
+let rejectFirstCopy;
+let resolveSecondCopy;
+navigator.clipboard.writeText = () => new Promise((resolve, reject) => {
+  if (!rejectFirstCopy) rejectFirstCopy = reject;
+  else resolveSecondCopy = resolve;
+});
+const firstCopy = editor.copyOrthogroupSequences(group, 'aa', 'race-case');
+const secondCopy = editor.copyOrthogroupSequences(group, 'aa', 'race-case');
+resolveSecondCopy();
+await secondCopy;
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa', null, 'race-case'),
+  'Copied!'
+);
+rejectFirstCopy(new Error('stale denial'));
+await firstCopy;
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa', null, 'race-case'),
+  'Copied!'
+);
+
+navigator.clipboard.writeText = async () => {};
+await editor.copyOrthogroupSequences(group, 'aa', 'rapid-case');
+advanceCopyFeedbackTime(1000);
+await editor.copyOrthogroupSequences(group, 'aa', 'rapid-case');
+advanceCopyFeedbackTime(600);
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa (2)', null, 'rapid-case'),
+  'Copied!'
+);
+advanceCopyFeedbackTime(900);
+assert.equal(
+  editor.orthogroupCopyFeedbackLabel(group, 'aa', 'Copy aa (2)', null, 'rapid-case'),
+  'Copy aa (2)'
+);
+
+advanceCopyFeedbackTime(1600);
+for (const [sequenceKind, originalLabel, member, context] of [
+  ['nt', 'Copy nt', null, 'drawer'],
+  ['aa', 'Copy aa', null, 'drawer'],
+  ['aa', 'aa', members[0], 'drawer'],
+  ['aa', 'Copy aa', null, 'failure-case'],
+  ['aa', 'Copy aa', null, 'fallback-case'],
+  ['aa', 'Copy aa', null, 'race-case']
+]) {
+  assert.equal(
+    editor.orthogroupCopyFeedbackLabel(group, sequenceKind, originalLabel, member, context),
+    originalLabel
+  );
+}
+navigator.clipboard.writeText = originalClipboardWriteText;
+copiedText = copiedNucleotidePayload;
+assert.match(copiedText, /AAAA/);
+copiedText = copiedAminoAcidPayload;
+assert.match(copiedText, />CAG34720\.1\b/);
 
 const membersWithoutStableIds = editor.getEnrichedOrthogroupMembers({
   id: 'og_no_stable_ids',

--- a/tests/web/right-drawer.playwright.spec.js
+++ b/tests/web/right-drawer.playwright.spec.js
@@ -12,11 +12,219 @@ const loadGallerySession = async (page, filename) => page.evaluate(async (name) 
   });
 }, filename);
 
+const ISSUE_461_VIEWPORTS = [
+  { id: 'issue-desktop', width: 2541, height: 1409 },
+  { id: 'desktop-common', width: 1920, height: 1080 },
+  { id: 'laptop', width: 1366, height: 768 },
+  { id: 'narrow-supported', width: 1024, height: 768 }
+];
+
+const waitForSettledDrawer = async (page) => {
+  await page.locator('.right-drawer').evaluate(async (drawer) => {
+    await Promise.all(
+      drawer.getAnimations().map((animation) => animation.finished.catch(() => {}))
+    );
+  });
+  await page.locator('.drawer-toggle').evaluate(async (toggle) => {
+    await Promise.all(
+      toggle.getAnimations().map((animation) => animation.finished.catch(() => {}))
+    );
+  });
+};
+
+const readSettledPreviewSurface = async (page) => page.locator(
+  '.gbdraw-preview-surface'
+).evaluate(async (surface) => {
+  await Promise.all(
+    surface.getAnimations().map((animation) => animation.finished.catch(() => {}))
+  );
+  const box = surface.getBoundingClientRect();
+  return {
+    left: box.left,
+    top: box.top,
+    width: box.width,
+    height: box.height,
+    transform: surface.style.transform
+  };
+});
+
+const readOverlayGeometry = (page) => page.evaluate(() => {
+  const preview = document.querySelector('[role="region"][aria-label="Result Preview"]');
+  const toggle = document.querySelector('.drawer-toggle');
+  const controls = document.querySelector('.preview-controls');
+  const zoomReset = document.querySelector('[aria-label="Reset zoom"]');
+  const zoomControls = zoomReset?.parentElement;
+  const drawer = document.querySelector('.right-drawer');
+  const rect = (element) => {
+    const box = element.getBoundingClientRect();
+    return {
+      left: box.left,
+      top: box.top,
+      right: box.right,
+      bottom: box.bottom,
+      width: box.width,
+      height: box.height
+    };
+  };
+  const receivesPointerAtCenter = (element) => {
+    const box = element.getBoundingClientRect();
+    const hit = document.elementFromPoint(
+      box.left + box.width / 2,
+      box.top + box.height / 2
+    );
+    return Boolean(hit && element.contains(hit));
+  };
+  if (!preview || !toggle || !controls || !zoomControls || !drawer) {
+    throw new Error('Issue #461 overlay controls are not mounted.');
+  }
+  return {
+    preview: rect(preview),
+    toggle: rect(toggle),
+    controls: rect(controls),
+    zoomControls: rect(zoomControls),
+    drawer: rect(drawer),
+    controlButtons: Array.from(controls.querySelectorAll('button')).map((button) => ({
+      name: button.getAttribute('aria-label') || button.getAttribute('title') || '',
+      box: rect(button),
+      receivesPointerAtCenter: receivesPointerAtCenter(button)
+    })),
+    toggleReceivesPointerAtCenter: receivesPointerAtCenter(toggle)
+  };
+});
+
+const boxOverlap = (first, second) => {
+  const x = Math.min(first.right, second.right) - Math.max(first.left, second.left);
+  const y = Math.min(first.bottom, second.bottom) - Math.max(first.top, second.top);
+  return { x, y, intersects: x > 0 && y > 0 };
+};
+
+const logOverlayGeometry = (viewport, drawerState, geometry) => console.log(
+  `[issue-461] ${JSON.stringify({
+    viewport,
+    drawerState,
+    editorToggle: geometry.toggle,
+    zoomControls: geometry.zoomControls,
+    drawer: geometry.drawer,
+    toggleZoomOverlap: boxOverlap(geometry.toggle, geometry.zoomControls),
+    drawerZoomOverlap: boxOverlap(geometry.drawer, geometry.zoomControls)
+  })}`
+);
+
+const assertOverlayGeometry = (geometry, label, drawerOpen) => {
+  const toggleZoomOverlap = boxOverlap(geometry.toggle, geometry.zoomControls);
+  expect(
+    toggleZoomOverlap.intersects,
+    `${label}: editor toggle intersects zoom controls `
+      + `(overlapX=${toggleZoomOverlap.x}, overlapY=${toggleZoomOverlap.y})`
+  ).toBe(false);
+
+  if (drawerOpen) {
+    const drawerZoomOverlap = boxOverlap(geometry.drawer, geometry.zoomControls);
+    expect(
+      drawerZoomOverlap.intersects,
+      `${label}: open Editor drawer intersects zoom controls `
+        + `(overlapX=${drawerZoomOverlap.x}, overlapY=${drawerZoomOverlap.y})`
+    ).toBe(false);
+  }
+
+  const insidePreview = (box) => (
+    box.left >= geometry.preview.left
+    && box.top >= geometry.preview.top
+    && box.right <= geometry.preview.right
+    && box.bottom <= geometry.preview.bottom
+  );
+  for (const [name, box] of [
+    ['editor toggle', geometry.toggle],
+    ['preview controls', geometry.controls],
+    ['zoom controls', geometry.zoomControls]
+  ]) {
+    expect(insidePreview(box), `${label}: ${name} is outside Preview bounds`).toBe(true);
+  }
+  expect(geometry.toggleReceivesPointerAtCenter, `${label}: editor toggle is blocked`).toBe(true);
+  for (const button of geometry.controlButtons) {
+    expect(
+      insidePreview(button.box),
+      `${label}: ${button.name || 'unnamed control'} is outside Preview bounds`
+    ).toBe(true);
+    expect(
+      button.receivesPointerAtCenter,
+      `${label}: ${button.name || 'unnamed control'} is blocked`
+    ).toBe(true);
+  }
+};
+
+const exercisePreviewControls = async (page) => {
+  const zoomIn = page.getByRole('button', { name: 'Zoom in', exact: true });
+  const resetZoom = page.getByRole('button', { name: 'Reset zoom', exact: true });
+  const zoomOut = page.getByRole('button', { name: 'Zoom out', exact: true });
+
+  await resetZoom.click();
+  await expect(resetZoom).toContainText('100%');
+  await zoomIn.click();
+  await expect(resetZoom).toContainText('110%');
+  await resetZoom.click();
+  await expect(resetZoom).toContainText('100%');
+  await zoomOut.click();
+  await expect(resetZoom).toContainText('90%');
+  await resetZoom.click();
+  await expect(resetZoom).toContainText('100%');
+
+  const canvasPadding = page.getByRole('button', {
+    name: 'Toggle canvas padding controls',
+    exact: true
+  });
+  await canvasPadding.click();
+  await expect(page.getByText('Canvas Padding', { exact: true })).toBeVisible();
+  await canvasPadding.click();
+  await expect(page.getByText('Canvas Padding', { exact: true })).toBeHidden();
+};
+
 test.beforeEach(async ({ page }) => {
   page.on('dialog', (dialog) => dialog.accept());
   await page.goto('/gbdraw/web/index.html', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(() => window.__GBDRAW_APP__);
 });
+
+for (const viewport of ISSUE_461_VIEWPORTS) {
+  test(`zoom controls do not overlap the Editor toggle or drawer at ${viewport.id}`, async ({
+    page
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    const imported = await loadGallerySession(
+      page,
+      'majanivirus_orthogroup.gbdraw-session.json.gz'
+    );
+    expect(imported.status).toBe('ok');
+
+    const toggle = page.locator('.drawer-toggle');
+    const drawer = page.locator('.right-drawer');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await waitForSettledDrawer(page);
+    const initialSurface = await readSettledPreviewSurface(page);
+
+    const closedGeometry = await readOverlayGeometry(page);
+    logOverlayGeometry(viewport, 'closed', closedGeometry);
+    assertOverlayGeometry(closedGeometry, `${viewport.id} drawer closed`, false);
+    await exercisePreviewControls(page);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'false');
+    await waitForSettledDrawer(page);
+
+    const openGeometry = await readOverlayGeometry(page);
+    logOverlayGeometry(viewport, 'open', openGeometry);
+    assertOverlayGeometry(openGeometry, `${viewport.id} drawer open`, true);
+    await exercisePreviewControls(page);
+    expect(await readSettledPreviewSurface(page)).toEqual(initialSurface);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+    await waitForSettledDrawer(page);
+    expect(await readSettledPreviewSurface(page)).toEqual(initialSurface);
+  });
+}
 
 test('a remembered unavailable Similarity groups tab reopens as Features', async ({
   page

--- a/tests/web/right-drawer.playwright.spec.js
+++ b/tests/web/right-drawer.playwright.spec.js
@@ -268,6 +268,142 @@ test('a remembered unavailable Similarity groups tab reopens as Features', async
   ).toBe('features');
 });
 
+test('preview similarity-group copy actions report isolated accessible outcomes', async ({
+  page
+}) => {
+  const imported = await loadGallerySession(
+    page,
+    'majanivirus_orthogroup.gbdraw-session.json.gz'
+  );
+  expect(imported.status).toBe('ok');
+  await expect.poll(
+    () => page.evaluate(() => window.__GBDRAW_APP__.orthogroupCount)
+  ).toBeGreaterThan(0);
+  await page.clock.install();
+  await page.evaluate(() => {
+    window.__copiedText = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (value) => { window.__copiedText = String(value); }
+      }
+    });
+  });
+
+  const toggle = page.locator('.drawer-toggle');
+  const drawer = page.locator('.right-drawer');
+  await toggle.click();
+  await drawer.getByRole('button', { name: 'Similarity groups' }).click();
+  const groupNtCopy = drawer.locator(
+    'button[title="Copy all member nucleotide FASTA"]'
+  );
+  const groupAaCopy = drawer.locator(
+    'button[title="Copy all member amino-acid FASTA"]'
+  );
+  await expect(groupNtCopy).toHaveText(/Copy nt/);
+  await expect(groupAaCopy).toHaveText(/Copy aa/);
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText(/Copied!/);
+  await expect(groupAaCopy).toHaveAccessibleName('Copied!');
+  await expect(groupAaCopy).toHaveAttribute('aria-live', 'polite');
+  await expect(groupAaCopy).toHaveAttribute('aria-atomic', 'true');
+  await expect(groupNtCopy).toHaveText(/Copy nt/);
+  const groupAminoAcidPayload = await page.evaluate(() => window.__copiedText);
+  expect(groupAminoAcidPayload).toMatch(/^>/);
+  expect(groupAminoAcidPayload).not.toMatch(/h_[a-z2-7]{26}/i);
+  await page.clock.fastForward(1500);
+  await expect(groupAaCopy).toHaveText(/Copy aa/);
+
+  const firstMemberAaCopy = drawer.locator(
+    'button[title="Copy amino-acid FASTA"]'
+  ).first();
+  const secondMemberAaCopy = drawer.locator(
+    'button[title="Copy amino-acid FASTA"]'
+  ).nth(1);
+  await firstMemberAaCopy.click();
+  await expect(firstMemberAaCopy).toHaveText(/Copied!/);
+  await expect(secondMemberAaCopy).toHaveText(/^\s*aa\s*$/);
+  const memberAminoAcidPayload = await page.evaluate(() => window.__copiedText);
+  expect(memberAminoAcidPayload).toMatch(/^>/);
+  expect(groupAminoAcidPayload).toContain(memberAminoAcidPayload.trim());
+  await page.clock.fastForward(1500);
+  await expect(firstMemberAaCopy).toHaveText(/^\s*aa\s*$/);
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => { throw new Error('denied'); } }
+    });
+    document.execCommand = () => false;
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText(/Copy failed/);
+  await expect(groupAaCopy).not.toHaveText(/Copied!/);
+  await expect(groupNtCopy).toHaveText(/Copy nt/);
+  await page.clock.fastForward(1500);
+  await expect(groupAaCopy).toHaveText(/Copy aa/);
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {}
+    });
+    document.execCommand = () => true;
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText(/Copied!/);
+  await page.clock.fastForward(1500);
+
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (value) => { window.__copiedText = String(value); }
+      }
+    });
+  });
+  await groupAaCopy.click();
+  await expect(groupAaCopy).toHaveText(/Copied!/);
+  await toggle.click();
+  await toggle.click();
+  await expect(groupAaCopy).toHaveText(/Copy aa/);
+
+  const openedFeaturePopup = await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const feature = app.extractedFeatures.find((candidate) => (
+      candidate?.orthogroupId && candidate?.type === 'CDS'
+    ));
+    if (!feature) return false;
+    app.openFeatureEditorFromList(feature, null);
+    return Boolean(app.clickedFeature);
+  });
+  expect(openedFeaturePopup).toBe(true);
+  const featurePopup = page.locator('.feature-popup');
+  const popupGroupAaCopy = featurePopup.locator(
+    'button[title="Copy all member amino-acid FASTA"]'
+  );
+  const popupMemberAaCopy = featurePopup.locator(
+    'button[title="Copy amino-acid FASTA"]'
+  ).first();
+  await popupGroupAaCopy.click();
+  await expect(popupGroupAaCopy).toHaveText(/Copied!/);
+  await expect(popupMemberAaCopy).toHaveText(/^\s*aa\s*$/);
+  await featurePopup.getByRole('button', { name: 'Close feature popup' }).click();
+
+  expect(await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const feature = app.extractedFeatures.find((candidate) => (
+      candidate?.orthogroupId && candidate?.type === 'CDS'
+    ));
+    if (!feature) return false;
+    app.openFeatureEditorFromList(feature, null);
+    return Boolean(app.clickedFeature);
+  })).toBe(true);
+  await expect(featurePopup.locator(
+    'button[title="Copy all member amino-acid FASTA"]'
+  )).toHaveText(/Copy aa/);
+});
+
 test('individual Feature, Label, and Legend edits update the mounted SVG', { tag: '@pr-smoke' }, async ({
   page
 }) => {

--- a/tests/web/right-drawer.playwright.spec.js
+++ b/tests/web/right-drawer.playwright.spec.js
@@ -504,3 +504,129 @@ test('individual Feature, Label, and Legend edits update the mounted SVG', { tag
   expect(result.visibilityResultContent).toContain('display="none"');
   expect(result.legendResultContent).toContain('#ab3412');
 });
+
+test('adjacent Collinear mixed groups remain selectable after current-session save/load', async ({ page }, testInfo) => {
+  test.setTimeout(180000);
+  const { execFileSync } = require('node:child_process');
+  const { mkdirSync, readFileSync } = require('node:fs');
+  const { join } = require('node:path');
+  const { gunzipSync } = require('node:zlib');
+  const directory = testInfo.outputPath('mixed');
+  mkdirSync(directory, { recursive: true });
+  execFileSync('python', ['-c',
+    'import sys; from pathlib import Path; from tests.test_api_session import _record_local_collinear_session; _record_local_collinear_session(Path(sys.argv[1]))',
+    directory
+  ], { cwd: process.cwd(), stdio: 'pipe' });
+  const typedSession = readFileSync(join(directory, 'mixed.gbdraw-session.json'), 'utf8');
+  await page.setViewportSize({ width: 1600, height: 1000 });
+  await page.goto('/gbdraw/web/index.html', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => window.__GBDRAW_APP__);
+  // The Python writer has no active Web draft; derive it from this request.
+  const session = Buffer.from(await page.evaluate(async (source) => {
+    const { projectCanonicalSessionRequest } = await import('./js/services/session-request.js');
+    const document = JSON.parse(source);
+    document.config = projectCanonicalSessionRequest({
+      renderRequest: document.renderRequest, resources: document.resources,
+      webFiles: document.webFiles
+    }).config;
+    document.config.linearComparisonPlan = { mode: 'none', defaultSource: 'losat', edges: [] };
+    return JSON.stringify(document);
+  }, typedSession));
+  const importSession = async (bytes, name) => page.evaluate(async ({ bytes, name }) => {
+    const file = new File([new Uint8Array(bytes)], name);
+    const result = await window.__GBDRAW_APP__.importSession({ target: { files: [file], value: 'selected' } });
+    if (result.status !== 'ok') throw new Error(result.error?.stack || result.status);
+    return { status: result.status };
+  }, { bytes: [...bytes], name });
+  expect(await importSession(session, 'mixed.gbdraw-session.json')).toMatchObject({ status: 'ok' });
+
+  const verifyGroups = async () => {
+    const state = await page.evaluate(async () => {
+      const app = window.__GBDRAW_APP__;
+      const { state } = await import('./js/state.js');
+      return {
+        semantic: app.orthogroups.map((group) => group.id),
+        presentation: state.collinearGroups.value.map((group) => group.id),
+        features: app.extractedFeatures.map((feature) => ({
+          protein: feature.protein_id, group: feature.orthogroupId || null,
+          role: feature.orthogroupMember?.role || null
+        }))
+      };
+    });
+    expect(state.semantic).toEqual(['og_1', 'og_2']);
+    expect(state.presentation).toEqual(['og_1']);
+    expect(Object.fromEntries(state.features.map((feature) => [feature.protein, feature.group]))).toEqual({
+      a0: 'og_1', a1: 'og_1', a3: 'og_2', a4: 'og_2', a2: null, b0: 'og_1', b1: null
+    });
+    expect(state.features.find((feature) => feature.protein === 'a1').role).toBe('inparalog');
+    for (const id of ['a3', 'a4']) {
+      expect(state.features.find((feature) => feature.protein === id).role).toBe('local_paralog');
+    }
+    if (!await page.evaluate(() => window.__GBDRAW_APP__.showRightDrawer)) {
+      await page.locator('.drawer-toggle').click();
+    }
+    const drawer = page.locator('.right-drawer');
+    const groupsTab = drawer.getByRole('button', { name: 'Similarity groups' });
+    await expect(groupsTab).toBeVisible();
+    await groupsTab.click();
+    const paths = page.locator('.gbdraw-preview-surface path[data-match-kind="collinear"]');
+    await expect(paths).toHaveCount(1);
+    const geometry = await paths.evaluateAll((elements) => elements.map((element) => element.getAttribute('d')));
+    for (const [id, expectedMembers] of [['og_1', ['a0', 'a1', 'b0']], ['og_2', ['a3', 'a4']]]) {
+      const entry = drawer.locator('button').filter({ has: page.locator('.font-mono', { hasText: new RegExp(`^${id}$`) }) });
+      await expect(entry).toHaveCount(1);
+      await entry.click();
+      expect(await page.evaluate(() => window.__GBDRAW_APP__.selectedOrthogroupId)).toBe(id);
+      expect(await page.evaluate(() => window.__GBDRAW_APP__.selectedOrthogroup.members.map((member) => member.proteinId).sort())).toEqual(expectedMembers);
+      const highlight = drawer.getByRole('button', { name: /Highlight$/ });
+      await expect(highlight).toBeVisible();
+      await highlight.click();
+      const highlighted = await page.evaluate(() => {
+        const app = window.__GBDRAW_APP__;
+        return app.extractedFeatures.filter((feature) => [...document.querySelectorAll('[data-gbdraw-feature-id]')].some((element) =>
+          element.getAttribute('data-gbdraw-feature-id') === feature.svg_id && element.getAttribute('stroke') === '#2563eb'
+        )).map((feature) => feature.protein_id).sort();
+      });
+      expect(highlighted).toEqual(expectedMembers);
+      await expect(paths).toHaveCount(1);
+      await expect(paths).toHaveAttribute('data-orthogroup-id', 'og_1');
+      expect(await paths.evaluateAll((elements) => elements.map((element) => element.getAttribute('d')))).toEqual(geometry);
+      await expect(page.locator('.gbdraw-preview-surface path[data-orthogroup-id="og_2"]')).toHaveCount(0);
+    }
+    await page.screenshot({ path: testInfo.outputPath('mixed-groups.png'), fullPage: true });
+    await paths.dispatchEvent('click', { clientX: 500, clientY: 350 });
+    expect(await page.evaluate(() => {
+      const match = window.__GBDRAW_APP__.clickedPairwiseMatch;
+      return match?.blockOrthogroups.map((group) => group.memberRows.length);
+    })).toEqual([3]);
+    await page.keyboard.press('Escape');
+    return geometry;
+  };
+  const before = await verifyGroups();
+  const downloadPromise = page.waitForEvent('download');
+  await page.evaluate(async () => {
+    window.__GBDRAW_APP__.sessionTitle = 'issue460-round-trip';
+    await window.__GBDRAW_APP__.saveSessionWithTitle();
+  });
+  const download = await downloadPromise;
+  const saved = readFileSync(await download.path());
+  const document = JSON.parse(gunzipSync(saved).toString('utf8'));
+  expect(document.version).toBe(40);
+  expect(document.editorState.featureCatalog.items[0].orthogroups.map((group) => group.id)).toEqual(['og_1', 'og_2']);
+  expect(await importSession(saved, download.suggestedFilename())).toMatchObject({ status: 'ok' });
+  expect(await verifyGroups()).toEqual(before);
+  const rollback = await page.evaluate(async (bytes) => {
+    const { state } = await import('./js/state.js');
+    const { importSession } = await import('./js/services/config.js');
+    const previous = state.collinearGroups.value;
+    const result = await importSession({ target: {
+      files: [new File([new Uint8Array(bytes)], 'failed.gbdraw-session.json.gz')], value: 'selected'
+    } }, { beforePreviewMount: () => { throw new Error('Issue 460 rollback probe'); } });
+    return {
+      status: result.status, message: result.error?.message,
+      samePresentation: state.collinearGroups.value === previous
+    };
+  }, [...saved]);
+  expect(rollback).toEqual({ status: 'error', message: 'Issue 460 rollback probe', samePresentation: true });
+  expect(await verifyGroups()).toEqual(before);
+});

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -84,6 +84,24 @@ const workerResponses = [];
 const workerHelperResponses = [];
 const workerMessages = [];
 
+const assertDownloadedFilesMatchCommands = (runInfo, entries) => {
+  const expected = runInfo.helperFiles.map(({ name }) => name).sort();
+  const downloaded = entries.map(({ name }) => name).sort();
+  assert.deepEqual(downloaded, expected);
+  const expectedSet = new Set(expected);
+  const tableDependencies = entries.flatMap(({ text }) => {
+    const rows = String(text || '').trim().split('\n').map((line) => line.split('\t'));
+    const blastIndex = rows[0]?.indexOf('blast') ?? -1;
+    return blastIndex < 0 ? [] : rows.slice(1).map((row) => row[blastIndex]).filter(Boolean);
+  });
+  const referenced = Array.from(new Set([
+    ...(runInfo.sourceRecipe?.commandArgs || []),
+    ...(runInfo.exactReplay?.commandArgs || []),
+    ...tableDependencies
+  ].filter((token) => expectedSet.has(token)))).sort();
+  assert.deepEqual(referenced, expected);
+};
+
 class AuditSimplePathWorker {
   constructor() {
     this.listeners = new Map();
@@ -590,6 +608,10 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   assert.deepEqual(state.featureCatalog.value, committedCatalog);
   assert.equal(state.extractedFeatures.value.length, 1);
   assert.equal(state.biologicalFeatures.value.length, 1);
+  assert.equal(state.lastRunInfo.value.sourceRecipe.available, true);
+  assert.match(state.lastRunInfo.value.sourceRecipe.command, /--gbk active\.gb/);
+  assert.doesNotMatch(state.lastRunInfo.value.sourceRecipe.command, /--session/);
+  assert.match(state.lastRunInfo.value.exactReplay.command, /--session audit-simple\.gbdraw-session\.json/);
   assert.ok(
     lifecycleEvents.indexOf('generate.processing-published')
       < lifecycleEvents.indexOf('test.after-paint-returned')
@@ -635,6 +657,7 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   assert.equal(structuralMetrics.canonicalReplayFullSerializationCount, 1);
   assert.equal(downloadedFilename, 'audit-simple-cli-files.zip');
   const helperEntries = await storedZipEntries(downloadedBlob);
+  assertDownloadedFilesMatchCommands(state.lastRunInfo.value, helperEntries);
   const replayEntry = helperEntries.find(({ name }) => name.endsWith('.gbdraw-session.json'));
   assert.ok(replayEntry);
   const replay = JSON.parse(replayEntry.text);
@@ -1158,7 +1181,7 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
     capturedSequences = Array.from(options.sequences.values());
     return jobs.map((job) => ({
       cacheKey: job.cacheKey,
-      text: 'SECOND\tTHIRD\t100\t4\t0\t0\t1\t4\t1\t4\t1e-10\t20\n'
+      text: 'MIDDLE\tTHIRD\t100\t8\t0\t0\t1\t8\t1\t8\t1e-10\t20\n'
     }));
   };
 
@@ -1209,7 +1232,7 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
 
     resourceMetrics.splice(0);
     const linearTable = adoptCurrentSessionResources({
-      multi: encodedResource('genbank', 'multi.gb', [
+      multi: encodedResource('genbank', 'alpha.gbk.tsv', [
         'LOCUS       FIRST 8 bp DNA',
         'ORIGIN',
         '        1 aaaaaaaa',
@@ -1217,6 +1240,13 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
         'LOCUS       SECOND 8 bp DNA',
         'ORIGIN',
         '        1 aaccggtt',
+        '//',
+        ''
+      ].join('\n')),
+      middle: encodedResource('genbank', 'middle.gbk', [
+        'LOCUS       MIDDLE 8 bp DNA',
+        'ORIGIN',
+        '        1 ccccgggg',
         '//',
         ''
       ].join('\n')),
@@ -1229,6 +1259,7 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
       ].join('\n'))
     });
     const multiView = createSessionResourceFileView(linearTable, 'multi');
+    const middleView = createSessionResourceFileView(linearTable, 'middle');
     const thirdView = createSessionResourceFileView(linearTable, 'third');
     state.mode.value = 'linear';
     state.lInputType.value = 'gb';
@@ -1256,6 +1287,21 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
       region_end: 5,
       region_reverse: true
     }, {
+      uid: 'middle',
+      gb: middleView,
+      gff: null,
+      fasta: null,
+      depth: null,
+      blast: null,
+      losat_gencode: 1,
+      losat_filename: '',
+      definition: '',
+      record_subtitle: '',
+      region_record_id: 'MIDDLE',
+      region_start: null,
+      region_end: null,
+      region_reverse: false
+    }, {
       uid: 'third',
       gb: thirdView,
       gff: null,
@@ -1277,14 +1323,14 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
     });
     state.linearComparisonPlan.edges.splice(0, state.linearComparisonPlan.edges.length, {
       id: 'lazy-linear-edge',
-      queryUid: 'multi',
+      queryUid: 'middle',
       subjectUid: 'third',
       included: true,
       source: 'losat',
       file: null,
       fileActive: false,
-      losatFilename: '',
-      losatFilenameActive: false
+      losatFilename: 'alpha.gbk',
+      losatFilenameActive: true
     });
     state.files.linearCanonicalComparisons = [];
     state.losatProgram.value = 'blastn';
@@ -1303,7 +1349,7 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
     workerHelperResponses.push({
       ok: true,
       result: {
-        tsv: 'SECOND\tTHIRD\t100\t4\t0\t0\t1\t4\t1\t4\t1e-10\t20\n'
+        tsv: 'MIDDLE\tTHIRD\t100\t8\t0\t0\t1\t8\t1\t8\t1e-10\t20\n'
       }
     });
     workerResponses.push(response(linearResult, validCatalog(linearResult.name)));
@@ -1313,24 +1359,70 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
       JSON.stringify({ error: state.errorLog.value, lastWorker: workerMessages.at(-1) })
     );
     assert.equal(losatCalls, 1);
-    assert.ok(capturedSequences.includes('>SECOND\nACCG\n'));
+    assert.ok(capturedSequences.includes('>MIDDLE\nCCCCGGGG\n'));
     assert.ok(capturedSequences.includes('>THIRD\nTTTTAAAA\n'));
     const conversionRequest = workerMessages.findLast((message) => (
       message.type === 'helper' &&
       message.operation === 'convertLosatNucleotideToDisplayTsv'
     ));
     assert.deepEqual(conversionRequest?.payload.queryViewTransform, {
-      length: 4,
-      reverse: true
+      length: 8,
+      reverse: false
     });
     assert.equal(
       resourceMetrics.filter(({ name }) => name === 'resourceByteReadCount').length,
-      2
+      3
     );
     assert.equal(
       resourceMetrics.filter(({ name }) => name === 'resourceTextReadCount').length,
       0,
       'the explicit staged text fast path must not materialize file text again'
+    );
+    assert.equal(
+      state.lastRunInfo.value.sourceRecipe.available,
+      true,
+      state.lastRunInfo.value.sourceRecipe.unavailableReason
+    );
+    assert.match(
+      state.lastRunInfo.value.sourceRecipe.command,
+      /--gbk alpha\.gbk\.tsv middle\.gbk third\.gb/
+    );
+    assert.match(
+      state.lastRunInfo.value.sourceRecipe.command,
+      /--comparisons_table comparisons\.tsv/
+    );
+    assert.doesNotMatch(state.lastRunInfo.value.sourceRecipe.command, /\/blast_0\.txt/);
+    assert.equal(state.lastRunInfo.value.reproducibility.level, 'session-recommended');
+    assert.match(
+      state.lastRunInfo.value.reproducibility.notes.join('\n'),
+      /Download reproducibility files/
+    );
+    assert.match(state.lastRunInfo.value.exactReplay.command, /--session lazy-linear\.gbdraw-session\.json/);
+    runner.downloadCliHelperFiles();
+    assert.equal(downloadedFilename, 'lazy-linear-cli-files.zip');
+    const linearHelperEntries = await storedZipEntries(downloadedBlob);
+    assertDownloadedFilesMatchCommands(state.lastRunInfo.value, linearHelperEntries);
+    assert.ok(linearHelperEntries.some(({ name }) => name.endsWith('.gbdraw-session.json')));
+    const blastEntry = linearHelperEntries.find(({ name }) => name === 'alpha.gbk-2.tsv');
+    const comparisonsEntry = linearHelperEntries.find(({ name }) => name === 'comparisons.tsv');
+    assert.ok(blastEntry?.text.includes('MIDDLE\tTHIRD'));
+    assert.ok(comparisonsEntry);
+    const [comparisonHeader, comparisonRow] = comparisonsEntry.text.trim()
+      .split('\n')
+      .map((line) => line.split('\t'));
+    assert.equal(comparisonRow[comparisonHeader.indexOf('blast')], 'alpha.gbk-2.tsv');
+    assert.doesNotMatch(comparisonsEntry.text, /^alpha\.gbk\.tsv\t/m);
+    assert.deepEqual(
+      state.lastRunInfo.value.sourceRecipe.helperFiles.map(({ name }) => name).sort(),
+      ['alpha.gbk-2.tsv', 'comparisons.tsv']
+    );
+    assert.doesNotMatch(
+      [
+        ...state.lastRunInfo.value.sourceRecipe.commandArgs,
+        ...state.lastRunInfo.value.exactReplay.commandArgs,
+        ...linearHelperEntries.map(({ name }) => name)
+      ].join('\n'),
+      /comparison-nucleotide-|\/blast_0\.txt/
     );
 
     const committedLosatCache = state.losatCache.value;
@@ -1344,7 +1436,7 @@ test('neutral conservation replay delegates lazy resources to the shared reader'
     workerHelperResponses.push({
       ok: true,
       result: {
-        tsv: 'SECOND\tTHIRD\t100\t4\t0\t0\t1\t4\t1\t4\t1e-10\t20\n'
+        tsv: 'MIDDLE\tTHIRD\t100\t8\t0\t0\t1\t8\t1\t8\t1e-10\t20\n'
       }
     });
     const failedLinearResult = result('lazy-linear-failed.svg', 'lazy-linear-failed');

--- a/tests/web/run-info.test.mjs
+++ b/tests/web/run-info.test.mjs
@@ -1,26 +1,749 @@
 import assert from 'node:assert/strict';
-import { readFile, writeFile, mkdtemp } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { cp, readFile, stat, writeFile, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
+import test from 'node:test';
 import { pathToFileURL } from 'node:url';
 
 const repoRoot = process.cwd();
-const sourcePath = join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'run-info.js');
 const tempDir = await mkdtemp(join(tmpdir(), 'gbdraw-run-info-'));
-const modulePath = join(tempDir, 'run-info.mjs');
-await writeFile(modulePath, await readFile(sourcePath, 'utf8'), 'utf8');
+await cp(join(repoRoot, 'gbdraw', 'web', 'js'), join(tempDir, 'js'), { recursive: true });
+await writeFile(join(tempDir, 'package.json'), '{"type":"module"}', 'utf8');
+const modulePath = join(tempDir, 'js', 'app', 'run-info.js');
 
 const {
   buildRunInfo,
+  buildSourceRecipe,
   isCliInvocationSessionExportable,
   quoteShellArg,
   reproducibilityLabel
 } = await import(pathToFileURL(modulePath));
 
+const base64 = (text) => Buffer.from(text).toString('base64');
+const resource = (kind, name, text = 'fixture') => ({
+  kind,
+  name,
+  type: 'text/plain',
+  size: Buffer.byteLength(text),
+  lastModified: 0,
+  encoding: 'base64',
+  data: base64(text)
+});
+const presentation = () => ({
+  label: null,
+  subtitle: null,
+  reverseComplement: false,
+  gridRow: null,
+  gridColumn: null
+});
+const baseOptions = (mode) => ({
+  configOverrides: {
+    'canvas.show_gc': true,
+    'canvas.show_skew': true,
+    'canvas.show_depth': false,
+    'canvas.strandedness': false,
+    'canvas.resolve_overlaps': false,
+    'objects.scale.show': true,
+    [mode === 'circular' ? 'labels.circular.scope' : 'labels.linear.scope']: 'none'
+  },
+  tracks: {
+    circularTrackSlots: null,
+    circularTrackAxisIndex: null,
+    linearTrackSlots: null,
+    linearTrackAxisIndex: null,
+    centerReservedRadius: null
+  },
+  output: { legend: 'right', plotTitlePosition: mode === 'circular' ? 'none' : 'bottom' },
+  colors: {
+    colorTable: null,
+    colorTableFile: null,
+    defaultColors: null,
+    defaultColorsPalette: 'default',
+    defaultColorsFile: null
+  },
+  selectedFeaturesSet: ['CDS', 'rRNA'],
+  featureShapes: { repeat_region: 'underlay' },
+  dinucleotide: 'GC',
+  window: null,
+  step: null,
+  depthWindow: null,
+  depthStep: null,
+  plotTitle: null,
+  plotTitleFontSize: null
+});
+const canonical = ({ mode, records, resources, comparisons = [], webFiles = {} }) => ({
+  renderRequest: {
+    schema: 6,
+    mode,
+    grouping: 'single',
+    records,
+    diagramOptions: baseOptions(mode),
+    layout: {},
+    comparisons,
+    output: {
+      prefix: mode === 'circular' ? 'input' : 'comparison',
+      formats: ['svg'],
+      overwrite: false,
+      interactiveMetadataPolicy: 'auto'
+    }
+  },
+  resources,
+  webFiles
+});
+const assertCliParserAccepts = (recipe) => {
+  const visibleArgs = recipe.args.map((token) => recipe.fileMetadata.get(token)?.name || token);
+  const script = [
+    'import json, sys',
+    'from gbdraw.circular import _get_args as circular_args',
+    'from gbdraw.linear import _get_args as linear_args',
+    '(linear_args if sys.argv[1] == "linear" else circular_args)(json.loads(sys.argv[2]))'
+  ].join('; ');
+  const parsed = spawnSync(
+    process.env.PYTHON || 'python',
+    ['-c', script, recipe.mode, JSON.stringify(visibleArgs)],
+    { cwd: repoRoot, encoding: 'utf8' }
+  );
+  assert.equal(parsed.status, 0, parsed.stderr || parsed.stdout);
+};
+
+const materializeAndRunRecipe = async (session, recipe, info, fixture) => {
+  const runDir = await mkdtemp(join(tmpdir(), 'gbdraw-source-recipe-'));
+  const generatedFiles = Array.isArray(info.sourceRecipe.generatedFiles)
+    ? info.sourceRecipe.generatedFiles
+    : recipe.generatedFiles;
+  const namesBySlot = new Map(
+    info.sourceRecipe.invocation.fileBindings.map(({ slot, name }) => [slot, name])
+  );
+  for (const [path, metadata] of recipe.fileMetadata) {
+    if (metadata.kind === 'generated') {
+      const generated = generatedFiles.find((file) => file.path === path);
+      assert.ok(generated, `${fixture}: missing generated file ${path}`);
+      await writeFile(join(runDir, generated.name), generated.data);
+      continue;
+    }
+    const name = namesBySlot.get(metadata.slot) || metadata.name;
+    const descriptor = session.resources[metadata.resourceId];
+    assert.ok(descriptor, `${fixture}: missing resource ${metadata.resourceId}`);
+    const data = descriptor.encoding === 'base64'
+      ? Buffer.from(descriptor.data, 'base64')
+      : descriptor.data;
+    await writeFile(join(runDir, name), data);
+  }
+  const args = info.sourceRecipe.commandArgs.slice(2);
+  const executed = spawnSync(
+    process.env.PYTHON || 'python',
+    ['-m', 'gbdraw.cli', recipe.mode, ...args],
+    {
+      cwd: runDir,
+      encoding: 'utf8',
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        PYTHONPATH: [repoRoot, process.env.PYTHONPATH].filter(Boolean).join(delimiter)
+      }
+    }
+  );
+  assert.equal(executed.status, 0, `${fixture}: ${executed.stderr || executed.stdout}`);
+  const outputIndex = args.indexOf('-o');
+  assert.notEqual(outputIndex, -1, `${fixture}: emitted command lacks -o`);
+  const output = await stat(join(runDir, `${args[outputIndex + 1]}.svg`));
+  assert.ok(output.size > 0, `${fixture}: CLI emitted an empty SVG`);
+};
+
 assert.equal(quoteShellArg('simple.tsv'), 'simple.tsv');
 assert.equal(quoteShellArg('two words.tsv'), "'two words.tsv'");
-assert.equal(quoteShellArg("Bob's.gbk"), "'Bob'\\''s.gbk'");
+assert.equal(quoteShellArg("Bob's genome.gbk"), "'Bob'\\''s genome.gbk'");
 assert.equal(quoteShellArg(''), "''");
+
+let circularGallerySession = null;
+let linearGallerySession = null;
+for (const { fixture, mode } of [
+  { fixture: 'HmmtDNA_ATskew.gbdraw-session.json', mode: 'circular' },
+  { fixture: 'lambda_basic_linear.gbdraw-session.json', mode: 'linear' }
+]) {
+  const session = JSON.parse(await readFile(
+    join(repoRoot, 'gbdraw', 'web', 'gallery', 'sessions', fixture),
+    'utf8'
+  ));
+  if (mode === 'circular') circularGallerySession = session;
+  else linearGallerySession = session;
+  const sourceRecipe = buildSourceRecipe(session);
+  assert.equal(sourceRecipe.available, true, `${fixture}: ${sourceRecipe.unavailableReason}`);
+  assert.equal(sourceRecipe.mode, mode);
+  assert.ok(sourceRecipe.args.includes('--gbk'), `${fixture}: expected direct GenBank input`);
+  assert.ok(sourceRecipe.args.includes('-o'), `${fixture}: expected output prefix`);
+  assert.ok(sourceRecipe.args.includes('-f'), `${fixture}: expected output formats`);
+  assertCliParserAccepts(sourceRecipe);
+  const info = buildRunInfo({ mode: sourceRecipe.mode, sourceRecipe });
+  await materializeAndRunRecipe(session, sourceRecipe, info, fixture);
+}
+
+test('source recipe preserves selectedFeaturesSet empty, invalid, and non-empty semantics', async () => {
+  for (const value of ['absent', null]) {
+    const defaulted = structuredClone(circularGallerySession);
+    if (value === 'absent') delete defaulted.renderRequest.diagramOptions.selectedFeaturesSet;
+    else defaulted.renderRequest.diagramOptions.selectedFeaturesSet = value;
+    const defaultedRecipe = buildSourceRecipe(defaulted);
+    assert.equal(defaultedRecipe.available, true, defaultedRecipe.unavailableReason);
+    assert.equal(defaultedRecipe.args.includes('-k'), false);
+  }
+
+  const empty = structuredClone(circularGallerySession);
+  empty.renderRequest.diagramOptions.selectedFeaturesSet = [];
+  const emptyRecipe = buildSourceRecipe(empty);
+  assert.equal(emptyRecipe.available, true, emptyRecipe.unavailableReason);
+  assert.equal(emptyRecipe.args.includes('-k'), false);
+  assertCliParserAccepts(emptyRecipe);
+  const emptyInfo = buildRunInfo({ mode: 'circular', sourceRecipe: emptyRecipe });
+  await materializeAndRunRecipe(empty, emptyRecipe, emptyInfo, 'empty-selected-features');
+
+  const invalid = structuredClone(circularGallerySession);
+  invalid.renderRequest.diagramOptions.selectedFeaturesSet = [''];
+  const invalidRecipe = buildSourceRecipe(invalid);
+  assert.equal(invalidRecipe.available, false);
+  assert.match(invalidRecipe.unavailableReason, /selected feature|non-empty/i);
+
+  const nonEmpty = structuredClone(circularGallerySession);
+  nonEmpty.renderRequest.diagramOptions.selectedFeaturesSet = ['CDS', 'tRNA'];
+  const nonEmptyRecipe = buildSourceRecipe(nonEmpty);
+  assert.equal(nonEmptyRecipe.available, true, nonEmptyRecipe.unavailableReason);
+  const featureOptionIndex = nonEmptyRecipe.args.indexOf('-k');
+  assert.notEqual(featureOptionIndex, -1);
+  assert.equal(nonEmptyRecipe.args[featureOptionIndex + 1], 'CDS,tRNA');
+  assertCliParserAccepts(nonEmptyRecipe);
+});
+
+test('source recipe preserves canonical string track slots', async () => {
+  const stringSlot = structuredClone(circularGallerySession);
+  stringSlot.renderRequest.diagramOptions.tracks.circularTrackSlots = ['ticks:ticks'];
+  stringSlot.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = 0;
+  const stringRecipe = buildSourceRecipe(stringSlot);
+  assert.equal(stringRecipe.available, true, stringRecipe.unavailableReason);
+  const slotOptionIndex = stringRecipe.args.indexOf('--circular_track_slot');
+  assert.notEqual(slotOptionIndex, -1);
+  assert.equal(stringRecipe.args[slotOptionIndex + 1], 'ticks:ticks');
+  assert.equal(stringRecipe.args.includes('gc_skew:dinucleotide_skew'), false);
+  assertCliParserAccepts(stringRecipe);
+  const stringInfo = buildRunInfo({ mode: 'circular', sourceRecipe: stringRecipe });
+  await materializeAndRunRecipe(stringSlot, stringRecipe, stringInfo, 'ticks-string-slot');
+});
+
+test('source recipe serializes validated object slots without dropping child fields', () => {
+  const objectSlot = structuredClone(circularGallerySession);
+  objectSlot.renderRequest.diagramOptions.tracks.circularTrackSlots = [{
+    kind: 'circularTrackSlot',
+    id: 'ticks',
+    renderer: 'ticks',
+    enabled: true,
+    side: null,
+    radius: null,
+    width: null,
+    z: 0,
+    params: { tick_label_layout: 'label_out_tick_in' },
+    innerGapPx: null,
+    outerGapPx: null
+  }];
+  objectSlot.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = 0;
+  const objectRecipe = buildSourceRecipe(objectSlot);
+  assert.equal(objectRecipe.available, true, objectRecipe.unavailableReason);
+  const optionIndex = objectRecipe.args.indexOf('--circular_track_slot');
+  assert.match(
+    objectRecipe.args[optionIndex + 1],
+    /^ticks:ticks@tick_label_layout=label_out_tick_in$/
+  );
+  assertCliParserAccepts(objectRecipe);
+
+  const unsupportedChild = structuredClone(objectSlot);
+  unsupportedChild.renderRequest.diagramOptions.tracks.circularTrackSlots[0].params.nt = 'GC';
+  const unsupportedRecipe = buildSourceRecipe(unsupportedChild);
+  assert.equal(unsupportedRecipe.available, false);
+  assert.match(unsupportedRecipe.unavailableReason, /params\.nt|losslessly/i);
+});
+
+test('source recipe distinguishes absent, null, and explicit empty track slots', () => {
+  const absent = structuredClone(circularGallerySession);
+  delete absent.renderRequest.diagramOptions.tracks.circularTrackSlots;
+  delete absent.renderRequest.diagramOptions.tracks.circularTrackAxisIndex;
+  assert.equal(buildSourceRecipe(absent).available, true);
+
+  const nullSlots = structuredClone(circularGallerySession);
+  nullSlots.renderRequest.diagramOptions.tracks.circularTrackSlots = null;
+  nullSlots.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = null;
+  assert.equal(buildSourceRecipe(nullSlots).available, true);
+
+  const emptySlots = structuredClone(circularGallerySession);
+  emptySlots.renderRequest.diagramOptions.tracks.circularTrackSlots = [];
+  emptySlots.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = null;
+  const emptyRecipe = buildSourceRecipe(emptySlots);
+  const emptyInfo = buildRunInfo({
+    mode: 'circular',
+    sourceRecipe: emptyRecipe,
+    exactReplayArgs: ['--session', '/exact-session'],
+    fileMetadata: {
+      '/exact-session': {
+        name: 'exact-session.gbdraw-session.json',
+        slot: 'generatedFiles.canonical_render_session',
+        kind: 'generated'
+      }
+    }
+  });
+  assert.equal(emptyRecipe.available, false);
+  assert.match(emptyRecipe.unavailableReason, /empty.*track|track.*empty|no tracks/i);
+  assert.equal(emptyInfo.sourceRecipe.available, false);
+  assert.equal(emptyInfo.exactReplay.available, true);
+
+  for (const slot of ['future:future', 'ticks:ticks@nt=GC']) {
+    const invalid = structuredClone(circularGallerySession);
+    invalid.renderRequest.diagramOptions.tracks.circularTrackSlots = [slot];
+    assert.equal(buildSourceRecipe(invalid).available, false, slot);
+  }
+});
+
+test('allocated helper names propagate into comparisons.tsv and the executable recipe', async () => {
+  const genomeTemplate = linearGallerySession.resources['record-1-genbank'];
+  const collision = canonical({
+    mode: 'linear',
+    records: ['alpha', 'middle', 'omega'].map((recordKey, index) => ({
+      recordKey,
+      cardinality: 'exactly_one',
+      source: { kind: 'genbank', resourceId: `genome-${index + 1}` },
+      selector: null,
+      region: null,
+      presentation: presentation()
+    })),
+    resources: {
+      'genome-1': { ...genomeTemplate, name: 'genome-1.gbk' },
+      'genome-2': { ...genomeTemplate, name: 'genome-2.gbk' },
+      'genome-3': { ...genomeTemplate, name: 'genome-3.gbk' },
+      'comparison-nucleotide-1': resource(
+        'nucleotide-blast',
+        'comparison-nucleotide-1.tsv',
+        'NC_001416\tNC_001416\t100\t100\t0\t0\t1\t100\t1\t100\t1e-20\t200\n'
+      )
+    },
+    comparisons: [{
+      kind: 'nucleotideBlast',
+      resourceId: 'comparison-nucleotide-1',
+      queryRecordIndex: 1,
+      subjectRecordIndex: 2
+    }],
+    webFiles: {
+      resourceOriginalNames: {
+        'genome-1': 'alpha.gbk',
+        'genome-2': 'middle.gbk',
+        'genome-3': 'omega.gbk'
+      }
+    }
+  });
+  collision.generatedFileNameHints = new Map([
+    ['generatedFiles.losat_blasts[0]', 'alpha.gbk']
+  ]);
+  const recipe = buildSourceRecipe(collision);
+  const info = buildRunInfo({ mode: 'linear', sourceRecipe: recipe });
+
+  assert.equal(recipe.available, true, recipe.unavailableReason);
+  assertCliParserAccepts(recipe);
+  const generatedFiles = recipe.generatedFiles;
+  assert.ok(Array.isArray(generatedFiles));
+  const blast = generatedFiles.find(
+    ({ slot }) => slot === 'generatedFiles.source_recipe.comparison_blasts[0]'
+  );
+  const comparisonsTable = generatedFiles.find(
+    ({ slot }) => slot === 'generatedFiles.source_recipe.comparisons_table'
+  );
+  assert.equal(blast?.name, 'alpha-2.gbk');
+  assert.equal(comparisonsTable?.name, 'comparisons.tsv');
+  const [header, row] = comparisonsTable.data.trim().split('\n').map((line) => line.split('\t'));
+  assert.equal(row[header.indexOf('blast')], 'alpha-2.gbk');
+  assert.doesNotMatch(comparisonsTable.data, /^alpha\.gbk\t/m);
+  assert.match(info.sourceRecipe.command, /--comparisons_table comparisons\.tsv/);
+  assert.deepEqual(
+    info.sourceRecipe.helperFiles.map(({ name }) => name).sort(),
+    ['alpha-2.gbk', 'comparisons.tsv']
+  );
+  assert.deepEqual(
+    generatedFiles.map(({ name }) => name).sort(),
+    info.sourceRecipe.helperFiles.map(({ name }) => name).sort()
+  );
+  assert.doesNotMatch(
+    `${info.sourceRecipe.command}\n${comparisonsTable.data}\n${generatedFiles.map(({ name }) => name).join('\n')}`,
+    /comparison-nucleotide-1|run-info-resource/
+  );
+  await materializeAndRunRecipe(collision, recipe, info, 'collision-dependent-helper');
+});
+
+const circularCanonical = canonical({
+  mode: 'circular',
+  records: [{
+    recordKey: 'record-1',
+    cardinality: 'exactly_one',
+    source: { kind: 'genbank', resourceId: 'record-1-genbank' },
+    selector: null,
+    region: null,
+    presentation: presentation()
+  }],
+  resources: {
+    'record-1-genbank': resource(
+      'genbank', 'record-1-genbank-input_file.gbk', 'LOCUS       input\n//\n'
+    )
+  },
+  webFiles: {
+    circularOutputPrefixExplicit: true,
+    resourceOriginalNames: { 'record-1-genbank': 'input file.gbk' },
+    circularInputOriginalName: 'input file.gbk'
+  }
+});
+
+{
+  const sourceRecipe = buildSourceRecipe(circularCanonical);
+  assert.equal(sourceRecipe.available, true);
+  assertCliParserAccepts(sourceRecipe);
+  const info = buildRunInfo({
+    mode: 'circular',
+    sourceRecipe,
+    exactReplayArgs: ['--session', '/canonical-render-session.gbdraw-session.json'],
+    fileMetadata: {
+      '/canonical-render-session.gbdraw-session.json': {
+        name: "Bob's replay.gbdraw-session.json",
+        slot: 'generatedFiles.canonical_render_session',
+        kind: 'generated'
+      }
+    },
+    elapsedMs: 321,
+    resultCount: 1
+  });
+
+  assert.match(info.sourceRecipe.command, /--gbk 'input file\.gbk'/);
+  assert.equal(info.command, info.sourceRecipe.command);
+  assert.equal(
+    info.exactReplay.command,
+    "gbdraw circular --session 'Bob'\\''s replay.gbdraw-session.json'"
+  );
+  assert.notEqual(info.sourceRecipe.command, info.exactReplay.command);
+  assert.equal(info.elapsedMs, 321);
+  assert.equal(info.resultCount, 1);
+  assert.equal(info.reproducibility.level, 'exact-uploaded-files');
+}
+
+{
+  const apostropheName = structuredClone(circularCanonical);
+  apostropheName.webFiles.resourceOriginalNames['record-1-genbank'] = "Bob's genome.gbk";
+  const info = buildRunInfo({
+    mode: 'circular',
+    sourceRecipe: buildSourceRecipe(apostropheName)
+  });
+  assert.match(info.command, /--gbk 'Bob'\\''s genome\.gbk'/);
+}
+
+{
+  const multiRecord = canonical({
+    mode: 'circular',
+    records: ['alpha', 'beta'].map((recordId, index) => ({
+      recordKey: `record-${index + 1}`,
+      cardinality: 'exactly_one',
+      source: { kind: 'genbank', resourceId: 'multi-genbank' },
+      selector: { kind: 'recordId', value: recordId },
+      region: null,
+      presentation: {
+        ...presentation(),
+        label: recordId.toUpperCase()
+      }
+    })),
+    resources: {
+      'multi-genbank': resource(
+        'genbank',
+        'multi-genbank-two-records.gbk',
+        'LOCUS       alpha\n//\nLOCUS       beta\n//\n'
+      )
+    },
+    webFiles: {
+      resourceOriginalNames: { 'multi-genbank': 'two-records.gbk' }
+    }
+  });
+  multiRecord.renderRequest.layout = {
+    multiRecordSizeMode: 'equal',
+    multiRecordPositions: ['alpha@1', 'beta@2']
+  };
+  const sourceRecipe = buildSourceRecipe(multiRecord);
+
+  assert.equal(sourceRecipe.available, true, sourceRecipe.unavailableReason);
+  assertCliParserAccepts(sourceRecipe);
+  assert.ok(sourceRecipe.args.includes('--records_table'));
+  assert.ok(sourceRecipe.args.includes('--multi_record_canvas'));
+  assert.equal(sourceRecipe.args.includes('--multi_record_position'), false);
+  const recordsTable = sourceRecipe.generatedFiles.find((file) => file.name === 'records.tsv');
+  assert.ok(recordsTable);
+  assert.match(recordsTable.data, /two-records\.gbk\tALPHA\t\talpha\t\t0\t1\t1\t/);
+  assert.match(recordsTable.data, /two-records\.gbk\tBETA\t\tbeta\t\t0\t2\t2\t/);
+}
+
+const linearCanonical = canonical({
+  mode: 'linear',
+  records: [
+    {
+      recordKey: 'alpha',
+      cardinality: 'exactly_one',
+      source: { kind: 'genbank', resourceId: 'record-1-genbank' },
+      selector: null,
+      region: null,
+      presentation: presentation()
+    },
+    {
+      recordKey: 'beta',
+      cardinality: 'exactly_one',
+      source: { kind: 'genbank', resourceId: 'record-2-genbank' },
+      selector: null,
+      region: null,
+      presentation: presentation()
+    }
+  ],
+  resources: {
+    'record-1-genbank': resource(
+      'genbank', 'record-1-genbank-alpha.gbk', 'LOCUS       alpha\n//\n'
+    ),
+    'record-2-genbank': resource(
+      'genbank', 'record-2-genbank-beta.gbk', 'LOCUS       beta\n//\n'
+    ),
+    'comparison-nucleotide-1': resource('nucleotide-blast', 'comparison-nucleotide-1-alpha_vs_beta.tsv')
+  },
+  comparisons: [{
+    kind: 'nucleotideBlast',
+    resourceId: 'comparison-nucleotide-1',
+    queryRecordIndex: 0,
+    subjectRecordIndex: 1
+  }],
+  webFiles: {
+    resourceOriginalNames: {
+      'record-1-genbank': 'alpha.gbk',
+      'record-2-genbank': 'beta.gbk',
+      'comparison-nucleotide-1': 'alpha_vs_beta.tsv'
+    }
+  }
+});
+
+{
+  const direct = buildSourceRecipe(linearCanonical);
+  assert.equal(direct.available, true);
+  assertCliParserAccepts(direct);
+  const info = buildRunInfo({
+    mode: 'linear',
+    sourceRecipe: direct,
+    exactReplayArgs: ['--session', '/linear-canonical-session'],
+    fileMetadata: {
+      '/linear-canonical-session': {
+        name: 'comparison.gbdraw-session.json',
+        slot: 'generatedFiles.canonical_render_session',
+        kind: 'generated'
+      }
+    }
+  });
+  assert.match(info.command, /--gbk alpha\.gbk beta\.gbk/);
+  assert.match(info.command, /-b alpha_vs_beta\.tsv/);
+  assert.equal(
+    info.exactReplay.command,
+    'gbdraw linear --session comparison.gbdraw-session.json'
+  );
+
+  const restored = structuredClone(linearCanonical);
+  restored.webFiles.bindings = {
+    schema: 1,
+    linearSeqs: [
+      { gb: { resourceId: 'record-1-genbank', name: 'alpha.gbk' } },
+      { gb: { resourceId: 'record-2-genbank', name: 'beta.gbk' } }
+    ],
+    linearComparisons: [{
+      id: 'edge-1',
+      file: { resourceId: 'comparison-nucleotide-1', name: 'alpha_vs_beta.tsv' }
+    }]
+  };
+  delete restored.webFiles.resourceOriginalNames;
+  const roundTrip = buildSourceRecipe(restored);
+  assert.equal(roundTrip.available, true);
+  assert.deepEqual(roundTrip.args, direct.args);
+}
+
+{
+  const generatedHelper = structuredClone(linearCanonical);
+  delete generatedHelper.webFiles.resourceOriginalNames['comparison-nucleotide-1'];
+  generatedHelper.resources['comparison-nucleotide-1'].name =
+    'comparison-nucleotide-1-browser-comparison.tsv';
+  generatedHelper.generatedFileNameHints = new Map([
+    ['generatedFiles.losat_blasts[0]', 'browser-comparison.tsv']
+  ]);
+  const sourceRecipe = buildSourceRecipe(generatedHelper);
+  const info = buildRunInfo({ mode: 'linear', sourceRecipe });
+
+  assert.equal(sourceRecipe.available, true);
+  assert.match(info.command, /-b browser-comparison\.tsv/);
+  assert.doesNotMatch(info.command, /comparison-nucleotide-1-browser/);
+  assert.equal(sourceRecipe.generatedFiles.length, 1);
+  assert.equal(sourceRecipe.generatedFiles[0].name, 'browser-comparison.tsv');
+  assert.ok(info.sourceRecipe.helperFiles.every(({ name }) => !name.includes('comparison-nucleotide-1')));
+  assert.equal(info.reproducibility.level, 'session-recommended');
+  assert.match(info.reproducibility.notes.join('\n'), /Download reproducibility files/);
+
+  const invalidHint = structuredClone(generatedHelper);
+  invalidHint.generatedFileNameHints = new Map([
+    ['generatedFiles.losat_blasts[0]', '..']
+  ]);
+  const unavailable = buildSourceRecipe(invalidHint);
+  assert.equal(unavailable.available, false);
+  assert.match(unavailable.unavailableReason, /trustworthy visible filename/);
+}
+
+{
+  const duplicateUploads = structuredClone(linearCanonical);
+  duplicateUploads.webFiles.resourceOriginalNames['record-1-genbank'] = 'Genome.gbk';
+  duplicateUploads.webFiles.resourceOriginalNames['record-2-genbank'] = 'genome.GBK';
+  const sourceRecipe = buildSourceRecipe(duplicateUploads);
+
+  assert.equal(sourceRecipe.available, false);
+  assert.match(sourceRecipe.unavailableReason, /multiple required files.*genome\.GBK/i);
+}
+
+{
+  const sourceRecipe = {
+    available: true,
+    mode: 'linear',
+    args: ['--gbk', '/uploaded', '-b', '/generated-a', '/generated-b'],
+    fileMetadata: new Map([
+      ['/uploaded', { name: 'Records.tsv', slot: 'resources.uploaded', kind: 'uploaded' }],
+      ['/generated-a', { name: 'records.tsv', slot: 'generatedFiles.first', kind: 'generated' }],
+      ['/generated-b', { name: 'records.tsv', slot: 'generatedFiles.second', kind: 'generated' }]
+    ]),
+    generatedFiles: [
+      { path: '/generated-a', name: 'records.tsv', slot: 'generatedFiles.first', data: 'a' },
+      { path: '/generated-b', name: 'records.tsv', slot: 'generatedFiles.second', data: 'b' }
+    ]
+  };
+  const info = buildRunInfo({
+    mode: 'linear',
+    sourceRecipe,
+    exactReplayArgs: ['--session', '/exact'],
+    fileMetadata: new Map([
+      ['/exact', {
+        name: 'records-2.tsv',
+        slot: 'generatedFiles.canonical_render_session',
+        kind: 'generated'
+      }]
+    ])
+  });
+
+  assert.deepEqual(
+    info.sourceRecipe.commandArgs.slice(-3),
+    ['-b', 'records-2.tsv', 'records-3.tsv']
+  );
+  assert.deepEqual(
+    info.sourceRecipe.helperFiles.map(({ name }) => name),
+    ['records-2.tsv', 'records-3.tsv']
+  );
+  assert.deepEqual(info.exactReplay.helperFiles.map(({ name }) => name), ['records-2-2.tsv']);
+  assert.match(info.exactReplay.command, /--session records-2-2\.tsv$/);
+  const allNames = info.helperFiles.map(({ name }) => name);
+  assert.equal(new Set(allNames.map((name) => name.toLowerCase())).size, allNames.length);
+}
+
+{
+  const cardinalityAll = structuredClone(linearCanonical);
+  cardinalityAll.renderRequest.records = [cardinalityAll.renderRequest.records[0]];
+  cardinalityAll.renderRequest.records[0].cardinality = 'all';
+  cardinalityAll.renderRequest.comparisons = [];
+  delete cardinalityAll.resources['record-2-genbank'];
+  delete cardinalityAll.resources['comparison-nucleotide-1'];
+  delete cardinalityAll.webFiles.resourceOriginalNames['record-2-genbank'];
+  delete cardinalityAll.webFiles.resourceOriginalNames['comparison-nucleotide-1'];
+  const sourceRecipe = buildSourceRecipe(cardinalityAll);
+
+  assert.equal(sourceRecipe.available, true, sourceRecipe.unavailableReason);
+  assert.ok(sourceRecipe.semanticCoverage.consumedPaths.includes('records[0].cardinality'));
+}
+
+{
+  const gridColumn = structuredClone(linearCanonical);
+  gridColumn.renderRequest.records.forEach((record, index) => {
+    record.presentation.gridRow = 1;
+    record.presentation.gridColumn = index + 1;
+  });
+  const sourceRecipe = buildSourceRecipe(gridColumn);
+
+  assert.equal(sourceRecipe.available, true, sourceRecipe.unavailableReason);
+  const table = sourceRecipe.generatedFiles.find((file) => file.name === 'records.tsv');
+  assert.ok(table);
+  assert.match(table.data, /alpha\.gbk.*\t1\t1\n/);
+  assert.match(table.data, /beta\.gbk.*\t1\t2\n/);
+}
+
+{
+  const unboundGeneratedProtein = structuredClone(linearCanonical);
+  unboundGeneratedProtein.renderRequest.comparisons = [{
+    kind: 'generatedProteinComparison',
+    mode: 'pairwise',
+    pairs: [{ queryRecordIndex: 0, subjectRecordIndex: 1 }],
+    settings: {}
+  }];
+  const sourceRecipe = buildSourceRecipe(unboundGeneratedProtein);
+
+  assert.equal(sourceRecipe.available, false);
+  assert.match(sourceRecipe.unavailableReason, /comparison.*lossless|binding/i);
+}
+
+{
+  const unknownSemanticField = structuredClone(circularCanonical);
+  unknownSemanticField.renderRequest.records[0].presentation.futurePlacement = 'spiral';
+  const sourceRecipe = buildSourceRecipe(unknownSemanticField);
+
+  assert.equal(sourceRecipe.available, false);
+  assert.match(sourceRecipe.unavailableReason, /presentation\.futurePlacement/);
+
+  const displayMetadata = structuredClone(circularCanonical);
+  displayMetadata.webFiles.displayOnlyNote = 'not part of render semantics';
+  assert.equal(buildSourceRecipe(displayMetadata).available, true);
+}
+
+{
+  const batch = structuredClone(circularCanonical);
+  batch.renderRequest.grouping = 'batch';
+  batch.renderRequest.output = [
+    { ...batch.renderRequest.output, prefix: 'first' },
+    { ...batch.renderRequest.output, prefix: 'second' }
+  ];
+  const sourceRecipe = buildSourceRecipe(batch);
+
+  assert.equal(sourceRecipe.available, false);
+  assert.match(sourceRecipe.unavailableReason, /batch|output/i);
+}
+
+{
+  const missingProvenance = structuredClone(circularCanonical);
+  missingProvenance.format = 'gbdraw-session';
+  missingProvenance.version = 32;
+  missingProvenance.renderRequest.schema = 2;
+  missingProvenance.webFiles = {};
+  const sourceRecipe = buildSourceRecipe(missingProvenance);
+  const info = buildRunInfo({
+    mode: 'circular',
+    sourceRecipe,
+    exactReplayArgs: ['--session', '/canonical-render-session.gbdraw-session.json'],
+    fileMetadata: {
+      '/canonical-render-session.gbdraw-session.json': {
+        name: 'legacy-replay.gbdraw-session.json',
+        slot: 'generatedFiles.canonical_render_session',
+        kind: 'generated'
+      }
+    }
+  });
+
+  assert.equal(sourceRecipe.available, false);
+  assert.match(sourceRecipe.unavailableReason, /source-file provenance/i);
+  assert.equal(info.sourceRecipe.command, '');
+  assert.match(info.sourceRecipe.unavailableReason, /source-file provenance/i);
+  assert.equal(
+    info.exactReplay.command,
+    'gbdraw circular --session legacy-replay.gbdraw-session.json'
+  );
+  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Source recipe unavailable');
+}
 
 {
   const info = buildRunInfo({
@@ -44,7 +767,7 @@ assert.equal(quoteShellArg(''), "''");
     { path: '/combined_d.tsv', name: 'combined_d.tsv', slot: 'generatedFiles.combined_d' }
   ]);
   assert.equal(info.reproducibility.level, 'requires-helper-files');
-  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Raw CLI needs files');
+  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Source recipe needs helper files');
   assert.match(info.reproducibility.notes.join('\n'), /combined_d\.tsv/);
   assert.match(info.reproducibility.notes.join('\n'), /\.gbdraw-session\.json/);
   assert.equal(isCliInvocationSessionExportable(info.invocation), false);
@@ -53,7 +776,14 @@ assert.equal(quoteShellArg(''), "''");
 {
   const info = buildRunInfo({
     mode: 'linear',
-    args: ['--session', '/canonical-render-session.gbdraw-session.json'],
+    sourceRecipe: {
+      available: false,
+      args: [],
+      fileMetadata: new Map(),
+      generatedFiles: [],
+      unavailableReason: 'Source recipe unavailable: source-file provenance is missing.'
+    },
+    exactReplayArgs: ['--session', '/canonical-render-session.gbdraw-session.json'],
     fileMetadata: {
       '/canonical-render-session.gbdraw-session.json': {
         name: 'comparison.gbdraw-session.json',
@@ -66,15 +796,15 @@ assert.equal(quoteShellArg(''), "''");
   });
 
   assert.equal(
-    info.command,
+    info.exactReplay.command,
     'gbdraw linear --session comparison.gbdraw-session.json'
   );
-  assert.equal(info.reproducibility.level, 'canonical-request');
+  assert.equal(info.reproducibility.level, 'source-unavailable');
   assert.equal(
     reproducibilityLabel(info.reproducibility.level),
-    'Exact typed request'
+    'Source recipe unavailable'
   );
-  assert.match(info.reproducibility.notes.join('\n'), /exact typed request/i);
+  assert.match(info.reproducibility.notes.join('\n'), /exact replay/i);
 }
 
 {
@@ -97,7 +827,7 @@ assert.equal(quoteShellArg(''), "''");
     { argIndex: 4, slot: 'files.linearSeqs[0].blast', name: 'alpha_vs_beta.tsv' }
   ]);
   assert.equal(info.reproducibility.level, 'exact-uploaded-files');
-  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Ready to rerun');
+  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Source recipe ready');
   assert.equal(isCliInvocationSessionExportable(info.invocation), true);
 }
 
@@ -115,8 +845,8 @@ assert.equal(quoteShellArg(''), "''");
   });
 
   assert.equal(info.reproducibility.level, 'session-recommended');
-  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Raw CLI needs files');
-  assert.match(info.reproducibility.notes.join('\n'), /Download CLI Files/);
+  assert.equal(reproducibilityLabel(info.reproducibility.level), 'Source recipe needs helper files');
+  assert.match(info.reproducibility.notes.join('\n'), /Download reproducibility files/);
   assert.match(info.reproducibility.notes.join('\n'), /session restore/);
   assert.equal(info.sessionCommand, '');
   assert.equal(isCliInvocationSessionExportable(info.invocation), false);

--- a/tests/web/session-active-files.test.mjs
+++ b/tests/web/session-active-files.test.mjs
@@ -14,6 +14,10 @@ globalThis.document = {};
 const { serializeActiveRenderFiles } = await import(
   '../../gbdraw/web/js/services/config.js'
 );
+const {
+  adoptCurrentSessionResources,
+  createSessionResourceFileView
+} = await import('../../gbdraw/web/js/services/session-resource-backing.js');
 
 const readableFile = (name, text) => {
   let reads = 0;
@@ -95,6 +99,28 @@ assert.equal(circular.c_gb.name, 'active.gb');
 assert.equal(circular.c_depth, null);
 assert.deepEqual(circular.linearSeqs, []);
 assert.equal(circular.d_color, null);
+
+const restoredPayload = new TextEncoder().encode('LOCUS restored');
+const restoredTable = adoptCurrentSessionResources({
+  'resource-0001': {
+    kind: 'genbank',
+    name: 'resource-0001-original.gbk',
+    type: 'text/plain',
+    size: restoredPayload.byteLength,
+    lastModified: 1,
+    encoding: 'base64',
+    data: Buffer.from(restoredPayload).toString('base64')
+  }
+});
+const restoredView = createSessionResourceFileView(restoredTable, 'resource-0001', {
+  name: 'original.gbk'
+});
+const restoredCircular = await serializeActiveRenderFiles('circular', {
+  ...sourceState,
+  files: { ...sourceState.files, c_gb: restoredView }
+});
+assert.equal(restoredCircular.c_gb.name, 'original.gbk');
+assert.equal(restoredCircular.c_gb.data, Buffer.from(restoredPayload).toString('base64'));
 
 const linearInput = readableFile('linear.gb', 'LOCUS linear');
 const linearState = {

--- a/tests/web/session-loading-feedback.playwright.spec.js
+++ b/tests/web/session-loading-feedback.playwright.spec.js
@@ -1,0 +1,260 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+const { gzipSync } = require('node:zlib');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+const repoRoot = resolve(process.env.GBDRAW_REPO || process.cwd());
+const sessionInputSelector =
+  'input[type="file"][accept*="application/json"][accept*="application/gzip"]';
+const baselineSession = {
+  name: 'HmmtDNA_basic_circular.gbdraw-session.json',
+  mimeType: 'application/json',
+  buffer: readFileSync(join(
+    repoRoot,
+    'gbdraw',
+    'web',
+    'gallery',
+    'sessions',
+    'HmmtDNA_basic_circular.gbdraw-session.json'
+  ))
+};
+const replacementSession = {
+  name: 'delayed-lambda.gbdraw-session.json.gz',
+  mimeType: 'application/gzip',
+  buffer: gzipSync(readFileSync(join(
+    repoRoot,
+    'gbdraw',
+    'web',
+    'gallery',
+    'sessions',
+    'lambda_basic_linear.gbdraw-session.json'
+  )))
+};
+
+const loadBaselineSession = async (page) => {
+  const dialogPromise = page.waitForEvent('dialog');
+  await page.locator(sessionInputSelector).setInputFiles(baselineSession);
+  const dialog = await dialogPromise;
+  expect(dialog.message()).toBe('Session loaded successfully!');
+  await dialog.accept();
+  await page.waitForFunction(() => (
+    window.__GBDRAW_APP__?.sessionTitle === 'HmmtDNA_basic_circular'
+  ));
+  await page.waitForFunction(() => (
+    window.__GBDRAW_APP__?.sessionImportPending === false
+  ));
+};
+
+const installImportReadGate = async (page, filename) => {
+  await page.evaluate((gatedFilename) => {
+    const nativeStream = Blob.prototype.stream;
+    let releaseGate;
+    const gate = new Promise((resolveGate) => {
+      releaseGate = resolveGate;
+    });
+    window.__GBDRAW_SESSION_IMPORT_GATE__ = {
+      filename: gatedFilename,
+      streamInvocations: 0,
+      release: () => releaseGate()
+    };
+    File.prototype.stream = function gatedSessionStream() {
+      if (this.name !== gatedFilename) return nativeStream.call(this);
+      window.__GBDRAW_SESSION_IMPORT_GATE__.streamInvocations += 1;
+      const source = nativeStream.call(this);
+      return new ReadableStream({
+        async start(controller) {
+          await gate;
+          const reader = source.getReader();
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              controller.enqueue(value);
+            }
+            controller.close();
+          } catch (error) {
+            controller.error(error);
+          } finally {
+            reader.releaseLock();
+          }
+        }
+      });
+    };
+  }, filename);
+};
+
+const installLifecycleProbe = async (page) => {
+  await page.evaluate(() => {
+    window.__GBDRAW_SESSION_LOADING_EVENTS__ = [];
+    window.__GBDRAW_TEST_HOOKS__ = {
+      onSessionLifecycleEvent(event) {
+        window.__GBDRAW_SESSION_LOADING_EVENTS__.push({ ...event });
+      }
+    };
+  });
+};
+
+const importSnapshot = (page) => page.evaluate(() => {
+  const app = window.__GBDRAW_APP__;
+  const selected = app.results?.[Number(app.selectedResultIndex) || 0] || null;
+  const preview = document.querySelector('.shadow-xl.origin-top > svg');
+  return {
+    title: String(app.sessionTitle || ''),
+    mode: String(app.mode || ''),
+    selectedResultName: String(selected?.name || ''),
+    selectedResultContent: String(selected?.content || ''),
+    previewHtml: String(preview?.outerHTML || '')
+  };
+});
+
+const expectLifecycleOrder = async (page, names) => {
+  const events = await page.evaluate(() => (
+    window.__GBDRAW_SESSION_LOADING_EVENTS__.map(({ name }) => name)
+  ));
+  let previous = -1;
+  names.forEach((name) => {
+    const current = events.indexOf(name);
+    expect(current, `${name} missing from ${events.join(', ')}`).toBeGreaterThan(previous);
+    previous = current;
+  });
+};
+
+test('session loading is painted before import work and prevents duplicate adoption', async ({
+  page
+}) => {
+  test.setTimeout(180_000);
+  await openApp(page);
+  await loadBaselineSession(page);
+  const before = await importSnapshot(page);
+  expect(before.previewHtml).toContain('<svg');
+
+  await installLifecycleProbe(page);
+  await installImportReadGate(page, replacementSession.name);
+  const dialogs = [];
+  page.on('dialog', async (dialog) => {
+    dialogs.push(dialog.message());
+    await dialog.accept();
+  });
+
+  const sessionInput = page.locator(sessionInputSelector);
+  const loadButton = page.getByRole('button', { name: 'Load Session', exact: true });
+  const loadingStatus = page.locator('[data-session-import-status]');
+  await sessionInput.setInputFiles(replacementSession);
+  await page.waitForFunction(() => (
+    window.__GBDRAW_SESSION_IMPORT_GATE__?.streamInvocations === 1
+  ));
+
+  await expect(loadingStatus).toBeVisible();
+  await expect(loadingStatus).toHaveText('Loading session…');
+  await expect(loadingStatus).toHaveAttribute('role', 'status');
+  await expect(loadingStatus).toHaveAttribute('aria-live', 'polite');
+  await expect(loadButton).toBeDisabled();
+  await expect(loadButton).toHaveAttribute('aria-busy', 'true');
+  expect(await importSnapshot(page)).toEqual(before);
+  await expectLifecycleOrder(page, [
+    'session-import-pending-published',
+    'session-import-paint-opportunity-completed',
+    'sessionSelection',
+    'gzip-to-text-start'
+  ]);
+
+  await sessionInput.setInputFiles({
+    name: 'duplicate-while-pending.gbdraw-session.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from('{"duplicate":true}')
+  });
+  expect(await importSnapshot(page)).toEqual(before);
+  expect(await page.evaluate(() => (
+    window.__GBDRAW_SESSION_LOADING_EVENTS__
+      .filter(({ name }) => name === 'sessionSelection').length
+  ))).toBe(1);
+  expect(await page.evaluate(() => (
+    window.__GBDRAW_SESSION_LOADING_EVENTS__
+      .filter(({ name }) => name === 'firstCommittedPreview').length
+  ))).toBe(0);
+  expect(dialogs).toEqual([]);
+
+  await page.evaluate(() => window.__GBDRAW_SESSION_IMPORT_GATE__.release());
+  await page.waitForFunction(() => window.__GBDRAW_APP__?.sessionImportPending === false);
+  await expect(loadingStatus).toBeHidden();
+  await expect(loadButton).toBeEnabled();
+  await expect(loadButton).toHaveAttribute('aria-busy', 'false');
+  await expect(sessionInput).toHaveValue('');
+  expect(dialogs).toEqual(['Session loaded successfully!']);
+  const after = await importSnapshot(page);
+  expect(after.title).toBe('lambda_basic_linear');
+  expect(after.mode).toBe('linear');
+  expect(after.selectedResultName).toBe('lambda_basic_linear');
+  expect(after.selectedResultContent).not.toBe(before.selectedResultContent);
+  expect(after.previewHtml).toContain('<svg');
+  expect(await page.evaluate(() => (
+    window.__GBDRAW_SESSION_LOADING_EVENTS__
+      .filter(({ name }) => name === 'firstCommittedPreview').length
+  ))).toBe(1);
+
+  await sessionInput.setInputFiles(replacementSession);
+  await page.waitForFunction(() => (
+    window.__GBDRAW_SESSION_LOADING_EVENTS__
+      .filter(({ name }) => name === 'sessionSelection').length === 2
+    && window.__GBDRAW_APP__?.sessionImportPending === false
+  ));
+  expect(dialogs).toEqual([
+    'Session loaded successfully!',
+    'Session loaded successfully!'
+  ]);
+  await expect(sessionInput).toHaveValue('');
+});
+
+test('failed session loading clears pending state and preserves the prior session', async ({
+  page
+}) => {
+  test.setTimeout(180_000);
+  await openApp(page);
+  await loadBaselineSession(page);
+  const before = await importSnapshot(page);
+  const invalidSession = {
+    name: 'delayed-invalid.gbdraw-session.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from('{not valid JSON')
+  };
+
+  await installLifecycleProbe(page);
+  await installImportReadGate(page, invalidSession.name);
+  const dialogs = [];
+  page.on('dialog', async (dialog) => {
+    dialogs.push(dialog.message());
+    await dialog.accept();
+  });
+
+  const sessionInput = page.locator(sessionInputSelector);
+  const loadButton = page.getByRole('button', { name: 'Load Session', exact: true });
+  const loadingStatus = page.locator('[data-session-import-status]');
+  await sessionInput.setInputFiles(invalidSession);
+  await page.waitForFunction(() => (
+    window.__GBDRAW_SESSION_IMPORT_GATE__?.streamInvocations === 1
+  ));
+  await expect(loadingStatus).toBeVisible();
+  await expect(loadButton).toBeDisabled();
+  expect(await importSnapshot(page)).toEqual(before);
+
+  await page.evaluate(() => window.__GBDRAW_SESSION_IMPORT_GATE__.release());
+  await page.waitForFunction(() => window.__GBDRAW_APP__?.sessionImportPending === false);
+  await expect(loadingStatus).toBeHidden();
+  await expect(loadButton).toBeEnabled();
+  await expect(sessionInput).toHaveValue('');
+  expect(dialogs).toHaveLength(1);
+  expect(dialogs[0]).toMatch(/^Failed to load session:/);
+  expect(await importSnapshot(page)).toEqual(before);
+
+  await sessionInput.setInputFiles(invalidSession);
+  await page.waitForFunction(() => (
+    window.__GBDRAW_SESSION_LOADING_EVENTS__
+      .filter(({ name }) => name === 'interactiveReady').length === 2
+    && window.__GBDRAW_APP__?.sessionImportPending === false
+  ));
+  expect(dialogs).toHaveLength(2);
+  expect(dialogs[1]).toMatch(/^Failed to load session:/);
+  expect(await importSnapshot(page)).toEqual(before);
+  await expect(sessionInput).toHaveValue('');
+});


### PR DESCRIPTION
## Plain-language summary

Linear comparison ribbons now reach the painted gene tracks when labels are shown on lower records, retaining the existing 4 px clearance and record spacing. This PR also includes the six completed Web fixes for Run Info and replay, pointer feedback, drawer overlap, session-loading feedback, sequence-copy feedback, and collinear similarity groups. Unfinished work for #464 and #465 is excluded.

## Change class

- [x] STANDARD

## Purpose

Base: `dev` at `df4157c7c6f45d5fa7c2f41445d48f77353445e6`. The work branch was created from this base and fast-forwarded to the verified completed checkpoint `51d2ae362ac154a3e360727ad086ad1d27bbc989`, without importing the dirty #464 worktree.

The protected PR checks are `Web base policy (trusted base)` and `PR / gate`. Promotion subsequently requires successful `Dev staging / gate` and `Gallery readiness / gate` on the exact merged `dev` SHA, then a `dev` → `main` PR with `Promotion / gate` and `CodeQL`.

## User-visible impact

The ribbon endpoint used the outer edge of a footprint that included feature labels. The fix keeps that footprint for row spacing and derives the final ribbon attachment from placed feature lanes and other painted tracks. Labels stay in the foreground at their original positions; numeric tracks retain their exclusion area.

## Changes

Included completed commits:

| Issue | Commit | Change |
| --- | --- | --- |
| #459 | `f169e629a917ee19d840702e45a5730a44ae41c9` | Pairwise pointer-down feedback |
| #461 | `a9446f6bcfcd050d74e51cf64765bce260e91f69` | Preview zoom controls and editor drawer overlap |
| #463 | `2940477a8155cfe708a38c7db6e3d18653d8485b` | Pending feedback during session loading |
| #462 | `86dd1ca19b164c2985d0cc7f9f9e6e56bc1c7e3d` | Orthogroup sequence-copy feedback |
| #458 | `7b71500de95c22d1158cd485185b7d1cf6ed59bf` | Run Info source recipes and exact replay |
| #460 | `51d2ae362ac154a3e360727ad086ad1d27bbc989` | Collinear similarity groups and dual catalog projections |

The hotfix changes `gbdraw/diagrams/linear/assemble.py`, adds a permanent regression to `tests/test_linear_multi_record_comparisons.py`, and corrects the endpoint explanation in the CLI reference and release notes. The existing H-CLI-13 and T-PY-08 recipes also regenerate their two tracked Interactive SVG exports to include the completed interaction fixes; their diagram geometry and browser screenshots are unchanged. The existing popup source contract now checks the match-specific catalog selection introduced by #460. No rotation implementation, schema change, test reference replacement, or CI framework is added.

## Verification

- New permanent test: `test_comparison_endpoints_follow_gene_tracks_with_labels`, with 12 cases covering label presence, font size, rotation, comparison height, both layout paths, a middle row, reversed record endpoints and reversed matches, and straight/curved ribbons. Before the fix, eight labeled cases fail at the final-SVG endpoint assertion and four existing cases pass; all 12 pass after the fix. The complete test file has 24 passing tests.
- CI collection: `.github/workflows/test.yml` runs this file in `Core PR (Python 3.11)` and the `Core (Python 3.10/3.11/3.12)` staging matrix through `python -m pytest tests/ -m "not slow and not (recipe or gallery or browser)" -n auto --dist loadfile --durations=30`. No extra marker or framework is needed.
- That same core selection passed locally with four workers: 2,731 passed, 17 skipped. Focused comparison, placement, label, popup, and read-only SVG reference checks: 225 passed. Web packaging: 36 passed. Four related JavaScript test files passed. Ruff passed.
- Realistic reproduction: the five-record BGC Gallery session with label scope changed from `first` to `orthogroup_top`, preserving its inputs, comparisons, color rules, labels, and legend. Three lower gaps of approximately 60.20, 81.18 and 49.00 SVG units become the established 4-unit clearance. All 77 matches remain; all non-ribbon SVG elements and all match metadata, styles and x coordinates are identical.
- The three recipe checks that initially failed in CI passed locally after those artifact and source-contract updates. Both SVGs were regenerated by their published recipe runners from clean external working directories; only embedded style/script nodes changed, and their before/after Chromium screenshots are byte-identical.
- Save → Load → Generate and repeated Load → Generate passed with the newly rendered endpoint assertions.
- The wheel was built from this isolated worktree and its source bytes were verified. Preview, raw SVG, Interactive SVG, PNG and PDF generation were exercised with external network requests blocked. The original #464 tracked diff and three new source/test files were reverified against their backup.

## Risk and review notes

- The user's exact saved session was unavailable. The Gallery-derived fixture reproduces the same interrupted record pairs; it does not establish every setting in the screenshot.
- A separate, pre-existing Save Session failure occurs after regenerating this Gallery-derived session: `Conflicting adopted session resource: colors-default-colors-file.` The same error was reproduced with a wheel whose complete Python sources match checkpoint `51d2ae36`. Saving before Generate succeeds. This hotfix does not change the session resource owner, and this failure must remain visible in review rather than be reported as a passing check.
- Gate result: local existing Web policy check PASS, with no blocking violations. Protected GitHub checks must pass on this PR's exact head before merge.
- Review result: REQUIRED because the combined completed Web fixes cross size thresholds and affect feedback, replay, catalog and session-related responsibilities. Human review is still required; a green policy gate is not that review.
- This is architecture-bearing in the combined Web change scope. Existing feature owners retain the feedback and replay responsibilities; the canonical render-request path, schema and privileged boundaries remain unchanged. The hotfix uses the existing final placement-to-render boundary for both layout paths. No new canonical or compatibility path is introduced, and no architecture exception is requested.
- Conditional Product Impact: no registered owner/path delta; the supplied hotfix contract explicitly selects track attachment with labels preserved. No Product decision JSON is asserted.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Rollback

Revert the ribbon hotfix commit to restore the previous attachment calculation. Keep the six completed issue commits separate from any future #464/#465 work. The #464 handoff must require retention of this hotfix and passing the same permanent ribbon regression on the eventual integrated code before publication.
