### PR TITLE
Include GUI palettes and exclude local files from packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ include gbdraw/data/color_palettes.toml
 include gbdraw/data/config.toml
 include gbdraw/data/*.ttf
 include gbdraw/web/index.html
-include gbdraw/web/*.whl
 include tools/build_lambda_gff3_fixture.py
 include tools/generate_open_source_notices.py
 recursive-include gbdraw/bin *
@@ -13,3 +12,4 @@ recursive-include gbdraw/web/tutorial-data *
 recursive-include gbdraw/web/vendor *
 recursive-include gbdraw/web/wasm *
 
+global-exclude *.py[cod] __pycache__ .DS_Store

--- a/gbdraw/_build_support.py
+++ b/gbdraw/_build_support.py
@@ -35,6 +35,7 @@ _NATIVE_RUNTIME_PACKAGE_DATA = [
 _WEB_APP_PACKAGE_DATA = [
     "web/index.html",
     "web/open-source-notices.html",
+    "web/gallery/palettes/palettes.json",
     "web/assets/*.ico",
     "web/assets/*.png",
     "web/assets/*.svg",

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -256,7 +256,9 @@ def test_local_web_package_data_excludes_gallery_assets() -> None:
         include_browser_wheel=True
     )
 
-    assert all("web/gallery" not in pattern for pattern in package_data_patterns)
+    assert [pattern for pattern in package_data_patterns if "web/gallery" in pattern] == [
+        "web/gallery/palettes/palettes.json"
+    ]
     assert "web/js/services/*.js" in package_data_patterns
     assert "web/tutorial-data/*.json" in package_data_patterns
     assert "web/tutorial-data/*/*.gb" in package_data_patterns
@@ -1346,7 +1348,10 @@ def test_build_py_copies_offline_gui_assets(tmp_path: Path) -> None:
     assert not missing, (
         "build_py did not copy required offline GUI assets:\n" + "\n".join(missing)
     )
-    assert not (build_root / "gbdraw" / "web" / "gallery").exists()
+    assert [
+        path.relative_to(build_root).as_posix()
+        for path in (build_root / "gbdraw/web/gallery").rglob("*") if path.is_file()
+    ] == ["gbdraw/web/gallery/palettes/palettes.json"]
     copied_wheels = sorted(
         path.name for path in (build_root / "gbdraw" / "web").glob("gbdraw-*.whl")
     )
@@ -1402,7 +1407,7 @@ def test_built_wheel_contains_offline_gui_assets(tmp_path: Path) -> None:
             name for name in outer_names if name.startswith("gbdraw/web/gallery/")
         )
         assert browser_wheels == [browser_wheel_member]
-        assert gallery_members == []
+        assert gallery_members == ["gbdraw/web/gallery/palettes/palettes.json"]
         assert "gbdraw/web/js/app/record-discovery.js" in outer_names
         assert "gbdraw/web/js/app/record-options.js" in outer_names
         assert "gbdraw/web/js/app/linear-record-selector.js" in outer_names

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -7,6 +7,7 @@ import hashlib
 import html
 import importlib.util
 import json
+import os
 import re
 import shutil
 import socket
@@ -1444,6 +1445,53 @@ def test_built_sdist_contains_tutorial_data(tmp_path: Path) -> None:
         suffix = f"/gbdraw/web/{path.as_posix()}"
         assert any(name.endswith(suffix) for name in names), suffix
     assert any(name.endswith("/tools/build_lambda_gff3_fixture.py") for name in names)
