### PR TITLE
Allow progress observers in the canonical render boundary check

### DIFF
--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -340,10 +340,22 @@ test('production rendering crosses the canonical request and Worker boundary', (
     new Map([['app/run-analysis.js', 1]])
   );
   assert.deepEqual(directImports.get('app/run-analysis.js')?.has('services/diagram-generation.js'), true);
-  assert.match(
-    productionSources.get('app/run-analysis.js'),
-    /runDiagramGeneration\s*\(\s*\{\s*request:\s*canonical\.renderRequest,\s*resources:\s*canonical\.resources\s*\}\s*\)/s
-  );
+  const canonicalPayloadCall = /runDiagramGeneration\s*\(\s*\{\s*request:\s*canonical\.renderRequest,\s*resources:\s*canonical\.resources\s*\}\s*(?=\)|,\s*\{\s*onProgress\s*:)/s;
+  assert.match(productionSources.get('app/run-analysis.js'), canonicalPayloadCall);
+  for (const ending of [')', ', { onProgress: observer })']) {
+    assert.match(
+      `runDiagramGeneration({ request: canonical.renderRequest, resources: canonical.resources }${ending}`,
+      canonicalPayloadCall
+    );
+  }
+  for (const call of [
+    'runDiagramGeneration({ request: alternateRequest, resources: canonical.resources })',
+    'runDiagramGeneration({ request: canonical.renderRequest, resources: alternateResources })',
+    'runDiagramGeneration({ request: canonical.renderRequest, resources: canonical.resources, argv: [] })',
+    'runDiagramGeneration({ request: canonical.renderRequest, resources: canonical.resources }, alternatePayload)'
+  ]) {
+    assert.doesNotMatch(call, canonicalPayloadCall);
+  }
 });
 
 test('the embedded Python render bridge has no alternate production caller', () => {


### PR DESCRIPTION
## Plain-language summary

The canonical render boundary test currently requires a single argument, so adding a progress observer fails even when the request and resources still use the canonical owners. This change lets the test accept a separate `onProgress` option while retaining the exact canonical payload, sole caller, and import checks. It includes positive and negative examples and changes no application behavior.

## Change class

- [x] GOVERNANCE

## Purpose

Support generation feedback for #466 without mixing the guarded test change with runtime changes. Base: `dev` at `db3192cb78f4a85ae8d03ba940b1848e19451210`. The existing required checks remain `Web base policy (trusted base)` and `PR / gate`.

## Changes

Only `tests/web/architecture-contracts.test.mjs` changes. The call must still pass `canonical.renderRequest` and `canonical.resources` as its complete first argument. A second object beginning with `onProgress` is permitted; alternate request/resource owners, extra payload fields, and an alternate second payload remain rejected.

## Verification

`node --test tests/web/architecture-contracts.test.mjs`: 137 PASS against unchanged base runtime. `node tools/check-web-change-budget.mjs --base db3192cb78f4a85ae8d03ba940b1848e19451210`: Gate PASS. The matcher characterizes both the existing call and the proposed observer call, with four negative payload examples. `git diff --check` passes.

## Risk and review notes

Human review is required because this changes a separated guard path. This is not architecture-bearing for application runtime: there are no runtime, owner, path, schema, output, workflow, detector, registry, threshold, or baseline changes. The matching expression checks payload shape; it does not claim to validate callback behavior. Request isolation and terminal behavior are verified by the following runtime PR's tests.

## Rollback

Revert this test-only commit before introducing the observer call.

## Conditional Product Impact

N/A; no product behavior changes. No Product Decision is recorded.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence — GOVERNANCE

- Separated guard file: `tests/web/architecture-contracts.test.mjs` only.
- Checker implementation, CI, normative authority and production runtime: unchanged.
- Branch protection and required checks: unchanged.
- Self-authorization separation: the generation feedback runtime patch is kept on a different work branch and PR.
