### PR TITLE
Set version to 0.14.0 for internal final acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ write-up of a release.
 - Includes the beta's package-root Python API and current session/request
   compatibility, plus isolated wheel/sdist installation and local GUI packaging fixes.
 - See the [full release notes](./docs/RELEASE_NOTES_0.14.0.md) for migration,
-  compatibility, and installation availability. The package remains `0.14.0b0`;
-  the final release has not been published.
+  compatibility, and installation availability. The source version is `0.14.0`
+  (internal final candidate); the final release has not been published.
 
 ## [0.14.0b0](./docs/RELEASE_NOTES_0.14.0b0.md) — unreleased (beta)
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use gbdraw in your research, please cite it."
 title: "gbdraw"
-version: "0.14.0b0"
+version: "0.14.0"
 license: "MIT"
 url: "https://github.com/satoshikawato/gbdraw"
 repository-code: "https://github.com/satoshikawato/gbdraw"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **gbdraw** is a Python bioinformatics tool for creating publication-quality genome diagrams from microbial genomes and organelles. It generates circular and linear visualizations of genomic features (CDS, tRNA, regulatory elements, etc.) with optional GC content/skew plots and BLAST comparison tracks.
 
-- **Version:** 0.14.0b0
+- **Version:** 0.14.0
 - **Python:** ≥3.10
 - **Output formats:** SVG, PNG, PDF, EPS, PS
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ python -m pip install -e ".[dev,export]"
 
 Local GUI/Web assets have no hosted Google Analytics injection.
 See [Installation](./docs/INSTALL.md) for details, supported Python versions,
-platform notes, and the PyPI route after publication. The package version is
-still `0.14.0b0`; 0.14.0 has not been published to PyPI.
+platform notes, and the PyPI route after publication. The source version is
+`0.14.0` (internal final candidate); 0.14.0 has not been published to PyPI.
 
 ## Bug reports and suggestions
 

