### PR TITLE
Reuse source record counts when building Run Info recipes

### DIFF
--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -7,7 +7,10 @@ import {
   runDiagramGeneration,
   runDiagramHelperOperation
 } from '../services/diagram-generation.js';
-import { buildCanonicalRenderRequest } from '../services/session-request.js';
+import {
+  buildCanonicalRenderRequest,
+  readCanonicalResourceText
+} from '../services/session-request.js';
 import {
   buildLabelOverrideTsv,
   serializeLabelOverrideRows
@@ -4301,6 +4304,24 @@ export const createRunAnalysis = ({
           + canonicalResourceBase64Characters * 2
           + 65_536
       });
+      let sourceRecipe = null;
+      if (!isReflow && manualRunStartedAt !== null) {
+        const generatedFileNameHints = new Map();
+        generatedCliFileMap.forEach((file) => {
+          const slot = String(file?.slot || '').trim();
+          const name = String(file?.name || '').trim();
+          if (slot && name && !generatedFileNameHints.has(slot)) {
+            generatedFileNameHints.set(slot, name);
+          }
+        });
+        // Reuse source text before Worker transfer releases the file-content cache.
+        sourceRecipe = await buildSourceRecipe({
+          ...canonical,
+          generatedFileNameHints,
+          readResourceText: (resourceId) => readCanonicalResourceText(canonical.resources, resourceId)
+        });
+        throwIfGenerationCanceled();
+      }
       const gbdrawStartedAt = getNow();
       const generationResponse = await runDiagramGeneration({
         request: canonical.renderRequest,
@@ -4422,15 +4443,6 @@ export const createRunAnalysis = ({
       let candidateRunInfo = null;
       let candidateCliHelpers = null;
       if (!isReflow && manualRunStartedAt !== null) {
-        const generatedFileNameHints = new Map();
-        generatedCliFileMap.forEach((file) => {
-          const slot = String(file?.slot || '').trim();
-          const name = String(file?.name || '').trim();
-          if (slot && name && !generatedFileNameHints.has(slot)) {
-            generatedFileNameHints.set(slot, name);
-          }
-        });
-        const sourceRecipe = buildSourceRecipe({ ...canonical, generatedFileNameHints });
         candidateRunInfo = buildRunInfo({
           mode: mode.value,
           sourceRecipe,

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -9,7 +9,7 @@ import {
 } from '../services/diagram-generation.js';
 import {
   buildCanonicalRenderRequest,
-  readCanonicalResourceText
+  readCanonicalResourceRecordCount
 } from '../services/session-request.js';
 import {
   buildLabelOverrideTsv,
@@ -4314,11 +4314,13 @@ export const createRunAnalysis = ({
             generatedFileNameHints.set(slot, name);
           }
         });
-        // Reuse source text before Worker transfer releases the file-content cache.
+        // Establish source counts before Worker transfer releases the file-content cache.
         sourceRecipe = await buildSourceRecipe({
           ...canonical,
           generatedFileNameHints,
-          readResourceText: (resourceId) => readCanonicalResourceText(canonical.resources, resourceId)
+          readResourceRecordCount: (resourceId, kind) => (
+            readCanonicalResourceRecordCount(canonical.resources, resourceId, kind)
+          )
         });
         throwIfGenerationCanceled();
       }

--- a/gbdraw/web/js/app/run-info.js
+++ b/gbdraw/web/js/app/run-info.js
@@ -199,7 +199,7 @@ const resourceBytes = (descriptor) => {
   return null;
 };
 
-const createRecipeFiles = (resources, webFiles, generatedFileNameHints, readResourceText) => {
+const createRecipeFiles = (resources, webFiles, generatedFileNameHints, readResourceRecordCount) => {
   const descriptors = isPlainObject(resources) ? resources : {};
   const originalNames = originalResourceNameHints(webFiles);
   const generatedNames = normalizeNameHints(generatedFileNameHints);
@@ -294,16 +294,16 @@ const createRecipeFiles = (resources, webFiles, generatedFileNameHints, readReso
     const resourceId = String(resourceIdRaw || '').trim();
     const cacheKey = `${resourceId}:${kind}`;
     if (recordCountCache.has(cacheKey)) return recordCountCache.get(cacheKey);
-    let text;
-    if (typeof readResourceText === 'function') {
-      text = await readResourceText(resourceId);
+    let count;
+    if (typeof readResourceRecordCount === 'function') {
+      count = await readResourceRecordCount(resourceId, kind);
     } else {
       const bytes = resourceBytes(descriptors[resourceId]);
-      text = bytes ? new TextDecoder().decode(bytes) : '';
+      const text = bytes ? new TextDecoder().decode(bytes) : '';
+      count = kind === 'genbank'
+        ? (text.match(/^LOCUS\s+/gm) || []).length
+        : (text.match(/^>/gm) || []).length;
     }
-    const count = kind === 'genbank'
-      ? (text.match(/^LOCUS\s+/gm) || []).length
-      : (text.match(/^>/gm) || []).length;
     recordCountCache.set(cacheKey, count);
     return count;
   };
@@ -1424,7 +1424,7 @@ export const buildSourceRecipe = async ({
   resources,
   webFiles,
   generatedFileNameHints,
-  readResourceText = null
+  readResourceRecordCount = null
 } = {}) => {
   const mode = String(renderRequest?.mode || '').trim();
   const unavailable = (reason) => ({
@@ -1443,7 +1443,7 @@ export const buildSourceRecipe = async ({
     const semanticCoverage = renderRequest.schema === 6
       ? validateSchema6SemanticCoverage(renderRequest)
       : { schema: renderRequest.schema, consumedPaths: [], metadataPaths: [] };
-    const files = createRecipeFiles(resources, webFiles, generatedFileNameHints, readResourceText);
+    const files = createRecipeFiles(resources, webFiles, generatedFileNameHints, readResourceRecordCount);
     const args = [];
     const recordsTableUsed = await appendInputArgs(args, renderRequest, files);
     appendDiagramOptions(args, renderRequest, files);

--- a/gbdraw/web/js/app/run-info.js
+++ b/gbdraw/web/js/app/run-info.js
@@ -199,7 +199,7 @@ const resourceBytes = (descriptor) => {
   return null;
 };
 
-const createRecipeFiles = (resources, webFiles, generatedFileNameHints) => {
+const createRecipeFiles = (resources, webFiles, generatedFileNameHints, readResourceText) => {
   const descriptors = isPlainObject(resources) ? resources : {};
   const originalNames = originalResourceNameHints(webFiles);
   const generatedNames = normalizeNameHints(generatedFileNameHints);
@@ -290,18 +290,20 @@ const createRecipeFiles = (resources, webFiles, generatedFileNameHints) => {
   };
 
   const visibleName = (path) => fileMetadata.get(path)?.name || fallbackNameFromPath(path);
-  const resourceRecordCount = (resourceIdRaw, kind) => {
+  const resourceRecordCount = async (resourceIdRaw, kind) => {
     const resourceId = String(resourceIdRaw || '').trim();
     const cacheKey = `${resourceId}:${kind}`;
     if (recordCountCache.has(cacheKey)) return recordCountCache.get(cacheKey);
-    const bytes = resourceBytes(descriptors[resourceId]);
-    let count = 0;
-    if (bytes) {
-      const text = new TextDecoder().decode(bytes);
-      count = kind === 'genbank'
-        ? (text.match(/^LOCUS\s+/gm) || []).length
-        : (text.match(/^>/gm) || []).length;
+    let text;
+    if (typeof readResourceText === 'function') {
+      text = await readResourceText(resourceId);
+    } else {
+      const bytes = resourceBytes(descriptors[resourceId]);
+      text = bytes ? new TextDecoder().decode(bytes) : '';
     }
+    const count = kind === 'genbank'
+      ? (text.match(/^LOCUS\s+/gm) || []).length
+      : (text.match(/^>/gm) || []).length;
     recordCountCache.set(cacheKey, count);
     return count;
   };
@@ -603,7 +605,7 @@ const gridCoordinate = (value) => {
   return Number.isInteger(numeric) && numeric > 0 ? numeric : '';
 };
 
-const appendInputArgs = (args, request, files) => {
+const appendInputArgs = async (args, request, files) => {
   const records = Array.isArray(request.records) ? request.records : [];
   if (records.length === 0) {
     throw new SourceRecipeUnavailable('Source recipe unavailable: the committed render has no source records.');
@@ -635,13 +637,21 @@ const appendInputArgs = (args, request, files) => {
       || gridCoordinate(record.presentation?.gridRow) !== ''
     ))
   ));
-  const circularSelectorNeedsTable = request.mode === 'circular' && records.some((record, index) => (
-    Boolean(record.region?.selector || record.selector)
-    && files.resourceRecordCount(
-      specs[index].ids.at(-1),
-      inputKind === 'genbank' ? 'genbank' : 'fasta'
-    ) !== 1
-  ));
+  let circularSelectorNeedsTable = false;
+  if (request.mode === 'circular') {
+    for (const [index, record] of records.entries()) {
+      if (
+        (record.region?.selector || record.selector)
+        && await files.resourceRecordCount(
+          specs[index].ids.at(-1),
+          inputKind === 'genbank' ? 'genbank' : 'fasta'
+        ) !== 1
+      ) {
+        circularSelectorNeedsTable = true;
+        break;
+      }
+    }
+  }
   const recordsTableRequired = hasDuplicateSources || circularSelectorNeedsTable || recordNeedsTable;
   if (
     request.schema === 6
@@ -660,14 +670,14 @@ const appendInputArgs = (args, request, files) => {
     const effectiveCardinality = request.mode === 'circular'
       ? 'all'
       : ((inputKind === 'gffFasta' || records.length > 1) && loadComparison ? 'first' : 'all');
-    records.forEach((record, index) => {
+    for (const [index, record] of records.entries()) {
       const canonicalCardinality = String(record.cardinality || '');
       const cliCardinality = (record.region?.selector || record.selector)
         ? 'exactly_one'
         : effectiveCardinality;
       if (
         canonicalCardinality !== cliCardinality
-        && files.resourceRecordCount(
+        && await files.resourceRecordCount(
           specs[index].ids.at(-1),
           inputKind === 'genbank' ? 'genbank' : 'fasta'
         ) !== 1
@@ -676,7 +686,7 @@ const appendInputArgs = (args, request, files) => {
           `Source recipe unavailable: record cardinality "${canonicalCardinality || 'missing'}" cannot be preserved by the current CLI.`
         );
       }
-    });
+    }
   }
 
   if (recordsTableRequired) {
@@ -1409,11 +1419,12 @@ const appendLayoutOptions = (args, request, recordsTableUsed = false) => {
   }
 };
 
-export const buildSourceRecipe = ({
+export const buildSourceRecipe = async ({
   renderRequest,
   resources,
   webFiles,
-  generatedFileNameHints
+  generatedFileNameHints,
+  readResourceText = null
 } = {}) => {
   const mode = String(renderRequest?.mode || '').trim();
   const unavailable = (reason) => ({
@@ -1432,9 +1443,9 @@ export const buildSourceRecipe = ({
     const semanticCoverage = renderRequest.schema === 6
       ? validateSchema6SemanticCoverage(renderRequest)
       : { schema: renderRequest.schema, consumedPaths: [], metadataPaths: [] };
-    const files = createRecipeFiles(resources, webFiles, generatedFileNameHints);
+    const files = createRecipeFiles(resources, webFiles, generatedFileNameHints, readResourceText);
     const args = [];
-    const recordsTableUsed = appendInputArgs(args, renderRequest, files);
+    const recordsTableUsed = await appendInputArgs(args, renderRequest, files);
     appendDiagramOptions(args, renderRequest, files);
     appendConfigOverrides(args, renderRequest);
     appendLayoutOptions(args, renderRequest, recordsTableUsed);

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -2833,12 +2833,26 @@ export const decodeCanonicalResourceText = (resources, resourceId) => {
   return bytesToText(bytes, { fatal: true });
 };
 
-export const readCanonicalResourceText = async (resources, resourceId) => {
+const sourceRecordCounts = new WeakMap();
+
+export const readCanonicalResourceRecordCount = async (resources, resourceId, kind) => {
   const descriptor = resources?.[resourceId];
   const owner = getResourcePayloadOwner(descriptor);
-  return owner && owner !== descriptor
-    ? readFileText(owner)
-    : decodeCanonicalResourceText(resources, resourceId);
+  const hasFileOwner = owner && owner !== descriptor;
+  let counts = hasFileOwner && sourceRecordCounts.get(owner);
+  if (!counts) {
+    const text = hasFileOwner
+      ? await readFileText(owner)
+      : decodeCanonicalResourceText(resources, resourceId);
+    counts = {
+      genbank: (text.match(/^LOCUS\s+/gm) || []).length,
+      fasta: (text.match(/^>/gm) || []).length
+    };
+    // Immutable File/view identity outlives transferred bytes. Retain only counts;
+    // a replacement source gets its own entry, and ownerless descriptors stay uncached.
+    if (hasFileOwner) sourceRecordCounts.set(owner, counts);
+  }
+  return counts[kind];
 };
 
 const resourceTextFromRef = (resources, ref) => (

--- a/gbdraw/web/js/services/session-request.js
+++ b/gbdraw/web/js/services/session-request.js
@@ -109,6 +109,7 @@ import {
   bytesToBase64,
   bytesToText,
   getSessionResourceSource,
+  readFileText,
   textToBase64,
   textToBytes
 } from './file-content-cache.js';
@@ -2830,6 +2831,14 @@ export const decodeCanonicalResourceText = (resources, resourceId) => {
     throw new Error(`Canonical resource ${resourceId} contains invalid base64 data.`, { cause: error });
   }
   return bytesToText(bytes, { fatal: true });
+};
+
+export const readCanonicalResourceText = async (resources, resourceId) => {
+  const descriptor = resources?.[resourceId];
+  const owner = getResourcePayloadOwner(descriptor);
+  return owner && owner !== descriptor
+    ? readFileText(owner)
+    : decodeCanonicalResourceText(resources, resourceId);
 };
 
 const resourceTextFromRef = (resources, ref) => (

--- a/tests/web/run-info.test.mjs
+++ b/tests/web/run-info.test.mjs
@@ -19,6 +19,18 @@ const {
   quoteShellArg,
   reproducibilityLabel
 } = await import(pathToFileURL(modulePath));
+const { adoptCurrentSessionResources, createSessionResourceFileView } = await import(
+  pathToFileURL(join(tempDir, 'js', 'services', 'session-resource-backing.js'))
+);
+const { readFileText } = await import(
+  pathToFileURL(join(tempDir, 'js', 'services', 'file-content-cache.js'))
+);
+const { setResourcePayloadOwner } = await import(
+  pathToFileURL(join(tempDir, 'js', 'services', 'resource-payload-owner.js'))
+);
+const { readCanonicalResourceText } = await import(
+  pathToFileURL(join(tempDir, 'js', 'services', 'session-request.js'))
+);
 
 const base64 = (text) => Buffer.from(text).toString('base64');
 const resource = (kind, name, text = 'fixture') => ({
@@ -168,7 +180,7 @@ for (const { fixture, mode } of [
   ));
   if (mode === 'circular') circularGallerySession = session;
   else linearGallerySession = session;
-  const sourceRecipe = buildSourceRecipe(session);
+  const sourceRecipe = await buildSourceRecipe(session);
   assert.equal(sourceRecipe.available, true, `${fixture}: ${sourceRecipe.unavailableReason}`);
   assert.equal(sourceRecipe.mode, mode);
   assert.ok(sourceRecipe.args.includes('--gbk'), `${fixture}: expected direct GenBank input`);
@@ -179,19 +191,74 @@ for (const { fixture, mode } of [
   await materializeAndRunRecipe(session, sourceRecipe, info, fixture);
 }
 
+test('source recipe reuses materialized source text and preserves record selection', async () => {
+  for (const format of ['genbank', 'fasta']) {
+    for (const recordCount of [1, 2]) {
+      const text = Array.from({ length: recordCount }, (_, index) => (
+        format === 'genbank' ? `LOCUS       record${index}\n//\n` : `>record${index}\nACGT\n`
+      )).join('');
+      const session = canonical({
+        mode: 'circular',
+        records: [{
+          recordKey: 'selected',
+          cardinality: 'exactly_one',
+          source: format === 'genbank'
+            ? { kind: 'genbank', resourceId: 'source' }
+            : { kind: 'gffFasta', gffResourceId: 'gff', fastaResourceId: 'source' },
+          selector: { kind: 'recordIndex', index: 0 },
+          region: null,
+          presentation: presentation()
+        }],
+        resources: {
+          source: resource(format, `source.${format === 'genbank' ? 'gbk' : 'fasta'}`, text),
+          gff: resource('gff', 'source.gff', '##gff-version 3\n'),
+          unused: { ...resource('web-file', 'unused.txt'), data: '%%%' }
+        },
+        webFiles: { resourceOriginalNames: { source: `source.${format}`, gff: 'source.gff' } }
+      });
+      const expected = await buildSourceRecipe(session);
+      assert.equal(expected.available, true, expected.unavailableReason);
+      assert.equal(expected.args.includes('--records_table'), recordCount > 1);
+      const readRecipe = () => buildSourceRecipe({
+        ...session,
+        readResourceText: (resourceId) => readCanonicalResourceText(session.resources, resourceId)
+      });
+      assert.deepEqual(await readRecipe(), expected);
+
+      const table = adoptCurrentSessionResources(session.resources);
+      const view = createSessionResourceFileView(table, 'source');
+      setResourcePayloadOwner(session.resources.source, view);
+      assert.equal(await readFileText(view), text);
+      const nativeAtob = globalThis.atob;
+      let decodes = 0;
+      globalThis.atob = (...args) => {
+        if (args[0] === session.resources.source.data) decodes += 1;
+        return nativeAtob(...args);
+      };
+      try {
+        assert.deepEqual(await readRecipe(), expected);
+        assert.deepEqual(await readRecipe(), expected);
+        assert.equal(decodes, 0, `${format}: recipe must reuse the materialized source`);
+      } finally {
+        globalThis.atob = nativeAtob;
+      }
+    }
+  }
+});
+
 test('source recipe preserves selectedFeaturesSet empty, invalid, and non-empty semantics', async () => {
   for (const value of ['absent', null]) {
     const defaulted = structuredClone(circularGallerySession);
     if (value === 'absent') delete defaulted.renderRequest.diagramOptions.selectedFeaturesSet;
     else defaulted.renderRequest.diagramOptions.selectedFeaturesSet = value;
-    const defaultedRecipe = buildSourceRecipe(defaulted);
+    const defaultedRecipe = await buildSourceRecipe(defaulted);
     assert.equal(defaultedRecipe.available, true, defaultedRecipe.unavailableReason);
     assert.equal(defaultedRecipe.args.includes('-k'), false);
   }
 
   const empty = structuredClone(circularGallerySession);
   empty.renderRequest.diagramOptions.selectedFeaturesSet = [];
-  const emptyRecipe = buildSourceRecipe(empty);
+  const emptyRecipe = await buildSourceRecipe(empty);
   assert.equal(emptyRecipe.available, true, emptyRecipe.unavailableReason);
   assert.equal(emptyRecipe.args.includes('-k'), false);
   assertCliParserAccepts(emptyRecipe);
@@ -200,13 +267,13 @@ test('source recipe preserves selectedFeaturesSet empty, invalid, and non-empty 
 
   const invalid = structuredClone(circularGallerySession);
   invalid.renderRequest.diagramOptions.selectedFeaturesSet = [''];
-  const invalidRecipe = buildSourceRecipe(invalid);
+  const invalidRecipe = await buildSourceRecipe(invalid);
   assert.equal(invalidRecipe.available, false);
   assert.match(invalidRecipe.unavailableReason, /selected feature|non-empty/i);
 
   const nonEmpty = structuredClone(circularGallerySession);
   nonEmpty.renderRequest.diagramOptions.selectedFeaturesSet = ['CDS', 'tRNA'];
-  const nonEmptyRecipe = buildSourceRecipe(nonEmpty);
+  const nonEmptyRecipe = await buildSourceRecipe(nonEmpty);
   assert.equal(nonEmptyRecipe.available, true, nonEmptyRecipe.unavailableReason);
   const featureOptionIndex = nonEmptyRecipe.args.indexOf('-k');
   assert.notEqual(featureOptionIndex, -1);
@@ -218,7 +285,7 @@ test('source recipe preserves canonical string track slots', async () => {
   const stringSlot = structuredClone(circularGallerySession);
   stringSlot.renderRequest.diagramOptions.tracks.circularTrackSlots = ['ticks:ticks'];
   stringSlot.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = 0;
-  const stringRecipe = buildSourceRecipe(stringSlot);
+  const stringRecipe = await buildSourceRecipe(stringSlot);
   assert.equal(stringRecipe.available, true, stringRecipe.unavailableReason);
   const slotOptionIndex = stringRecipe.args.indexOf('--circular_track_slot');
   assert.notEqual(slotOptionIndex, -1);
@@ -229,7 +296,7 @@ test('source recipe preserves canonical string track slots', async () => {
   await materializeAndRunRecipe(stringSlot, stringRecipe, stringInfo, 'ticks-string-slot');
 });
 
-test('source recipe serializes validated object slots without dropping child fields', () => {
+test('source recipe serializes validated object slots without dropping child fields', async () => {
   const objectSlot = structuredClone(circularGallerySession);
   objectSlot.renderRequest.diagramOptions.tracks.circularTrackSlots = [{
     kind: 'circularTrackSlot',
@@ -245,7 +312,7 @@ test('source recipe serializes validated object slots without dropping child fie
     outerGapPx: null
   }];
   objectSlot.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = 0;
-  const objectRecipe = buildSourceRecipe(objectSlot);
+  const objectRecipe = await buildSourceRecipe(objectSlot);
   assert.equal(objectRecipe.available, true, objectRecipe.unavailableReason);
   const optionIndex = objectRecipe.args.indexOf('--circular_track_slot');
   assert.match(
@@ -256,26 +323,26 @@ test('source recipe serializes validated object slots without dropping child fie
 
   const unsupportedChild = structuredClone(objectSlot);
   unsupportedChild.renderRequest.diagramOptions.tracks.circularTrackSlots[0].params.nt = 'GC';
-  const unsupportedRecipe = buildSourceRecipe(unsupportedChild);
+  const unsupportedRecipe = await buildSourceRecipe(unsupportedChild);
   assert.equal(unsupportedRecipe.available, false);
   assert.match(unsupportedRecipe.unavailableReason, /params\.nt|losslessly/i);
 });
 
-test('source recipe distinguishes absent, null, and explicit empty track slots', () => {
+test('source recipe distinguishes absent, null, and explicit empty track slots', async () => {
   const absent = structuredClone(circularGallerySession);
   delete absent.renderRequest.diagramOptions.tracks.circularTrackSlots;
   delete absent.renderRequest.diagramOptions.tracks.circularTrackAxisIndex;
-  assert.equal(buildSourceRecipe(absent).available, true);
+  assert.equal((await buildSourceRecipe(absent)).available, true);
 
   const nullSlots = structuredClone(circularGallerySession);
   nullSlots.renderRequest.diagramOptions.tracks.circularTrackSlots = null;
   nullSlots.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = null;
-  assert.equal(buildSourceRecipe(nullSlots).available, true);
+  assert.equal((await buildSourceRecipe(nullSlots)).available, true);
 
   const emptySlots = structuredClone(circularGallerySession);
   emptySlots.renderRequest.diagramOptions.tracks.circularTrackSlots = [];
   emptySlots.renderRequest.diagramOptions.tracks.circularTrackAxisIndex = null;
-  const emptyRecipe = buildSourceRecipe(emptySlots);
+  const emptyRecipe = await buildSourceRecipe(emptySlots);
   const emptyInfo = buildRunInfo({
     mode: 'circular',
     sourceRecipe: emptyRecipe,
@@ -296,7 +363,7 @@ test('source recipe distinguishes absent, null, and explicit empty track slots',
   for (const slot of ['future:future', 'ticks:ticks@nt=GC']) {
     const invalid = structuredClone(circularGallerySession);
     invalid.renderRequest.diagramOptions.tracks.circularTrackSlots = [slot];
-    assert.equal(buildSourceRecipe(invalid).available, false, slot);
+    assert.equal((await buildSourceRecipe(invalid)).available, false, slot);
   }
 });
 
@@ -339,7 +406,7 @@ test('allocated helper names propagate into comparisons.tsv and the executable r
   collision.generatedFileNameHints = new Map([
     ['generatedFiles.losat_blasts[0]', 'alpha.gbk']
   ]);
-  const recipe = buildSourceRecipe(collision);
+  const recipe = await buildSourceRecipe(collision);
   const info = buildRunInfo({ mode: 'linear', sourceRecipe: recipe });
 
   assert.equal(recipe.available, true, recipe.unavailableReason);
@@ -396,7 +463,7 @@ const circularCanonical = canonical({
 });
 
 {
-  const sourceRecipe = buildSourceRecipe(circularCanonical);
+  const sourceRecipe = await buildSourceRecipe(circularCanonical);
   assert.equal(sourceRecipe.available, true);
   assertCliParserAccepts(sourceRecipe);
   const info = buildRunInfo({
@@ -431,7 +498,7 @@ const circularCanonical = canonical({
   apostropheName.webFiles.resourceOriginalNames['record-1-genbank'] = "Bob's genome.gbk";
   const info = buildRunInfo({
     mode: 'circular',
-    sourceRecipe: buildSourceRecipe(apostropheName)
+    sourceRecipe: await buildSourceRecipe(apostropheName)
   });
   assert.match(info.command, /--gbk 'Bob'\\''s genome\.gbk'/);
 }
@@ -465,7 +532,7 @@ const circularCanonical = canonical({
     multiRecordSizeMode: 'equal',
     multiRecordPositions: ['alpha@1', 'beta@2']
   };
-  const sourceRecipe = buildSourceRecipe(multiRecord);
+  const sourceRecipe = await buildSourceRecipe(multiRecord);
 
   assert.equal(sourceRecipe.available, true, sourceRecipe.unavailableReason);
   assertCliParserAccepts(sourceRecipe);
@@ -523,7 +590,7 @@ const linearCanonical = canonical({
 });
 
 {
-  const direct = buildSourceRecipe(linearCanonical);
+  const direct = await buildSourceRecipe(linearCanonical);
   assert.equal(direct.available, true);
   assertCliParserAccepts(direct);
   const info = buildRunInfo({
@@ -558,7 +625,7 @@ const linearCanonical = canonical({
     }]
   };
   delete restored.webFiles.resourceOriginalNames;
-  const roundTrip = buildSourceRecipe(restored);
+  const roundTrip = await buildSourceRecipe(restored);
   assert.equal(roundTrip.available, true);
   assert.deepEqual(roundTrip.args, direct.args);
 }
@@ -571,7 +638,7 @@ const linearCanonical = canonical({
   generatedHelper.generatedFileNameHints = new Map([
     ['generatedFiles.losat_blasts[0]', 'browser-comparison.tsv']
   ]);
-  const sourceRecipe = buildSourceRecipe(generatedHelper);
+  const sourceRecipe = await buildSourceRecipe(generatedHelper);
   const info = buildRunInfo({ mode: 'linear', sourceRecipe });
 
   assert.equal(sourceRecipe.available, true);
@@ -587,7 +654,7 @@ const linearCanonical = canonical({
   invalidHint.generatedFileNameHints = new Map([
     ['generatedFiles.losat_blasts[0]', '..']
   ]);
-  const unavailable = buildSourceRecipe(invalidHint);
+  const unavailable = await buildSourceRecipe(invalidHint);
   assert.equal(unavailable.available, false);
   assert.match(unavailable.unavailableReason, /trustworthy visible filename/);
 }
@@ -596,7 +663,7 @@ const linearCanonical = canonical({
   const duplicateUploads = structuredClone(linearCanonical);
   duplicateUploads.webFiles.resourceOriginalNames['record-1-genbank'] = 'Genome.gbk';
   duplicateUploads.webFiles.resourceOriginalNames['record-2-genbank'] = 'genome.GBK';
-  const sourceRecipe = buildSourceRecipe(duplicateUploads);
+  const sourceRecipe = await buildSourceRecipe(duplicateUploads);
 
   assert.equal(sourceRecipe.available, false);
   assert.match(sourceRecipe.unavailableReason, /multiple required files.*genome\.GBK/i);
@@ -653,7 +720,7 @@ const linearCanonical = canonical({
   delete cardinalityAll.resources['comparison-nucleotide-1'];
   delete cardinalityAll.webFiles.resourceOriginalNames['record-2-genbank'];
   delete cardinalityAll.webFiles.resourceOriginalNames['comparison-nucleotide-1'];
-  const sourceRecipe = buildSourceRecipe(cardinalityAll);
+  const sourceRecipe = await buildSourceRecipe(cardinalityAll);
 
   assert.equal(sourceRecipe.available, true, sourceRecipe.unavailableReason);
   assert.ok(sourceRecipe.semanticCoverage.consumedPaths.includes('records[0].cardinality'));
@@ -665,7 +732,7 @@ const linearCanonical = canonical({
     record.presentation.gridRow = 1;
     record.presentation.gridColumn = index + 1;
   });
-  const sourceRecipe = buildSourceRecipe(gridColumn);
+  const sourceRecipe = await buildSourceRecipe(gridColumn);
 
   assert.equal(sourceRecipe.available, true, sourceRecipe.unavailableReason);
   const table = sourceRecipe.generatedFiles.find((file) => file.name === 'records.tsv');
@@ -682,7 +749,7 @@ const linearCanonical = canonical({
     pairs: [{ queryRecordIndex: 0, subjectRecordIndex: 1 }],
     settings: {}
   }];
-  const sourceRecipe = buildSourceRecipe(unboundGeneratedProtein);
+  const sourceRecipe = await buildSourceRecipe(unboundGeneratedProtein);
 
   assert.equal(sourceRecipe.available, false);
   assert.match(sourceRecipe.unavailableReason, /comparison.*lossless|binding/i);
@@ -691,14 +758,14 @@ const linearCanonical = canonical({
 {
   const unknownSemanticField = structuredClone(circularCanonical);
   unknownSemanticField.renderRequest.records[0].presentation.futurePlacement = 'spiral';
-  const sourceRecipe = buildSourceRecipe(unknownSemanticField);
+  const sourceRecipe = await buildSourceRecipe(unknownSemanticField);
 
   assert.equal(sourceRecipe.available, false);
   assert.match(sourceRecipe.unavailableReason, /presentation\.futurePlacement/);
 
   const displayMetadata = structuredClone(circularCanonical);
   displayMetadata.webFiles.displayOnlyNote = 'not part of render semantics';
-  assert.equal(buildSourceRecipe(displayMetadata).available, true);
+  assert.equal((await buildSourceRecipe(displayMetadata)).available, true);
 }
 
 {
@@ -708,7 +775,7 @@ const linearCanonical = canonical({
     { ...batch.renderRequest.output, prefix: 'first' },
     { ...batch.renderRequest.output, prefix: 'second' }
   ];
-  const sourceRecipe = buildSourceRecipe(batch);
+  const sourceRecipe = await buildSourceRecipe(batch);
 
   assert.equal(sourceRecipe.available, false);
   assert.match(sourceRecipe.unavailableReason, /batch|output/i);
@@ -720,7 +787,7 @@ const linearCanonical = canonical({
   missingProvenance.version = 32;
   missingProvenance.renderRequest.schema = 2;
   missingProvenance.webFiles = {};
-  const sourceRecipe = buildSourceRecipe(missingProvenance);
+  const sourceRecipe = await buildSourceRecipe(missingProvenance);
   const info = buildRunInfo({
     mode: 'circular',
     sourceRecipe,

--- a/tests/web/run-info.test.mjs
+++ b/tests/web/run-info.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { File } from 'node:buffer';
 import { spawnSync } from 'node:child_process';
 import { cp, readFile, stat, writeFile, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -28,8 +29,11 @@ const { readFileText } = await import(
 const { setResourcePayloadOwner } = await import(
   pathToFileURL(join(tempDir, 'js', 'services', 'resource-payload-owner.js'))
 );
-const { readCanonicalResourceText } = await import(
+const { readCanonicalResourceRecordCount } = await import(
   pathToFileURL(join(tempDir, 'js', 'services', 'session-request.js'))
+);
+const { createDiagramResourceTransport } = await import(
+  pathToFileURL(join(tempDir, 'js', 'services', 'diagram-resource-staging.js'))
 );
 
 const base64 = (text) => Buffer.from(text).toString('base64');
@@ -221,7 +225,9 @@ test('source recipe reuses materialized source text and preserves record selecti
       assert.equal(expected.args.includes('--records_table'), recordCount > 1);
       const readRecipe = () => buildSourceRecipe({
         ...session,
-        readResourceText: (resourceId) => readCanonicalResourceText(session.resources, resourceId)
+        readResourceRecordCount: (resourceId, kind) => (
+          readCanonicalResourceRecordCount(session.resources, resourceId, kind)
+        )
       });
       assert.deepEqual(await readRecipe(), expected);
 
@@ -244,6 +250,103 @@ test('source recipe reuses materialized source text and preserves record selecti
       }
     }
   }
+});
+
+test('source recipe counts survive transfer and follow same-name source replacements', async () => {
+  for (const input of ['native', 'lazy']) {
+    for (const format of ['genbank', 'fasta']) {
+      const transport = createDiagramResourceTransport();
+      let previousToken;
+      for (const recordCount of [1, 2, 1]) {
+        const text = Array.from({ length: recordCount }, (_, index) => (
+          format === 'genbank' ? `LOCUS       record${index}\n//\n` : `>record${index}\nACGT\n`
+        )).join('').padEnd(128, ' ');
+        const descriptor = resource(format, 'same-source.txt', text);
+        const session = canonical({
+          mode: 'circular',
+          records: [{
+            recordKey: 'selected',
+            cardinality: 'exactly_one',
+            source: format === 'genbank'
+              ? { kind: 'genbank', resourceId: 'source' }
+              : { kind: 'gffFasta', gffResourceId: 'gff', fastaResourceId: 'source' },
+            selector: { kind: 'recordIndex', index: recordCount - 1 },
+            region: null,
+            presentation: presentation()
+          }],
+          resources: {
+            source: descriptor,
+            gff: resource('gff', 'same-source.gff', '##gff-version 3\n'),
+            unused: { ...resource('web-file', 'unused.txt'), data: '%%%' }
+          },
+          webFiles: { resourceOriginalNames: { source: 'same-source.txt', gff: 'same-source.gff' } }
+        });
+        const expected = await buildSourceRecipe(session);
+        assert.equal(expected.available, true, expected.unavailableReason);
+        assert.equal(expected.args.includes('--records_table'), recordCount === 2);
+        if (recordCount === 2) {
+          assert.match(expected.generatedFiles[0].data, /#2/);
+        }
+        let reads = 0;
+        let decodes = 0;
+        const nativeAtob = globalThis.atob;
+        const file = input === 'native'
+          ? new class extends File {
+            async arrayBuffer() {
+              reads += 1;
+              return super.arrayBuffer();
+            }
+          }([text], descriptor.name, { lastModified: 7 })
+          : createSessionResourceFileView(adoptCurrentSessionResources(session.resources), 'source');
+        const readRecipe = () => buildSourceRecipe({
+          ...session,
+          readResourceRecordCount: (resourceId, kind) => (
+            readCanonicalResourceRecordCount(session.resources, resourceId, kind)
+          )
+        });
+        setResourcePayloadOwner(descriptor, file);
+        globalThis.atob = (encoded) => {
+          if (encoded === descriptor.data) decodes += 1;
+          return nativeAtob(encoded);
+        };
+        try {
+          assert.equal(await readFileText(file), text);
+          assert.deepEqual(await readRecipe(), expected);
+          const first = await transport.prepare({ request: session.renderRequest, resources: session.resources });
+          const sourceTransfer = first.stagedResources.find(({ resourceId }) => resourceId === 'source');
+          assert.ok(sourceTransfer);
+          assert.notEqual(sourceTransfer.cacheToken, previousToken);
+          previousToken = sourceTransfer.cacheToken;
+          const transferred = structuredClone(sourceTransfer.bytes, { transfer: [sourceTransfer.bytes] });
+          assert.equal(sourceTransfer.bytes.byteLength, 0);
+          assert.equal(new TextDecoder().decode(transferred), text);
+          first.commit();
+          for (let run = 0; run < 2; run += 1) {
+            // Canonical projection creates a fresh descriptor for the same payload owner.
+            session.resources.source = setResourcePayloadOwner({ ...descriptor }, file);
+            assert.deepEqual(await readRecipe(), expected);
+            const warm = await transport.prepare({ request: session.renderRequest, resources: session.resources });
+            assert.equal(warm.stagedResources.length, 0);
+            assert.equal(warm.resourceManifest.find(({ resourceId }) => resourceId === 'source').cacheToken, previousToken);
+            warm.commit();
+          }
+          assert.equal(reads, input === 'native' ? 1 : 0);
+          assert.equal(decodes, input === 'lazy' ? 1 : 0);
+          // Discovery may refill released content; recipe construction must not do so.
+          assert.equal(await readFileText(file), text);
+          assert.deepEqual(await readRecipe(), expected);
+          assert.equal(reads, input === 'native' ? 2 : 0);
+          assert.equal(decodes, input === 'lazy' ? 2 : 0);
+        } finally {
+          globalThis.atob = nativeAtob;
+        }
+      }
+    }
+  }
+  const resources = { source: resource('genbank', 'mutable.gb', 'LOCUS one\n//\n') };
+  assert.equal(await readCanonicalResourceRecordCount(resources, 'source', 'genbank'), 1);
+  Object.assign(resources.source, resource('genbank', 'mutable.gb', 'LOCUS one\n//\nLOCUS two\n//\n'));
+  assert.equal(await readCanonicalResourceRecordCount(resources, 'source', 'genbank'), 2);
 });
 
 test('source recipe preserves selectedFeaturesSet empty, invalid, and non-empty semantics', async () => {


### PR DESCRIPTION
## Plain-language summary

Repeated Generate now reuses the source record counts after Worker transfer releases the source bytes. The first commit removes duplicate decoding for loaded sessions; the follow-up fixes an extra native-file read introduced by that change. Source selection and Source recipe output remain the same, and Run Info is published only for a successfully committed Result.

## Change class

- [x] STANDARD

## Purpose and changes

Base: `dev` at `0f00436da728402d06d4a8fdce80cff63b552488`, the merge of #467. The original approved commit `98b988bd3919d496dadef36f7ae5096a237d0500` is retained, followed by `e7805614349423129337aa2061dfddeb5ad1fe97` (`Preserve source record counts across Worker transfers`).

The first commit routes recipe reads through the existing resource backing. Its remote Web PR smoke subsequently failed the unchanged simple-path assertion: `activePrimaryReads=2`, expected `1` (Tests run [33965016757](https://github.com/satoshikawato/gbdraw/actions/runs/33965016757), job `101303848464`). This failure is retained; the old head's checks are not evidence for the new head.

The follow-up adds a private WeakMap within `session-request.js`, keyed by immutable File/lazy-view source identity, containing only the two numeric GenBank/FASTA record counts. This is derived-value memoization, with no second payload cache: values retain no text, bytes, Base64, descriptor, recipe, or Result. Equal-name/equal-size/equal-lastModified replacements receive new counts. Ownerless descriptors remain uncached and use the existing decoder. Required discovery refills, byte release on Worker transfer, and retransmission after Cancel remain intact. The superseded internal text callback/export is removed.

Both commits affect the same four files. Production: `gbdraw/web/js/app/run-analysis.js`, `gbdraw/web/js/app/run-info.js`, `gbdraw/web/js/services/session-request.js`. Tests: `tests/web/run-info.test.mjs`. No documentation or generated artifact is included.

## Verification

Local results below were reported for the final reviewed source in `/home/kawato/gbdraw-verification/pr470-direct-source-read-20260905T125127Z/RESULT.md`; they are not new-head remote CI results. File hashes and the full additional binary diff were independently matched before stage, after stage, and after the normal-hook commit.

- A: Original direct simple-path file: 5/5 passed. One native read across the first six attempts; the later attempt after Cancel legitimately brings the total to two. Inactive reads remain zero. Focused resource/Run Info contracts: 19/19 passed.
- B: Existing fast Web JavaScript CI selection: 354/354 passed, with no failed, canceled, or skipped tests. The unchanged simple-path assertion and new count-lifetime regression are included.
- C: Functional shard 1/4: 30/30 passed, including all eight unchanged lazy-session tests. The existing operation sequence retained two decodes / two resource reads and one Worker construction/initialization.
- D: Non-slow Python browser tests: 13 passed. Playwright PR smoke: 8/8 passed. These steps were skipped after the earlier remote JavaScript failure and must execute on this new PR head.
- E: Ribbon owner: 24/24 passed, including the 12 formal `test_comparison_endpoints_follow_gene_tracks_with_labels` cases. Architecture: 137/137 passed. Budget, syntax, lint, and diff checks passed.
- The new formal test covers native/lazy × GenBank/FASTA source replacement through one/two/one records, same source metadata, real buffer detachment, warm Worker tokens, required discovery refill, and ownerless descriptor mutation.
- Source recipe CLI succeeded and preserved helper/selector output. This does not establish successful Exact replay or every Save path.

Remote status at this update: new-head required CI is pending. No new exact-dev staging/Gallery PASS, main merge, Pages deployment, or fresh hosted verification is claimed. These stages will be recorded separately as they occur.

## Risk and review notes

- Review: REQUIRED and received from the user for this exact additional checksum in the current conversation, separately from the original commit approval. This records actual human delta approval; it is not a GitHub review submission. Current branch protection requires zero GitHub approving reviews, and both protected checks remain mandatory.
- Original approved binary diff SHA-256: `7f6aa786eb17e3fc9991b4fc070010506f158b5aaee7d4cca43e0d17a033daf4`.
- Additional approved binary diff SHA-256: `6e53efa6b387f49c1d29eb49f50f18bdf27ca0321ce4ae9eb605a6887299145b`; parent: `98b988bd3919d496dadef36f7ae5096a237d0500`; final head: `e7805614349423129337aa2061dfddeb5ad1fe97`. The four committed file hashes match the reviewed manifest; worktree/index are clean.
- This is architecture-bearing. Label: `architecture-change`. `session-request.js` retains canonical identity resolution and the derived counts; the existing resource cache/backing owns payload materialization and lifetime; staging owns transfer/release. Run Info retains selector/cardinality decisions. Result, History, and cancellation remain with their existing owners. Changed-scope OE/PE/CB do not increase; the superseded text callback/export is removed. No new semantic owner, canonical generation path, persisted compatibility path, or architecture exception is introduced.
- Current dev protection: `Web base policy (trusted base)` and `PR / gate`, strict status checks, administrators included. Main promotion requires the new exact dev SHA's `Dev staging / gate` and `Gallery readiness / gate`, then `Promotion / gate`, `CodeQL`, and applicable approval conditions. No policy, test selection, assertion, threshold, required job, or protection setting is relaxed.
- #468 remains an unresolved Generate → Save Session resource conflict. #469 remains the Exact replay helper failure `Session version 40 requires a results array`. Neither is repaired or hidden by Source recipe CLI success.
- Unfinished #464/#465 are excluded. The original #464 worktree, index, local dev ref, and backup remain preserved. The ribbon hotfix owner and formal test remain unchanged.

## Conditional Product Impact

Preflight: `IMPLEMENT_EXISTING_AUTHORITY`. Existing resource lifetime, request/cardinality, successful-Result, and failure-isolation authority select the preserved behavior. No registered Product Impact delta or unresolved outcome was reported; no new Product Decision is added.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Rollback

Revert the affected commit through the protected PR route. Keep #467 and the separate #468/#469 work outside that rollback.
