### PR TITLE
Resolve feature placement choices from the current draft layout

### DIFF
--- a/gbdraw/web/js/app/feature-editor/placement-actions.js
+++ b/gbdraw/web/js/app/feature-editor/placement-actions.js
@@ -1,30 +1,46 @@
 import { canonicalFeaturePlacements } from '../../services/feature-placement.js';
+import { resolveCircularTrackFeaturePlacement } from '../circular-track-slots.js';
+import { createDefaultLinearTrackSlots, effectiveLinearSlotPlacement } from '../linear-track-slots.js';
+import { validateCustomTrackPlan } from '../track-slot-validation.js';
 
 const identity = (feature) => [feature?.record_key, feature?.biological_feature_id];
 const keyFor = (feature) => JSON.stringify(identity(feature));
 
 export const createFeaturePlacementActions = ({ state, history, getCommittedRequest, isCurrentFeature }) => {
-  const targetsFor = (feature) => {
-    if (!getCommittedRequest()) return [];
+  const targetsFor = (features, sides) => {
+    const mode = state.mode.value;
+    if (!features.length || getCommittedRequest()?.mode !== mode) return [];
     const items = state.featureCatalog.value?.items || [];
-    const resultIndex = items.findIndex((item) => item.recordKeys.includes(feature?.record_key));
-    const recordIndex = items[resultIndex]?.recordKeys.indexOf(feature?.record_key) ?? -1;
-    const geometry = state.trackSlotResolvedGeometry.value;
-    if (recordIndex < 0 || geometry?.mode !== state.mode.value) return [];
-    return geometry.records?.find((record) => record.resultIndex === resultIndex
-      && record.recordIndex === recordIndex)?.featurePlacementTargets || [];
+    if (!features.every((feature) => items.some((item) => item.recordKeys.includes(feature?.record_key)))) return [];
+    const { form, adv } = state;
+    const trackType = mode === 'circular' ? form.track_type : form.linear_track_layout;
+    // Resolve the draft through the same slot owner used by request projection.
+    // Result geometry continues to describe the last successful Generate.
+    const slot = adv[`${mode}_track_slots_enabled`]
+      ? validateCustomTrackPlan({
+        mode, slots: adv[`${mode}_track_slots`],
+        axisIndex: adv[`${mode}_track_slots_axis_index`], trackType
+      }).enabledSlots.find((entry) => entry.renderer === 'features')
+      : (mode === 'circular' ? {} : createDefaultLinearTrackSlots({ trackLayout: trackType })[0]);
+    if (!slot) return [];
+    const bidirectional = mode === 'circular'
+      ? resolveCircularTrackFeaturePlacement(slot, trackType).laneDirection === 'split'
+      : effectiveLinearSlotPlacement(slot) === 'overlay' && !form.separate_strands;
+    return [{ kind: 'main' }, ...(bidirectional
+      ? sides.map((side) => ({ kind: 'lane', side, level: 1 })) : [])];
   };
   const choices = (features) => {
     const sides = state.mode.value === 'circular' ? ['outward', 'inward'] : ['above', 'below'];
+    const targets = targetsFor(features, sides);
     return ['auto', 'main', ...sides].map((value) => {
       const enabled = features.length > 0 && features.every((feature) => {
         if (identity(feature).some((part) => !part) || !isCurrentFeature(feature)) return false;
         if (value === 'auto') return true;
-        return targetsFor(feature).some((target) => value === 'main' ? target.kind === 'main' : target.side === value);
+        return targets.some((target) => value === 'main' ? target.kind === 'main' : target.side === value);
       });
       return { value, enabled, label: value === 'auto' ? 'Auto' : value === 'main' ? 'Main'
         : `${value[0].toUpperCase()}${value.slice(1)} lane 1`,
-      reason: enabled ? '' : 'Unavailable in the resolved feature slot. Generate after changing the layout.' };
+      reason: enabled ? '' : 'Unavailable in the current draft feature slot.' };
     });
   };
   const setPlacement = (features, value) => {

--- a/tests/web/draft-placement-capability.playwright.spec.js
+++ b/tests/web/draft-placement-capability.playwright.spec.js
@@ -1,0 +1,152 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+for (const mode of ['circular', 'linear']) {
+  test(`@pr-smoke ${mode} draft placement capability survives history and dirty session restore`, async ({ browser }, testInfo) => {
+    test.setTimeout(240000);
+    const external = [];
+    let context;
+    let page;
+    const load = async (file) => {
+      if (context) await context.close();
+      context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+      await context.route('**/*', (route) => {
+        const url = new URL(route.request().url());
+        if (url.origin === 'http://127.0.0.1:4173') return route.continue();
+        external.push(url.origin);
+        return route.abort();
+      });
+      page = await context.newPage();
+      page.on('dialog', (dialog) => dialog.dismiss());
+      await openApp(page);
+      await page.locator('input[accept^=".json,"]').setInputFiles(file);
+      await expect.poll(() => page.evaluate(() => !window.__GBDRAW_APP__.sessionImportPending
+        && window.__GBDRAW_APP__.extractedFeatures.length > 0), { timeout: 180000 }).toBe(true);
+    };
+    const artifact = () => page.evaluate(async () => {
+      const { state } = await import('./js/state.js');
+      return { results: window.__GBDRAW_APP__.results.map((result) => result.content),
+        geometry: JSON.parse(JSON.stringify(state.trackSlotResolvedGeometry.value)) };
+    });
+    const generate = async () => {
+      const key = await page.evaluate(async () => (await import('./js/state.js')).state.resultGenerationKey.value);
+      await page.getByRole('button', { name: 'Generate Diagram', exact: true }).click();
+      await expect.poll(() => page.evaluate(async () => {
+        const { state } = await import('./js/state.js');
+        return { key: state.resultGenerationKey.value, processing: state.processing.value,
+          error: state.errorLog.value };
+      }), { timeout: 180000 }).toEqual({ key: key + 1, processing: false, error: null });
+    };
+    const popup = async () => {
+      if (!await page.locator('.right-drawer').isVisible()) await page.locator('.drawer-toggle').click();
+      await page.locator('.right-drawer').getByRole('button', { name: 'Edit', exact: true }).first().click();
+      return page.getByRole('combobox', { name: 'Feature placement', exact: true });
+    };
+    const closePopup = async () => {
+      await page.getByRole('button', { name: 'Close feature popup', exact: true }).click();
+      await page.locator('.drawer-toggle').click();
+    };
+    const sides = mode === 'circular' ? ['outward', 'inward'] : ['above', 'below'];
+    const checkChoices = async (enabled) => {
+      const placement = await popup();
+      for (const side of sides) {
+        await expect(placement.locator(`option[value=${side}]`)).toHaveJSProperty('disabled', !enabled);
+      }
+      for (const value of ['auto', 'main']) {
+        await expect(placement.locator(`option[value=${value}]`)).toHaveJSProperty('disabled', false);
+      }
+      if (!enabled) {
+        // An action caller cannot bypass the disabled DOM option.
+        const rejected = await page.evaluate((sides) => {
+          const app = window.__GBDRAW_APP__;
+          const feature = app.extractedFeatures[0];
+          const before = app.featurePlacementActions.valueFor(feature);
+          const errors = sides.map((side) => {
+            try { app.featurePlacementActions.setPlacement([feature], side); return ''; }
+            catch (error) { return error.message; }
+          });
+          return { errors, before, after: app.featurePlacementActions.valueFor(feature) };
+        }, sides);
+        expect(rejected.errors.every((message) => message.includes('Unavailable'))).toBe(true);
+        expect(rejected.after).toBe(rejected.before);
+      }
+      await closePopup();
+    };
+    const assertControl = async (changed) => {
+      if (mode === 'circular') {
+        await expect(page.locator('#circular-track-preset')).toHaveValue(changed ? 'tuckin' : 'middle');
+      } else {
+        await expect(page.getByRole('checkbox', { name: 'Separate Strands', exact: true })).toBeChecked({ checked: !changed });
+      }
+    };
+    try {
+      const seed = mode === 'circular' ? 'HmmtDNA_basic_circular' : 'lambda_basic_linear';
+      await load(`gbdraw/web/gallery/sessions/${seed}.gbdraw-session.json`);
+      await assertControl(false);
+      await generate();
+      const baseline = await artifact();
+      await checkChoices(mode === 'circular');
+      const ordinary = await popup();
+      await ordinary.selectOption(mode === 'circular' ? 'outward' : 'main');
+      await ordinary.selectOption('auto');
+      await closePopup();
+      expect(await artifact()).toEqual(baseline);
+
+      if (mode === 'circular') {
+        const preset = page.locator('#circular-track-preset');
+        await preset.focus();
+        await preset.selectOption('tuckin');
+        await preset.press('Tab');
+      } else {
+        await page.getByRole('checkbox', { name: 'Separate Strands', exact: true }).uncheck();
+      }
+      await assertControl(true);
+      await checkChoices(mode === 'linear');
+      expect(await artifact()).toEqual(baseline);
+      await page.getByRole('button', { name: /^Undo/ }).first().click();
+      await assertControl(false);
+      await checkChoices(mode === 'circular');
+      expect(await artifact()).toEqual(baseline);
+      await page.getByRole('button', { name: /^Redo/ }).first().click();
+      await assertControl(true);
+      await checkChoices(mode === 'linear');
+      expect(await artifact()).toEqual(baseline);
+
+      const pending = page.waitForEvent('download');
+      await page.getByRole('button', { name: 'Save Session', exact: true }).click();
+      const download = await pending;
+      const saved = testInfo.outputPath(download.suggestedFilename());
+      await download.saveAs(saved);
+      await load(saved);
+      await assertControl(true);
+      expect(await artifact()).toEqual(baseline);
+      await checkChoices(mode === 'linear');
+      const placement = await popup();
+      const valid = mode === 'circular' ? 'main' : 'above';
+      await placement.selectOption(valid);
+      await expect(placement).toHaveValue(valid);
+      await page.screenshot({ path: testInfo.outputPath('dirty-restored-placement.png') });
+      await closePopup();
+      expect(await artifact()).toEqual(baseline);
+      await generate();
+      await assertControl(true);
+      await checkChoices(mode === 'linear');
+      const generated = await artifact();
+      expect(generated.results).not.toEqual(baseline.results);
+      expect(generated.geometry.records[0].featurePlacementTargets.map((target) => target.side || target.kind))
+        .toEqual(mode === 'circular' ? ['main'] : ['main', ...sides]);
+      const finalPlacement = await popup();
+      await expect(finalPlacement).toHaveValue(valid);
+      await closePopup();
+      await fs.writeFile(testInfo.outputPath('generated.svg'), generated.results[0]);
+      for (let step = 0; step < 3; step += 1) {
+        await page.getByRole('button', { name: 'Zoom out', exact: true }).click();
+      }
+      await page.screenshot({ path: testInfo.outputPath('generated.png') });
+      expect(external).toEqual([]);
+    } finally {
+      if (context) await context.close();
+    }
+  });
+}

--- a/tests/web/joint-display-placement.test.mjs
+++ b/tests/web/joint-display-placement.test.mjs
@@ -89,13 +89,14 @@ test('Main, resolved side, bulk Auto and history share one draft owner', async (
   const overrides = {};
   const transactions = [];
   const state = { mode: { value: 'linear' }, selectedResultIndex: { value: 0 }, featurePlacementOverrides: overrides,
+    form: { linear_track_layout: 'middle', separate_strands: false }, adv: {},
     featureCatalog: { value: { items: [{ recordKeys: ['card'] }] } },
     trackSlotResolvedGeometry: { value: { mode: 'linear', records: [{ recordIndex: 0, resultIndex: 0,
       featurePlacementTargets: [{ kind: 'main' }, { kind: 'lane', side: 'below', level: 1 }] }] } } };
   const actions = createFeaturePlacementActions({ state, isCurrentFeature: () => true,
-    getCommittedRequest: () => ({ records: [{ recordKey: 'card' }], grouping: 'single' }),
+    getCommittedRequest: () => ({ mode: 'linear', records: [{ recordKey: 'card' }], grouping: 'single' }),
     history: { runUndoable: async (label, fn) => { transactions.push({ label, before: structuredClone(overrides) }); fn(); } } });
-  assert.equal(actions.choices(features).find((choice) => choice.value === 'above').enabled, false);
+  assert.equal(actions.choices(features).find((choice) => choice.value === 'above').enabled, true);
   await actions.setPlacement(features, 'below');
   assert.equal(Object.keys(overrides).length, 2);
   assert.equal(transactions.length, 1);
@@ -103,8 +104,64 @@ test('Main, resolved side, bulk Auto and history share one draft owner', async (
   assert.deepEqual(overrides, {});
   assert.equal(transactions.length, 2);
   assert.equal(Object.keys(transactions[1].before).length, 2);
+  state.form.separate_strands = true;
   assert.throws(() => actions.setPlacement(features, 'above'), /Unavailable/);
 });
+
+for (const mode of ['circular', 'linear']) {
+  test(`${mode} placement admission follows draft slots and preserves artifact geometry`, () => {
+    const feature = { record_key: 'record-1', biological_feature_id: 'feature' };
+    const state = { mode: { value: mode }, form: createDefaultForm(), adv: createDefaultAdv(mode),
+      featurePlacementOverrides: {}, featureCatalog: { value: { items: [{ recordKeys: ['record-1'] }] } },
+      trackSlotResolvedGeometry: { value: { mode, records: [] } } };
+    const geometry = structuredClone(state.trackSlotResolvedGeometry.value);
+    const actions = createFeaturePlacementActions({ state, getCommittedRequest: () => ({ mode }),
+      isCurrentFeature: (entry) => entry === feature, history: { runUndoable: (_label, fn) => fn() } });
+    const sides = mode === 'circular' ? ['outward', 'inward'] : ['above', 'below'];
+    const check = (enabled) => {
+      for (const side of sides) {
+        assert.equal(actions.choices([feature]).find((choice) => choice.value === side).enabled, enabled);
+        if (enabled) {
+          actions.setPlacement([feature], side);
+          assert.equal(actions.valueFor(feature), side);
+        } else {
+          const before = structuredClone(state.featurePlacementOverrides);
+          assert.throws(() => actions.setPlacement([feature], side), /current draft feature slot/);
+          assert.deepEqual(state.featurePlacementOverrides, before);
+        }
+      }
+      assert.deepEqual(state.trackSlotResolvedGeometry.value, geometry);
+    };
+    const layoutField = mode === 'circular' ? 'track_type' : 'linear_track_layout';
+    for (const separate of [true, false]) {
+      state.form.separate_strands = separate;
+      for (const layout of mode === 'circular' ? ['middle', 'tuckin', 'spreadout'] : ['middle', 'above', 'below']) {
+        state.form[layoutField] = layout;
+        check(layout === 'middle' && (mode === 'circular' || !separate));
+      }
+    }
+    // A custom slot's resolved direction takes precedence over the preset name.
+    state.adv[`${mode}_track_slots_enabled`] = true;
+    state.form[layoutField] = mode === 'circular' ? 'tuckin' : 'above';
+    state.form.separate_strands = false;
+    const slot = { id: 'features', renderer: 'features', enabled: true, side: 'overlay',
+      params: mode === 'circular' ? { lane_direction: 'split' } : {} };
+    state.adv[`${mode}_track_slots`] = [slot];
+    state.adv[`${mode}_track_slots_axis_index`] = 0;
+    check(true);
+    state.form[layoutField] = 'middle';
+    slot.side = mode === 'circular' ? 'inside' : 'below';
+    slot.params = {};
+    check(false);
+    // Omitted side uses the same Axis resolution as request projection.
+    delete slot.side;
+    check(false);
+    slot.enabled = false;
+    assert.deepEqual(actions.choices([feature]).filter((entry) => entry.enabled).map((entry) => entry.value), ['auto']);
+    assert.throws(() => actions.setPlacement([feature], 'main'), /Unavailable/);
+    assert.ok(actions.choices([{ ...feature, record_key: 'unknown' }]).every((entry) => !entry.enabled));
+  });
+}
 
 test('historical session 40 schema 6 promotes without Generate and preserves cardinality', async () => {
   const bytes = await readFile('tests/fixtures/sessions/test_linear_cli_sidecar_reuses0.v40-schema6.json.gz');


### PR DESCRIPTION
## Plain-language summary

Feature placement choices now follow the current layout and Separate Strands settings before Generate. Changing Circular Middle to Tuckin immediately disables Outward/Inward, while turning off Separate Strands in Linear immediately enables Above/Below. These choices also survive dirty Save and fresh Load, and the previous Result remains available until Generate succeeds.

## Change class

- [x] STANDARD

## Purpose

Fix BUG-01 from SESSION 02B, starting at `dev` commit `05edbb3ad739ec4f458ab39a0527e8bca23f0c88`. Required admission checks are `Web base policy (trusted base)` and `PR / gate`.

## Changes

`gbdraw/web/js/app/feature-editor/placement-actions.js` resolves the draft feature slot through the existing Circular/Linear slot functions and the custom-track validator used by request projection. Both option availability and `setPlacement` use the same result, computed once per selection. The reference to the last artifact's `featurePlacementTargets` is removed from admission; its geometry and SVG remain artifact data.

## Verification

- Reproduced both capability loss/gain, their dirty Save/fresh Load variants, and F1's enabled invalid selection followed by typed-renderer rejection on the exact base, twice each.
- Two new `@pr-smoke` Gallery browser journeys cover enabled options, rejected action calls, newly admitted placement, Undo/Redo of layout/strand settings, dirty Save/fresh Load, unchanged old SVG/geometry, and successful Generate.
- Focused JS coverage includes all simple presets and strand states, custom-slot precedence and Axis resolution, disabled feature slots, stale identities, bulk placement, and unchanged artifact geometry.
- Related session/history/slot JS suites pass; 446 Python placement/track/chloroplast tests pass; 137 architecture contracts pass.
- Existing chloroplast SESSION 00, session regeneration, and input history browser journeys pass alongside the new journeys: 9 tests. Existing joint rotation/placement smoke journeys are also checked.
- Local Web policy: Gate PASS, automated Review CLEAR; `git diff --check` passes. Browser requests are restricted to the local origin.

## Risk and review notes

This is architecture-bearing because placement admission changes its dependency from committed artifact targets to current draft slot resolution. Human Review is REQUIRED under `docs/internal/WEB_CHANGE_POLICY.md` despite the automatic inventory review reporting CLEAR.

The placement-action owner remains `placement-actions.js`; Circular and Linear slot resolution remain in their existing owners. One admission path serves UI and action callers. There is no new semantic owner, planner, geometry cache, schema, compatibility path, public export, reactive state, watcher, or render lifecycle. Owner/path excess and compatibility burden do not increase. The superseded artifact-to-admission lookup is removed; artifact preservation and typed validation remain intact. Production, test, documentation, and generated-asset diffs were reviewed separately; this PR changes production and tests only.

## Rollback

Revert this commit to restore the previous placement capability lookup and its tests.

## Conditional Product Impact

- Role: IMPLEMENTATION. Preflight: IMPLEMENT_EXISTING_AUTHORITY.
- Authority: the resolved-layout table and draft/Result separation in `docs/REFERENCE/palettes-feature-rules-labels-shapes-and-tracks.md#manual-feature-placement`, plus the shared availability/action predicate in `gbdraw/web/CLAUDE.md`.
- Affected checkpoints: edit after layout/strand change, Undo/Redo, dirty Save/fresh Load, admission, and Generate. The documented supported placement domain is restored at each checkpoint. No alternative product outcome or authority change is needed.
- No registered Product Impact subject changed. Existing typed validation still rejects unsupported directions and unrelated invalid requests; the fix does not redefine placement semantics.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
