### PR TITLE
Reconcile documentation for the upcoming 0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and full feature descriptions) live under `docs/RELEASE_NOTES_*.md`. This
 file is the short, chronological index; follow the links below for the full
 write-up of a release.
 
+## [0.14.0](./docs/RELEASE_NOTES_0.14.0.md) — unreleased
+
+- Added circular-record display-start rotation and manual feature lane placement.
+- Improved Run Info / Exact replay, Save Session resource preservation, preview
+  navigation, and Generate processing-stage feedback.
+- Includes the beta's package-root Python API and current session/request
+  compatibility, plus isolated wheel/sdist installation and local GUI packaging fixes.
+- See the [full release notes](./docs/RELEASE_NOTES_0.14.0.md) for migration,
+  compatibility, and installation availability. The package remains `0.14.0b0`;
+  the final release has not been published.
+
 ## [0.14.0b0](./docs/RELEASE_NOTES_0.14.0b0.md) — unreleased (beta)
 
 - Added a small top-level Python interface (`read_genbank`, `read_gff`,

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The [documentation home](./docs/DOCS.md) links the four routes above. Supporting
 pages cover [installation](./docs/INSTALL.md), [tutorial
 inputs](./docs/GETTING_TUTORIAL_DATA.md), [citation and project
 background](./docs/ABOUT.md), and the [changelog](./CHANGELOG.md).
+See the [0.14.0 release notes (unreleased)](./docs/RELEASE_NOTES_0.14.0.md)
+for the upcoming release and migration from 0.13.
 See [Contributing](./CONTRIBUTING.md) to report a bug, set up a development
 environment, or submit a pull request.
 
@@ -77,7 +79,10 @@ If you need PNG/PDF/EPS/PS export from a source install, add the optional export
 python -m pip install -e ".[dev,export]"
 ```
 
-See [Installation](./docs/INSTALL.md) for details and platform notes.
+Local GUI/Web assets have no hosted Google Analytics injection.
+See [Installation](./docs/INSTALL.md) for details, supported Python versions,
+platform notes, and the PyPI route after publication. The package version is
+still `0.14.0b0`; 0.14.0 has not been published to PyPI.
 
 ## Bug reports and suggestions
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -16,7 +16,8 @@ Project links:
 
 - GitHub: https://github.com/satoshikawato/gbdraw/
 - Web app: https://gbdraw.app/
-- [Release notes](./RELEASE_NOTES_0.14.0b0.md) and the [full changelog](../CHANGELOG.md)
+- [0.14.0 release notes (unreleased)](./RELEASE_NOTES_0.14.0.md),
+  [0.14.0b0 beta history](./RELEASE_NOTES_0.14.0b0.md), and the [full changelog](../CHANGELOG.md)
 - [Contributing](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
 
 ## Acknowledgments and inspiration

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -61,7 +61,8 @@ back to reproducible Tutorials or the relevant technical documentation.
 - [Get the tutorial inputs](./GETTING_TUTORIAL_DATA.md)
 - [Palette Explorer](./PALETTE_EXPLORER.md)
 - [About and citation](./ABOUT.md)
-- [Release notes](./RELEASE_NOTES_0.14.0b0.md)
+- [0.14.0 release notes (unreleased)](./RELEASE_NOTES_0.14.0.md)
+- [0.14.0b0 beta history](./RELEASE_NOTES_0.14.0b0.md)
 
 ## Entry points
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,13 +4,13 @@
 
 # Installation
 
-`gbdraw` supports three common ways of working:
+Choose an installation route according to the version and interface you need:
 
 | Method | Best for | Notes |
 | --- | --- | --- |
 | Hosted web app | Making a diagram without a local installation | Runs at [gbdraw.app](https://gbdraw.app/) in your browser. |
 | Bioconda | Routine command-line use and reproducible environments | Recommended for most users. |
-| PyPI | Installing into an existing Python environment | Uses `python -m pip install gbdraw`. |
+| PyPI (after publication) | Installing into an existing Python environment | Future release route: `python -m pip install gbdraw`. |
 | Source install | Developing or testing the current checkout | Uses `pip install -e ".[dev]"`. |
 
 ## 1. Hosted web app
@@ -36,11 +36,19 @@ The same UI can also be launched locally after installation with:
 gbdraw gui
 ```
 
-Local `gbdraw gui` analysis runs on your machine. The interactive gallery examples are hosted separately at [https://gbdraw.app/gallery/](https://gbdraw.app/gallery/) and are not bundled into local installs.
+Local `gbdraw gui` analysis runs on your machine. Its packaged Web assets and
+browser wheel have no hosted Google Analytics injection. Prepared local installs
+include the browser runtime assets and GUI palette data needed for offline
+analysis; obtaining the package and its dependencies initially requires network
+access or a local package source. The interactive Gallery examples are hosted
+separately at [gbdraw.app/gallery](https://gbdraw.app/gallery/) and are not bundled
+into local installs.
 
 ## 2. Bioconda installation
 
 Bioconda is the recommended local installation path for routine command-line use.
+The command installs the version available on that channel; it does not select
+the unreleased 0.14.0 checkout.
 
 ```bash
 mamba create -n gbdraw -c conda-forge -c bioconda gbdraw
@@ -56,7 +64,13 @@ gbdraw gui
 
 ## 3. PyPI installation
 
-Install the released package into an activated Python 3.10 or newer environment:
+**Not yet published:** the package version remains `0.14.0b0`, and 0.14.0 has
+not been published to PyPI. The Trusted Publishing workflow is prepared;
+publisher setup and the release transaction must complete before this route is
+available. To test the current implementation now, use a source install below.
+
+After publication, install the released package in an activated environment
+using a supported Python version (3.10, 3.11, or 3.12):
 
 ```bash
 python -m pip install gbdraw
@@ -64,6 +78,9 @@ gbdraw -h
 ```
 
 Use an isolated virtual environment rather than modifying the system Python installation.
+An unpinned command selects the version available on PyPI, not an unpublished
+candidate. For the release's migration notes, see
+[0.14.0 release notes (unreleased)](./RELEASE_NOTES_0.14.0.md).
 
 ## 4. Source installation for development
 
@@ -85,7 +102,8 @@ pytest tests/ -v -m "not slow"
 
 ## Optional: non-SVG export support
 
-SVG export works with the base install. PNG, PDF, EPS, and PS export require CairoSVG:
+SVG export works with the base install. PNG, PDF, EPS, and PS export require
+CairoSVG. After PyPI publication:
 
 ```bash
 python -m pip install "gbdraw[export]"
@@ -93,7 +111,17 @@ python -m pip install "gbdraw[export]"
 
 For an editable source checkout, use `python -m pip install -e ".[dev,export]"` instead.
 
-Depending on your platform, CairoSVG may also require system Cairo/Pango libraries.
+Depending on your platform, CairoSVG may also require system Cairo/Pango
+libraries. On Ubuntu, the tested system packages are `libcairo2-dev` and
+`libpango1.0-dev`.
+
+## Supported and verified environments
+
+The supported Python versions are 3.10, 3.11, and 3.12. The 0.14.0 development
+package has passed isolated wheel/sdist installation, CLI, Python API, session
+replay, and export checks on Linux across those versions. The installed local
+GUI has also been checked with Chromium. These checks do not establish
+Windows/macOS installation, Edge, or later-Python validation.
 
 ## Related commands
 

--- a/docs/REFERENCE/session-and-request-compatibility.md
+++ b/docs/REFERENCE/session-and-request-compatibility.md
@@ -47,9 +47,24 @@ request. Rendering that request alone does not replay saved comparison
 artifacts; use `render_session()` when those artifacts belong in the result.
 
 `render_request()` accepts current typed requests, not historical session
-envelopes. Canonical schema 6 records each input's cardinality, including
-selectorless `all` inputs. Resolve a typed request before encoding when it still
-contains deferred paths or collection-level transforms.
+envelopes. Public typed session conversion accepts versions 31–33 and 39–41;
+versions 27–30 are CLI replay inputs only. Canonical schema 7 retains schema 6's
+input cardinality, including selectorless `all` inputs. Resolve a typed request
+before encoding when it still contains deferred paths or collection-level transforms.
+
+In Web **Run Info**, **Source recipe** uses the original input filenames and
+public CLI settings. Keep those original files and download any listed generated
+helpers with **Download reproducibility files**. That bundle also includes the
+canonical session referenced by **Exact replay**, with its embedded resources
+and saved analysis artifacts. An unavailable Source recipe reports why it cannot
+express the committed semantics losslessly.
+
+Both commands target the successful generation represented by Run Info, even
+after Undo/Redo or edits to the current controls. Exact replay reconstructs that
+committed generation; it does not apply later preview-only editor changes or an
+ungenerated draft. **Save Session** is the route for preserving editable work
+alongside the earlier Result. Exact replay does not promise byte-identical SVG
+across gbdraw versions or font environments.
 
 ## Saved comparison results and cache reuse
 

--- a/docs/REFERENCE/web-app.md
+++ b/docs/REFERENCE/web-app.md
@@ -296,10 +296,12 @@ Generate rebuilds the final slot geometry before Main/side choices become
 available. Auto removal can use the saved source binding without decoding inputs.
 
 **Run Info** describes the successful Result. **Source recipe** reconstructs it
-from embedded original inputs and public CLI settings; **Exact replay** uses its
+from original input files and public CLI settings; **Exact replay** uses its
 saved canonical session and analysis artifacts. Both downloads refer to the
 successful Result, even when controls hold a newer draft. An unavailable Source
 recipe includes a reason; it does not silently omit unsupported settings.
+See [Replay boundaries](session-and-request-compatibility.md#replay-boundaries)
+for required files and the distinction from saving subsequent editor changes.
 Rotation may split one logical comparison match into several SVG paths. Popups
 and sequence downloads still refer to one source match. Gapped matches are split
 by endpoint interpolation, not by reconstructing their aligned bases.

--- a/docs/RELEASE_NOTES_0.14.0.md
+++ b/docs/RELEASE_NOTES_0.14.0.md
@@ -1,0 +1,220 @@
+[Documentation home](./DOCS.md) | [Installation](./INSTALL.md) | [Changelog](../CHANGELOG.md) | [Beta history](./RELEASE_NOTES_0.14.0b0.md)
+
+# gbdraw 0.14.0 release notes
+
+**Status: unreleased.** These notes describe the implemented changes planned for
+the final 0.14.0 release. The package version remains `0.14.0b0`; 0.14.0 has not
+been published to PyPI. Installation availability is documented in
+[Installation](./INSTALL.md).
+
+## Highlights
+
+- Rotate the display start of a complete circular record in Circular or Linear
+  diagrams without changing its sequence or source coordinates.
+- Place a whole feature on Main or an available secondary lane, with its labels
+  and comparison endpoints following the placement.
+- Resume work with preserved session resources, and use **Run Info** to obtain
+  a Source recipe or an Exact replay of the successful Result.
+- Pan large previews reliably and see actual processing stages during Generate.
+- Use the package-root Python drawing API introduced during the beta, with
+  `Diagram` results and mode-specific options.
+- Install self-contained wheel or sdist packages with the local GUI's palette
+  data and browser runtime assets included.
+
+## Web app improvements
+
+**Generate Diagram** reports runtime and input preparation, comparison work,
+rendering, and finalization as those stages occur. Comparison status reflects
+the work being performed, including eligible cache reuse. It is stage feedback,
+not a predicted percentage or completion time. A cancelled or failed run leaves
+the previous successful Result available.
+
+Preview dragging now follows pointer movement over both blank space and
+comparison ribbons, including large diagrams. Pan, zoom, Fit, and Reset change
+the view without regenerating the biological diagram.
+
+The hosted app at [gbdraw.app](https://gbdraw.app/) and local `gbdraw gui` share
+the browser interface. Only hosted gbdraw.app uses Google Analytics 4 for
+aggregate page-usage metrics; gbdraw does not send uploaded genome files or
+generated diagrams to Google Analytics. Local Web assets and the browser wheel
+have no hosted analytics injection. See [Installation](./INSTALL.md#1-hosted-web-app)
+for the local/offline and hosted Gallery boundaries.
+
+## Circular / Linear layout and editing
+
+**Display start** accepts a 1-based source coordinate on a complete circular
+record. That base appears at 12 o'clock in Circular mode or the left edge of
+the wrapped record in Linear mode. An unset start differs from explicit 1 after
+reverse complementation. Rotation can split a displayed feature or match into
+multiple fragments; it does not create additional biological features or alter
+source coordinates. Cropping and an explicit display start cannot be combined.
+
+**Feature placement** applies to an entire feature, including multipart
+features. Auto removes the manual override. Main fixes it on its nominal lane;
+directional lane 1 is available only in compatible layouts. Fixed placements
+work with the overlap resolver on or off. The base-pair overlap tolerance
+defaults to 0, and conflicting fixed placements fail with an explanation.
+See the [placement reference](./REFERENCE/palettes-feature-rules-labels-shapes-and-tracks.md#manual-feature-placement)
+for lane availability, conflict rules, and dormant placements.
+
+Rotation and placement changes remain editable drafts until Generate succeeds.
+Undo/Redo and Save/Load preserve those drafts separately from the last successful
+Result. Feature labels, leaders, and feature-associated comparison ribbons
+follow the final placement.
+
+Linear **Arrange in rows** applies a source card's row to all records selected
+from that source, preserving card and source order. Measured feature, label,
+and track occupancy determines row spacing. Sparse Depth inputs keep their
+logical series: a missing cell draws no coverage and is not treated as zero.
+Circular grids, docked legends, and titles use visible diagram bounds to reduce
+unused canvas space.
+
+Arrow head length and shaft width can be controlled independently. New
+configurations draw `repeat_region` as an underlay behind foreground features;
+use `repeat_region=rectangle` to request the earlier appearance. Supported older
+sessions retain their previous effective repeat shape.
+
+## Session / replay / save compatibility
+
+Current writers emit session version 41 and canonical `renderRequest` schema 7.
+These persisted-format numbers are separate from the package version. The
+[session and request compatibility reference](./REFERENCE/session-and-request-compatibility.md)
+owns the accepted-reader table and migration details.
+
+**Save Session** preserves the resources needed by the committed Result along
+with editable state, including saved comparison data. Saving after edits but
+before Generate retains both the newer draft and earlier Result; loading does
+not silently treat that draft as an already generated result.
+
+**Run Info** separates a Source recipe using original inputs and public CLI
+settings from an Exact replay using the committed canonical session and analysis
+artifacts. Its downloadable helpers remain tied to the successful generation
+through supported history operations. Keep the original files for a Source
+recipe; **Download reproducibility files** supplies the listed generated helpers
+and Exact replay session. Neither command represents ungenerated control edits.
+See [Replay boundaries](./REFERENCE/session-and-request-compatibility.md#replay-boundaries)
+for the target Result and saved-editor limits.
+
+## Python API / CLI changes
+
+The package-root interface, already available in the beta, exports
+`read_genbank()`, `read_gff()`, `draw_circular()`, and `draw_linear()`.
+`CircularOptions` and `LinearOptions` keep mode-specific settings separate.
+One Circular function accepts a single record or a collection; `CircularLayout`
+selects a grid. A `Diagram` provides `to_svg()`, `to_bytes()`, and `save(path)`.
+Saving a non-SVG format writes the requested file without an extra base SVG.
+
+Integrations that need typed requests, tables, resource materialization, or
+session replay continue to use `gbdraw.api`. See the [Python API](./REFERENCE/python-api.md)
+and [typed request reference](./REFERENCE/typed-requests.md) for the supported
+entry points.
+
+The CLI adds record display and placement controls through
+`--record_topology`, `--display_start_coordinate`, `--feature_placement_table`,
+and `--feature_overlap_tolerance_bp`. Use a records table for multiple display
+targets. The [command-line reference](./REFERENCE/command-line.md) includes a
+reproducible rotation/placement example and links to the generated option inventory.
+
+Explicit output prefixes retain dots; Circular batch output uses numbered
+suffixes for multiple records. Output targets are checked before rendering,
+and existing files require explicit overwrite permission. Python export failures
+raise `ValidationError` or `ExportError` (both `GbdrawError` subclasses);
+`save_figure_to()` returns only files actually written. Multi-format exports
+remain sequential: earlier completed files survive a later conversion failure.
+
+## Packaging / installation
+
+Bioconda remains the recommended local installation route. The PyPI Trusted
+Publishing workflow is prepared, but publication has not occurred. The future
+PyPI command and current source-install route are distinguished in
+[Installation](./INSTALL.md); no final package availability is implied here.
+
+Wheel and sdist installation has been verified in isolated Linux environments
+on Python 3.10, 3.11, and 3.12, including CLI, Python API, session replay, and
+non-SVG exports. Package contents exclude development tests, private artifacts,
+and hosted Gallery examples while retaining the GUI palette data and required
+local browser assets. The local GUI was also verified from an installed package.
+SVG needs only the base package; other formats need the `export` extra and
+platform-appropriate Cairo libraries.
+
+## Breaking or renamed interfaces
+
+Fresh CLI commands and Python/configuration inputs reject retired spellings.
+Supported saved documents use the dedicated compatibility readers instead.
+
+| Earlier interface | Current replacement |
+| --- | --- |
+| `--show_gc`, `--suppress_gc` | `--gc`, `--no-gc` |
+| `--show_skew`, `--suppress_skew` | `--skew`, `--no-skew` |
+| `--depth`, `--show_depth` | Repeat `--depth_track` for each series |
+| `--depth_tick_interval` | `--depth_large_tick_interval` |
+| `--feature_table` / Python `feature_table` | `--feature_visibility_table` / `feature_visibility_table` |
+| `--collinear_max_gene_gap` | `--collinear_max_unit_gap` |
+| Circular `--multi_record_size_mode sqrt` | `--multi_record_size_mode auto` |
+| Linear `--label_placement on_feature` | `--label_placement above_feature` |
+| Linear `--track_layout spreadout` / `tuckin` | `--track_layout above` / `below` |
+| Flat `show_labels` / `allow_inner_labels` configuration | Mode-specific `labels.circular.*` / `labels.linear.*` leaves |
+| Circular slot `spacing`, `strict`, `compress`, `reserve` | Explicit `inner_gap_px` / `outer_gap_px`; geometry determines reservation and compression |
+| `gbdraw.api` shared `DiagramOptions`, `TrackOptions`, `OutputOptions` | Root mode-specific options or typed mode-specific request options |
+| Low-level canvas/configurator/assembler re-exports and `plot_*_diagram` save wrappers | Root `draw_circular()` / `draw_linear()`, or typed request/render helpers |
+| `OutputOptions.output_prefix` | `RenderOutputRequest.output_prefix` in typed integrations |
+
+The thin `gbdraw.api.canvas`, `gbdraw.api.configurators`, and
+`gbdraw.circular_diagram_components` modules are removed. Undocumented SVG ID
+spellings are not an integration contract; use the documented
+[semantic hooks](./REFERENCE/interactive-svg-and-semantic-hooks.md).
+The internal `gbdraw.render.export.save_figure` compatibility function emits
+`DeprecationWarning`; use `save_figure_to()` or `render_to_bytes()`.
+
+## Migration notes
+
+1. For 0.13 scripts, update retired names using the table above and check the
+   installed CLI help or Python reference. `ComparisonRingOptions` and
+   `comparison_rings` are the preferred Circular names; the older
+   `Conservation*` names and `conservation` option remain compatibility aliases.
+2. Review rendering defaults when comparing a new figure: Circular shows GC
+   content/skew by default, Linear hides them, and new repeat regions use
+   underlays. Explicitly select settings when a prior appearance matters.
+3. Keep the original session before opening and saving it in the new version.
+   Let the reader migrate supported formats; never edit version numbers or
+   resource identities by hand. Legacy factor-based Circular slot spacing can
+   replay but needs explicit pixel gaps before lossless saving to the current format.
+4. Use Exact replay for a successful generation with its saved analysis artifacts,
+   and Save Session to resume editable work. Keep the same gbdraw version when
+   comparing output; SVG bytes and text metrics can differ across versions.
+
+Two layout/identity corrections can affect older results: overlapping
+undefined- and negative-strand Auto features share the negative pool when
+separate strands and overlap resolution are enabled, and colliding GFF feature
+IDs are disambiguated using the complete original source order. Also, an
+explicit non-default `collinearity_anchor_mode` is now honored; set `rbh` if
+you relied on the previously forced default.
+
+## Compatibility
+
+The supported Python versions for this release are 3.10, 3.11, and 3.12. Linux
+isolated-install evidence does not establish Windows/macOS or later-Python
+validation. Hosted Web and the packaged local GUI are supported entry points;
+saved interactive SVG files remain a separate, self-contained output.
+
+See [Session and request compatibility](./REFERENCE/session-and-request-compatibility.md)
+for supported legacy readers, save/load behavior, and replay limits, and
+[Output formats and export](./REFERENCE/output-formats-and-export.md) for export
+requirements.
+
+## Known limitations / deferred work
+
+- Annotation TSV Download from the Web editor is deferred to v0.15. Existing
+  annotation-table input and rendering remain available.
+- Manual feature placement is limited to Main and supported lane 1 directions;
+  higher lanes, arbitrary pixel dragging, and per-exon placement are not offered.
+- Rotation requires a complete circular record with known length. Gapped
+  comparison fragments use endpoint interpolation, not reconstructed alignments.
+- Source recipe is unavailable when the committed semantics cannot be expressed
+  losslessly as a CLI recipe; Run Info explains the reason.
+- Generate remains explicit for rotation and placement drafts. A new automatic
+  redraw scheduler and new zoom-to-selection navigation are not release features.
+- The hosted Gallery is not bundled with local installs. Windows/macOS installed
+  package verification remains outstanding.
+
+[Documentation home](./DOCS.md) | [Beta history](./RELEASE_NOTES_0.14.0b0.md)

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from gbdraw import __version__
 from gbdraw.session_io import CURRENT_SESSION_VERSION, SUPPORTED_SESSION_VERSIONS
 from gbdraw.session_request_codec import (
     CANONICAL_REQUEST_SCHEMA,
@@ -16,7 +17,8 @@ pytestmark = pytest.mark.recipe
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-RELEASE_NOTES = REPO_ROOT / "docs" / "RELEASE_NOTES_0.14.0b0.md"
+RELEASE_NOTES = REPO_ROOT / "docs" / "RELEASE_NOTES_0.14.0.md"
+BETA_NOTES = REPO_ROOT / "docs" / "RELEASE_NOTES_0.14.0b0.md"
 SESSION_COMPATIBILITY = (
     REPO_ROOT / "docs" / "REFERENCE" / "session-and-request-compatibility.md"
 )
@@ -70,21 +72,56 @@ def test_session_compatibility_table_matches_implementation() -> None:
 
 def test_release_session_history_and_acceptance_use_current_authority() -> None:
     release_notes = RELEASE_NOTES.read_text(encoding="utf-8")
+    beta_notes = BETA_NOTES.read_text(encoding="utf-8")
     acceptance_source = BROWSER_ACCEPTANCE.read_text(encoding="utf-8")
 
-    assert f"## Python/Web session version {CURRENT_SESSION_VERSION}" in release_notes
     assert re.search(
-        rf"gbdraw 0\.14\.0b0 writes session version {CURRENT_SESSION_VERSION} and\s+"
+        rf"Current writers emit session version {CURRENT_SESSION_VERSION} and\s+"
         rf"canonical `renderRequest`\s+schema {CANONICAL_REQUEST_SCHEMA}",
         release_notes,
     )
-    assert "Session version 39 introduced compact runtime handles" in release_notes
-    assert "Current session version 39" not in release_notes
-    assert "Current writers emit version 39" not in release_notes
+    assert "session-and-request-compatibility.md" in release_notes
+    assert "| Accepted by current readers |" not in release_notes
+    assert "# gbdraw 0.14.0b0 release notes" in beta_notes
+    assert "Session version 39 introduced compact runtime handles" in beta_notes
     assert "from gbdraw.session_io import CURRENT_SESSION_VERSION" in acceptance_source
     assert re.search(
         r"^CURRENT_SESSION_VERSION\s*=\s*\d+", acceptance_source, re.MULTILINE
     ) is None
+
+
+def test_release_navigation_retains_beta_history_and_marks_final_unreleased() -> None:
+    changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    final_heading = "## [0.14.0](./docs/RELEASE_NOTES_0.14.0.md) — unreleased"
+    beta_heading = "## [0.14.0b0](./docs/RELEASE_NOTES_0.14.0b0.md) — unreleased (beta)"
+    assert changelog.index(final_heading) < changelog.index(beta_heading)
+    for relative_path in ("README.md", "docs/DOCS.md", "docs/ABOUT.md"):
+        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert re.search(
+            r"\[0\.14\.0 release notes \(unreleased\)\]\([^)]*RELEASE_NOTES_0\.14\.0\.md\)",
+            source,
+        ), relative_path
+    for path in (RELEASE_NOTES, REPO_ROOT / "docs/DOCS.md", REPO_ROOT / "docs/ABOUT.md"):
+        assert "RELEASE_NOTES_0.14.0b0.md" in path.read_text(encoding="utf-8")
+    assert "**Status: unreleased.**" in RELEASE_NOTES.read_text(encoding="utf-8")
+
+
+def test_installation_distinguishes_current_package_from_future_pypi_route() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    install = (REPO_ROOT / "docs/INSTALL.md").read_text(encoding="utf-8")
+    for source in (readme, install, RELEASE_NOTES.read_text(encoding="utf-8")):
+        prose = " ".join(source.split())
+        assert f"`{__version__}`" in prose
+        assert "0.14.0 has not been published to PyPI" in prose
+    assert "Bioconda is the main installation path" in readme
+    assert "Bioconda is the recommended local installation path" in install
+    pypi_section = install.split("## 3. PyPI installation\n", 1)[1].split("\n## ", 1)[0]
+    assert pypi_section.index("After publication") < pypi_section.index(
+        "python -m pip install gbdraw"
+    )
+    for command in ('python -m pip install gbdraw', 'python -m pip install "gbdraw[export]"'):
+        assert command in install
+    assert "3.10, 3.11, and 3.12" in install
 
 
 def test_current_task_docs_delegate_persisted_format_details_to_one_authority() -> None:

--- a/tests/test_documentation_reference_contracts.py
+++ b/tests/test_documentation_reference_contracts.py
@@ -43,6 +43,13 @@ REFERENCE_FILES = {
 }
 DOCUMENTATION_PAGES = (
     *(REFERENCE_ROOT / name for name in REFERENCE_FILES),
+    REPO_ROOT / "README.md",
+    REPO_ROOT / "CHANGELOG.md",
+    REPO_ROOT / "docs" / "DOCS.md",
+    REPO_ROOT / "docs" / "ABOUT.md",
+    REPO_ROOT / "docs" / "INSTALL.md",
+    REPO_ROOT / "docs" / "RELEASE_NOTES_0.14.0b0.md",
+    REPO_ROOT / "docs" / "RELEASE_NOTES_0.14.0.md",
     REPO_ROOT / "docs" / "FAQ.md",
     REPO_ROOT / "docs" / "GALLERY.md",
     REPO_ROOT / "docs" / "PALETTE_EXPLORER.md",
@@ -207,7 +214,7 @@ def test_public_reference_rejects_artificially_split_lambda_fixture() -> None:
     assert "does not split one biological sequence into artificial records" in public_prose
 
 
-def test_technical_faq_and_gallery_local_links_resolve() -> None:
+def test_release_reference_faq_and_gallery_local_links_resolve() -> None:
     missing: list[str] = []
     for source in DOCUMENTATION_PAGES:
         for raw_target in MARKDOWN_LINK_RE.findall(source.read_text(encoding="utf-8")):


### PR DESCRIPTION
## Plain-language summary

Add final 0.14.0 release notes with user-facing highlights and migration guidance, while preserving the beta notes as history. Clarify that PyPI publication is pending and that Run Info replay targets the successful generation, then update the documentation links and existing contract tests. The package version remains `0.14.0b0`.

## Change class

- [x] STANDARD

## Purpose

Reconcile release documentation with `dev` at `2f2f38fdbc2ae15e4b085eeaf639d5e4e91afc05`. Required checks are `PR / gate` and `Web base policy (trusted base)`; the existing CI planner selects the validation jobs.

## User-visible impact

Readers can find the final release summary, identify renamed CLI/Python interfaces, and distinguish available installation routes from future PyPI publication. Bioconda remains the recommended local route. The current compatibility reference retains the reader table and clarifies required replay files and saved-editor limits.

## Changes

- Add `docs/RELEASE_NOTES_0.14.0.md`, marked unreleased, and link it from README, CHANGELOG, DOCS, and ABOUT.
- Keep beta release notes and older changelog entries byte-identical.
- Reconcile INSTALL and the session/Web references with existing implementation and merged regression evidence.
- Extend `tests/test_documentation_contracts.py` and the existing reference link-check inventory.

## Verification

- Documentation contracts: 74 passed; final focused check after prose wrapping: 20 passed.
- Existing standard recipe lane: 188 passed, including clean-directory CLI/Python examples.
- Local links/anchors: 228 links and 21 Markdown anchors passed using existing test helpers.
- Installation sanity: 11 shell blocks parse; pip package/extra names match metadata; future PyPI installation was not attempted.
- Generated CLI help inventory, Ruff, and whitespace checks passed.
- Beta history and older changelog entries are byte-identical; runtime, version metadata, workflows, and generated artifacts have no diff.
- Installed-package and browser behavior claims reuse the already merged package/replay/save/navigation evidence; no repeat audit of the completed release sessions.

## Risk and review notes

- Local Gate: PASS. Local Review: CLEAR; exact-head trusted checks must also pass.
- This is not architecture-bearing. Existing installation, compatibility, API, and CLI detail owners remain in place. OE/PE/CB: N/A; no production owner, path, or reader changes.
- No runtime or Product Impact delta. The hosted-only GA4 policy is retained, and Annotation TSV Download remains deferred to v0.15.
- Version synchronization and publication remain later release tasks. The unreleased wording checks must be updated with the final release transaction.

## Rollback

Revert these documentation and documentation-test changes through an ordinary dev PR.

## Conditional Product Impact

- Product-impact role: N/A
- Product preflight classification: N/A
- Affected concerns: none; documentation describes the accepted implementation without changing supported outcomes.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
