### PR TITLE
Allow setup time in the Web PR smoke job budget

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -328,7 +328,7 @@ jobs:
       needs.ci-impact.result == 'success' &&
       contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-pr-smoke')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1048,7 +1048,7 @@ test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
   assert.match(webPrSmoke, /needs: ci-impact/);
   assert.match(webPrSmoke, /needs\.ci-impact\.result == 'success'/);
   assert.match(webPrSmoke, /requiredJobs, 'web-pr-smoke'/);
-  assert.match(webPrSmoke, /timeout-minutes: 5/);
+  assert.match(webPrSmoke, /timeout-minutes: 10/);
   assert.equal([...webPrSmoke.matchAll(/uses: actions\/checkout@/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/npm ci/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/playwright install --with-deps chromium/g)].length, 1);


### PR DESCRIPTION
## Plain-language summary

Increase the `Web PR smoke` job's total execution limit from 5 to 10 minutes so setup and the existing tests can finish within an explicit, finite budget. The previous #474 run reached 8 of 10 Playwright cases before the five-minute job cancellation; Typography was interrupted and right-drawer was not reached. Completion within ten minutes remains to be verified on the updated #474 head after this CI-only change reaches `dev`.

## Change class

- [x] GOVERNANCE

## Purpose and changes

Base: `dev` at `f1144fd714a80e8f0307b3a98e13555412345345`. Change only `jobs.web-pr-smoke.timeout-minutes` in `.github/workflows/test.yml` and the matching `webPrSmoke` expectation in `tests/web/architecture-contracts.test.mjs`, both from 5 to 10.

Individual test timeouts, assertions, performance thresholds, selection, retries, workers, and operation sequences are preserved. Job identity, required-job selection, trusted-base checkout, gates, dependencies, wheel preparation, all three test commands, and artifact handling are unchanged. No application runtime, checker implementation, permissions, or protection settings change. No current normative document was found that separately fixes this job budget at five minutes.

## Verification

- Parsed YAML comparison: only the smoke job's total timeout differs.
- `node --test tests/web/architecture-contracts.test.mjs`
- `node --test tests/ci/*.test.mjs`
- `node tools/check-web-change-budget.mjs --base origin/dev`
- PR language check and `git diff --check`.

Previous #474 Tests run: https://github.com/satoshikawato/gbdraw/actions/runs/34077931678 (cancelled, not a pass). It recorded 128 seconds before Playwright, 185 seconds of interrupted Playwright execution, and 316 seconds overall including cancellation/cleanup. Both joint modes passed real CLI replay and SVG comparison in that run; the interrupted and unreached cases remain unverified remotely. This change does not claim that the old five-minute gate passed. New required checks and the updated #474 run will provide fresh evidence.

## Risk and review notes

- Gate: local PASS; required remote checks must pass before merge.
- Review: REQUIRED because CI authority changes. The task requester explicitly approved this exact two-line budget/contract change and its protected CI-only merge once required checks and applicable review conditions are satisfied. This is not a GitHub review posted on the requester's behalf or approval of #474 as a whole.
- This is not architecture-bearing. Runtime owners and canonical/compatibility paths are unchanged; OE/PE/CB: N/A.
- The extra five minutes is an operational allowance, not a test-performance relaxation or a measured completion guarantee.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- User-visible runtime impact: none.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## GOVERNANCE evidence

Authority/evidence producer: `.github/workflows/test.yml`; synchronized existing contract: `tests/web/architecture-contracts.test.mjs`. Checker implementation files: none. The complete diff contains only these two lines and no runtime, so the base policy's self-authorization separation is preserved. Required checks remain `Web base policy (trusted base)` and `PR / gate`, with strict base synchronization, zero mandatory GitHub approvals, and no additional active branch rulesets at inspection.

Rollback: revert these two synchronized lines through a separate protected CI-only PR. No branch-protection restore is needed because settings are unchanged.

Related: #474. After this PR merges, merge updated `dev` normally into the existing #474 branch and verify its new head. #474 merge/auto-merge, main promotion, release, and manual deployment are outside this authorization. This PR closes neither #464 nor #465.
