### PR TITLE
Prevent preview pans from jumping during native drag cancellation

### DIFF
--- a/gbdraw/web/js/app/ui.js
+++ b/gbdraw/web/js/app/ui.js
@@ -229,6 +229,8 @@ export const createPanZoom = (state) => {
       return;
     }
 
+    // Own the accepted pan instead of starting native SVG text selection/drag.
+    event.preventDefault?.();
     cancelPanFrame();
     pendingPanPointer = null;
     beginPreviewTransformInteraction('pan', event);
@@ -254,8 +256,10 @@ export const createPanZoom = (state) => {
 
   const endPan = (event) => {
     const wasPanning = isPanning.value;
+    // Cancellation and capture loss may carry (0, 0), not a pointer position.
     const finalPointer =
-      typeof event?.clientX === 'number' && typeof event?.clientY === 'number'
+      event?.type !== 'pointercancel' && event?.type !== 'lostpointercapture'
+      && Number.isFinite(event?.clientX) && Number.isFinite(event?.clientY)
         ? { x: event.clientX, y: event.clientY }
         : pendingPanPointer;
     cancelPanFrame();

--- a/tests/web/preview-navigation.playwright.spec.js
+++ b/tests/web/preview-navigation.playwright.spec.js
@@ -1,0 +1,159 @@
+const { test, expect } = require('@playwright/test');
+const { join } = require('node:path');
+const { writeFile } = require('node:fs/promises');
+const { openApp, getDiagramWorkerActivity } = require('./helpers/app-lifecycle.cjs');
+
+const geometry = (page) => page.evaluate(() => {
+  const app = window.__GBDRAW_APP__;
+  const wrapper = app.svgContainer;
+  const svg = wrapper.querySelector('svg');
+  const container = app.canvasContainerRef;
+  const matrix = svg.getScreenCTM();
+  const point = (x, y) => {
+    const p = new DOMPoint(x, y).matrixTransform(matrix);
+    return { x: p.x, y: p.y };
+  };
+  const bounds = wrapper.getBoundingClientRect();
+  return {
+    zoom: app.zoom, pan: { ...app.canvasPan },
+    scroll: { x: container.scrollLeft, y: container.scrollTop },
+    points: [point(0, 0), point(100, 100)],
+    anchor: { x: bounds.x + bounds.width / 2, y: bounds.y },
+    panning: app.isPanning
+  };
+});
+
+const settle = async (page) => {
+  await expect.poll(() => page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    const transform = new DOMMatrix(getComputedStyle(app.svgContainer).transform);
+    return Math.max(Math.abs(transform.a - app.zoom),
+      Math.abs(transform.e - app.canvasPan.x), Math.abs(transform.f - app.canvasPan.y));
+  })).toBeLessThan(0.001);
+};
+
+const backgroundPoint = (page) => page.evaluate(() => {
+  const app = window.__GBDRAW_APP__;
+  const container = app.canvasContainerRef;
+  const rect = container.getBoundingClientRect();
+  const svg = app.svgContainer.querySelector('svg');
+  for (let y = rect.bottom - 160; y > rect.y + 30; y -= 30) {
+    for (let x = rect.x + 50; x < rect.right - 40; x += 60) {
+      const target = document.elementFromPoint(x, y);
+      if (target === container || target === app.svgContainer || target === svg) return { x, y };
+    }
+  }
+  throw new Error('No visible non-editing background point.');
+});
+
+const move = async (page, point, dx, dy) => {
+  await page.mouse.move(point.x, point.y);
+  await page.mouse.down();
+  await page.mouse.move(point.x + dx, point.y + dy, { steps: 10 });
+  await page.mouse.up();
+  await settle(page);
+};
+
+const expectTranslation = (before, after, dx, dy) => {
+  for (let i = 0; i < before.points.length; i += 1) {
+    expect(after.points[i].x - before.points[i].x).toBeCloseTo(dx, 1);
+    expect(after.points[i].y - before.points[i].y).toBeCloseTo(dy, 1);
+  }
+  expect(after.panning).toBe(false);
+};
+
+test('@pr-smoke background pan preserves screen displacement after text selection and zoom', async ({ page }, testInfo) => {
+  test.setTimeout(180000);
+  await openApp(page);
+  page.on('dialog', (dialog) => dialog.dismiss());
+  await page.locator('input[type=file][accept*="application/json"][accept*="application/gzip"]')
+    .setInputFiles(join(process.cwd(), 'gbdraw/web/gallery/sessions/BGC0000708-BGC0000713.gbdraw-session.json'));
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.results.length)).toBe(1);
+  await settle(page);
+  const committed = await page.evaluate(async () => {
+    const { getCommittedCanonicalSession } = await import('./js/services/config.js');
+    return JSON.stringify(getCommittedCanonicalSession());
+  });
+  const evidence = [];
+  for (const zoom of [0.3, 1, 2.8]) {
+    await page.getByRole('button', { name: 'Reset layout', exact: true }).click();
+    const direction = zoom < 1 ? 'Zoom out' : 'Zoom in';
+    for (let i = 0; i < Math.round(Math.abs(zoom - 1) * 10); i += 1) {
+      await page.getByRole('button', { name: direction, exact: true }).click();
+    }
+    await settle(page);
+    const before = await geometry(page);
+    const point = await backgroundPoint(page);
+    await move(page, point, 60, 80);
+    const after = await geometry(page);
+    evidence.push({ zoom, point, before, after });
+    await writeFile(testInfo.outputPath('navigation.json'), JSON.stringify(evidence, null, 2));
+    expectTranslation(before, after, 60, 80);
+    // Preserve the existing top-center zoom anchor, including after panning.
+    await page.mouse.move(point.x, point.y);
+    await page.mouse.wheel(0, -100);
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.zoom)).toBeCloseTo(zoom + 0.1, 5);
+    await settle(page);
+    const zoomed = await geometry(page);
+    expect(zoomed.anchor.x).toBeCloseTo(after.anchor.x, 1);
+    expect(zoomed.anchor.y).toBeCloseTo(after.anchor.y, 1);
+    await page.mouse.wheel(0, 100);
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.zoom)).toBeCloseTo(zoom, 5);
+    await settle(page);
+    expectTranslation(after, await geometry(page), 0, 0);
+  }
+  await page.getByRole('button', { name: 'Reset layout', exact: true }).click();
+  await settle(page);
+  expect(await geometry(page)).toMatchObject({ zoom: 1, pan: { x: 0, y: 0 }, panning: false });
+  expect(await page.evaluate(async () => {
+    const { getCommittedCanonicalSession } = await import('./js/services/config.js');
+    return JSON.stringify(getCommittedCanonicalSession());
+  })).toBe(committed);
+  expect(await getDiagramWorkerActivity(page)).toMatchObject({ constructions: 0 });
+});
+
+test('@pr-smoke preview pan leaves feature and match gestures available', async ({ page }) => {
+  test.setTimeout(180000);
+  // Keep the wide comparison's editing targets visible at its existing zoom anchor.
+  await page.setViewportSize({ width: 2520, height: 1327 });
+  await openApp(page);
+  page.on('dialog', (dialog) => dialog.dismiss());
+  await page.locator('input[type=file][accept*="application/json"][accept*="application/gzip"]')
+    .setInputFiles(join(process.cwd(), 'gbdraw/web/gallery/sessions/BGC0000708-BGC0000713.gbdraw-session.json'));
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.results.length)).toBe(1);
+  for (let i = 0; i < 7; i += 1) await page.getByRole('button', { name: 'Zoom out', exact: true }).click();
+  await settle(page);
+
+  for (const selector of ['[data-gbdraw-feature-id]', '[data-gbdraw-pairwise-match-id]']) {
+    const point = await page.evaluate((selector) => {
+      for (const element of window.__GBDRAW_APP__.svgContainer.querySelectorAll(selector)) {
+        const bounds = element.getBoundingClientRect();
+        const x = bounds.x + bounds.width / 2;
+        const y = bounds.y + bounds.height / 2;
+        if (document.elementFromPoint(x, y)?.closest(selector)) return { x, y };
+      }
+      throw new Error(`No visible gesture target: ${selector}`);
+    }, selector);
+    const before = await geometry(page);
+    await move(page, point, 10, 10);
+    expectTranslation(before, await geometry(page), 0, 0);
+    await page.mouse.click(point.x, point.y);
+    const selectionKey = selector.includes('pairwise') ? 'clickedPairwiseMatch' : 'clickedFeature';
+    await expect.poll(() => page.evaluate((key) => Boolean(window.__GBDRAW_APP__[key]), selectionKey)).toBe(true);
+    await page.keyboard.press('Escape');
+  }
+
+  await page.locator('.drawer-toggle').click();
+  await expect(page.locator('.right-drawer')).toBeVisible();
+  const before = await geometry(page);
+  await move(page, await backgroundPoint(page), 30, 20);
+  expectTranslation(before, await geometry(page), 30, 20);
+  await page.getByRole('button', { name: 'Reset zoom', exact: true }).focus();
+  await page.keyboard.press('Enter');
+  await settle(page);
+  expect(await geometry(page)).toMatchObject({ zoom: 1, pan: { x: 30, y: 20 } });
+  await page.getByRole('button', { name: 'Reset layout', exact: true }).click();
+  await settle(page);
+  expect(await geometry(page)).toMatchObject({ zoom: 1, pan: { x: 0, y: 0 }, panning: false });
+  expect(await getDiagramWorkerActivity(page)).toMatchObject({ constructions: 0 });
+});

