### PR TITLE
Batch protein cache-key validation during generation

### DIFF
--- a/gbdraw/web/js/app/python-helpers.js
+++ b/gbdraw/web/js/app/python-helpers.js
@@ -836,34 +836,35 @@ def resolve_legacy_protein_reference_map_json(
     except Exception:
         return json.dumps({"status": "error", "error": traceback.format_exc()})
 
-def build_protein_losat_cache_key_json(
+def build_protein_losat_cache_keys_json(
     identity_manifest_json,
-    query_record_instance_key,
-    subject_record_instance_key,
-    expected_options_json,
+    pairs_json,
 ):
-    """Build the directional schema-4 key with the Python identity owner."""
+    """Build directional schema-4 keys after validating the manifest once."""
     try:
         from gbdraw.analysis.protein_colinearity import (
             build_protein_losat_cache_key,
             build_protein_losat_pair_identity,
+            validate_protein_identity_manifest,
         )
 
-        manifest = json.loads(str(identity_manifest_json))
-        options = json.loads(str(expected_options_json))
-        pair_identity = build_protein_losat_pair_identity(
-            manifest,
-            query_record_instance_key=str(query_record_instance_key),
-            subject_record_instance_key=str(subject_record_instance_key),
-        )
-        return json.dumps({
-            "key": build_protein_losat_cache_key(
+        manifest = validate_protein_identity_manifest(json.loads(str(identity_manifest_json)))
+        pairs = json.loads(str(pairs_json))
+        keys = []
+        for pair in pairs:
+            pair_identity = build_protein_losat_pair_identity(
+                manifest,
+                query_record_instance_key=str(pair["queryRecordInstanceKey"]),
+                subject_record_instance_key=str(pair["subjectRecordInstanceKey"]),
+            )
+            options = pair["expectedOptions"]
+            keys.append(build_protein_losat_cache_key(
                 pair_identity,
                 args=options.get("args") or [],
                 program=str(options.get("program") or "blastp"),
                 outfmt=str(options.get("outfmt") or "6"),
-            )
-        })
+            ))
+        return json.dumps({"keys": keys})
     except Exception:
         return json.dumps({"error": traceback.format_exc()})
 

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -3274,30 +3274,6 @@ export const createRunAnalysis = ({
           };
         };
 
-        const buildCacheKey = async (metadata) => {
-          if (metadata?.identityKind === 'protein') {
-            const response = await runDiagramHelperOperation(
-              DIAGRAM_HELPER_OPERATIONS.BUILD_PROTEIN_LOSAT_CACHE_KEY,
-              {
-                identityManifest: cloneJsonData(workingProteinIdentityManifest),
-                queryRecordInstanceKey: metadata.queryRecordInstanceKey,
-                subjectRecordInstanceKey: metadata.subjectRecordInstanceKey,
-                expectedOptions: {
-                  program: metadata.program,
-                  outfmt: metadata.outfmt,
-                  args: normalizeLosatArgs(metadata.args)
-                }
-              }
-            );
-            const result = response.result;
-            if (result.error || !result.key) {
-              throw new Error(result.error || 'Protein cache key generation failed.');
-            }
-            return String(result.key);
-          }
-          return hashText(JSON.stringify(buildLosatCachePayload(metadata)));
-        };
-
         const tryPromoteLegacyProteinEntry = async ({
           cacheKey,
           metadata,
@@ -3616,15 +3592,54 @@ export const createRunAnalysis = ({
             }));
           }
 
+          const preparedJobs = [];
           for (const spec of jobSpecs) {
+            throwIfGenerationCanceled();
+            const losatArgs = buildLosatArgs(spec.queryIndex, spec.subjectIndex);
+            const cacheMetadata = await buildCacheMetadata(
+              losatArgs, spec.queryIndex, spec.subjectIndex
+            );
+            preparedJobs.push({ spec, losatArgs, cacheMetadata });
+          }
+          let proteinCacheKeys = null;
+          if (useProteinBlastp && preparedJobs.length > 0) {
+            throwIfGenerationCanceled();
+            const response = await runDiagramHelperOperation(
+              DIAGRAM_HELPER_OPERATIONS.BUILD_PROTEIN_LOSAT_CACHE_KEYS,
+              {
+                identityManifest: cloneJsonData(workingProteinIdentityManifest),
+                pairs: preparedJobs.map(({ cacheMetadata }) => ({
+                  queryRecordInstanceKey: cacheMetadata.queryRecordInstanceKey,
+                  subjectRecordInstanceKey: cacheMetadata.subjectRecordInstanceKey,
+                  expectedOptions: {
+                    program: cacheMetadata.program,
+                    outfmt: cacheMetadata.outfmt,
+                    args: normalizeLosatArgs(cacheMetadata.args)
+                  }
+                }))
+              }
+            );
+            throwIfGenerationCanceled();
+            const result = response.result;
+            if (
+              result.error || !Array.isArray(result.keys)
+              || result.keys.length !== preparedJobs.length
+              || result.keys.some((key) => !/^[0-9a-f]{64}$/.test(key))
+            ) {
+              throw new Error(result.error || 'Protein cache key generation failed.');
+            }
+            proteinCacheKeys = result.keys;
+          }
+
+          for (const [jobIndex, { spec, losatArgs, cacheMetadata }] of preparedJobs.entries()) {
             throwIfGenerationCanceled();
             const queryEntry = await getSeqEntry(spec.queryIndex);
             throwIfGenerationCanceled();
             const subjectEntry = await getSeqEntry(spec.subjectIndex);
             throwIfGenerationCanceled();
-            const losatArgs = buildLosatArgs(spec.queryIndex, spec.subjectIndex);
-            const cacheMetadata = await buildCacheMetadata(losatArgs, spec.queryIndex, spec.subjectIndex);
-            const cacheKey = await buildCacheKey(cacheMetadata);
+            const cacheKey = useProteinBlastp
+              ? proteinCacheKeys[jobIndex]
+              : await hashText(JSON.stringify(buildLosatCachePayload(cacheMetadata)));
             throwIfGenerationCanceled();
             const queryCanonicalHash = await getSeqHash(spec.queryIndex);
             throwIfGenerationCanceled();

--- a/gbdraw/web/js/services/diagram-worker-protocol.js
+++ b/gbdraw/web/js/services/diagram-worker-protocol.js
@@ -1,5 +1,5 @@
 export const DIAGRAM_HELPER_OPERATIONS = Object.freeze({
-  BUILD_PROTEIN_LOSAT_CACHE_KEY: 'buildProteinLosatCacheKey',
+  BUILD_PROTEIN_LOSAT_CACHE_KEYS: 'buildProteinLosatCacheKeys',
   CONVERT_LOSAT_NUCLEOTIDE_TO_DISPLAY_TSV: 'convertLosatNucleotideToDisplayTsv',
   CONVERT_LOSATP_PAIRS_TO_GENOMIC_PAYLOAD: 'convertLosatpPairsToGenomicPayload',
   EXTRACT_CDS_PROTEIN_FASTA: 'extractCdsProteinFasta',

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -558,22 +558,15 @@ const HELPER_OPERATION_SPECS = Object.freeze({
       ]);
     }
   },
-  [DIAGRAM_HELPER_OPERATIONS.BUILD_PROTEIN_LOSAT_CACHE_KEY]: {
-    keys: [
-      'identityManifest',
-      'queryRecordInstanceKey',
-      'subjectRecordInstanceKey',
-      'expectedOptions'
-    ],
+  [DIAGRAM_HELPER_OPERATIONS.BUILD_PROTEIN_LOSAT_CACHE_KEYS]: {
+    keys: ['identityManifest', 'pairs'],
     fileRoles: [],
     run: (pyodide, payload) => callJsonHelper(
       pyodide,
-      'build_protein_losat_cache_key_json',
+      'build_protein_losat_cache_keys_json',
       [
         jsonArgument(payload.identityManifest, {}),
-        String(payload.queryRecordInstanceKey || ''),
-        String(payload.subjectRecordInstanceKey || ''),
-        jsonArgument(payload.expectedOptions, {})
+        jsonArgument(payload.pairs, [])
       ]
     )
   },

--- a/tests/test_protein_colinearity.py
+++ b/tests/test_protein_colinearity.py
@@ -3092,20 +3092,76 @@ def test_web_extract_cds_protein_fasta_uses_coordinate_stable_ids(tmp_path: Path
     assert result["display_binding_hash"].startswith("sha256:")
     boundary_key = json.loads(
         str(
-            namespace["build_protein_losat_cache_key_json"](
+            namespace["build_protein_losat_cache_keys_json"](
                 json.dumps(result["identity_manifest"]),
-                "record_a_region",
-                "record_a_region",
-                json.dumps({"program": "blastp", "outfmt": "6", "args": []}),
+                json.dumps([{
+                    "queryRecordInstanceKey": "record_a_region",
+                    "subjectRecordInstanceKey": "record_a_region",
+                    "expectedOptions": {"program": "blastp", "outfmt": "6", "args": []},
+                }]),
             )
         )
-    )["key"]
+    )["keys"][0]
     expected_identity = build_protein_losat_pair_identity(
         result["identity_manifest"],
         query_record_instance_key="record_a_region",
         subject_record_instance_key="record_a_region",
     )
     assert boundary_key == build_protein_losat_cache_key(expected_identity, args=[])
+
+
+@pytest.mark.linear
+def test_web_protein_cache_keys_validate_once_and_preserve_direction_and_options(monkeypatch) -> None:
+    namespace = _load_web_helper_namespace()
+    extraction = extract_protein_identity_manifest(
+        [_record("a", features=[_cds(0, 9, qualifiers={"translation": ["MKT"]})]),
+         _record("b", features=[_cds(0, 9, qualifiers={"translation": ["MGG"]})])],
+        record_instance_keys=("row-a", "row-b"),
+    )
+    manifest = extraction.identity_manifest.to_dict()
+    pairs = [
+        {"queryRecordInstanceKey": query, "subjectRecordInstanceKey": subject,
+         "expectedOptions": {"program": "blastp", "outfmt": "6", "args": args}}
+        for query, subject, args in [
+            ("row-a", "row-b", []), ("row-b", "row-a", []),
+            ("row-a", "row-a", []), ("row-a", "row-b", ["--max-target-seqs", "6"]),
+            ("row-a", "row-b", []),
+        ]
+    ]
+    expected = [
+        build_protein_losat_cache_key(
+            build_protein_losat_pair_identity(
+                manifest, query_record_instance_key=pair["queryRecordInstanceKey"],
+                subject_record_instance_key=pair["subjectRecordInstanceKey"],
+            ), args=pair["expectedOptions"]["args"],
+        ) for pair in pairs
+    ]
+    validation_calls = []
+
+    def validate_once(value):
+        validation_calls.append(1)
+        return validate_protein_identity_manifest(value)
+
+    monkeypatch.setattr(protein_colinearity_module, "validate_protein_identity_manifest", validate_once)
+    result = json.loads(namespace["build_protein_losat_cache_keys_json"](
+        json.dumps(manifest), json.dumps(pairs),
+    ))
+    assert result == {"keys": expected}
+    assert len(set(expected)) == 4
+    assert validation_calls == [1]
+    # A bad later pair must not expose a partial key list.
+    pairs[-1]["subjectRecordInstanceKey"] = "unknown"
+    rejected = json.loads(namespace["build_protein_losat_cache_keys_json"](
+        json.dumps(manifest), json.dumps(pairs),
+    ))
+    assert "error" in rejected and "keys" not in rejected
+    # Validate the full manifest even when a bad record is not in a requested pair.
+    pairs = pairs[2:3]
+    manifest["recordInstances"]["row-b"]["runtimeBindingHash"] = "invalid"
+    rejected = json.loads(namespace["build_protein_losat_cache_keys_json"](
+        json.dumps(manifest), json.dumps(pairs),
+    ))
+    assert "error" in rejected and "keys" not in rejected
 
 
 @pytest.mark.linear

--- a/tests/web/contracts/vibrio-full-generation.serial.spec.js
+++ b/tests/web/contracts/vibrio-full-generation.serial.spec.js
@@ -865,6 +865,8 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
       }
     };
   });
+  const loadedSvgPath = testInfo.outputPath('vibrio-loaded-preview.svg');
+  writeFileSync(loadedSvgPath, loaded.originalPreview, 'utf8');
   const loadedPreviewIdentity = svgSourceIdentity(loaded.originalPreview);
   const preFirstGenerateActiveIntent = await activeIntentSummary(page);
   const loadProbe = await probeSnapshot(page);
@@ -922,6 +924,10 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
   const firstProbe = !page.isClosed() && !terminal.pageCrashed
     ? await probeSnapshot(page)
     : { metrics: {}, details: [], lifecycle: [] };
+  await testInfo.attach('vibrio-first-generation-diagnostics.json', {
+    body: Buffer.from(JSON.stringify({ diagnostic: first, probe: firstProbe })),
+    contentType: 'application/json'
+  });
   const firstRecovery = await assertRecoverableErrorState(page, first, loaded.originalPreview);
   expect(first.classification, JSON.stringify(first, null, 2)).toBe('success');
   expect(first.outcome).toMatchObject({
@@ -934,6 +940,8 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     return String(app.results?.[app.selectedResultIndex]?.content || '');
   });
   const firstRecordPlacements = await recordPlacementSummary(page);
+  const firstSvgPath = testInfo.outputPath('vibrio-generate-1.svg');
+  writeFileSync(firstSvgPath, firstGeneratedSvg, 'utf8');
   const firstGeneratedIdentity = svgSourceIdentity(firstGeneratedSvg);
 
   const derivedMutationBefore = await page.evaluate(async () => {
@@ -953,6 +961,10 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
   const secondProbe = !page.isClosed() && !terminal.pageCrashed
     ? await probeSnapshot(page)
     : { metrics: {}, details: [], lifecycle: [] };
+  await testInfo.attach('vibrio-second-generation-diagnostics.json', {
+    body: Buffer.from(JSON.stringify({ diagnostic: second, probe: secondProbe })),
+    contentType: 'application/json'
+  });
   const secondRecovery = await assertRecoverableErrorState(page, second, loaded.originalPreview);
   expect(second.classification, JSON.stringify(second, null, 2)).toBe('success');
   expect(second.outcome).toMatchObject({
@@ -964,6 +976,8 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     const app = window.__GBDRAW_APP__;
     return String(app.results?.[app.selectedResultIndex]?.content || '');
   });
+  const secondSvgPath = testInfo.outputPath('vibrio-generate-2.svg');
+  writeFileSync(secondSvgPath, secondGeneratedSvg, 'utf8');
   const secondRecordPlacements = await recordPlacementSummary(page);
   const postSecondGenerateActiveIntent = await activeIntentSummary(page);
   const derivedMutationAfter = await page.evaluate(async () => {
@@ -980,7 +994,7 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
   const capturedCanonicalRequests = canonicalRequestCapture.requests;
   expect(capturedCanonicalRequests).toHaveLength(2);
   expect(capturedCanonicalRequests[0]).toMatchObject({
-    schema: 6,
+    schema: 7,
     mode: 'linear',
     recordCount: 11,
     comparisonCount: 2,
@@ -1107,9 +1121,9 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
   });
   expect(firstComparisonSummary).toEqual(loadedComparisonSummary);
   expect(secondComparisonSummary).toEqual(firstComparisonSummary);
-  expect(loaded.originalPreview).toContain('data-query-unit-id="h_');
-  expect(firstGeneratedSvg).toContain('data-query-unit-id="gbd_r');
-  expect(firstGeneratedIdentity.sha256).not.toBe(loadedPreviewIdentity.sha256);
+  expect(loaded.originalPreview.includes('data-query-unit-id="gbd_r')).toBe(true);
+  expect(firstGeneratedSvg.includes('data-query-unit-id="gbd_r')).toBe(true);
+  expect(firstGeneratedIdentity.sha256).toBe(loadedPreviewIdentity.sha256);
   const generatedFeatureCatalogDigest = await featureCatalogDigest(page);
 
   const activity = second.worker;
@@ -1138,21 +1152,9 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     resultMetadataBinaryDecodedBytes: Number(
       firstProbe.metrics.resultMetadataBinaryDecodedBytes || 0
     ),
-    legacyFeatureOverrideFullDescriptorComparisonCount: Number(
-      firstProbe.metrics.legacyFeatureOverrideFullDescriptorComparisonCount || 0
-    ),
-    legacyFeatureOverrideIndexedDescriptorComparisonCount: Number(
-      firstProbe.metrics.legacyFeatureOverrideIndexedDescriptorComparisonCount || 0
-    ),
-    legacyFeatureOverrideLegacyFeaturesVisited: Number(
-      firstProbe.metrics.legacyFeatureOverrideLegacyFeaturesVisited || 0
-    ),
-    legacyFeatureOverrideMigrationCallCount: Number(
-      firstProbe.metrics.legacyFeatureOverrideMigrationCallCount || 0
-    ),
-    legacyFeatureOverrideScanSkipCount: Number(
-      firstProbe.metrics.legacyFeatureOverrideScanSkipCount || 0
-    )
+    currentLegacyNormalizationCount: Number(firstProbe.metrics.currentLegacyNormalizationCount),
+    legacyOverrideMigrationCount: Number(firstProbe.metrics.legacyOverrideMigrationCount),
+    manualRuleFeatureMatchCount: Number(firstProbe.metrics.manualRuleFeatureMatchCount)
   };
   const secondStructural = {
     canonicalReplayFullSerializationCount: Number(
@@ -1170,21 +1172,9 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     resultMetadataBinaryDecodedBytes: Number(
       secondProbe.metrics.resultMetadataBinaryDecodedBytes || 0
     ),
-    legacyFeatureOverrideFullDescriptorComparisonCount: Number(
-      secondProbe.metrics.legacyFeatureOverrideFullDescriptorComparisonCount || 0
-    ),
-    legacyFeatureOverrideIndexedDescriptorComparisonCount: Number(
-      secondProbe.metrics.legacyFeatureOverrideIndexedDescriptorComparisonCount || 0
-    ),
-    legacyFeatureOverrideLegacyFeaturesVisited: Number(
-      secondProbe.metrics.legacyFeatureOverrideLegacyFeaturesVisited || 0
-    ),
-    legacyFeatureOverrideMigrationCallCount: Number(
-      secondProbe.metrics.legacyFeatureOverrideMigrationCallCount || 0
-    ),
-    legacyFeatureOverrideScanSkipCount: Number(
-      secondProbe.metrics.legacyFeatureOverrideScanSkipCount || 0
-    )
+    currentLegacyNormalizationCount: Number(secondProbe.metrics.currentLegacyNormalizationCount),
+    legacyOverrideMigrationCount: Number(secondProbe.metrics.legacyOverrideMigrationCount),
+    manualRuleFeatureMatchCount: Number(secondProbe.metrics.manualRuleFeatureMatchCount)
   };
   const resultTransportEvents = [firstProbe, secondProbe].flatMap((probe) => (
     probe.lifecycle.filter(({ name }) => name === 'result-transport-ready')
@@ -1231,6 +1221,12 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     artifactReplacementHistoryEntryCount: 1
   };
 
+  for (const [generation, count] of [[first, 1], [second, 2]]) {
+    const keyBatches = generation.worker.instances.flatMap(({ helpers }) => helpers)
+      .filter(({ operation }) => operation === 'buildProteinLosatCacheKeys');
+    expect(keyBatches).toHaveLength(count);
+  }
+
   expect(activity.constructions).toBe(1);
   expect(activity.initializations).toBe(1);
   expect(activity.runs).toBe(2);
@@ -1262,21 +1258,25 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     losatCacheHits: 47,
     losatCacheMisses: 0
   });
-  expect(second.outcome.historyStructural).toEqual(expectedGeneratedHistory);
+  const expectedUnchangedHistory = {
+    ...expectedGeneratedHistory,
+    artifactReplacementHistoryEntryCount: 0
+  };
+  expect(second.outcome.historyStructural).toEqual(expectedUnchangedHistory);
   expect(secondPhaseAttribution.historyStructural).toMatchObject(
-    expectedGeneratedHistory
+    expectedUnchangedHistory
   );
   expect(second.outcome.undoCountAfter).toBe(second.outcome.undoCountBefore);
   expect(second.outcome.redoCountAfter).toBe(second.outcome.redoCountBefore);
   expect(first.outcome.historyStructural).toMatchObject(expectedGeneratedHistory);
   expect(secondStructural.resourceMaterializationCount).toBe(0);
-  expect(secondStructural).toMatchObject({
-    legacyFeatureOverrideFullDescriptorComparisonCount: 0,
-    legacyFeatureOverrideIndexedDescriptorComparisonCount: 0,
-    legacyFeatureOverrideLegacyFeaturesVisited: 0,
-    legacyFeatureOverrideMigrationCallCount: 2,
-    legacyFeatureOverrideScanSkipCount: 2
-  });
+  for (const perGeneration of [firstStructural, secondStructural]) {
+    expect(perGeneration).toMatchObject({
+      currentLegacyNormalizationCount: 0,
+      legacyOverrideMigrationCount: 0,
+      manualRuleFeatureMatchCount: 0
+    });
+  }
   expect(secondPhaseAttribution.pythonInvocationMs).toBeGreaterThan(0);
   expect(firstPhaseAttribution.preparedInputCacheStructural).toMatchObject({
     decodedResourceCacheHitCount: 0,
@@ -1390,12 +1390,6 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
   expect(afterPing.initializations).toBe(1);
   expect(afterPing.instances[0].terminated).toBe(false);
 
-  const loadedSvgPath = testInfo.outputPath('vibrio-loaded-preview.svg');
-  const firstSvgPath = testInfo.outputPath('vibrio-generate-1.svg');
-  const secondSvgPath = testInfo.outputPath('vibrio-generate-2.svg');
-  writeFileSync(loadedSvgPath, loaded.originalPreview, 'utf8');
-  writeFileSync(firstSvgPath, firstGeneratedSvg, 'utf8');
-  writeFileSync(secondSvgPath, secondGeneratedSvg, 'utf8');
   const svgComparisonCommand = [
     'import sys',
     'from tests.utils.svg_compare import compare_svgs',
@@ -1515,7 +1509,7 @@ test('real Vibrio preview regenerates after a derived-only mutation', async ({
     },
     deterministicOutput: {
       comparison: 'tests.utils.svg_compare.compare_svgs',
-      loadedToFirstRelationship: 'derived-unit-metadata-refresh',
+      loadedToFirstRelationship: 'current-gallery-preview-regenerated',
       loadedToFirstExactBytesEqual: loaded.originalPreview === firstGeneratedSvg,
       loadedPreviewIdentity,
       firstGeneratedIdentity,


### PR DESCRIPTION
## Plain-language summary

Batch protein cache-key requests so Generate validates and transfers the full protein identity manifest once per generation. The real Vibrio session previously repeated that work for all 47 active comparisons, consuming several minutes before rendering. Directional cache keys, complete manifest validation, comparison results, and Preview readiness remain unchanged.

## Change class

- [x] STANDARD

## Purpose

- Base: `dev` at `2efb21e57a5db81344930c54928fac5654e73b2b`.
- Required checks: `Web base policy (trusted base)` and `PR / gate`, with strict branch protection.
- Scope: S01 real Vibrio Load → Generate → `orthogroupMemberMaxHits` 5→6 → Generate and continuation checks.

## User-visible impact

Generation avoids repeated full-manifest validation while preserving the existing biological inputs, cache identities, and final results. Timeout and performance thresholds are unchanged.

## Changes

- Replace the private per-pair Worker operation with one batch operation through the same caller, Worker dispatcher, and canonical Python identity/key functions.
- Add a regression that checks one complete validation, directional/options equivalence, duplicate pairs, and rejection without partial results. Reintroducing per-pair validation fails this test.
- Update previously unreachable Vibrio assertions to the base branch's schema 7, current Gallery feature IDs and identical saved/regenerated SVG, current migration counters, and unchanged-artifact History behavior. Retain result comparisons, cache reuse, readiness, Undo/Redo, and Worker continuation checks; save each generated SVG and diagnostic at its completion boundary.

## Verification

- Real Vibrio formal test: **PASS on `47f5cebd`**, 14.0 minutes total with the unchanged 20-minute timeout. Fresh Load → first Generate (428.980 s) → member limit 5→6 → second Generate (341.936 s) → SVG comparison, current feature catalog, no-op History preservation and live Worker ping all completed. Both generations reused all 47 raw-cache entries with zero raw Worker calls; generated SVGs and metadata fingerprints matched exactly.
- Python protein colinearity tests: 116 passed, 1 existing opt-in external BLAST smoke skipped.
- Node cache, Result, History, Worker, and startup tests: 9 file-level tests passed.
- Related browser generation tests: 2 passed. Fresh mobile Circular Load and two Generates also passed with external requests blocked.
- Required Gallery follow-ups: publication Node test passed; 55 Python tests passed; artifact manifest validation passed.
- All 59 stored Vibrio cache keys matched the previous implementation. Native validation calls fell from 59 to 1; this is supplementary structural evidence, not a new timing gate.
- Ruff, changed-JS syntax, and diff checks passed.

The unchanged baseline completed both local Generates but failed its old schema assertion; a first candidate completed both Generates and exposed an old Gallery-ID assertion. A following run confirmed that the saved and regenerated SVG bytes are identical, exposing the corresponding old inequality expectation. These stale expectations were corrected against current base behavior; the complete final formal test, including live continuation, now passes. Local checks used Python 3.13, Node 20.20.2, Chromium 1228, and a freshly prepared `0.14.0b0` browser wheel. Main-only promotion verification is not claimed here.

## Risk and review notes

- Required remote CI: **PASS**, including `Web base policy (trusted base)` and `PR / gate` on this head ([Tests run](https://github.com/satoshikawato/gbdraw/actions/runs/34112251837)). Core PR (Python 3.11), Gallery, recipes, lint, Web budget and Web smoke passed.
- Gate: PASS locally and remotely; no blocking Web policy violation.
- Review: REQUIRED because resource-like declaration names changed (four added, four removed, net zero). Ordinary human review remains required before merge.
- This is not architecture-bearing in owner/path terms: the existing caller → diagram helper → canonical Python identity/key owner is retained. No persistent cache, new canonical or compatibility path, public export, reactive owner, or scientific output owner is introduced. The singular private operation is removed in the same change.
- Architecture baseline: existing semantic owners and canonical paths are unchanged; owner/path/compatibility excess does not increase. The ordinary review profile applies; no `architecture-change` label or exception is requested.

## Rollback

Revert this commit to restore the previous per-pair operation and its matching tests. No persisted format or dependency migration is involved.

## Conditional Product Impact

- Product-impact role: N/A; no registered Product Impact delta.
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY.
- Journey effects: successful Generate and available Preview, unchanged raw-cache identity and complete validation, and existing no-op History semantics.
- Authority: base canonical identity validation/key functions, current Gallery fixture and render-request schema, current History behavior; no new Product decision or retirement.
- Decision Pack: N/A. Performance observations are runner-specific; the formal operation still uses its existing timeout.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
