### PR TITLE
Add Annotation TSV download for the current editor draft

### DIFF
--- a/docs/REFERENCE/input-formats-and-tsv-schemas.md
+++ b/docs/REFERENCE/input-formats-and-tsv-schemas.md
@@ -91,6 +91,19 @@ selector uses qualifier expressions, with multiple conditions separated by
 semicolons. Explicit `lane` values are zero-based. The renderer selects rows by
 `set_id`, so one table can hold independently placed annotation sets.
 
+In the Web app, **Region Annotations → Download TSV** saves the current editor
+draft as `annotations.tsv`, including edits made since the last Generate.
+It works offline and is disabled until the draft contains an annotation row.
+The file can be loaded with **Import TSV**, Python's `read_annotation_table()`,
+or the CLI's `--annotation_table` option.
+
+The download preserves effective row targets and styles, including explicit
+no-fill, unique record IDs, and one-based `#N` record bindings. A blank `fill`
+cell in a styled row means no fill; omitting the column retains the Web import
+default. TSV does not retain empty sets, metadata, or the distinction between
+an inherited set style and a row override. Tabs and line breaks within cells
+are replaced with spaces.
+
 ## Styling tables
 
 Most styling tables are headerless TSV. Label-override and visibility readers

--- a/docs/RELEASE_NOTES_0.14.0.md
+++ b/docs/RELEASE_NOTES_0.14.0.md
@@ -33,6 +33,14 @@ Preview dragging now follows pointer movement over both blank space and
 comparison ribbons, including large diagrams. Pan, zoom, Fit, and Reset change
 the view without regenerating the biological diagram.
 