+
+    # Rebuild using only the sdist. Local caches and obsolete browser wheels
+    # must not enter a subsequent distribution through broad manifest globs.
+    source_dir = tmp_path / "source"
+    with tarfile.open(sdist_path, "r:gz") as sdist:
+        sdist.extractall(source_dir, filter="data")
+    source = next(source_dir.iterdir())
+    sentinels = (
+        "gbdraw/web/gbdraw-0.0.0-py3-none-any.whl",
+        "gbdraw/web/vendor/vue/__pycache__/local.pyc",
+        "gbdraw/web/vendor/vue/.DS_Store",
+        "docs/internal/local-evidence.txt",
+    )
+    for name in sentinels:
+        path = source / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("local file; not distribution content\n", encoding="utf-8")
+    rebuilt_dir = tmp_path / "rebuilt"
+    subprocess.run(
+        [sys.executable, "-m", "build", "--no-isolation", "--outdir", str(rebuilt_dir)],
+        cwd=source, check=True,
+    )
+    with tarfile.open(next(rebuilt_dir.glob("*.tar.gz")), "r:gz") as sdist:
+        rebuilt_names = {name.split("/", 1)[-1] for name in sdist.getnames()}
+    assert not set(sentinels) & rebuilt_names
+    wheel_path = next(rebuilt_dir.glob("*.whl"))
+    verify_module.inspect_wheel(wheel_path)
+    with zipfile.ZipFile(wheel_path) as wheel:
+        assert not set(sentinels) & set(wheel.namelist())
+
+    # The entry point and resources must work without an editable checkout or
+    # shared site-packages. Copy only the input and standalone assertion script.
+    env = {key: value for key, value in os.environ.items()
+           if key not in {"PYTHONPATH", "PYTHONHOME"}}
+    venv_dir = tmp_path / "venv"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True, env=env)
+    python = venv_dir / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    subprocess.run(
+        [str(python), "-m", "pip", "install", str(wheel_path)],
+        cwd=tmp_path, check=True, env=env,
+    )
+    smoke_dir = tmp_path / "installed-smoke"
+    smoke_dir.mkdir()
+    shutil.copy2(REPO_ROOT / "tests/test_inputs/HmmtDNA.gbk", smoke_dir)
+    script = smoke_dir / "installed_package_smoke.py"
+    shutil.copy2(REPO_ROOT / "tests/utils/installed_package_smoke.py", script)
+    subprocess.run([str(python), "-I", str(script)], cwd=smoke_dir, check=True, env=env)
 
 
 def _run_offline_gui_browser_contract(contract: str) -> None:

--- a/tests/utils/installed_package_smoke.py
+++ b/tests/utils/installed_package_smoke.py
@@ -16,6 +16,9 @@ def main() -> None:
     assert package_path.is_relative_to(Path(sysconfig.get_path("purelib")).resolve())
     assert sys.prefix != sys.base_prefix
     assert gbdraw.__version__ == importlib.metadata.version("gbdraw")
+    # App-shell startup fetches this JSON before the first Generate.
+    palettes = json.loads((package_path.parent / "web/gallery/palettes/palettes.json").read_text())
+    assert palettes["palettes"]["default"]["CDS"]
     cli = Path(sysconfig.get_path("scripts")) / (
         "gbdraw.exe" if sys.platform == "win32" else "gbdraw"
     )

