### PR TITLE
Use Cloudflare as the sole Web publisher

### DIFF
--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -1,4 +1,4 @@
-name: Deploy Web App to GitHub Pages
+name: Verify hosted Web app
 
 on:
   push:
@@ -7,20 +7,18 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: "pages"
+  group: "hosted-web-verification"
   cancel-in-progress: false
 
 jobs:
   gallery-publication-browser:
-    name: Gallery publication browser (exact deploy SHA)
+    name: Gallery publication browser (exact main SHA)
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - name: Checkout exact deploy SHA
+      - name: Checkout exact main SHA
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
@@ -44,68 +42,8 @@ jobs:
           npm run test:web:gallery-publication
           npm run test:web:vibrio-generate
 
-  build:
-    needs: gallery-publication-browser
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel build
-          python -m pip install -e ".[dev]"
-
       - name: Verify reviewed Gallery artifacts
         run: |
           node --test tests/web/gallery-session-publication.test.mjs
           python -m pytest tests/test_gallery_session_semantics.py tests/test_refresh_gallery_sessions.py -q
           python tools/gallery_artifact_manifest.py
-
-      - name: Prepare browser wheel
-        run: python tools/prepare_browser_wheel.py --refresh-cache-bust
-
-      - name: Build Wheel
-        run: python -m build --wheel
-
-      - name: Prepare Web Directory
-        run: |
-          mkdir public
-          # Copy the web app assets
-          cp -r gbdraw/web/* public/
-          # Verify that the packaged Gallery bytes match the reviewed checkout
-          python tools/gallery_artifact_manifest.py --package-root public
-          # Remove any prebundled wheels from the repo copy
-          rm -f public/*.whl
-          # Copy the built package wheel to the site root
-          cp dist/*.whl public/
-          # Create CNAME file for custom domain
-          echo "gbdraw.app" > public/CNAME
-          # Stamp the hosted app with the package version and commit SHA
-          python tools/stamp_web_build.py public
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./public
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -19,8 +19,8 @@ To create a figure without installing `gbdraw`, open:
 
 [https://gbdraw.app/](https://gbdraw.app/)
 
-The hosted app is served as a static site on Cloudflare Pages behind the `gbdraw.app`
-custom domain.
+The hosted app is served by Cloudflare Workers with static assets at the `gbdraw.app`
+custom domain. GitHub Pages is not used for deployment.
 
 Pyodide and the main browser-side assets used by the hosted app are vendored and
 self-hosted from the repository, so the web UI does not need to fetch those runtime

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -132,7 +132,7 @@ either Gallery test job for those changes.
 
 The blocking `browser` job runs the common 9 Gallery parity suite. The heavyweight
 Vibrio Generate test remains available as `test:web:vibrio-generate` and continues to
-run in the separate exact-SHA main deployment workflow as stress and health evidence;
+run in the separate exact-SHA main verification workflow as stress and health evidence;
 it is not part of Gallery promotion readiness. The `browser` and `performance` job IDs
 retain their timeouts and performance baseline. Every `workflow_dispatch` run is full.
 When `complete_refresh=true`, the full performance job still runs its three-trial
@@ -246,8 +246,10 @@ their unconditional event behavior and restore the fixed two-job readiness check
 `Gallery readiness / gate` keeps the same display name, so repository settings do not
 need to change. The planner and the other two profiles can remain active.
 
-Selective CI does not alter `.github/workflows/deploy_web.yml`, deployment triggering,
-or GitHub's CodeQL setup. Those systems remain outside the impact planner.
+Selective CI does not alter `.github/workflows/deploy_web.yml`, Cloudflare deployment
+triggering, or GitHub's CodeQL setup. The main workflow retains browser verification
+only; Cloudflare Workers Builds is the sole production publisher. Those systems
+remain outside the impact planner.
 
 ## Observability
 

--- a/docs/internal/WEB_CHANGE_POLICY.md
+++ b/docs/internal/WEB_CHANGE_POLICY.md
@@ -45,7 +45,9 @@ re-review every implementation diff already admitted and staged on `dev`.
 Legacy jobs may still execute on promotion pull requests during the staged
 migration, but those reruns are not the normative promotion decision model.
 
-A push to `main` verifies and builds the exact release SHA before deployment.
+A push to `main` runs browser verification for the exact release SHA. Cloudflare
+Workers Builds owns production builds and deployment through the existing Git
+integration; GitHub Actions does not publish the site.
 Direct `main` hotfixes are unsupported; urgent changes still enter through
 `dev`, complete staging, and use the promotion boundary.
 
@@ -58,7 +60,9 @@ Direct `main` hotfixes are unsupported; urgent changes still enter through
 | Trusted PR/promotion admission | `.github/workflows/web-base-policy.yml` |
 | Ordinary Web policy CLI | `tools/check-web-change-budget.mjs` |
 | Promotion evidence verifier | `tools/check-promotion-readiness.mjs` |
-| Release verification/build/deploy | `.github/workflows/deploy_web.yml` |
+| Release browser verification | `.github/workflows/deploy_web.yml` |
+| Hosted bundle construction | `tools/prepare_cloudflare_pages.py` |
+| Production deployment | Cloudflare Workers Builds and `wrangler.toml` |
 
 `tools/check-promotion-readiness.mjs` is the planned checker implementation
 owner. It does not exist yet and must be introduced in a checker-only pull

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -1188,7 +1188,7 @@ def test_conda_build_prepares_browser_wheel_before_install() -> None:
     assert re.search(r"^\s+- wheel\s*$", meta_yaml, re.MULTILINE)
 
 
-def test_hosted_web_build_verifies_gallery_without_refreshing() -> None:
+def test_hosted_web_uses_cloudflare_and_retains_browser_verification() -> None:
     deploy_yml = (REPO_ROOT / ".github" / "workflows" / "deploy_web.yml").read_text(
         encoding="utf-8"
     )
@@ -1197,13 +1197,24 @@ def test_hosted_web_build_verifies_gallery_without_refreshing() -> None:
     )
 
     assert 'python -m pip install -e ".[dev]"' in deploy_yml
-    checkout_verify_index = deploy_yml.index("python tools/gallery_artifact_manifest.py")
-    copy_index = deploy_yml.index("cp -r gbdraw/web/* public/")
-    package_verify_index = deploy_yml.index(
-        "python tools/gallery_artifact_manifest.py --package-root public"
+    assert "npm run test:web:gallery-publication" in deploy_yml
+    assert "npm run test:web:vibrio-generate" in deploy_yml
+    assert "node --test tests/web/gallery-session-publication.test.mjs" in deploy_yml
+    assert (
+        "tests/test_gallery_session_semantics.py tests/test_refresh_gallery_sessions.py"
+        in deploy_yml
     )
-    stamp_index = deploy_yml.index("python tools/stamp_web_build.py public")
-    assert checkout_verify_index < copy_index < package_verify_index < stamp_index
+    assert "python tools/gallery_artifact_manifest.py" in deploy_yml
+    assert 'ref: ${{ github.sha }}' in deploy_yml
+    assert 'branches: ["main"]' in deploy_yml
+    assert "workflow_dispatch:" in deploy_yml
+    assert "pages: write" not in deploy_yml
+    assert "id-token: write" not in deploy_yml
+    assert "actions/deploy-pages" not in deploy_yml
+    assert "actions/upload-pages-artifact" not in deploy_yml
+    assert "github-pages" not in deploy_yml
+    assert "CNAME" not in deploy_yml
+    assert "cp -r gbdraw/web/* public/" not in deploy_yml
     assert "refresh_gallery_sessions" not in cloudflare_source
     assert '"--refresh-gallery"' not in cloudflare_source
     assert "verify_gallery_artifacts()" in cloudflare_source


### PR DESCRIPTION
## Plain-language summary

This PR retires the GitHub Pages publisher so the hosted app uses the existing Cloudflare Workers deployment at https://gbdraw.app/. The main-branch workflow continues to verify Gallery artifacts and run the Gallery and Vibrio browser checks for the exact main commit. Cloudflare Workers Builds keeps its existing Git integration and bundle preparation path.

## Change class

- [x] GOVERNANCE

## Purpose

- Base: `dev` at `f16204a9f5fe83051c2a5e6e32946e7ec31897f9`.
- The maintainer explicitly requested retiring GitHub Pages and consolidating hosting on Cloudflare.
- The source-record-count fix is already merged through #470 and #471. This PR contains five hosting, test, and documentation files.

## User-visible impact

`https://gbdraw.app/` remains the public app URL. The GitHub Pages site is retired. The application, generated diagrams, session behavior, and Cloudflare asset handling are unchanged.

## Changes

- Remove the GitHub Pages build, artifact upload, deployment jobs, and Pages/OIDC write permissions.
- Retain the exact-main browser verification job, including its Gallery and standalone Vibrio commands and existing timeouts. Keep the Gallery artifact verification that previously ran in the Pages build job.
- Update the packaging contract and document Cloudflare Workers as the production publisher.

## Verification

- Focused packaging checks: 10 passed (`python -m pytest tests/test_web_packaging.py -q -k 'cloudflare or hosted_web or wrangler'`).
- Architecture contracts: 137 passed (`node --test tests/web/architecture-contracts.test.mjs`).
- Web policy against `origin/dev`: `Gate: PASS`, `Review: REQUIRED` for governance files; no blocking violations or runtime inventory changes.
- Workflow YAML parsing and `git diff --check`: passed.
- Existing Cloudflare build for main `cd8e2249ffb378a9b95b390bf48ee86ea5fcad1a`: successful. Fresh-browser hosted checks confirmed BGC regeneration, direct input with two successful Generate calls, and a visible Source recipe. Hosted source and all 202 tracked Python wheel members match that main commit.

## Risk and review notes

- Gate result: PASS locally and on remote required checks: `PR / gate` (run `33972165754`, job `101323395945`) and `Web base policy (trusted base)` (run `33972165743`, job `101322484775`).
- Review: REQUIRED because this changes registered governance files and removes a publication owner/path. The maintainer explicitly approved this five-file diff in the current conversation (response: “承認します。”), referring to head `c45550475344625e308a3927cc4894c8e4493df7` and binary diff SHA-256 `167abdf985db052b0e7117f33e220b3428da469c8cc5d31018fb5e335b9f9746`. This is a separate approval from #470; no human GitHub review is being submitted by the agent.
- This is architecture-bearing for site publication. Changed-scope owners and paths go from GitHub Pages plus Cloudflare to the existing Cloudflare owner/path alone: publication `O: 2 -> 1`, target `T: 1`, `OE: 1 -> 0`; publication `P: 2 -> 1`, `PE: 1 -> 0`; compatibility burden `CB: 0 -> 0`. Browser verification retains the same workflow path and job. No new owner or compatibility path is introduced; ordinary non-increasing evidence applies.
- The `architecture-change` label routes this responsibility change for review.
- The previous GitHub Pages run failed in the standalone Vibrio test after the nine Gallery tests passed. That failure remains recorded; this PR neither changes the test nor claims that it passed.
- #468 and #469 remain unresolved. The paused #464 worktree and backup are untouched.

## Rollback

Revert this commit through the normal dev admission and promotion path. Re-enabling GitHub Pages would also require an explicit hosting decision and restoring its site settings; Cloudflare remains available throughout.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected journey/checkpoint effects: hosting-provider retirement requested by the maintainer; no Web runtime or session behavior change.
- Behavior contracts and residual risk: existing browser assertions and timeouts are retained. The standalone main Vibrio result is stress/health evidence outside the staging/Gallery promotion gates.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority or evidence-producer files touched: `.github/workflows/deploy_web.yml`, `docs/internal/WEB_CHANGE_POLICY.md`; supporting documentation and `tests/test_web_packaging.py`.
- Checker implementation files touched: none.
- Self-authorization separation: no checker, runtime, authority-rule JSON, test selection, or browser assertion changes. The base checker evaluates this governance change.
- Branch-protection/ruleset impact: no changes; use `PR / gate` and `Web base policy (trusted base)` for dev admission, exact-dev staging/Gallery evidence for promotion, and `Promotion / gate` plus `CodeQL` for main.
- Governance rollback: restore the workflow via a reviewed revert; GitHub Pages settings retirement is recorded separately.
