### PR TITLE
Show the actual processing stage during Generate

### DIFF
--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1118,7 +1118,7 @@
     <div v-if="processing" class="fixed inset-0 bg-white/90 backdrop-blur-sm z-50 flex flex-col items-center justify-center">
         <div class="animate-spin w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full mb-6"></div>
         <h3 class="text-xl font-bold text-slate-800 animate-pulse">Generating Diagram...</h3>
-        <p v-if="processingStatus" class="text-xs text-slate-500 mt-3 font-mono" v-text="processingStatus"></p>
+        <p role="status" aria-live="polite" aria-atomic="true" class="text-xs text-slate-500 mt-3 font-mono" v-text="processingStatus"></p>
         <button @click="cancelGeneration"
                 :disabled="generationCancelRequested"
                 class="btn mt-6 px-5 py-2 text-sm bg-white text-slate-700 border border-slate-300 hover:bg-slate-50 disabled:opacity-60 disabled:cursor-wait flex items-center gap-2">

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -2484,6 +2484,7 @@ export const createRunAnalysis = ({
         circularConservation.enabled = shouldDrawCircularPairwiseComparisons;
 
         if (shouldDrawCircularPairwiseComparisons) {
+          setProcessingStatus('Preparing conservation comparisons...');
           circularConservation.ring_width = normalizePositiveNumberOrNull(
             circularConservation.ring_width
           );
@@ -2601,7 +2602,7 @@ export const createRunAnalysis = ({
             }
 
             if (losatJobs.length > 0) {
-              setProcessingStatus(`Running ${circularLosatSuffix.toUpperCase()} conservation: 0/${losatJobs.length} jobs complete`);
+              setProcessingStatus('Preparing comparison search runtime...');
               const runtime = await prepareLosatRuntime({ includeThreaded: executionMode !== 'serial' }).catch((error) => {
                 console.warn('LOSAT runtime warmup failed; execution will report the error.', error);
                 return null;
@@ -2610,6 +2611,7 @@ export const createRunAnalysis = ({
                 const { wasmModule: _wasmModule, ...threadedStatus } = runtime.threaded;
                 losatThreadingStatus.value = threadedStatus;
               }
+              setProcessingStatus(`Running ${circularLosatSuffix.toUpperCase()} conservation: 0/${losatJobs.length} jobs complete`);
               const losatResults = await executeLosatJobs(losatJobs, {
                 concurrency: getLosatParallelWorkers(),
                 executionMode,
@@ -2764,6 +2766,7 @@ export const createRunAnalysis = ({
         const useOrthogroupBlastp = useProteinBlastp && blastpMode === 'orthogroup';
         const useCollinearBlastp = useProteinBlastp && blastpMode === 'collinear';
         if (hasComparisonIntent) {
+          setProcessingStatus('Preparing comparisons...');
           adv.pairwise_match_style = normalizePairwiseMatchStyle(adv.pairwise_match_style);
           adv.min_bitscore = normalizeBlastThresholdNumber(
             adv.min_bitscore,
@@ -3744,11 +3747,12 @@ export const createRunAnalysis = ({
           losatTiming.jobBuildMs += Math.max(0, jobBuildWallMs - nestedFastaMs - nestedHashMs);
 
           if (losatJobs.length > 0) {
-            setProcessingStatus(`Running LOSAT: 0/${losatJobs.length} LOSAT jobs complete`);
+            setProcessingStatus('Preparing comparison search runtime...');
             const runtimeWaitStartedAt = getNow();
             await waitForCancelablePromise(losatRuntimeWarmup, generationAbortSignal);
             throwIfGenerationCanceled();
             losatTiming.runtimeWaitMs += getNow() - runtimeWaitStartedAt;
+            setProcessingStatus(`Running LOSAT: 0/${losatJobs.length} LOSAT jobs complete`);
             const executionStartedAt = getNow();
             const losatResults = await executeLosatJobs(losatJobs, {
               concurrency: getLosatParallelWorkers(),
@@ -4005,6 +4009,7 @@ export const createRunAnalysis = ({
               }
             }
           } else {
+            setProcessingStatus('Preparing nucleotide comparison results...');
             for (const pair of losatPairs) {
               throwIfGenerationCanceled();
               const cached = cacheMap.get(pair.cacheKey);
@@ -4208,7 +4213,12 @@ export const createRunAnalysis = ({
       }
 
       throwIfGenerationCanceled();
-      setProcessingStatus('Rendering SVG...');
+      setProcessingStatus('Preparing render inputs and session...');
+      if (!isReflow) {
+        await nextTick();
+        await waitForAfterPaint();
+        throwIfGenerationCanceled();
+      }
       if (typeof serializeCanonicalFiles !== 'function') {
         throw new Error('Canonical input serialization is unavailable.');
       }
@@ -4347,9 +4357,19 @@ export const createRunAnalysis = ({
       const generationResponse = await runDiagramGeneration({
         request: canonical.renderRequest,
         resources: canonical.resources
+      }, {
+        onProgress: ({ stage }) => {
+          const message = {
+            'preparing-runtime': 'Preparing diagram runtime (first use)...',
+            'preparing-resources': 'Preparing diagram input resources...',
+            rendering: 'Rendering diagram...',
+            finalizing: 'Finalizing diagram results...'
+          }[stage];
+          if (message) setProcessingStatus(message);
+        }
       });
       console.info(`gbdraw ${mode.value} typed request render: ${formatDuration(getNow() - gbdrawStartedAt)}.`);
-      setProcessingStatus('Preparing generated diagram...');
+      setProcessingStatus('Preparing preview...');
       await nextTick();
       await waitForAfterPaint();
       throwIfGenerationCanceled();

--- a/gbdraw/web/js/services/diagram-generation.js
+++ b/gbdraw/web/js/services/diagram-generation.js
@@ -316,7 +316,7 @@ const settleActiveRequest = (request, callback) => {
   callback();
 };
 
-export const runDiagramGeneration = (payload = {}) => {
+export const runDiagramGeneration = (payload = {}, { onProgress = null } = {}) => {
   if (activeRequest) {
     return Promise.reject(new Error('A diagram generation request is already running.'));
   }
@@ -338,10 +338,16 @@ export const runDiagramGeneration = (payload = {}) => {
     reject: rejectRequest
   };
   activeRequest = request;
+  const reportProgress = (stage) => {
+    if (!request.settled && activeRequest === request && typeof onProgress === 'function') {
+      onProgress({ requestId, stage });
+    }
+  };
 
   (async () => {
     try {
       const initializationWasWarm = workerInitialized;
+      if (!initializationWasWarm) reportProgress('preparing-runtime');
       const initializationStartedAt = globalThis.performance?.now?.() ?? Date.now();
       const currentWorker = await ensureWorkerInitialized();
       recordSessionLifecycleEvent('worker-initialization-resolved', {
@@ -351,6 +357,7 @@ export const runDiagramGeneration = (payload = {}) => {
           : (globalThis.performance?.now?.() ?? Date.now()) - initializationStartedAt
       });
       if (request.settled || activeRequest !== request) return;
+      reportProgress('preparing-resources');
       const preparedResources = await resourceTransport.prepare(payload);
       if (request.settled || activeRequest !== request) return;
       const workerPayload = {
@@ -378,6 +385,10 @@ export const runDiagramGeneration = (payload = {}) => {
         const data = event.data || {};
         if (data.type === 'test-lifecycle' && data.requestId === requestId) {
           recordSessionLifecycleEvent(data.event?.name, data.event);
+          return;
+        }
+        if (data.type === 'progress' && data.requestId === requestId) {
+          reportProgress(data.stage);
           return;
         }
         if (data.type !== 'run' || data.requestId !== requestId) return;

--- a/gbdraw/web/js/workers/diagram-generation-worker.js
+++ b/gbdraw/web/js/workers/diagram-generation-worker.js
@@ -844,6 +844,7 @@ const runGeneration = async ({
       requestId,
       'worker-resource-linking-start'
     );
+    self.postMessage({ type: 'progress', requestId, stage: 'preparing-resources' });
     const resourcePaths = await stageRenderResources(
       pyodide,
       workspace,
@@ -880,6 +881,7 @@ const runGeneration = async ({
       requestId,
       'worker-workspace-preparation-end'
     );
+    self.postMessage({ type: 'progress', requestId, stage: 'rendering' });
     emitTestLifecycle(testLifecycleEnabled, requestId, 'python-wrapper-start');
     pythonWrapperStarted = true;
     resultHandle = runWrapper(
@@ -890,6 +892,7 @@ const runGeneration = async ({
       preparedResourceIdentitiesJson
     );
     emitTestLifecycle(testLifecycleEnabled, requestId, 'python-wrapper-end');
+    self.postMessage({ type: 'progress', requestId, stage: 'finalizing' });
     emitTestLifecycle(testLifecycleEnabled, requestId, 'result-object-conversion-start');
     result = typeof resultHandle?.toJs === 'function'
       ? resultHandle.toJs({ dict_converter: Object.fromEntries })

--- a/tests/web/generation-feedback.playwright.spec.js
+++ b/tests/web/generation-feedback.playwright.spec.js
@@ -1,0 +1,195 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+const source = readFileSync(join(__dirname, '../test_inputs/HmmtDNA.gbk'), 'utf8');
+const status = page => page.locator('p[role="status"][aria-live="polite"][aria-atomic="true"]');
+const generate = page => page.getByRole('button', { name: 'Generate Diagram', exact: true });
+const prepare = async (page, baseURL) => {
+  const externalRequests = [];
+  await page.context().route(/^https?:\/\//, async route => {
+    if (new URL(route.request().url()).origin !== new URL(baseURL).origin) {
+      externalRequests.push(route.request().url());
+      return route.abort('blockedbyclient');
+    }
+    return route.continue();
+  });
+  await page.addInitScript(() => {
+    window.feedbackEvents = [];
+    window.__GBDRAW_TEST_HOOKS__ = {
+      onSessionLifecycleEvent(event) {
+        window.feedbackEvents.push({ ...event, observedAt: performance.now() });
+      }
+    };
+  });
+  await openApp(page);
+  await page.evaluate(() => {
+    window.feedbackStatuses = [];
+    window.Vue.watch(() => window.__GBDRAW_APP__.processingStatus, value => {
+      window.feedbackStatuses.push({ value, at: performance.now() });
+    }, { flush: 'sync' });
+  });
+  return externalRequests;
+};
+const resetObservations = page => page.evaluate(() => {
+  window.feedbackStatuses = [];
+  window.feedbackEvents = [];
+});
+const awaitSuccess = async page => {
+  await expect.poll(() => page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    return { processing: app.processing, error: app.errorLog?.summary || '', results: app.results.length };
+  }), { timeout: 180_000 }).toEqual({ processing: false, error: '', results: 1 });
+  await expect(status(page)).toHaveCount(0);
+  await expect(generate(page)).toBeEnabled();
+  await expect(page.locator('.gbdraw-preview-surface svg').first()).toBeVisible();
+};
+const record = async (page, testInfo, label) => {
+  const evidence = await page.evaluate(() => ({
+    statuses: window.feedbackStatuses,
+    events: window.feedbackEvents,
+    workers: window.__GBDRAW_DIAGRAM_WORKER_ACTIVITY__
+  }));
+  const path = testInfo.outputPath(`${label}.json`);
+  writeFileSync(path, JSON.stringify(evidence, null, 2));
+  await testInfo.attach(label, { path, contentType: 'application/json' });
+  return evidence;
+};
+const screenshot = async (page, testInfo, label) => {
+  const path = testInfo.outputPath(`${label}.png`);
+  await page.screenshot({ path });
+  await testInfo.attach(label, { path, contentType: 'image/png' });
+};
+const expectRenderStages = evidence => {
+  const values = evidence.statuses.map(entry => entry.value);
+  const expected = [
+    'Preparing render inputs and session...',
+    'Preparing diagram input resources...',
+    'Rendering diagram...',
+    'Finalizing diagram results...',
+    'Preparing preview...',
+    ''
+  ];
+  let previous = -1;
+  for (const value of expected) {
+    const index = values.indexOf(value, previous + 1);
+    expect(index, JSON.stringify(values)).toBeGreaterThan(previous);
+    previous = index;
+  }
+  const names = evidence.events.map(event => event.name);
+  expect(names.indexOf('generate.completed')).toBeGreaterThan(names.indexOf('preview.post-bind-frame-completed'));
+  expect(values.every(value => !value.includes('%'))).toBe(true);
+};
+
+test('Generate reports real cold/warm stages and preserves the successful Result through cancel, error, and retry', async ({ page, baseURL }, testInfo) => {
+  test.setTimeout(180_000);
+  const external = await prepare(page, baseURL);
+  const setInput = text => page.evaluate(async content => {
+    const app = window.__GBDRAW_APP__;
+    app.files.c_gb = new File([content], 'HmmtDNA.gbk', { type: 'text/plain' });
+    await window.Vue.nextTick();
+  }, text);
+  await setInput(source);
+  await generate(page).click();
+  await expect(status(page)).toHaveText('Preparing diagram runtime (first use)...');
+  await expect(generate(page)).toBeDisabled();
+  await screenshot(page, testInfo, 'cold-runtime-visible');
+  await awaitSuccess(page);
+  const cold = await record(page, testInfo, 'cold');
+  expectRenderStages(cold);
+  expect(cold.workers.constructions).toBe(1);
+
+  await resetObservations(page);
+  await generate(page).click();
+  await awaitSuccess(page);
+  const warm = await record(page, testInfo, 'warm');
+  expectRenderStages(warm);
+  expect(warm.statuses.map(entry => entry.value)).not.toContain('Preparing diagram runtime (first use)...');
+  expect(warm.workers.constructions).toBe(1);
+
+  await page.evaluate(() => {
+    const app = window.__GBDRAW_APP__;
+    window.successfulResults = app.results;
+    window.__GBDRAW_TEST_HOOKS__.beforeDiagramGenerationResponse = () => new Promise(resolve => {
+      window.releaseFeedbackResponse = resolve;
+    });
+  });
+  await generate(page).click();
+  await page.waitForFunction(() => Boolean(window.releaseFeedbackResponse));
+  await expect(status(page)).toHaveText('Finalizing diagram results...');
+  await expect(generate(page)).toBeDisabled();
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.results === window.successfulResults)).toBe(true);
+  await screenshot(page, testInfo, 'finalization-visible');
+  await page.getByRole('button', { name: /Cancel$/ }).click();
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.processing)).toBe(false);
+  await page.evaluate(() => {
+    delete window.__GBDRAW_TEST_HOOKS__.beforeDiagramGenerationResponse;
+    window.releaseFeedbackResponse();
+  });
+  expect(await page.evaluate(() => ({
+    status: window.__GBDRAW_APP__.processingStatus,
+    sameResult: window.__GBDRAW_APP__.results === window.successfulResults,
+    preserved: window.__GBDRAW_APP__.failedGeneratePreservedResult
+  }))).toEqual({ status: 'Canceled.', sameResult: true, preserved: true });
+  await record(page, testInfo, 'canceled');
+
+  await setInput('invalid GenBank');
+  await generate(page).click();
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.processing), { timeout: 180_000 }).toBe(false);
+  await expect(page.getByRole('alert', { name: 'Generation Error' })).toBeVisible();
+  await expect(generate(page)).toBeEnabled();
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.results === window.successfulResults)).toBe(true);
+  await record(page, testInfo, 'error');
+
+  await setInput(source);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await resetObservations(page);
+  await generate(page).click();
+  await awaitSuccess(page);
+  expectRenderStages(await record(page, testInfo, 'retry-mobile'));
+  await screenshot(page, testInfo, 'ready-mobile');
+  expect(external).toEqual([]);
+});
+
+test('Linear comparison preparation, real search counts, cache reuse, and no-comparison generation use the same status', async ({ page, baseURL }, testInfo) => {
+  test.setTimeout(180_000);
+  const external = await prepare(page, baseURL);
+  await page.evaluate(async content => {
+    const app = window.__GBDRAW_APP__;
+    app.mode = 'linear';
+    await window.Vue.nextTick();
+    while (app.linearSeqs.length < 2) app.addLinearSeq();
+    for (let i = 0; i < 2; i += 1) {
+      app.setLinearSeqPrimaryFile(i, 'gb', new File([content], `record-${i}.gbk`, { type: 'text/plain' }));
+    }
+    app.setLinearComparisonGlobalAction('losat');
+    await window.Vue.nextTick();
+  }, source);
+  await generate(page).click();
+  await awaitSuccess(page);
+  const search = await record(page, testInfo, 'linear-search');
+  expectRenderStages(search);
+  expect(search.statuses.map(entry => entry.value)).toEqual(expect.arrayContaining([
+    'Preparing comparisons...', 'Preparing LOSAT jobs...',
+    'Running LOSAT: 0/1 LOSAT jobs complete', 'Running LOSAT: 1/1 LOSAT jobs complete',
+    'Preparing nucleotide comparison results...'
+  ]));
+
+  await resetObservations(page);
+  await generate(page).click();
+  await awaitSuccess(page);
+  const cached = await record(page, testInfo, 'linear-cached');
+  expectRenderStages(cached);
+  expect(cached.statuses.map(entry => entry.value)).toContain('Using cached LOSAT results...');
+  expect(cached.statuses.some(entry => entry.value.startsWith('Running LOSAT:'))).toBe(false);
+
+  await page.evaluate(() => window.__GBDRAW_APP__.setLinearComparisonGlobalAction('none'));
+  await resetObservations(page);
+  await generate(page).click();
+  await awaitSuccess(page);
+  const none = await record(page, testInfo, 'linear-none');
+  expectRenderStages(none);
+  expect(none.statuses.some(entry => /comparison|LOSAT/.test(entry.value))).toBe(false);
+  expect(external).toEqual([]);
+});

--- a/tests/web/generation-feedback.test.mjs
+++ b/tests/web/generation-feedback.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// Hold real client boundaries; no clock drives progress.
+globalThis.location = { href: 'https://example.test/gbdraw/web/' };
+const { EXPECTED_WEB_RUNTIME_CAPABILITIES } = await import(
+  '../../gbdraw/web/js/services/runtime-capabilities.js'
+);
+class ControlledWorker {
+  static instances = [];
+  constructor() {
+    this.listeners = new Map();
+    this.messages = [];
+    ControlledWorker.instances.push(this);
+  }
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+    this.listeners.get(type).add(listener);
+  }
+  removeEventListener(type, listener) { this.listeners.get(type)?.delete(listener); }
+  postMessage(message) { this.messages.push(message); }
+  emit(data) {
+    for (const listener of this.listeners.get('message') || []) listener({ data });
+  }
+  initialize() {
+    const { id } = this.messages.find(({ type }) => type === 'init');
+    this.emit({ type: 'init', id, ok: true, capabilities: EXPECTED_WEB_RUNTIME_CAPABILITIES });
+  }
+  terminate() { this.terminated = true; }
+}
+globalThis.Worker = ControlledWorker;
+const { runDiagramGeneration, cancelDiagramGeneration, disposeDiagramGenerationWorker } = await import(
+  '../../gbdraw/web/js/services/diagram-generation.js'
+);
+const flush = async () => { for (let i = 0; i < 12; i += 1) await Promise.resolve(); };
+const payload = () => ({ request: {}, resources: {} });
+const latestRequest = (worker) => worker.messages.filter(({ type }) => type === 'run').at(-1).requestId;
+const assertClean = (worker) => {
+  for (const listeners of worker.listeners.values()) assert.equal(listeners.size, 0);
+};
+
+test('Generate feedback follows cold/warm work, rejects duplicates, and ignores stale and settled progress', async () => {
+  const events = [];
+  const first = runDiagramGeneration(payload(), { onProgress: event => events.push(event) });
+  const worker = ControlledWorker.instances.at(-1);
+  assert.deepEqual(events.map(e => e.stage), ['preparing-runtime']);
+  await flush();
+  assert.equal(events.length, 1, 'pending initialization must not advance by itself');
+  await assert.rejects(runDiagramGeneration(payload()), /already running/);
+  worker.initialize();
+  await flush();
+  const requestId = latestRequest(worker);
+  assert.deepEqual(events.map(e => e.stage), ['preparing-runtime', 'preparing-resources']);
+  worker.emit({ type: 'progress', requestId: requestId + 1, stage: 'rendering' });
+  assert.equal(events.length, 2);
+  worker.emit({ type: 'progress', requestId, stage: 'rendering' });
+  worker.emit({ type: 'progress', requestId, stage: 'finalizing' });
+  assert.deepEqual(events.map(e => e.stage), ['preparing-runtime', 'preparing-resources', 'rendering', 'finalizing']);
+  assert.ok(events.every(e => e.requestId === requestId));
+  worker.emit({ type: 'run', requestId, ok: true, results: [{ name: 'out.svg', content: '<svg/>' }] });
+  assert.equal((await first).results[0].name, 'out.svg');
+  assertClean(worker);
+  worker.emit({ type: 'progress', requestId, stage: 'rendering' });
+  assert.equal(events.length, 4);
+
+  const warmEvents = [];
+  const second = runDiagramGeneration(payload(), { onProgress: event => warmEvents.push(event) });
+  await flush();
+  assert.deepEqual(warmEvents.map(e => e.stage), ['preparing-resources']);
+  const secondId = latestRequest(worker);
+  worker.emit({ type: 'progress', requestId, stage: 'finalizing' });
+  assert.equal(warmEvents.length, 1);
+  worker.emit({ type: 'progress', requestId: secondId, stage: 'rendering' });
+  worker.emit({ type: 'run', requestId: secondId, ok: true, results: [] });
+  await second;
+  assert.equal(ControlledWorker.instances.length, 1);
+  assertClean(worker);
+  disposeDiagramGenerationWorker();
+});
+
+test('Cancel and failure clean progress listeners and permit a fresh run', async () => {
+  for (const terminal of ['cancel-init', 'cancel-render', 'error']) {
+    const events = [];
+    const pending = runDiagramGeneration(payload(), { onProgress: event => events.push(event) });
+    const rejection = assert.rejects(pending, terminal === 'error' ? /render failed/ : /cancel/i);
+    const worker = ControlledWorker.instances.at(-1);
+    if (terminal !== 'cancel-init') {
+      worker.initialize();
+      await flush();
+      const requestId = latestRequest(worker);
+      worker.emit({ type: 'progress', requestId, stage: 'rendering' });
+      if (terminal === 'error') {
+        worker.emit({ type: 'run', requestId, ok: false, error: { message: 'render failed' } });
+      }
+    }
+    if (terminal !== 'error') await cancelDiagramGeneration();
+    await rejection;
+    const count = events.length;
+    worker.emit({ type: 'progress', requestId: 1, stage: 'finalizing' });
+    assert.equal(events.length, count);
+    assertClean(worker);
+    assert.equal(worker.terminated, true);
+  }
+  const retry = runDiagramGeneration(payload());
+  const worker = ControlledWorker.instances.at(-1);
+  worker.initialize();
+  await flush();
+  worker.emit({ type: 'run', requestId: latestRequest(worker), ok: true, results: [] });
+  await retry;
+  assertClean(worker);
+  disposeDiagramGenerationWorker();
+});

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -532,6 +532,9 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   const readinessRuntime = createImmediatePreviewRuntime({
     onEvent(name) {
       assert.equal(state.processing.value, true, name);
+      if (name === 'test.preview-mounted' || name === 'test.preview-ready') {
+        assert.equal(state.processingStatus.value, 'Preparing preview...', name);
+      }
       lifecycleEvents.push(name);
       if (cancelDuringPreview && name === 'test.preview-mounted') {
         runner.cancelRunAnalysis();
@@ -562,7 +565,10 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
       generationHistory.runUndoableArtifactReplacement(...args)
     ),
     state,
-    serializeCanonicalFiles: () => serializeActiveRenderFiles(state.mode.value, state),
+    serializeCanonicalFiles: () => {
+      assert.equal(state.processingStatus.value, 'Preparing render inputs and session...');
+      return serializeActiveRenderFiles(state.mode.value, state);
+    },
     canonicalSessionVersion: SESSION_VERSION,
     adoptCanonicalRenderArtifacts: () => {
       if (failArtifactAdoption) {


### PR DESCRIPTION
## Plain-language summary

Generate now names the work actually in progress: input/session preparation, comparison preparation or search, runtime initialization, diagram rendering, result finalization, and preview preparation. Previously, `Rendering SVG...` appeared before input serialization and cold Worker initialization; a measured first run spent 5.69 of 6.30 seconds initializing the runtime under that label. The existing busy display now follows real processing boundaries, with actual LOSAT job counts and no estimated percentages or progress timer.

## Change class

- [x] STANDARD

## Purpose

Fixes #466. Base: `dev`, starting at `db3192cb78f4a85ae8d03ba940b1848e19451210`. PR #483 is merged at `fcf0e21729c04a93f46d300f7cff2d75fdad1ba1`; it preserves the request/resource checks while allowing the observer option used here. The PR diff is seven runtime/test files and contains no guard or CI changes. Required checks remain `Web base policy (trusted base)` and `PR / gate`.

## Changes and user-visible impact

`processingStatus` remains the sole displayed status. The existing Generate owner adds labels at input serialization and comparison boundaries. The Worker client reports cold initialization from its actual reuse state and resource staging from the existing transport. The Worker sends request-ID-bound notices when staging inputs, entering the Python render wrapper, and converting/finalizing its result. A small adapter feeds the existing generation-token-guarded setter.

The existing overlay uses `role="status"` with polite, atomic announcements. A paint opportunity precedes canonical input serialization. `Preparing preview...` remains active through existing admission, activation, binding, readiness, and History settlement. Search result conversion has its own label after the last job finishes.

Cancel, failure, success, stale-result rejection, Worker ownership, Result admission, History, Run Info, and Save/Load contracts are unchanged. No new reactive state, progress model, queue, timer, telemetry, schema, or compatibility reader is introduced.

## Verification

- Formal Node regressions cover cold/warm feedback, duplicate request rejection, stale and post-settlement progress, cancel during initialization/render, failure, listener cleanup, and retry. Existing Generate-owner tests assert input and Preview stage boundaries while retaining Result/History/replay recovery checks.
- Related runtime, cache, lifecycle, and History tests: PASS; final focused run: 8 PASS as reported by Node (includes file-level tests).
- Real Chromium, blocked external HTTP: Circular cold/warm, held result finalization followed by UI Cancel, invalid-input error, preserved last Result, and successful retry at 390px width: PASS. Linear real LOSAT, completed-job counts, cached rerun, and No comparison: PASS. Stage events and screenshots were captured and inspected.
- Web packaging: 33 PASS, 12 unrelated slow/browser cases deselected. Browser Python wheel built from this worktree; changed JS files are not members of that wheel.
- Final head `3aac6be7bfbc6fc00937c30e301d7524d097d66a`: full architecture suite 137 PASS with the separately merged PR #483 guard; local Web policy Gate PASS; `git diff --check` PASS. Production and browser-test bytes are identical to the tested runtime commit. No renderer or reference-output change. Required CI will be checked on this head before requesting human review.

## Risk and review notes

This is architecture-bearing because it extends the internal Worker notification contract. Semantic owners, resource lifecycle, canonical request path, persisted contracts, and compatibility paths remain the same; OE/PE/CB do not increase. There is no architecture exception. The old premature render label is removed in this change; there is no parallel status owner to retire.

Local policy Gate PASS. Human review is REQUIRED for the new Worker notification signal even when the automated size report says CLEAR. The `architecture-change` label identifies that review scope. The timing evidence is fixture-specific; this does not guarantee a maximum generation duration or eliminate all main-thread freezes. Very brief stages may pass between screen paints; they are not artificially prolonged.

## Rollback

Revert this runtime/test commit. The preceding test-only PR remains valid for the original single-argument call.

## Conditional Product Impact

- Role: IMPLEMENTATION.
- Preflight: IMPLEMENT_EXISTING_AUTHORITY. The requested stage feedback preserves merged Web contracts for explicit operation settlement, immutable Result replacement, and preview readiness.
- Effects: users can identify the active operation; the same success, cancel, error, recovery, and next actions remain available.
- No durable behavior decision is inferred or changed; no unresolved Product choice or retirement is introduced.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