+**Region Annotations → Download TSV** saves the current editor draft as
+`annotations.tsv`, including changes made since the last Generate. The file
+works with Web **Import TSV** and the existing Python/CLI annotation-table
+readers. Download works offline and preserves effective row targets and styles,
+including explicit no-fill. Empty drafts cannot be downloaded. See the
+[annotation-table reference](./REFERENCE/input-formats-and-tsv-schemas.md#annotation-table-fields)
+for the TSV round-trip limits.
+
 The hosted app at [gbdraw.app](https://gbdraw.app/) and local `gbdraw gui` share
 the browser interface. Only hosted gbdraw.app uses Google Analytics 4 for
 aggregate page-usage metrics; gbdraw does not send uploaded genome files or
@@ -204,8 +212,6 @@ requirements.
 
 ## Known limitations / deferred work
 
-- Annotation TSV Download from the Web editor is deferred to v0.15. Existing
-  annotation-table input and rendering remain available.
 - Manual feature placement is limited to Main and supported lane 1 directions;
   higher lanes, arbitrary pixel dragging, and per-exon placement are not offered.
 - Rotation requires a complete circular record with known length. Gapped

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -2245,7 +2245,9 @@
                             <div class="flex gap-1">
                                 <button type="button" class="btn btn-secondary text-[10px] flex-1" @click="addAnnotationSet()"><i class="ph ph-plus"></i> Add set</button>
                                 <label class="btn btn-secondary text-[10px] flex-1 cursor-pointer"><i class="ph ph-upload-simple"></i> Import TSV<input type="file" accept=".tsv,.tab,.txt,text/tab-separated-values,text/plain" class="hidden" @change="importAnnotationTableFile"></label>
+                                <button type="button" data-history-ignore class="btn btn-secondary text-[10px] flex-1" @click="downloadAnnotationTable()" :disabled="!canDownloadAnnotationTable()" :aria-describedby="!canDownloadAnnotationTable() ? 'annotation-download-help' : null"><i aria-hidden="true" class="ph ph-download-simple"></i> Download TSV</button>
                             </div>
+                            <p v-if="!canDownloadAnnotationTable()" id="annotation-download-help" class="text-[10px] text-slate-500">Add an annotation row to download TSV.</p>
                             <div v-if="annotationSets.length === 0" class="rounded border border-dashed border-slate-200 p-2 text-[10px] text-slate-400">No annotation sets.</div>
                             <div v-for="set in annotationSets" :key="set.id" class="rounded border border-slate-200 bg-white p-2 space-y-2">
                                 <div class="grid grid-cols-[minmax(0,1fr)_auto_auto] gap-1">

--- a/gbdraw/web/js/app/annotations.js
+++ b/gbdraw/web/js/app/annotations.js
@@ -1,11 +1,12 @@
 import { createAnnotationSet, normalizeAnnotationSets, uniqueAnnotationSetId } from './annotations/state.js';
 import { coordinateTarget, featureTarget, featureTargetsFromSelection } from './annotations/target-actions.js';
-import { parseAnnotationTable } from './annotations/table-codec.js';
+import { encodeAnnotationTable, parseAnnotationTable } from './annotations/table-codec.js';
 import {
   createAnnotationRecordSelector,
   reconcileAnnotationRecordBindings
 } from './annotations/record-selector.js';
 import { readFileText } from '../services/file-content-cache.js';
+import { downloadTextFile } from '../services/text-download.js';
 
 export const createAnnotationEditor = ({ state, getRecordCatalog }) => {
   const recordSelector = createAnnotationRecordSelector({ getCatalog: getRecordCatalog });
@@ -71,6 +72,11 @@ export const createAnnotationEditor = ({ state, getRecordCatalog }) => {
     item.target.record = record;
   };
   const importAnnotationTable = (text) => replaceSets(parseAnnotationTable(text));
+  const canDownloadAnnotationTable = () => state.annotationSets.some((set) => set.annotations.length > 0);
+  const downloadAnnotationTable = () => {
+    if (!canDownloadAnnotationTable()) return;
+    downloadTextFile('annotations.tsv', encodeAnnotationTable(state.annotationSets));
+  };
   const importAnnotationTableFile = async (event) => {
     const file = event?.target?.files?.[0];
     if (!file) return;
@@ -81,6 +87,7 @@ export const createAnnotationEditor = ({ state, getRecordCatalog }) => {
     addAnnotationSet, renameAnnotationSet, duplicateAnnotationSet, removeAnnotationSet,
     addCoordinateAnnotation, addSelectedFeatures, removeAnnotation, setAnnotationTargetKind,
     importAnnotationTable, importAnnotationTableFile, replaceAnnotationSets: replaceSets,
+    canDownloadAnnotationTable, downloadAnnotationTable,
     recordOptionsFor: recordSelector.optionsFor,
     recordValueFor: recordSelector.valueFor,
     setRecordValue: recordSelector.setValue,

--- a/gbdraw/web/js/app/annotations/table-codec.js
+++ b/gbdraw/web/js/app/annotations/table-codec.js
@@ -29,7 +29,8 @@ const styleFromRow = (row) => {
   if (row.stroke_width) style.strokeWidth = Number(row.stroke_width);
   if (row.stroke_dasharray) style.strokeDasharray = row.stroke_dasharray.split(/[ ,]+/).filter(Boolean).map(Number);
   if (row.line_cap) style.lineCap = row.line_cap;
-  if (row.fill) style.fill = row.fill;
+  // The encoder writes explicit no-fill as a blank cell; an omitted column keeps the default.
+  if (row.fill != null) style.fill = row.fill || null;
   if (row.fill_opacity) style.fillOpacity = Number(row.fill_opacity);
   if (row.label_color) style.labelColor = row.label_color;
   if (row.label_font_size) style.labelFontSize = Number(row.label_font_size);

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -3334,6 +3334,8 @@ export const createAppSetup = () => {
     removeAnnotation: annotationEditor.removeAnnotation,
     setAnnotationTargetKind: annotationEditor.setAnnotationTargetKind,
     importAnnotationTableFile: annotationEditor.importAnnotationTableFile,
+    canDownloadAnnotationTable: annotationEditor.canDownloadAnnotationTable,
+    downloadAnnotationTable: annotationEditor.downloadAnnotationTable,
     annotationRecordOptions: annotationEditor.recordOptionsFor,
     annotationRecordValue: annotationEditor.recordValueFor,
     setAnnotationRecord: annotationEditor.setRecordValue,

--- a/tests/web/annotation-download.playwright.spec.js
+++ b/tests/web/annotation-download.playwright.spec.js
@@ -1,0 +1,152 @@
+const { test, expect } = require('@playwright/test');
+const { readFile, writeFile } = require('node:fs/promises');
+const { execFileSync } = require('node:child_process');
+const { join } = require('node:path');
+const { openApp, assertDiagramWorkerIdle, getDiagramWorkerActivity } = require('./helpers/app-lifecycle.cjs');
+
+const panel = (page) => page.locator('details').filter({ has: page.locator('summary[aria-label="Region Annotations"]') });
+const effectiveRows = (page) => page.evaluate(() => window.__GBDRAW_APP__.annotationSets.flatMap((set) =>
+  set.annotations.map((item) => ({
+    setId: set.id, id: item.id, target: item.target, mark: item.mark, label: item.label,
+    lane: item.lane, legendLabel: item.legendLabel ?? set.legendLabel,
+    style: item.style || set.defaultStyle
+  }))
+));
+
+const snapshot = (page) => page.evaluate(async () => {
+  const app = window.__GBDRAW_APP__;
+  const history = window.__GBDRAW_HISTORY__;
+  const { getCommittedCanonicalSession } = await import('./js/services/config.js');
+  return JSON.stringify({
+    draft: app.annotationSets, results: app.results, resultIndex: app.selectedResultIndex,
+    annotation: app.selectedAnnotation, features: app.selectedFeatures,
+    zoom: app.zoom, pan: app.canvasPan, svg: app.svgContainer?.innerHTML,
+    scroll: [app.canvasContainerRef?.scrollLeft, app.canvasContainerRef?.scrollTop],
+    committed: getCommittedCanonicalSession(), runInfo: app.lastRunInfo,
+    history: [history.getUndoCount(), history.getRedoCount(), history.revision.value,
+      history.getCurrentIntentSignature(), history.getCurrentCheckpointSignature(), history.getDiagnostics()]
+  });
+});
+
+for (const width of [1440, 390]) {
+  test(`@pr-smoke annotation TSV download/re-import and Python round-trip offline (${width}px)`, async ({ page, browser }, testInfo) => {
+    test.setTimeout(180000);
+    await page.setViewportSize({ width, height: 960 });
+    const external = [];
+    const requests = [];
+    page.on('request', (request) => requests.push(request.url()));
+    await page.context().route('**/*', (route) => {
+      const url = new URL(route.request().url());
+      if (url.hostname === '127.0.0.1') return route.continue();
+      external.push(url.href);
+      return route.abort();
+    });
+    await openApp(page);
+    const downloads = [];
+    page.on('download', (download) => downloads.push(download));
+    await panel(page).locator('summary').click();
+    const button = panel(page).getByRole('button', { name: 'Download TSV', exact: true });
+    await expect(button).toBeDisabled();
+    await expect(button).toHaveAccessibleDescription('Add an annotation row to download TSV.');
+    await page.evaluate(() => window.__GBDRAW_APP__.downloadAnnotationTable());
+    await panel(page).getByRole('button', { name: /Add set/ }).click();
+    await expect(button).toBeDisabled();
+    await page.evaluate(() => window.__GBDRAW_APP__.downloadAnnotationTable());
+    expect(downloads).toHaveLength(0);
+
+    // A saved Result remains present while its annotation draft is edited.
+    await page.locator('input[type=file][accept*="application/json"][accept*="application/gzip"]')
+      .setInputFiles(join(process.cwd(), 'gbdraw/web/gallery/sessions/tobacco-chloroplast.gbdraw-session.json'));
+    await page.waitForFunction(() => !window.__GBDRAW_APP__.sessionImportPending, null, { timeout: 180000 });
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.results.length)).toBe(1);
+    await page.evaluate(async () => {
+      const { normalizeAnnotationSets } = await import('./js/app/annotations/state.js');
+      const { coordinateTarget, featureTarget } = await import('./js/app/annotations/target-actions.js');
+      const app = window.__GBDRAW_APP__;
+      app.annotationSets.splice(0, app.annotationSets.length, ...normalizeAnnotationSets([
+        { id: 'empty', annotations: [] },
+        { id: 'draft', legendLabel: 'Regions', defaultStyle: { fill: null, stroke: '#123456' }, annotations: [
+          { id: 'unique', target: coordinateTarget({ recordId: 'unique', start: 7, end: 21 }), mark: 'band', label: 'Before edit', lane: 1 },
+          { id: 'duplicate', target: coordinateTarget({ recordIndex: 1, start: 90, end: 10 }), mark: 'highlight', label: 'Origin span', style: {
+            fill: null, strokeWidth: 2, strokeDasharray: [3, 2], lineCap: 'arrow', fillOpacity: 0,
+            hatch: { angle: 30, spacing: 6, color: '#654321', width: 2, cross: true },
+            labelColor: '#345678', labelFontSize: 14, labelOrientation: 'tangent', labelPosition: 'end', labelOffset: 0
+          } }
+        ] },
+        { id: 'features', annotations: [
+          { id: 'gene', target: featureTarget({ recordIndex: 0, selector: 'locus_tag=ABC_1;gene=abc', extent: 'segments', circularPath: 'forward' }), mark: 'bracket', label: 'Gene α', legendLabel: 'Genes' },
+          { id: 'local', target: { ...coordinateTarget({ start: 2, end: 8, coordinateSpace: 'local' }), outOfBounds: 'skip' }, mark: 'line' }
+        ] }
+      ]));
+    });
+    await panel(page).getByPlaceholder('Label', { exact: true }).first().fill('Edited draft α');
+    await panel(page).locator('summary').focus();
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.capturing.value)).toBe(false);
+    const expected = await effectiveRows(page);
+    await expect(button).toBeEnabled();
+    await button.scrollIntoViewIfNeeded();
+    await button.locator('..').screenshot({ path: testInfo.outputPath('annotation-download.png') });
+    const bounds = await button.boundingBox();
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(width);
+    // Instrument the shared service's browser URL lifecycle after session loading.
+    await page.evaluate(() => {
+      window.__annotationUrls = { created: [], revoked: [] };
+      const create = URL.createObjectURL.bind(URL);
+      const revoke = URL.revokeObjectURL.bind(URL);
+      URL.createObjectURL = (blob) => {
+        const url = create(blob);
+        window.__annotationUrls.created.push({ url, type: blob.type });
+        return url;
+      };
+      URL.revokeObjectURL = (url) => { window.__annotationUrls.revoked.push(url); revoke(url); };
+    });
+    const before = await snapshot(page);
+    const workerBefore = await getDiagramWorkerActivity(page);
+    const requestCount = requests.length;
+    await page.context().setOffline(true);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const pending = page.waitForEvent('download');
+      await button.click();
+      const downloaded = await pending;
+      expect(downloaded.suggestedFilename()).toBe('annotations.tsv');
+      const path = testInfo.outputPath(`annotations-${attempt}.tsv`);
+      await downloaded.saveAs(path);
+      expect(await downloaded.failure()).toBeNull();
+      expect(await snapshot(page)).toBe(before);
+      if (attempt === 0) {
+        const expectedPath = testInfo.outputPath('expected-rows.json');
+        await writeFile(expectedPath, JSON.stringify(expected, null, 2));
+        const pythonResult = execFileSync('python', ['tests/web/helpers/annotation-roundtrip.py', path, expectedPath], { encoding: 'utf8' });
+        await writeFile(testInfo.outputPath('python-reader.txt'), pythonResult);
+        const context = await browser.newContext({ baseURL: 'http://127.0.0.1:4173', viewport: { width, height: 960 } });
+        try {
+          await context.route('**/*', (route) => {
+            if (new URL(route.request().url()).hostname === '127.0.0.1') return route.continue();
+            external.push(route.request().url());
+            return route.abort();
+          });
+          const fresh = await context.newPage();
+          await openApp(fresh);
+          await context.setOffline(true);
+          await panel(fresh).locator('summary').click();
+          await panel(fresh).locator('input[type=file]').setInputFiles(path);
+          await expect.poll(() => effectiveRows(fresh)).toEqual(expected);
+          await assertDiagramWorkerIdle(fresh);
+        } finally {
+          await context.close();
+        }
+      } else {
+        expect(await readFile(path, 'utf8')).toBe(await readFile(testInfo.outputPath('annotations-0.tsv'), 'utf8'));
+      }
+    }
+    expect(downloads).toHaveLength(2);
+    expect(requests).toHaveLength(requestCount);
+    expect(external).toEqual([]);
+    const urls = await page.evaluate(() => window.__annotationUrls);
+    expect(urls.created.map(({ type }) => type)).toEqual(Array(2).fill('text/tab-separated-values;charset=utf-8'));
+    expect(urls.revoked).toEqual(urls.created.map(({ url }) => url));
+    expect(await getDiagramWorkerActivity(page)).toEqual(workerBefore);
+    await writeFile(testInfo.outputPath('browser-evidence.json'), JSON.stringify({ width, external, requests, urls, downloads: downloads.length, unchangedState: true }, null, 2));
+  });
+}

--- a/tests/web/annotations.test.mjs
+++ b/tests/web/annotations.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import test from 'node:test';
 import { cp, mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -51,6 +52,79 @@ const restored = parseAnnotationTable(table);
 assert.equal(restored[0].id, 'review');
 assert.equal(restored[0].annotations[0].target.start, 10);
 assert.equal(restored[0].annotations[1].target.selectors[0].value, 'ABC_1');
+
+test('explicit no-fill survives TSV while omitted fill keeps the Web default', () => {
+  const draft = [createAnnotationSet({
+    id: 'no-fill', defaultStyle: { fill: null },
+    annotations: [
+      { id: 'inherited', target: coordinateTarget({ start: 5, end: 8 }), mark: 'band' },
+      { id: 'override', target: featureTarget({ selector: 'locus_tag=ABC_1' }),
+        mark: 'bracket', style: { fill: null } }
+    ]
+  })];
+  const reimported = parseAnnotationTable(encodeAnnotationTable(draft));
+  assert.deepEqual(reimported[0].annotations.map((item) => item.style.fill), [null, null]);
+  const omittedFill = parseAnnotationTable('set_id\tid\tmark\tstart\tend\tstroke\ns\ta\tband\t1\t5\t#123456\n');
+  assert.equal(omittedFill[0].annotations[0].style.fill, '#94a3b8');
+});
+
+test('download reads the current rows without mutating state or resolving a catalog', async () => {
+  const draftState = {
+    annotationSets: [],
+    results: [{ content: '<svg/>', annotations: 'committed, older data' }],
+    selectedResultIndex: 0, selectedAnnotation: { setId: 'review', id: 'coords' },
+    selectedFeatures: [{ id: 'feature' }], zoom: 2, canvasPan: { x: 5, y: 8 },
+    history: ['before', 'after']
+  };
+  const draftEditor = createAnnotationEditor({
+    state: draftState, getRecordCatalog: () => { throw new Error('Download must not resolve records'); }
+  });
+  const calls = [];
+  let blob;
+  const original = { document: globalThis.document, create: URL.createObjectURL, revoke: URL.revokeObjectURL };
+  globalThis.document = {
+    body: {
+      appendChild(link) { link.parentNode = this; calls.push('append'); },
+      removeChild() { calls.push('remove'); }
+    },
+    createElement(tag) {
+      assert.equal(tag, 'a');
+      return { click() { calls.push(['click', this.download, this.href]); } };
+    }
+  };
+  URL.createObjectURL = (value) => { blob = value; calls.push('blob'); return 'blob:annotation'; };
+  URL.revokeObjectURL = (url) => calls.push(['revoke', url]);
+  try {
+    assert.equal(draftEditor.canDownloadAnnotationTable(), false);
+    draftEditor.downloadAnnotationTable();
+    draftState.annotationSets.push(createAnnotationSet());
+    assert.equal(draftEditor.canDownloadAnnotationTable(), false);
+    draftEditor.downloadAnnotationTable();
+    assert.deepEqual(calls, []);
+    draftState.annotationSets.push(createAnnotationSet({ id: 'current', annotations: [
+      { id: 'id-bound', target: coordinateTarget({ recordId: 'unique', start: 7, end: 20 }), label: 'Current draft', mark: 'band' },
+      { id: 'index-bound', target: featureTarget({ recordIndex: 1, selector: 'locus_tag=ABC_1' }), mark: 'bracket', style: { fill: null } }
+    ] }));
+    assert.equal(draftEditor.canDownloadAnnotationTable(), true);
+    const before = structuredClone(draftState);
+    draftEditor.downloadAnnotationTable();
+    assert.deepEqual(draftState, before);
+    assert.deepEqual(calls, ['blob', 'append', ['click', 'annotations.tsv', 'blob:annotation'], 'remove', ['revoke', 'blob:annotation']]);
+    assert.equal(blob.type, 'text/tab-separated-values;charset=utf-8');
+    const text = await blob.text();
+    assert.equal(text, encodeAnnotationTable(draftState.annotationSets));
+    const rows = parseAnnotationTable(text)[0].annotations;
+    assert.equal(rows[0].label, 'Current draft');
+    assert.deepEqual(rows.map((item) => item.target.record), [
+      { kind: 'recordId', value: 'unique' }, { kind: 'recordIndex', index: 1 }
+    ]);
+  } finally {
+    if (original.document === undefined) delete globalThis.document;
+    else globalThis.document = original.document;
+    URL.createObjectURL = original.create;
+    URL.revokeObjectURL = original.revoke;
+  }
+});
 
 assert.equal(annotationRecordSelectorValue(annotationRecordSelectorFromValue('')), '');
 assert.equal(annotationRecordSelectorValue(annotationRecordSelectorFromValue('RecA')), 'RecA');

--- a/tests/web/helpers/annotation-roundtrip.py
+++ b/tests/web/helpers/annotation-roundtrip.py
@@ -1,0 +1,43 @@
+"""Compare an actual browser download with its effective Web draft rows."""
+
+from dataclasses import asdict
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from gbdraw.annotations import CoordinateSpan, read_annotation_table
+
+
+def camel_fields(value):
+    if isinstance(value, dict):
+        return {
+            key.split("_")[0] + "".join(part.title() for part in key.split("_")[1:]): camel_fields(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (tuple, list)):
+        return [camel_fields(item) for item in value]
+    return value
+
+
+rows = []
+for annotation_set in read_annotation_table(sys.argv[1]):
+    for item in annotation_set.annotations:
+        target = camel_fields(asdict(item.target))
+        target["kind"] = "coordinateSpan" if isinstance(item.target, CoordinateSpan) else "featureSpan"
+        record = item.target.record
+        target["record"] = (
+            None if record is None else
+            {"kind": "recordIndex", "index": record.record_index} if record.record_index is not None else
+            {"kind": "recordId", "value": record.record_id}
+        )
+        rows.append({
+            "setId": annotation_set.id, "id": item.id, "target": target,
+            "mark": item.mark, "label": item.label or "", "lane": item.lane,
+            "legendLabel": item.legend_label or annotation_set.legend_label,
+            "style": camel_fields(asdict(item.style or annotation_set.default_style)),
+        })
+expected = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+assert rows == expected, json.dumps({"python": rows, "web": expected}, indent=2)
+print(f"Python reader: {len(rows)} effective annotation rows match the downloaded Web draft")

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { webcrypto } from 'node:crypto';
 import test from 'node:test';
 import { installFakeSvgDom } from './fake-svg-dom.mjs';
+import { encodeAnnotationTable, parseAnnotationTable } from '../../gbdraw/web/js/app/annotations/table-codec.js';
 
 globalThis.window = {
   location: { href: 'https://audit.invalid/' },
@@ -1688,7 +1689,7 @@ test('Linear mode none ignores dormant comparison state while active depth and a
       legendLabel: null,
       metadata: {}
     }],
-    defaultStyle: null,
+    defaultStyle: { fill: null },
     legendLabel: null
   });
 
@@ -1757,6 +1758,18 @@ test('Linear mode none ignores dormant comparison state while active depth and a
 
   const linearResult = result('linear-none.svg', 'linear-none');
   workerResponses.push(response(linearResult, validCatalog(linearResult.name)));
+  // Observe the existing internal helper staging boundary. Run Info deliberately
+  // withholds annotation Source recipes because TSV cannot preserve inheritance.
+  const stagedAnnotationTables = [];
+  const NativeMap = globalThis.Map;
+  globalThis.Map = class extends NativeMap {
+    set(key, value) {
+      if (key === '/web_annotations.tsv' && typeof value?.data === 'string') {
+        stagedAnnotationTables.push(value.data);
+      }
+      return super.set(key, value);
+    }
+  };
   try {
     assert.deepEqual(
       await runner.runAnalysis(comparisonPlanSnapshot),
@@ -1764,6 +1777,7 @@ test('Linear mode none ignores dormant comparison state while active depth and a
       JSON.stringify(state.errorLog.value)
     );
   } finally {
+    globalThis.Map = NativeMap;
     if (previousLosatExecutor === undefined) {
       delete globalThis.__GBDRAW_LOSAT_EXECUTOR__;
     } else {
@@ -1772,6 +1786,11 @@ test('Linear mode none ignores dormant comparison state while active depth and a
   }
 
   const workerRunMessages = workerMessages.filter(({ type }) => type === 'run');
+  assert.ok(stagedAnnotationTables.length > 0, 'Generate stages the annotation helper');
+  for (const text of stagedAnnotationTables) {
+    assert.equal(text, encodeAnnotationTable(state.annotationSets));
+    assert.equal(parseAnnotationTable(text)[0].annotations[0].style.fill, null);
+  }
   const payload = workerRunMessages.at(-1).payload;
   assert.equal(workerRunMessages.length, workerRunCountBefore + 1);
   assert.equal(serializedSnapshot, comparisonPlanSnapshot);


### PR DESCRIPTION
## Plain-language summary

Add **Download TSV** beside **Add set** and **Import TSV** in Region Annotations. It saves the current editor draft as `annotations.tsv`, so edits can be re-imported in the Web app or read by Python without generating a diagram. Empty drafts cannot be downloaded, and explicit no-fill now survives the Web round-trip.

## Change class

- [x] STANDARD

## Purpose and changes

Base: `dev` at `2698fe695a3704253f1cc91ed81d334a2867d615`.
Required checks: `PR / gate` and `Web base policy (trusted base)`.

The existing annotation editor calls `encodeAnnotationTable()` and `downloadTextFile()`. Its row-availability predicate controls both the button and action; the button uses the existing History exclusion. The shared codec reads a blank fill cell in a styled row as no fill and retains the Web default when the column is omitted. The annotation reference documents TSV limits, and final release notes replace the deferred-download entry.

## Verification

- Two new focused tests fail on the base for the missing download action and no-fill drift, then pass with this change.
- Source and packaged-wheel Chromium: desktop 1440px and mobile 390px pass actual download, fresh-context Web re-import, and Python `read_annotation_table()` of the same downloaded file. Four effective rows cover unique and one-based index bindings, coordinate and feature targets, styles, no-fill, hatching, Unicode, and origin wrapping.
- Two consecutive downloads work offline, one Blob/file per click, with every object URL revoked. Result, committed session/resources, History, selection, viewport and diagram Worker activity remain unchanged. Fresh Web re-import does not construct a Worker.
- Existing Generate helper staging emits the shared encoder's bytes, including no-fill.
- All 518 Web JavaScript tests pass; 38 annotation Python tests pass; 186 packaging/session/documentation/reference-output tests pass. All 16 tracked SVG comparisons pass without reference changes.
- Ruff, diff whitespace, packaged asset inspection and local Web policy pass. The final browser tests are tagged `@pr-smoke` for required CI.

## Risk and review notes

This is not architecture-bearing: this is another consumer of the existing editor, TSV codec and text-download owners. No semantic owner or responsibility moves; no parallel serialization, normalization, schema, compatibility path, global state, dependency, watcher or privileged boundary is introduced. Named production exports and reactive-owner inventory are unchanged. Existing Generate, request/session writers, renderer, worker and analysis code remain unchanged. Changed-scope owner/path excess and compatibility burden do not increase; there is no superseded path to remove.

Local policy: Gate **PASS**, Review **CLEAR**; no deterministic violation or registered Product Impact delta. Current dev protection requires zero approvals. TSV preserves effective row semantics, not empty sets, metadata or set-default inheritance identity. Run Info's existing stricter Source recipe eligibility is unchanged. Package version remains `0.14.0b0`.

## Rollback

Revert this commit to remove the Download control and restore the previous Web blank-fill import behavior. No schema migration or artifact regeneration is needed.

## Conditional Product Impact

N/A for registered concerns; the maintainer's explicit S06 instructions select current-draft export, empty-row behavior and bounded no-fill repair. Preflight found no unresolved product choice. Existing Python TSV semantics establish empty fill as no fill; no `BD-###` or candidate authority is claimed. Contracts are the annotation tests and real browser/Python round-trip above.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
