### PR TITLE
Fix keyboard select edits missing from Undo history

### DIFF
--- a/gbdraw/web/js/app/history-inputs.js
+++ b/gbdraw/web/js/app/history-inputs.js
@@ -22,7 +22,7 @@ export const isIgnoredTarget = (target) =>
 const isEditableControl = (element) => {
   if (!element) return false;
   const tag = String(element.tagName || '').toLowerCase();
-  if (tag === 'textarea') return true;
+  if (tag === 'textarea' || tag === 'select') return true;
   if (tag !== 'input') return false;
   return TEXT_INPUT_TYPES.has(String(element.type || '').toLowerCase());
 };

--- a/tests/web/history-inputs.playwright.spec.js
+++ b/tests/web/history-inputs.playwright.spec.js
@@ -1,0 +1,135 @@
+const { test, expect } = require('@playwright/test');
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+const { gunzipSync } = require('node:zlib');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+const seed = resolve('gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json');
+const sessionInput = 'input[type="file"][accept^=".json,"]';
+
+const preparePage = async (page) => {
+  await page.addInitScript(() => {
+    window.__HISTORY_INPUT_EVENTS__ = [];
+    window.__GBDRAW_TEST_HOOKS__ = {
+      onSessionLifecycleEvent: (event) => window.__HISTORY_INPUT_EVENTS__.push(event)
+    };
+  });
+  page.on('dialog', (dialog) => dialog.accept());
+  await openApp(page);
+};
+
+const loadSession = async (page, path) => {
+  await page.locator(sessionInput).setInputFiles(path);
+  await page.waitForFunction(() => (
+    window.__HISTORY_INPUT_EVENTS__.some((event) => event.name === 'interactiveReady')
+    && !window.__GBDRAW_APP__.sessionImportPending
+  ));
+};
+
+const generate = async (page) => {
+  const before = await page.evaluate(() => window.__HISTORY_INPUT_EVENTS__
+    .filter((event) => event.name === 'generate.processing-cleared').length);
+  await page.getByRole('button', { name: 'Generate Diagram', exact: true }).click();
+  await page.waitForFunction((count) => window.__HISTORY_INPUT_EVENTS__
+    .filter((event) => event.name === 'generate.processing-cleared').length > count, before,
+  { timeout: 180_000 });
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.errorLog?.summary || '')).toBe('');
+  return page.evaluate(() => window.__GBDRAW_APP__.results[0].content);
+};
+
+const expectHistory = async (page, undo, redo, label) => {
+  await expect.poll(() => page.evaluate(() => {
+    const history = window.__GBDRAW_HISTORY__;
+    return [history.getUndoCount(), history.getRedoCount(), history.undoLabel()];
+  })).toEqual([undo, redo, label]);
+};
+
+for (const inputMethod of ['keyboard', 'pointer']) {
+  test(`Label Mode ${inputMethod} edit has one Undo step and survives generation and fresh Load @pr-smoke`, async ({
+    page, context, browser
+  }, testInfo) => {
+    test.setTimeout(300_000);
+    const externalRequests = [];
+    const allowLocal = (route) => {
+      if (new URL(route.request().url()).origin === 'http://127.0.0.1:4173') {
+        return route.continue();
+      }
+      externalRequests.push(route.request().url());
+      return route.abort();
+    };
+    await context.route('**/*', allowLocal);
+    await preparePage(page);
+    await loadSession(page, seed);
+    const originalSvg = await generate(page);
+    const baseline = await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount());
+    await expectHistory(page, baseline, 0, 'Generate diagram');
+
+    const summary = page.locator('summary[aria-label="Labels"]');
+    await summary.click();
+    const select = page.locator('#circular-label-mode');
+    await expect(select).toHaveValue('out');
+    if (inputMethod === 'keyboard') {
+      await summary.focus();
+      await page.keyboard.press('Tab');
+      await expect(select).toBeFocused();
+      await page.keyboard.press('ArrowDown');
+    } else {
+      // Open the native popup through its pointer admission path.
+      await select.click();
+      await page.keyboard.press('ArrowDown');
+      await page.keyboard.press('Enter');
+    }
+    await page.keyboard.press('Tab');
+    await expect(select).toHaveValue('both');
+    await testInfo.attach('after-select', {
+      body: JSON.stringify(await page.evaluate(() => ({
+        labels: window.__GBDRAW_APP__.form.labels_mode,
+        undo: window.__GBDRAW_HISTORY__.getUndoCount(),
+        undoLabel: window.__GBDRAW_HISTORY__.undoLabel()
+      }))),
+      contentType: 'application/json'
+    });
+    await expectHistory(page, baseline + 1, 0, 'Change setting');
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.results[0].content)).toBe(originalSvg);
+
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expect(select).toHaveValue('out');
+    await expectHistory(page, baseline, 1, 'Generate diagram');
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    await expect(select).toHaveValue('both');
+    await expectHistory(page, baseline + 1, 0, 'Change setting');
+    const bothSvg = await generate(page);
+    expect(bothSvg).not.toBe(originalSvg);
+    await expectHistory(page, baseline + 2, 0, 'Generate diagram');
+
+    // Undo the artifact replacement, then the form edit; neither may consume both.
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expectHistory(page, baseline + 1, 1, 'Change setting');
+    await expect(select).toHaveValue('both');
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expect(select).toHaveValue('out');
+    await expectHistory(page, baseline, 2, 'Generate diagram');
+
+    const downloadPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: 'Save Session', exact: true }).click();
+    const download = await downloadPromise;
+    const savedPath = testInfo.outputPath('restored.gbdraw-session.json.gz');
+    await download.saveAs(savedPath);
+    const saved = JSON.parse(gunzipSync(readFileSync(savedPath)));
+    expect(saved.config.form.labels_mode).toBe('out');
+    expect(await generate(page)).toBe(originalSvg);
+
+    const freshContext = await browser.newContext({ baseURL: 'http://127.0.0.1:4173' });
+    try {
+      await freshContext.route('**/*', allowLocal);
+      const freshPage = await freshContext.newPage();
+      await preparePage(freshPage);
+      await loadSession(freshPage, savedPath);
+      expect(await freshPage.evaluate(() => window.__GBDRAW_APP__.form.labels_mode)).toBe('out');
+      expect(await generate(freshPage)).toBe(originalSvg);
+    } finally {
+      await freshContext.close();
+    }
+    expect(externalRequests).toEqual([]);
+  });
+}

