### PR TITLE
Add tag-gated PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# Trusted Publisher identity includes this filename: keep release.yml stable.
+name: Publish Python distributions
+
+on:
+  push:
+    tags: ['v[0-9]*.[0-9]*.[0-9]*']
+
+permissions: {}
+
+concurrency:
+  group: pypi-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-release-distributions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      artifact-id: ${{ steps.distributions.outputs.artifact-id }}
+    steps:
+      - name: Check out exact tag event source and main history
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.11'
+
+      - name: Admit release source
+        run: python tools/check_release_source.py
+
+      - name: Install build tools
+        run: python -m pip install build twine
+
+      - name: Build release distributions once
+        run: |
+          python tools/prepare_browser_wheel.py
+          python -m build --outdir "$RUNNER_TEMP/release-dist"
+          git diff --exit-code
+
+      - name: Check metadata and clean installation
+        run: |
+          python -m twine check --strict "$RUNNER_TEMP/release-dist/"*
+          python -m venv "$RUNNER_TEMP/release-venv"
+          "$RUNNER_TEMP/release-venv/bin/python" -m pip install "$RUNNER_TEMP/release-dist/"*.whl
+          "$RUNNER_TEMP/release-venv/bin/python" tools/verify_gui_offline.py inspect-distributions "$RUNNER_TEMP/release-dist"
+          mkdir "$RUNNER_TEMP/release-smoke"
+          cp tests/utils/installed_package_smoke.py tests/test_inputs/HmmtDNA.gbk "$RUNNER_TEMP/release-smoke/"
+          cd "$RUNNER_TEMP/release-smoke"
+          env -u PYTHONPATH -u PYTHONHOME "$RUNNER_TEMP/release-venv/bin/python" -I installed_package_smoke.py
+
+      - name: Save verified distributions
+        id: distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-distributions-${{ github.sha }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/release-dist/
+          if-no-files-found: error
+          compression-level: 0
+
+  pypi-publish:
+    needs: build-release-distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download this build's verified distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build-release-distributions.outputs.artifact-id }}
+          path: dist/
+          merge-multiple: true
+          digest-mismatch: error
+
+      - name: Publish through PyPI Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist/
+          skip-existing: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,8 @@ jobs:
   ci-impact:
     name: CI impact plan
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Full-history checkout can take nearly five minutes before trusted-base setup.
+    timeout-minutes: 10
     outputs:
       plan: ${{ steps.pr_plan.outputs.plan || steps.dev_plan.outputs.plan }}
     steps:

--- a/tests/ci/release-workflow.test.mjs
+++ b/tests/ci/release-workflow.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(new URL('../../.github/workflows/release.yml', import.meta.url), 'utf8');
+const build = source.split('  build-release-distributions:\n')[1].split('  pypi-publish:\n')[0];
+const publish = source.split('  pypi-publish:\n')[1];
+
+test('publishing has only a version tag push entry and immutable actions', () => {
+  assert.match(source, /\non:\n  push:\n    tags: \['v\[0-9\]\*\.\[0-9\]\*\.\[0-9\]\*'\]\n\n/);
+  assert.doesNotMatch(source, /workflow_dispatch|workflow_call|pull_request|\n  release:|branches:/);
+  assert.match(source, /\npermissions: \{\}/);
+  assert.equal((source.match(/id-token: write/g) || []).length, 1);
+  assert.doesNotMatch(source, /secrets\.|password:|username:|user:|PYPI_TOKEN|TWINE_|repository-url:|continue-on-error|retry|always\(\)/);
+  assert.equal((source.match(/^  [\w-]+:\n    (?:needs|runs-on):/gm) || []).length, 2);
+  for (const line of source.split('\n').filter(line => line.includes('uses:'))) {
+    assert.match(line, /uses: [\w/-]+@[0-9a-f]{40} # v\d+\.\d+\.\d+$/);
+  }
+});
+
+test('build checks exact source before one standard build and package verification', () => {
+  assert.match(build, /permissions:\n      contents: read/);
+  assert.match(build, /ref: \$\{\{ github.sha \}\}/);
+  assert.match(build, /fetch-depth: 0/);
+  assert.match(build, /persist-credentials: false/);
+  const commands = [
+    'python tools/check_release_source.py',
+    'python tools/prepare_browser_wheel.py',
+    'python -m build --outdir "$RUNNER_TEMP/release-dist"',
+    'python -m twine check --strict',
+    'tools/verify_gui_offline.py inspect-distributions "$RUNNER_TEMP/release-dist"',
+    '-I installed_package_smoke.py',
+    'uses: actions/upload-artifact@'
+  ];
+  let previous = -1;
+  for (const command of commands) {
+    const index = build.indexOf(command);
+    assert.ok(index > previous, command);
+    previous = index;
+  }
+  assert.equal((build.match(/python -m build /g) || []).length, 1);
+  assert.match(build, /artifact-id: \$\{\{ steps.distributions.outputs.artifact-id \}\}/);
+  assert.match(build, /path: \$\{\{ runner.temp \}\}\/release-dist\//);
+  assert.match(build, /if-no-files-found: error/);
+});
+
+test('credential job only downloads the same verified artifact and publishes with OIDC', () => {
+  assert.match(publish, /needs: build-release-distributions/);
+  assert.match(publish, /environment: pypi/);
+  assert.match(publish, /permissions:\n      id-token: write\n    steps:/);
+  assert.equal((publish.match(/- name:/g) || []).length, 2);
+  assert.doesNotMatch(publish, /\brun:|checkout|setup-python|build --|pytest|git |contents:|github-token:|run-id:|repository:|\bif:/);
+  assert.match(publish, /uses: actions\/download-artifact@/);
+  assert.match(publish, /artifact-ids: \$\{\{ needs.build-release-distributions.outputs.artifact-id \}\}/);
+  assert.match(publish, /path: dist\//);
+  assert.match(publish, /digest-mismatch: error/);
+  assert.match(publish, /uses: pypa\/gh-action-pypi-publish@/);
+  assert.match(publish, /packages-dir: dist\//);
+  assert.match(publish, /skip-existing: false/);
+});

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -1,0 +1,153 @@
+"""Release admission uses real Git refs; archive verification never publishes."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from runpy import run_path
+import subprocess
+import tarfile
+import zipfile
+
+import pytest
+
+from tests.test_web_packaging import _load_verify_module
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def release_source(tmp_path, monkeypatch):
+    def git(*args):
+        return subprocess.check_output(["git", *args], cwd=tmp_path, text=True).strip()
+
+    git("init", "-b", "main")
+    git("config", "user.name", "Release test")
+    git("config", "user.email", "release-test@example.invalid")
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "0.14.0rc1"\n')
+    git("add", "pyproject.toml")
+    git("commit", "-m", "Release fixture")
+    sha = git("rev-parse", "HEAD")
+    git("update-ref", "refs/remotes/origin/main", sha)
+    git("tag", "v0.14.0rc1")
+    check = run_path(str(ROOT / "tools/check_release_source.py"))["check_release_source"]
+    # Reuse the real version reader, directed at the isolated fixture's TOML.
+    read_version = run_path(str(ROOT / "gbdraw/_build_support.py"))["read_project_version"]
+    read_version.__globals__["PYPROJECT_PATH"] = tmp_path / "pyproject.toml"
+    monkeypatch.setitem(check.__globals__, "REPO_ROOT", tmp_path)
+    monkeypatch.setitem(check.__globals__, "run_path", lambda _: {"read_project_version": read_version})
+    for name, value in {
+        "GITHUB_EVENT_NAME": "push", "GITHUB_REF_TYPE": "tag",
+        "GITHUB_REF": "refs/tags/v0.14.0rc1", "GITHUB_SHA": sha,
+    }.items():
+        monkeypatch.setenv(name, value)
+    return check, git, tmp_path
+
+
+@pytest.mark.parametrize("annotated", [False, True])
+def test_release_admits_exact_main_tag(release_source, monkeypatch, annotated):
+    check, git, _ = release_source
+    if annotated:
+        git("tag", "-f", "-a", "v0.14.0rc1", "-m", "Release candidate")
+        monkeypatch.setenv("GITHUB_SHA", git("rev-parse", "refs/tags/v0.14.0rc1"))
+    assert check() == "0.14.0rc1"
+
+
+def test_release_admits_final_and_historical_main_source(release_source, monkeypatch):
+    check, git, root = release_source
+    (root / "pyproject.toml").write_text('[project]\nversion = "0.14.0"\n')
+    git("commit", "-am", "Final version")
+    final = git("rev-parse", "HEAD")
+    git("tag", "v0.14.0")
+    git("commit", "--allow-empty", "-m", "Later main progress")
+    git("update-ref", "refs/remotes/origin/main", git("rev-parse", "HEAD"))
+    git("checkout", "--detach", final)
+    monkeypatch.setenv("GITHUB_SHA", final)
+    monkeypatch.setenv("GITHUB_REF", "refs/tags/v0.14.0")
+    assert check() == "0.14.0"
+
+
+@pytest.mark.parametrize("ref", ["refs/remotes/origin/main", "refs/tags/v0.14.0rc1"])
+def test_release_rejects_missing_source_refs(release_source, ref):
+    check, git, _ = release_source
+    git("update-ref", "-d", ref)
+    with pytest.raises(subprocess.CalledProcessError):
+        check()
+
+
+@pytest.mark.parametrize("key,value", [
+    ("GITHUB_REF", "refs/tags/v0.14.0"),
+    ("GITHUB_REF", "refs/heads/main"),
+    ("GITHUB_REF", "v0.14.0rc1"),
+    ("GITHUB_REF", "refs/tags/v0.14.0b0"),
+    ("GITHUB_REF", "refs/tags/v0.14.0rc1/extra"),
+    ("GITHUB_REF_TYPE", "branch"),
+    ("GITHUB_EVENT_NAME", "workflow_dispatch"),
+    ("GITHUB_EVENT_NAME", "release"),
+    ("GITHUB_SHA", "HEAD"),
+    ("GITHUB_SHA", "0" * 40),
+])
+def test_release_rejects_wrong_event_identity(release_source, monkeypatch, key, value):
+    check, _, _ = release_source
+    monkeypatch.setenv(key, value)
+    with pytest.raises(ValueError):
+        check()
+
+
+@pytest.mark.parametrize("state", ["non-main", "side-parent", "wrong-checkout", "moved-tag", "dirty"])
+def test_release_rejects_wrong_source(release_source, monkeypatch, state):
+    check, git, root = release_source
+    if state == "dirty":
+        (root / "pyproject.toml").write_text('[project]\nversion = "0.14.0rc1"\n# dirty\n')
+    else:
+        initial = git("rev-parse", "HEAD")
+        git("switch", "-c", "candidate")
+        git("commit", "--allow-empty", "-m", "Unpromoted candidate")
+        candidate = git("rev-parse", "HEAD")
+        if state != "wrong-checkout":
+            git("tag", "-f", "v0.14.0rc1")
+        if state in {"non-main", "side-parent"}:
+            monkeypatch.setenv("GITHUB_SHA", candidate)
+        if state == "side-parent":
+            git("switch", "main")
+            git("commit", "--allow-empty", "-m", "Main progress")
+            git("merge", "--no-ff", "candidate", "-m", "Integrate candidate")
+            git("update-ref", "refs/remotes/origin/main", git("rev-parse", "HEAD"))
+            git("checkout", "--detach", candidate)
+        if state == "moved-tag":
+            git("checkout", "--detach", initial)
+    with pytest.raises(ValueError):
+        check()
+
+
+@pytest.mark.parametrize("fault", ["missing-wheel", "missing-sdist", "extra", "wheel-version", "sdist-version", "missing-content", "missing-wheel-content", None])
+def test_release_distribution_pair_reuses_package_inspectors(tmp_path, monkeypatch, fault):
+    verify = _load_verify_module()
+    version = verify.BUILD_SUPPORT.read_project_version()
+    metadata = f"Name: gbdraw\nVersion: {version}\n".encode()
+    wrong = b"Name: gbdraw\nVersion: 0.0.0\n"
+    wheel = tmp_path / verify.BUILD_SUPPORT.expected_browser_wheel_name()
+    sdist = tmp_path / f"gbdraw-{version}.tar.gz"
+    if fault != "missing-wheel":
+        with zipfile.ZipFile(wheel, "w") as archive:
+            archive.writestr(f"gbdraw-{version}.dist-info/METADATA", wrong if fault == "wheel-version" else metadata)
+    if fault != "missing-sdist":
+        with tarfile.open(sdist, "w:gz") as archive:
+            data = wrong if fault == "sdist-version" else metadata
+            member = tarfile.TarInfo(f"gbdraw-{version}/PKG-INFO")
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+    if fault == "extra":
+        (tmp_path / "unexpected.txt").write_text("not a distribution")
+    calls = []
+    if fault != "missing-content":
+        monkeypatch.setattr(verify, "inspect_sdist", lambda path: calls.append(path))
+    if fault not in {"missing-content", "missing-wheel-content"}:
+        monkeypatch.setattr(verify, "inspect_wheel", lambda path: calls.append(path))
+    if fault:
+        with pytest.raises((RuntimeError, FileNotFoundError)):
+            verify.inspect_distributions(tmp_path)
+    else:
+        verify.inspect_distributions(tmp_path)
+        assert calls == [sdist, wheel]

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -1444,12 +1444,7 @@ def test_built_sdist_contains_tutorial_data(tmp_path: Path) -> None:
     )
 
     sdist_path = next(dist_dir.glob("gbdraw-*.tar.gz"))
-    with tarfile.open(sdist_path, "r:gz") as sdist:
-        names = set(sdist.getnames())
-    for path in verify_module.REQUIRED_TUTORIAL_DATA_FILES:
-        suffix = f"/gbdraw/web/{path.as_posix()}"
-        assert any(name.endswith(suffix) for name in names), suffix
-    assert any(name.endswith("/tools/build_lambda_gff3_fixture.py") for name in names)
+    verify_module.inspect_sdist(sdist_path)
 
     # Rebuild using only the sdist. Local caches and obsolete browser wheels
     # must not enter a subsequent distribution through broad manifest globs.

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1394,6 +1394,7 @@ test('steady-state topology removes legacy main producers without changing final
   assert.deepEqual(WORKFLOW_NAMES, [
     'deploy_web.yml',
     'gallery-publication.yml',
+    'release.yml',
     'test.yml',
     'web-base-policy.yml'
   ]);

--- a/tools/check_release_source.py
+++ b/tools/check_release_source.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Admit only the exact version-tagged release source on main, before building."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+from runpy import run_path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def check_release_source() -> str:
+    ref = os.environ["GITHUB_REF"]
+    if (
+        os.environ["GITHUB_EVENT_NAME"] != "push"
+        or os.environ["GITHUB_REF_TYPE"] != "tag"
+        or not re.fullmatch(r"refs/tags/v\d+\.\d+\.\d+(?:rc\d+)?", ref)
+    ):
+        raise ValueError("Release source requires a final or RC version tag push")
+    version = run_path(str(REPO_ROOT / "gbdraw/_build_support.py"))["read_project_version"]()
+    if ref != f"refs/tags/v{version}":
+        raise ValueError("Release tag does not exactly match the project version")
+    event_sha = os.environ["GITHUB_SHA"]
+    if not re.fullmatch(r"[0-9a-f]{40}", event_sha):
+        raise ValueError("Release event SHA must be an exact commit or tag object ID")
+
+    def git(*args: str) -> str:
+        return subprocess.check_output(["git", *args], cwd=REPO_ROOT, text=True).strip()
+
+    target = git("rev-parse", "--verify", f"{ref}^{{commit}}")
+    tag_object = git("rev-parse", "--verify", ref)
+    if event_sha not in {tag_object, target} or git("rev-parse", "HEAD") != target:
+        raise ValueError("Checkout, event SHA and release tag target must agree")
+    # A release source is a main integration commit, not a side-branch commit
+    # merely reachable through a merge. Historical main release commits work too.
+    if target not in git("rev-list", "--first-parent", "refs/remotes/origin/main").splitlines():
+        raise ValueError("Release tag target is not on main's first-parent history")
+    if git("status", "--porcelain", "--untracked-files=no"):
+        raise ValueError("Release checkout has modified tracked source")
+    print(f"Release source admitted: {ref} -> {target}; version={version}")
+    return version
+
+
+if __name__ == "__main__":
+    check_release_source()

--- a/tools/verify_gui_offline.py
+++ b/tools/verify_gui_offline.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+from email.parser import BytesParser
+import hashlib
 import http.server
 import io
 import json
@@ -1150,6 +1152,42 @@ def smoke_test(contract: str = "all") -> None:
         _run_browser_contract(browser_contract)
 
 
+def inspect_sdist(sdist_path: Path) -> None:
+    with tarfile.open(sdist_path, "r:gz") as sdist:
+        names = set(sdist.getnames())
+    for path in REQUIRED_TUTORIAL_DATA_FILES:
+        suffix = f"/gbdraw/web/{path.as_posix()}"
+        if not any(name.endswith(suffix) for name in names):
+            raise FileNotFoundError(f"Sdist is missing {suffix}")
+    if not any(name.endswith("/tools/build_lambda_gff3_fixture.py") for name in names):
+        raise FileNotFoundError("Sdist is missing tools/build_lambda_gff3_fixture.py")
+
+
+def inspect_distributions(dist_dir: Path) -> None:
+    """Validate the single publishable pair without rebuilding either archive."""
+    version = BUILD_SUPPORT.read_project_version()
+    wheel_name = BUILD_SUPPORT.expected_browser_wheel_name(version)
+    sdist_name = f"gbdraw-{version}.tar.gz"
+    if {path.name for path in dist_dir.iterdir()} != {wheel_name, sdist_name}:
+        raise RuntimeError("Release distributions must contain exactly the versioned wheel and sdist")
+    wheel_path, sdist_path = dist_dir / wheel_name, dist_dir / sdist_name
+    with zipfile.ZipFile(wheel_path) as wheel:
+        wheel_metadata = wheel.read(f"gbdraw-{version}.dist-info/METADATA")
+    with tarfile.open(sdist_path, "r:gz") as sdist:
+        member = sdist.extractfile(f"gbdraw-{version}/PKG-INFO")
+        if member is None:
+            raise FileNotFoundError("Sdist is missing PKG-INFO")
+        sdist_metadata = member.read()
+    for metadata_bytes in (wheel_metadata, sdist_metadata):
+        metadata = BytesParser().parsebytes(metadata_bytes)
+        if metadata.get_all("Name") != ["gbdraw"] or metadata.get_all("Version") != [version]:
+            raise RuntimeError("Distribution metadata does not match the project name/version")
+    inspect_sdist(sdist_path)
+    inspect_wheel(wheel_path)
+    for path in (sdist_path, wheel_path):
+        print(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}")
+
+
 def inspect_wheel(wheel_path: Path) -> None:
     if not wheel_path.exists():
         raise FileNotFoundError(wheel_path)
@@ -1267,6 +1305,11 @@ def main() -> int:
     inspect_parser = subparsers.add_parser("inspect-wheel", help="Inspect a built wheel for offline GUI assets.")
     inspect_parser.add_argument("wheel_path", type=Path)
 
+    distributions_parser = subparsers.add_parser(
+        "inspect-distributions", help="Verify a release wheel/sdist pair without rebuilding."
+    )
+    distributions_parser.add_argument("dist_dir", type=Path)
+
     args = parser.parse_args()
 
     try:
@@ -1278,6 +1321,8 @@ def main() -> int:
             smoke_test(args.contract)
         elif args.command == "inspect-wheel":
             inspect_wheel(args.wheel_path)
+        elif args.command == "inspect-distributions":
+            inspect_distributions(args.dist_dir)
         else:
             parser.error(f"Unknown command: {args.command}")
     except (FileNotFoundError, RuntimeError, urllib.error.URLError, subprocess.SubprocessError) as exc:


### PR DESCRIPTION
## Plain-language summary

Add a dedicated GitHub Actions workflow that builds and verifies the tagged Python distributions before publishing them to PyPI through Trusted Publishing. It accepts only final or RC version tags whose version matches `pyproject.toml` and whose exact source is a release commit on `main`. The publishing job downloads the verified artifacts and runs the official PyPA publisher; this PR performs no publication.

## Change class

- [x] GOVERNANCE

## Purpose

- Baseline: `dev` at `4666ffb6d92eff31eec29430e8cb4a96fb10d85b`.
- Required checks: `Web base policy (trusted base)` and `PR / gate`.
- Add the missing PyPI delivery path using the existing package builder, package inspector, and installed-package smoke.

## User-visible impact

Pushing a matching `v<version>` tag can publish the verified wheel and sdist after the `pypi` environment permits the job. Both RC and final tags require the tagged commit to appear on `main`'s first-parent history; a side-branch commit merely reachable through a merge is rejected. The current `0.14.0b0` source version is unchanged and is not an admitted release tag.

## Changes

- `.github/workflows/release.yml`: tag-only trigger, exact-SHA checkout, read-only build job, and a separate OIDC publishing job. All actions are pinned to immutable commits with their upstream release labels.
- `tools/check_release_source.py`: fail on mismatched tag/version/event/checkout, missing refs, dirty source, or a source outside main release history. Version still comes from `_build_support.read_project_version()`.
- `tools/verify_gui_offline.py`: verify the exact wheel/sdist pair, metadata versions, existing package-content contracts, and print their hashes. The existing sdist assertions move here from the package test so both consumers share them.
- `tests/ci/release-workflow.test.mjs` and `tests/test_release_pipeline.py`: protect trigger, source, artifact, metadata, and credential boundaries. Existing CI discovers them through its existing test commands. The existing architecture contract adds `release.yml` to its exact workflow inventory.

The existing `test.yml` CI-planning job receives a 10-minute total budget instead of five. Two runs spent 4m44s and 4m47s fetching full history, passed their CI contract tests, then exhausted the five-minute budget during trusted-base checkout. This adjusts setup time only; permissions, required checks, test selection, test timeouts, and performance thresholds are unchanged.

The standard build creates the release sdist and builds its wheel once. The publisher consumes the upload action's artifact ID from the same workflow run. Download digest mismatches and duplicate/rejected PyPI uploads fail; there is no retry loop, token secret, alternate index, manual trigger, or publisher-side rebuild.

## Verification

- `actionlint` 1.7.12 and YAML structure validation: PASS.
- `python -m pytest tests/test_release_pipeline.py -q`: 28 PASS, including real temporary Git repositories and rejected archive mutations.
- `node --test tests/ci/*.test.mjs`: 47 PASS.
- Existing `test_built_sdist_contains_tutorial_data`: PASS, including its independent rebuild, contamination checks, and clean installation.
- Standard isolated wheel/sdist build, `twine check --strict`, shared distribution inspector, and copied installed-package CLI/API/session replay smoke: PASS locally.
- `ruff check gbdraw/ tools/check_release_source.py tests/test_release_pipeline.py` and `git diff --check`: PASS.
- Core fast suite: 3,641 PASS, 17 SKIP; final four added gate cases also passed in the focused run. The exact-commit Python 3.11 clean-export build and installed CLI/API/session smoke also passed.
- Initial remote CI found the old four-workflow inventory in an architecture test. Its expected list now includes the requested `release.yml`; all other topology assertions are unchanged.
- No PyPI/TestPyPI upload, release tag, GitHub Release, main promotion, or manual deployment was performed. Actual Trusted Publishing success belongs to the later authorized release execution.

## Risk and review notes

- Gate: local policy PASS; remote required checks must pass on this head before merge.
- Review: REQUIRED by the release task for workflow/security changes; the executable Web policy also reports REQUIRED after the CI-planning budget change.
- This is architecture-bearing: one new publishing workflow owns the new PyPI delivery path; the source gate is its private helper. Existing builder/version/verification ownership stays in place, and the duplicated sdist assertion location is removed. Owner/path excess does not increase; no compatibility path is introduced. No Web runtime or Product behavior contract changes.

## External setup before any release tag

Repository code does not create or configure these external controls:

| Setting | Required value / action | Observed state |
| --- | --- | --- |
| GitHub Environment | `pypi`, release reviewer approval/protection, restrict deployment to version tags | Not present |
| GitHub version-tag ruleset | Limit creation to authorized release maintainers; prevent updates/deletion | No repository rulesets returned |
| PyPI Owner | `satoshikawato` | Registration unverified |
| PyPI Repository | `gbdraw` | Registration unverified |
| PyPI Workflow | `release.yml` — retain this filename | Registration unverified |
| PyPI Environment | `pypi` | Registration unverified |
| PyPI Project | `gbdraw` | Public project page returned 404 |

Register a Pending Trusted Publisher if the project is still absent; do not make a manual first upload. Registration and environment protection must be completed before pushing any release tag. The source checks do not replace tag protection: a tag selects the workflow code as well as package source.

Official references: [PyPI publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/), [Pending Trusted Publishers](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/), [download-artifact v8.0.1 inputs](https://github.com/actions/download-artifact/blob/v8.0.1/action.yml).

## Rollback

Revert this PR through the normal dev route before creating release tags. No package has been published. The CI-planning budget can be reverted independently; Gallery and Web deployment workflows are unchanged.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concerns and journeys: none; package publication wiring only.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

### GOVERNANCE

- Evidence producer: new `.github/workflows/release.yml`.
- Existing trusted-admission checker, authority, and guard rules: unchanged. The only existing workflow change is the measured CI-planning setup budget. Only the architecture test's expected filename inventory expands to include the explicitly requested publishing workflow. No assertion is removed or bypassed. The new release source helper does not participate in or authorize PR admission.
- No protection/ruleset settings are modified by this PR. Required setup is recorded above for a maintainer to perform before release execution.
- DEV_DELIVERY only: normal dev merge requires human review and passing CI; both gates on the resulting exact dev SHA must then be verified.