--- a/docs/CLI_Reference.md
+++ b/docs/CLI_Reference.md
@@ -28,7 +28,7 @@ see [Session and request compatibility](./SESSION_COMPATIBILITY.md#retired-input
 ## Main command
 
 ```text
-gbdraw v. 0.14.0b0: A diagram generator for small genomes
+gbdraw v. 0.14.0: A diagram generator for small genomes
 
 Usage:
   gbdraw <subcommand> [options]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -64,8 +64,8 @@ gbdraw gui
 
 ## 3. PyPI installation
 
-**Not yet published:** the package version remains `0.14.0b0`, and 0.14.0 has
-not been published to PyPI. The Trusted Publishing workflow is prepared;
+**Not yet published:** the source version is `0.14.0` (internal final candidate);
+0.14.0 has not been published to PyPI. The Trusted Publishing workflow is prepared;
 publisher setup and the release transaction must complete before this route is
 available. To test the current implementation now, use a source install below.
 

--- a/docs/RELEASE_NOTES_0.14.0.md
+++ b/docs/RELEASE_NOTES_0.14.0.md
@@ -3,8 +3,8 @@
 # gbdraw 0.14.0 release notes
 
 **Status: unreleased.** These notes describe the implemented changes planned for
-the final 0.14.0 release. The package version remains `0.14.0b0`; 0.14.0 has not
-been published to PyPI. Installation availability is documented in
+the final 0.14.0 release. The source version is `0.14.0` (internal final candidate);
+0.14.0 has not been published to PyPI. Installation availability is documented in
 [Installation](./INSTALL.md).
 
 ## Highlights

--- a/gbdraw/version.py
+++ b/gbdraw/version.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-__version__ = "0.14.0b0"
-__version_display__ = "0.14.0b0"
+__version__ = "0.14.0"
+__version_display__ = "0.14.0"
 
 

--- a/gbdraw/web/js/config.js
+++ b/gbdraw/web/js/config.js
@@ -1,4 +1,4 @@
-export const GBDRAW_WHEEL_NAME = "gbdraw-0.14.0b0-py3-none-any.whl";
+export const GBDRAW_WHEEL_NAME = "gbdraw-0.14.0-py3-none-any.whl";
 export const GBDRAW_WHEEL_CACHE_BUST = "20260730-014339";
 export const PYODIDE_INDEX_URL = "./vendor/pyodide/v0.29.0/full/";
 export const PYODIDE_LOCAL_WHEELS = [

--- a/gbdraw/web/open-source-notices.html
+++ b/gbdraw/web/open-source-notices.html
@@ -262,7 +262,7 @@
                 <tbody>
                     <tr>
                         <td><strong>gbdraw</strong></td>
-                        <td>0.14.0b0</td>
+                        <td>0.14.0</td>
                         <td>MIT. See <a href="#license-mit">MIT</a>.</td>
                         <td><code>gbdraw/web/</code></td>
                         <td><a href="https://github.com/satoshikawato/gbdraw" target="_blank" rel="noopener noreferrer">https://github.com/satoshikawato/gbdraw</a></td>
@@ -352,7 +352,7 @@
                 <h3>gbdraw</h3>
                 <dl>
                     <dt>Version</dt>
-                    <dd>0.14.0b0</dd>
+                    <dd>0.14.0</dd>
                     <dt>License</dt>
                     <dd>MIT. See <a href="#license-mit">MIT</a>.</dd>
                     <dt>Bundled path</dt>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gbdraw"
-version = "0.14.0b0"
+version = "0.14.0"
 description = "A genome diagram generator for microbes and organelles"
 readme = "README.md"
 license = "MIT"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: gbdraw
-  version: 0.14.0b0
+  version: 0.14.0
 
 source:
   path: ../

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -216,7 +216,7 @@ def _assert_white_gallery_thumbnail(path: Path) -> None:
 @pytest.mark.browser
 def test_web_offline_assets_can_be_prepared_for_packaging() -> None:
     verify_module, expected_wheel_path = ensure_prepared_browser_wheel()
-    expected_wheel_name = "gbdraw-0.14.0b0-py3-none-any.whl"
+    expected_wheel_name = "gbdraw-0.14.0-py3-none-any.whl"
     assert verify_module._parse_wheel_name() == expected_wheel_name
     assert expected_wheel_path.name == expected_wheel_name
     verify_module.assert_browser_wheel_is_not_recursive(expected_wheel_path)
@@ -862,7 +862,7 @@ def test_prepare_browser_wheel_refreshes_open_source_notices(
     repo_root = tmp_path / "repo"
     web_root = repo_root / "gbdraw" / "web"
     web_root.mkdir(parents=True)
-    expected_name = "gbdraw-0.14.0b0-py3-none-any.whl"
+    expected_name = "gbdraw-0.14.0-py3-none-any.whl"
     calls: list[object] = []
 
     def fake_run(
@@ -1382,7 +1382,7 @@ def test_built_wheel_contains_offline_gui_assets(tmp_path: Path) -> None:
     )
 
     wheel_path = next(dist_dir.glob("gbdraw-*.whl"))
-    assert wheel_path.name == "gbdraw-0.14.0b0-py3-none-any.whl"
+    assert wheel_path.name == "gbdraw-0.14.0-py3-none-any.whl"
     subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Plain-language summary

Set the source and package version to `0.14.0` so the final release can be tested with its intended version. Synchronize the existing Python, browser-wheel, citation, and local package metadata, and describe the source as an unreleased internal final candidate. The beta release notes and changelog history remain unchanged; PyPI publication and release tagging remain pending.

## Changes

- Update existing version declarations and the three browser-wheel filename expectations.
- Regenerate browser configuration and open-source notices with the existing preparation tool.
- Correct current-version wording in the README, installation guide, final release notes, changelog, and maintenance guide. Keep the existing development-status classifier.

Version and package verification still use the existing build-support, package inspection, and release-source owners. Runtime behavior, session writer 41, request schema 7, release workflow, and Gallery artifacts are unchanged.

## Validation

- Focused version, documentation, release-source and browser-package contracts: 65 passed.
- Web JavaScript: 381 behavior tests and 137 architecture tests passed; release workflow contracts: 3 passed.
- Existing wheel/sdist resource, contamination exclusion, independent rebuild and installed-package regressions: 3 passed.
- Clean source wheel/sdist build, build-from-sdist, strict Twine, artifact inventory, and Linux Python 3.10/3.11/3.12 installed CLI/API/render/session smoke passed.
- Full Python acceptance: 3,970 distinct tests passed, 17 existing skips. Browser functional: 138 passed; Gallery publication/parity: 9 passed. Installed GUI startup, offline rendering and downloaded Exact replay passed.
- Native Windows clean-wheel CLI/API/render/session and GUI startup/resource checks passed. macOS remains unverified; no new CI matrix was added.
- Ruff and committed-head Web policy passed; Review CLEAR.

Initial local failures in six browser cases and one Python case came from subprocesses calling an old host editable install. Those cases passed with the final installed wheel selected; initial logs are retained and assertions are unchanged. The final CLI reference version correction affects repository documentation only and is excluded from wheel/sdist; 20 affected documentation contracts passed.

S11 closure requires required PR CI and both gates on the merged exact dev SHA. That SHA will be the technical baseline; README/docs/media editorial work remains open until S12, with verification based on whether changes affect repository prose, packaged metadata, or technical source. This PR performs no main promotion, tag, or package publication.