--- a/tests/utils/installed_package_smoke.py
+++ b/tests/utils/installed_package_smoke.py
@@ -1,0 +1,59 @@
+"""Run with a fresh venv's Python from a directory containing copied inputs."""
+
+from pathlib import Path
+import importlib.metadata
+import json
+import subprocess
+import sys
+import sysconfig
+import xml.etree.ElementTree as ET
+
+import gbdraw
+
+
+def main() -> None:
+    package_path = Path(gbdraw.__file__).resolve()
+    assert package_path.is_relative_to(Path(sysconfig.get_path("purelib")).resolve())
+    assert sys.prefix != sys.base_prefix
+    assert gbdraw.__version__ == importlib.metadata.version("gbdraw")
+    cli = Path(sysconfig.get_path("scripts")) / (
+        "gbdraw.exe" if sys.platform == "win32" else "gbdraw"
+    )
+
+    def run(*args: str) -> str:
+        result = subprocess.run([str(cli), *args], check=True, capture_output=True, text=True)
+        print(result.stdout)
+        print(result.stderr)
+        return result.stdout
+
+    assert gbdraw.__version__ in run("--version")
+    assert "circular" in run("--help")
+    for mode in ("circular", "linear"):
+        assert "--gbk" in run(mode, "--help")
+        run(mode, "--gbk", "HmmtDNA.gbk", "-o", mode,
+            "--session_output", f"{mode}.session.json")
+        run(mode, "--session", f"{mode}.session.json", "-o", f"{mode}-replay")
+        original = ET.parse(f"{mode}.svg").getroot()
+        replay = ET.parse(f"{mode}-replay.svg").getroot()
+        assert original.tag == "{http://www.w3.org/2000/svg}svg"
+        assert original.findall(".//{http://www.w3.org/2000/svg}path")
+        assert original.findall(".//{http://www.w3.org/2000/svg}text")
+        assert ET.tostring(original) == ET.tostring(replay)
+
+    records = gbdraw.read_genbank("HmmtDNA.gbk")
+    for mode, diagram in (
+        ("circular", gbdraw.draw_circular(records[0])),
+        ("linear", gbdraw.draw_linear(records)),
+    ):
+        diagram.save(f"api-{mode}.svg")
+        assert ET.parse(f"api-{mode}.svg").findall(".//{http://www.w3.org/2000/svg}path")
+
+    print(json.dumps({
+        "python": sys.version, "prefix": sys.prefix,
+        "package_path": str(package_path), "version": gbdraw.__version__,
+        "sys_path": sys.path, "result": "PASS",
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_gui_offline.py
+++ b/tools/verify_gui_offline.py
@@ -1166,6 +1166,7 @@ def inspect_wheel(wheel_path: Path) -> None:
     required = {
         "gbdraw/web/index.html",
         "gbdraw/web/open-source-notices.html",
+        "gbdraw/web/gallery/palettes/palettes.json",
         "gbdraw/web/assets/favicon.ico",
         "gbdraw/web/assets/gbdraw-logo.svg",
         "gbdraw/web/assets/gbdraw-logo-title.svg",


### PR DESCRIPTION
## Plain-language summary

Installed local GUIs cannot load their color palettes because the package excludes the JSON file needed at startup. This PR includes that runtime file while keeping Gallery pages and examples out of Python packages. It also prevents old browser wheels and local cache files from entering source distributions, and tests rendering after an independent installation built from the source archive.

## Change class

- [x] STANDARD

## Purpose

- Base: `dev`, `36f16bdb901ff509b40b80456149662f9429cdd7`.
- Required checks: `Web base policy (trusted base)` and `PR / gate`.
- Scope: v0.14.0 Python package artifacts. Version remains `0.14.0b0`.

## User-visible impact

`gbdraw gui` can load its palette definitions after installation. CLI rendering, session formats, export dependencies, and hosted analytics retain their existing behavior.

## Changes

- Add only `gallery/palettes/palettes.json` to the existing local GUI package-data selection.
- Remove the broad browser-wheel include from `MANIFEST.in`; the existing version-derived package-data pattern selects the current wheel.
- Exclude compiled Python caches and `.DS_Store` from source archives.
- Extend the existing sdist test to inject unwanted files, rebuild both artifacts, install into a fresh venv, and run CLI/API Circular and Linear rendering plus saved-session replay outside the checkout.
- Check the palette dependency in the existing wheel inspector and installed-package smoke test.

## Verification

- Related packaging tests: 28 passed; build-tree and wheel asset tests: 2 passed.
- Clean source export of `acb7d3070c96ae0122a166fe0d6d2be557c101c6`: standard isolated sdist/wheel build, direct wheel build, and independent sdist-to-wheel build passed.
- Fresh Linux Python 3.10.17, 3.11.14, 3.12.13 installs: import provenance, entry point/help/version, CLI/API Circular and Linear SVG, session replay, and export-extra PNG/PDF passed.
- Independent sdist-wheel install on Python 3.11: the same base rendering checks passed.
- `twine check --strict`, metadata, all RECORD hashes/sizes, licenses, payload hygiene, and wheel member-content equivalence across build routes passed. ZIP bytes are not required to match.
- Installed GUI in Chromium: cold startup, Circular/Linear Generate, repeat Generate, downloaded Exact replay and SVG semantic comparison passed; no external requests. Desktop and narrow viewport evidence retained locally.
- Ruff and local policy gate passed; executable Review reports `CLEAR`.
- Complete non-browser fast suite: 3,905 passed, 17 skipped (`pytest tests/ -v -m "not slow and not browser" -n 4`). Remote required CI is being completed before merge.
- Windows/macOS execution has not been verified in this Linux/WSL environment.

## Risk and review notes

- Human review: REQUIRED under `docs/internal/WEB_CHANGE_POLICY.md` for the packaging owner convergence and new standalone test helper; the automated Web-only review result does not replace that review.
- This is architecture-bearing at the package inclusion boundary. The existing `_build_support.py` package-data owner still selects runtime assets; the redundant sdist wildcard for browser wheels is removed. No new production owner, build backend, version authority, compatibility path, or runtime fallback is introduced. Owner/path excess does not increase; compatibility burden is unchanged.
- Scientific output and tracked reference files are unchanged. Local release evidence and generated distributions are not committed.

## Rollback

Revert this change through the normal dev PR path. That restores the previous archive behavior and the known installed-GUI palette failure.

## Conditional Product Impact

- Product-impact role: N/A (no registered Product Impact delta).
- Product preflight classification: `IMPLEMENT_EXISTING_AUTHORITY`.
- Authority: base `gbdraw/web/CLAUDE.md` requires palette definitions for app-shell readiness; base `docs/INSTALL.md` supports local `gbdraw gui` and excludes hosted Gallery examples. Including the one required JSON fulfills both contracts without a new product choice.
- Decision Pack: not required. Hosted-only GA4 remains unchanged; S07 is outside this PR.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