--- a/tests/web/history-inputs.test.mjs
+++ b/tests/web/history-inputs.test.mjs
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { test } from 'node:test';
 
 const repoRoot = process.cwd();
 const sourcePath = join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'history-inputs.js');
@@ -12,7 +13,120 @@ await writeFile(join(tempDir, 'package.json'), '{"type":"module"}\n', 'utf8');
 await mkdir(join(tempDir, 'app'), { recursive: true });
 await writeFile(join(tempDir, 'app', 'history-inputs.js'), await readFile(sourcePath, 'utf8'), 'utf8');
 
-const { isIgnoredTarget } = await import(pathToFileURL(join(tempDir, 'app', 'history-inputs.js')));
+const { isIgnoredTarget, setupHistoryInputs } = await import(pathToFileURL(join(tempDir, 'app', 'history-inputs.js')));
+await mkdir(join(tempDir, 'services'), { recursive: true });
+for (const name of ['history.js', 'history-files.js', 'runtime-test-hooks.js']) {
+  await writeFile(
+    join(tempDir, 'services', name),
+    await readFile(join(repoRoot, 'gbdraw', 'web', 'js', 'services', name), 'utf8')
+  );
+}
+const { createHistoryManager } = await import(pathToFileURL(join(tempDir, 'services', 'history.js')));
+
+const createSelectHarness = async (attributes = {}) => {
+  let intent = { labels_mode: 'out' };
+  const history = createHistoryManager({
+    buildIntent: () => ({ ...intent }),
+    applyIntent: (restored) => { intent = { ...restored }; },
+    buildCheckpoint: () => assert.fail('Select edits must use intent history'),
+    applyCheckpoint: () => assert.fail('Select edits must restore intent history')
+  });
+  await history.initializeIntentBaseline();
+  const listeners = new Map();
+  const root = {
+    addEventListener: (name, handler) => listeners.set(name, handler),
+    removeEventListener: (name) => listeners.delete(name)
+  };
+  const select = {
+    tagName: 'SELECT',
+    closest: (selector) => {
+      if (selector.startsWith('input,')) return select;
+      return attributes.managed && selector.includes('data-history-managed') ? select : null;
+    },
+    ...attributes
+  };
+  const cleanup = setupHistoryInputs({ root, history, nextTick: () => Promise.resolve() });
+  const settle = () => new Promise((resolve) => setImmediate(resolve));
+  return {
+    history, cleanup, settle,
+    dispatch: (name) => listeners.get(name)?.({ target: select }),
+    change: (value) => { intent.labels_mode = value; },
+    value: () => intent.labels_mode
+  };
+};
+
+for (const inputMethod of ['keyboard', 'pointer']) {
+  test(`${inputMethod} select edits capture pre-change intent once and support Undo/Redo`, async () => {
+    const h = await createSelectHarness();
+    try {
+      if (inputMethod === 'pointer') h.dispatch('pointerdown');
+      h.dispatch('focusin');
+      await h.settle();
+      for (const value of ['both', 'none']) {
+        h.dispatch('keydown');
+        h.change(value);
+        await h.settle();
+        h.dispatch('change');
+        await h.settle();
+      }
+      h.dispatch('focusout');
+      await h.settle();
+      assert.equal(h.history.getUndoCount(), 2);
+      assert.equal(h.history.undoLabel(), 'Change setting');
+      await h.history.undo();
+      assert.equal(h.value(), 'both');
+      await h.history.undo();
+      assert.equal(h.value(), 'out');
+      assert.equal(h.history.getUndoCount(), 0);
+      await h.history.redo();
+      assert.equal(h.value(), 'both');
+      await h.history.redo();
+      assert.equal(h.value(), 'none');
+      assert.equal(h.history.getUndoCount(), 2);
+    } finally {
+      h.cleanup();
+    }
+  });
+}
+
+test('leaving an unchanged select closes its transaction without an Undo step', async () => {
+  const h = await createSelectHarness();
+  try {
+    h.dispatch('focusin');
+    await h.settle();
+    h.dispatch('focusout');
+    await h.settle();
+    assert.equal(h.history.getUndoCount(), 0);
+    // A later external change must not be swept into the abandoned focus transaction.
+    h.change('both');
+    const next = await h.history.begin('Later edit');
+    assert.equal(next.before.labels_mode, 'both');
+    h.history.cancel(next);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test('disabled and explicitly managed selects stay outside input-adapter history', async () => {
+  for (const attributes of [
+    { disabled: true },
+    { managed: true }
+  ]) {
+    const h = await createSelectHarness(attributes);
+    try {
+      h.dispatch('focusin');
+      h.dispatch('keydown');
+      await h.settle();
+      h.change('both');
+      h.dispatch('change');
+      h.dispatch('focusout');
+      await h.settle();
+      assert.equal(h.history.getUndoCount(), 0);
+    } finally {
+      h.cleanup();
+    }
+  }
+});
 
 const targetMatching = (attribute) => ({
   closest: (selector) => (String(selector).includes(attribute) ? {} : null)


### PR DESCRIPTION
## Plain-language summary

Changing Label Mode from Out to Both with the keyboard currently leaves the next Undo pointing at the earlier Generate operation. This change records native select edits through the existing form History transaction, so keyboard and pointer edits each have one undo step. Undo and Redo restore the selected value, and Generate and saved sessions use that restored intent.

## Change class

- [x] STANDARD

## Purpose

Fix BUG-02 from SESSION 02A on `dev` at `4001f5874d0f55274fab04b069a3688a2864468c`. Required admission checks are `Web base policy (trusted base)` and `PR / gate`.

## Changes and user-visible impact

- Include native selects in `history-inputs.js`'s existing focus, keydown, and focusout transaction handling. Change and pointer handlers continue using the same transaction.
- Add input-adapter tests against the real History manager for sequential edits, Undo/Redo, duplicate prevention, unchanged focus, and disabled/managed controls.
- Add Chromium keyboard and pointer regressions using the Human mitochondrial Gallery session. They exercise Generate, artifact and form Undo separately, Redo, Save, and fresh-context Load with external requests blocked. Both are included in the existing `@pr-smoke` selection.

## Verification

- Before the fix, the Chromium keyboard case failed: Label Mode was Both but History still contained only `Generate diagram`. The pointer counterpart passed.
- After the fix, both Chromium journeys pass. Restored Out generates exactly the original SVG, including after fresh Load; Both generates a different SVG.
- `node --test tests/web/history-inputs.test.mjs tests/web/history.test.mjs tests/web/session*.test.mjs`: 68 passed.
- `playwright test tests/web/feature-fill-scope.playwright.spec.js tests/web/contracts/session-regenerate-intent.playwright.spec.js --workers=1`: all 6 existing Session and editor History journeys passed.
- `node --test tests/web/architecture-contracts.test.mjs`: 137 passed. Web policy reports `Gate: PASS / Review: CLEAR`.
- `git diff --check`: passed.

## Risk and review notes

- Web policy: `Gate: PASS`, `Review: CLEAR`.
- This is not architecture-bearing. `history-inputs.js` remains the input admission owner, and `services/history.js` remains the sole transaction owner. No owner, canonical path, schema, compatibility path, dependency, global shortcut, or reactive state is added or moved.
- The change affects native selects already supported by this adapter. Repeated key changes must reopen a transaction after change commits; leaving an unchanged field must not retain an abandoned transaction. Focused tests cover both cases.
- Production and test diffs were reviewed separately. No documentation or generated artifact changes are needed. BUG-01, BUG-03, and BUG-04 are outside this change.
- Branch protection requires zero approving reviews; no repository human-review trigger applies to this local admission correction. Recheck CI Review results before merge.

## Rollback

Revert this commit through a normal PR to `dev`.

## Conditional Product Impact

- Product-impact role: N/A.
- Product preflight classification: `IMPLEMENT_EXISTING_AUTHORITY`.
- Authority: the base-branch `docs/REFERENCE/web-app.md` promises Undo/Redo of supported form and editor changes; SESSION 02A explicitly requires input-method independence.
- No registered architecture subject changes, competing supported outcome, or new Product Decision is required. The tests verify the authorized keyboard, pointer, Generate, and session continuations.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