--- a/tests/web/preview-transform-interaction.test.mjs
+++ b/tests/web/preview-transform-interaction.test.mjs
@@ -267,29 +267,25 @@ panZoom.endPan({ clientX: 130, clientY: 150 });
 assert.equal(panZoom.previewTransformInteraction.isActive(), false);
 completeCase('wheel then pan keeps pan active after wheel ends');
 
-panZoom.startPan({
-  button: 0,
-  shiftKey: false,
-  clientX: 130,
-  clientY: 150,
-  target: backgroundTarget
-});
-panZoom.endPan({ type: 'pointercancel', clientX: 130, clientY: 150 });
-assert.equal(uiState.isPanning.value, false);
-assert.equal(panZoom.previewTransformInteraction.isActive(), false);
-completeCase('pointercancel routes to complete pan cleanup');
-
-panZoom.startPan({
-  button: 0,
-  shiftKey: false,
-  clientX: 130,
-  clientY: 150,
-  target: backgroundTarget
-});
-panZoom.endPan({ type: 'lostpointercapture', clientX: 130, clientY: 150 });
-assert.equal(uiState.isPanning.value, false);
-assert.equal(panZoom.previewTransformInteraction.isActive(), false);
-completeCase('lostpointercapture routes to complete pan cleanup');
+for (const type of ['pointercancel', 'lostpointercapture']) {
+  panZoom.resetPreviewViewport();
+  let defaultPrevented = false;
+  panZoom.startPan({
+    button: 0, shiftKey: false, clientX: 130, clientY: 150,
+    target: backgroundTarget,
+    preventDefault() { defaultPrevented = true; }
+  });
+  panZoom.doPan({ clientX: 160, clientY: 190 });
+  // Native text dragging can cancel a mouse pointer with zero coordinates.
+  // Flush the pending real move even if its animation frame has not run.
+  panZoom.endPan({ type, clientX: 0, clientY: 0 });
+  assert.equal(uiState.canvasPan.x, 30);
+  assert.equal(uiState.canvasPan.y, 40);
+  assert.equal(defaultPrevented, true);
+  assert.equal(uiState.isPanning.value, false);
+  assert.equal(panZoom.previewTransformInteraction.isActive(), false);
+  completeCase(`${type} preserves the last real pointer and completes cleanup`);
+}
 
 panZoom.startPan({
   button: 0,


### PR DESCRIPTION
## Plain-language summary

Dragging the preview could start a native text drag, whose cancellation reported a pointer position of `(0, 0)` and sent the diagram in the opposite direction. Accepted background pans now suppress that native drag, and interrupted pans finish at the last real pointer position. Feature and match editing, the existing zoom anchor, and Reset controls keep their current behavior.

Fixes #457.

## Change class

- [x] STANDARD

## Purpose

Restore preview movement that follows the pointer. Base: `dev` at `67bab304ef6d990a1e69f9713937def30893eb7b`. Required admission checks are `Web base policy (trusted base)` and `PR / gate`.

## User-visible impact

At 30%, 100%, and 280% zoom, a 60px right / 80px down background drag moves two independent SVG screen reference points by the same amount. Wheel zoom keeps the existing top-center anchor. Match and feature gestures remain reserved for selection/editing; navigation does not start a diagram worker or change the committed session.

## Changes

- Keep native text selection/drag from taking over an accepted pan in `createPanZoom`.
- Ignore cancellation/capture-loss coordinates and flush the pending real pointer through the existing transform owner.
- Add real-browser navigation regression tests and strengthen the existing cancellation unit regression.

## Verification

- Both the unit regression and the original BGC browser gesture failed on the base revision and passed with the fix.
- Chromium and actual Windows Edge 152: both new browser tests passed, including match/feature selection, drawer pan, and keyboard Reset zoom.
- BGC and Hepatoplasmataceae Gallery diagrams: measured screen displacement at 30%, 100%, and 280%; visually inspected output.
- Existing preview-transform, preview-runtime, and feature-selection Node test files passed.
- Existing Feature editing browser tests: 2 passed; Linear layout-edit/history/session/reset/export browser test: 1 passed.
- Existing large-preview structural performance tests: 4 passed. Dedicated serial timing profile: responsiveness guardrail and native-wheel diagnostic passed; no thresholds or retries changed.
- Architecture contracts: 137 passed. Web policy: Gate PASS, Review CLEAR. `git diff --check` passed.

## Risk and review notes

- Gate: PASS locally; required remote admission remains authoritative.
- Review: CLEAR. One existing production file changes by 5 additions / 1 deletion, with no new modules, exports, watchers, resource signals, scientific outputs, compatibility paths, or performance baselines.
- This is not architecture-bearing. `createPanZoom` remains the single gesture/transform owner; owner/path/compatibility sets are unchanged. OE/PE/CB: N/A.
- Production and test diffs were checked separately. No instruction-pack, release-result, generated-wheel, CI, or policy files are included.
- Initial additional gesture-test setup placed editing targets outside a narrow viewport; it now uses the Issue screenshot's 2520×1327 viewport. Sandbox child-process restrictions were resolved for architecture checks. These initial results are retained in the session evidence.

## Rollback

Revert this commit to restore the previous gesture handling and tests.

## Conditional Product Impact

- Product-impact role: N/A.
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY.
- Affected journey: preview pan interruption; implement the existing pointer-following gesture behavior reported in #457.
- Authority: existing preview controls and `docs/internal/RESPONSIVE_PREVIEW_PHASE_1_IMPLEMENTATION_PLAN_2026-08-11.md`, which excludes new cursor-centred navigation. No registered Product concern or unresolved product outcome is introduced.
- Behavior contracts: existing transform lifecycle and performance tests, plus the new real-browser regression.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
