### PR TITLE
Preserve Circular record identity across mode round trips

### DIFF
--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -1649,7 +1649,10 @@ export const createRunAnalysis = ({
       });
       circularRecordList.value = nextRecords;
       circularRecordDiscovery.status = 'ready';
-      circularRecordDiscovery.canonicalRecordIdentities = [];
+      // Identity belongs to the source, including while its mode is inactive.
+      circularRecordDiscovery.canonicalRecordIdentities = nextRecords
+        .filter((record) => record.recordKey)
+        .map(({ selector, record_id, recordKey }) => ({ selector, record_id, recordKey }));
       const nextPositions = mergeCircularRecordPositions(nextRecords, adv.multi_record_positions);
       adv.multi_record_positions.splice(0, adv.multi_record_positions.length, ...nextPositions);
     } catch (error) {

--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -18,6 +18,7 @@ import {
 import { resolveCircularLayoutPreference } from './layout-preferences.js';
 import { readFileText } from '../services/file-content-cache.js';
 import { isCommittedSvgResultMounted } from '../services/svg-result-ingestion.js';
+import { featureStateFromCatalog } from '../services/feature-catalog.js';
 
 export const runRecordDiscoveryWatcher = async ({
   rollbackInProgress,
@@ -409,10 +410,14 @@ export const setupWatchers = ({
         resetPreviewViewport();
       }
 
-      extractedFeatures.value = [];
-      if (biologicalFeatures) biologicalFeatures.value = [];
-      featureSelectorSafetyScope.value = [];
-      featureRecordIds.value = [];
+      // The retained Result's catalog owns this projection across mode inactivity.
+      const features = state.featureCatalog?.value && generatedMode.value === mode.value
+        ? featureStateFromCatalog(window.Vue.toRaw(state.featureCatalog.value), { mode: mode.value })
+        : {};
+      extractedFeatures.value = features.extractedFeatures || [];
+      if (biologicalFeatures) biologicalFeatures.value = features.biologicalFeatures || [];
+      featureSelectorSafetyScope.value = features.featureSelectorSafetyScope || [];
+      featureRecordIds.value = features.featureRecordIds || [];
       selectedFeatureRecordIdx.value = 0;
       featureVisibilityManualRules.splice(0);
       Object.keys(featureVisibilityOverrides).forEach((k) => delete featureVisibilityOverrides[k]);

--- a/tests/web/mode-record-identity.playwright.spec.js
+++ b/tests/web/mode-record-identity.playwright.spec.js
@@ -1,0 +1,217 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { gunzipSync } = require('node:zlib');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+const seed = 'gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json';
+const external = new WeakMap();
+const load = async (browser, file = seed) => {
+  const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+  const attempted = [];
+  await context.route('**/*', route => {
+    if (new URL(route.request().url()).hostname === '127.0.0.1') return route.continue();
+    attempted.push(route.request().url());
+    return route.abort();
+  });
+  const page = await context.newPage();
+  external.set(page, attempted);
+  page.on('dialog', dialog => dialog.dismiss());
+  await openApp(page);
+  await page.locator('input[accept^=".json,"]').setInputFiles(file);
+  await expect.poll(() => page.evaluate(() => !window.__GBDRAW_APP__.sessionImportPending
+    && window.__GBDRAW_APP__.extractedFeatures.length > 0), { timeout: 180000 }).toBe(true);
+  return page;
+};
+const generate = async page => {
+  const key = await page.evaluate(async () => (await import('./js/state.js')).state.resultGenerationKey.value);
+  await page.getByRole('button', { name: 'Generate Diagram', exact: true }).click();
+  await expect.poll(() => page.evaluate(async () => {
+    const { state } = await import('./js/state.js');
+    return { key: state.resultGenerationKey.value, processing: state.processing.value, error: state.errorLog.value };
+  }), { timeout: 180000 }).toEqual({ key: key + 1, processing: false, error: null });
+};
+const placement = async (page, value) => {
+  await page.locator('.drawer-toggle').click();
+  const edit = page.locator('.right-drawer').getByRole('button', { name: 'Edit', exact: true }).first();
+  await expect(edit).toBeVisible();
+  await edit.click();
+  const control = page.getByRole('combobox', { name: 'Feature placement', exact: true });
+  await expect(control.locator('option[value=outward]')).toHaveJSProperty('disabled', false);
+  if (value) await control.selectOption(value);
+  await expect(control).toHaveValue('outward');
+  await page.getByRole('button', { name: 'Close feature popup', exact: true }).click();
+  await page.locator('.drawer-toggle').click();
+};
+const snapshot = page => page.evaluate(async () => {
+  const { state } = await import('./js/state.js');
+  const { getCommittedCanonicalRenderRequest } = await import('./js/services/config.js');
+  const feature = state.extractedFeatures.value.find(f => f.biological_feature_id === 'fb8ff22d9');
+  return { mode: state.mode.value, records: state.circularRecordList.value,
+    placements: state.featurePlacementOverrides,
+    feature: feature && { recordKey: feature.record_key, biologicalFeatureId: feature.biological_feature_id },
+    featureCount: state.extractedFeatures.value.length,
+    committedPlacements: getCommittedCanonicalRenderRequest()?.diagramOptions.featurePlacements || [],
+    results: state.results.value.map(result => result.content) };
+});
+const switchMode = async (page, mode) => {
+  await page.getByRole('button', { name: mode === 'circular' ? 'Circular' : 'Linear', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(mode);
+  if (mode === 'circular') await expect.poll(() => page.evaluate(async () =>
+    (await import('./js/state.js')).state.circularRecordDiscovery.status)).not.toBe('loading');
+};
+const structure = (page, svg) => page.evaluate(svg => {
+  const visit = node => node.nodeType === Node.ELEMENT_NODE
+    ? [node.tagName, Object.fromEntries([...node.attributes].map(a => [a.name, a.value]).sort()), [...node.childNodes].map(visit)]
+    : node.textContent;
+  return visit(new DOMParser().parseFromString(svg, 'image/svg+xml').documentElement);
+}, svg);
+
+for (const committed of [false, true]) {
+  test(`@pr-smoke ${committed ? 'committed' : 'ungenerated'} Circular placement retains source identity through mode history and Save/Load`, async ({ browser }, testInfo) => {
+    test.setTimeout(360000);
+    const pages = [];
+    try {
+      const reference = await load(browser);
+      pages.push(reference);
+      await generate(reference);
+      await placement(reference, 'outward');
+      await generate(reference);
+      const unswitched = await snapshot(reference);
+      const expectedSvg = await structure(reference, unswitched.results[0]);
+      await reference.context().close();
+
+      const page = await load(browser);
+      pages.push(page);
+      await generate(page);
+      await placement(page, 'outward');
+      if (committed) await generate(page);
+      const before = await snapshot(page);
+      expect(before.feature).toEqual({ recordKey: 'record-1', biologicalFeatureId: 'fb8ff22d9' });
+      expect(Object.values(before.placements)).toEqual([{ ...before.feature,
+        placement: { kind: 'lane', side: 'outward', level: 1 } }]);
+      await page.evaluate(async () => { window.__MODE_SOURCE__ = (await import('./js/state.js')).state.files.c_gb; });
+      const checkReturned = async () => {
+        await expect.poll(async () => (await snapshot(page)).feature).toEqual(before.feature);
+        const returned = await snapshot(page);
+        expect(returned.records).toEqual(before.records);
+        expect(returned.placements).toEqual(before.placements);
+        expect(returned.featureCount).toBe(before.featureCount);
+        expect(returned.results).toEqual(before.results);
+        expect(await page.evaluate(async () => (await import('./js/state.js')).state.files.c_gb === window.__MODE_SOURCE__)).toBe(true);
+        await placement(page);
+      };
+      await switchMode(page, 'linear');
+      await switchMode(page, 'circular');
+      await checkReturned();
+      await page.screenshot({ path: testInfo.outputPath('returned-circular.png') });
+
+      // Each mode control remains one undoable operation; the placement is not rewritten.
+      for (const mode of ['linear', 'circular']) {
+        await page.getByRole('button', { name: /^Undo/ }).first().click();
+        await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(mode);
+      }
+      await checkReturned();
+      for (const mode of ['linear', 'circular']) {
+        await page.getByRole('button', { name: /^Redo/ }).first().click();
+        await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(mode);
+      }
+      await checkReturned();
+
+      const pending = page.waitForEvent('download');
+      await page.getByRole('button', { name: 'Save Session', exact: true }).click();
+      const download = await pending;
+      const saved = testInfo.outputPath(download.suggestedFilename());
+      await download.saveAs(saved);
+      const bytes = await fs.readFile(saved);
+      const savedSession = JSON.parse((bytes[0] === 0x1f ? gunzipSync(bytes) : bytes).toString());
+      expect(savedSession.renderRequest.diagramOptions.featurePlacements || []).toEqual(before.committedPlacements);
+      await generate(page);
+      const generated = await snapshot(page);
+      expect(generated.committedPlacements).toEqual(unswitched.committedPlacements);
+      expect(await structure(page, generated.results[0])).toEqual(expectedSvg);
+      await fs.writeFile(testInfo.outputPath('roundtrip.svg'), generated.results[0]);
+
+      const restored = await load(browser, saved);
+      pages.push(restored);
+      const loaded = await snapshot(restored);
+      expect(loaded.placements).toEqual(before.placements);
+      expect(loaded.feature).toEqual(before.feature);
+      // Save flushes the mounted SVG, including its editor metadata and styles.
+      expect(loaded.results).toHaveLength(savedSession.results.length);
+      for (const [index, result] of savedSession.results.entries()) {
+        expect(await structure(restored, loaded.results[index])).toEqual(await structure(restored, result.content));
+      }
+      await placement(restored);
+      await generate(restored);
+      expect(await structure(restored, (await snapshot(restored)).results[0])).toEqual(expectedSvg);
+      for (let step = 0; step < 3; step += 1) await restored.getByRole('button', { name: 'Zoom out', exact: true }).click();
+      await restored.screenshot({ path: testInfo.outputPath('restored-generated.png') });
+      for (const checked of pages) expect(external.get(checked)).toEqual([]);
+    } finally {
+      for (const page of pages) await page.context().close();
+    }
+  });
+}
+
+for (const operation of ['replacement', 'removal']) {
+  test(`Circular source ${operation} invalidates old identity and placement after mode inactivity`, async ({ browser }) => {
+    test.setTimeout(180000);
+    const page = await load(browser);
+    try {
+      await generate(page);
+      await placement(page, 'outward');
+      const before = await snapshot(page);
+      const source = await page.evaluate(async () => {
+        const { state } = await import('./js/state.js');
+        window.__MODE_SOURCE__ = state.files.c_gb;
+        window.__MODE_FEATURE__ = state.extractedFeatures.value[0];
+        return (await import('./js/services/file-content-cache.js')).readFileText(state.files.c_gb);
+      });
+      await switchMode(page, 'linear');
+      await switchMode(page, 'circular');
+      if (operation === 'replacement') {
+        // Keep the biological record ID: file/source identity must still invalidate its binding.
+        await page.getByLabel('GenBank/DDBJ File', { exact: true }).setInputFiles({ name: 'replacement.gbk',
+          mimeType: 'text/plain', buffer: Buffer.from(source.replace(/Homo sapiens/g, 'Replacement source')) });
+        await expect.poll(() => page.evaluate(async () => (await import('./js/state.js')).state.circularRecordDiscovery.status)).toBe('ready');
+      } else {
+        await page.getByLabel('GenBank/DDBJ File', { exact: true })
+          .locator('xpath=ancestor::div[@role="group"]')
+          .getByRole('button', { name: /Remove/ }).click();
+      }
+      await expect.poll(() => page.evaluate(async () => Object.keys((await import('./js/state.js')).state.featurePlacementOverrides))).toEqual([]);
+      const invalidation = await page.evaluate(async () => {
+        const { state } = await import('./js/state.js');
+        return { sameSource: state.files.c_gb === window.__MODE_SOURCE__,
+          identities: state.circularRecordDiscovery.canonicalRecordIdentities,
+          choices: window.__GBDRAW_APP__.featurePlacementActions.choices([window.__MODE_FEATURE__]) };
+      });
+      expect(invalidation.sameSource).toBe(false);
+      expect(invalidation.identities).toEqual([]);
+      expect(invalidation.choices.every(choice => !choice.enabled)).toBe(true);
+      const changed = await snapshot(page);
+      expect(changed.records.some(record => record.recordKey === before.feature.recordKey)).toBe(false);
+      if (operation === 'replacement') await generate(page);
+      else expect(changed.records).toEqual([]);
+      expect(external.get(page)).toEqual([]);
+    } finally { await page.context().close(); }
+  });
+}
+
+test('no-placement Circular and Linear mode round trips remain generatable', async ({ browser }) => {
+  test.setTimeout(240000);
+  for (const [file, original, temporary] of [[seed, 'circular', 'linear'],
+    ['gbdraw/web/gallery/sessions/lambda_basic_linear.gbdraw-session.json', 'linear', 'circular']]) {
+    const page = await load(browser, file);
+    try {
+      await generate(page);
+      const before = await snapshot(page);
+      await switchMode(page, temporary);
+      await switchMode(page, original);
+      await generate(page);
+      expect((await snapshot(page)).placements).toEqual({});
+      expect(await structure(page, (await snapshot(page)).results[0])).toEqual(await structure(page, before.results[0]));
+      expect(external.get(page)).toEqual([]);
+    } finally { await page.context().close(); }
+  }
+});

--- a/tests/web/run-analysis-simple-path.test.mjs
+++ b/tests/web/run-analysis-simple-path.test.mjs
@@ -935,7 +935,39 @@ test('audit-5 owner: direct simple createRunAnalysis path is worker-only and cat
   releaseCoalescedDiscovery();
   await Promise.all([firstCoalescedDiscovery, secondCoalescedDiscovery]);
   assert.equal(state.circularRecordList.value[0].recordKey, 'record-1');
+  const identities = [{ selector: '#1', record_id: 'audit', recordKey: 'record-1' }];
+  assert.deepEqual(state.circularRecordDiscovery.canonicalRecordIdentities, identities);
+
+  state.mode.value = 'linear';
+  await runner.refreshCircularRecordOrder();
+  assert.equal(state.files.c_gb, fallbackPrimary);
+  assert.deepEqual(state.circularRecordList.value, []);
+  assert.deepEqual(state.circularRecordDiscovery.canonicalRecordIdentities, identities);
+  state.mode.value = 'circular';
+  workerHelperResponses.push({ ok: true, result: {
+    records: [{ selector: '#1', record_id: 'audit', record_length: 10 }]
+  } });
+  await runner.refreshCircularRecordOrder();
+  assert.equal(state.circularRecordList.value[0].recordKey, 'record-1');
+  assert.deepEqual(state.circularRecordDiscovery.canonicalRecordIdentities, identities);
+
+  // Equal biological names on a different source cannot inherit the retired key,
+  // even if replacement/removal happens while Circular is inactive.
+  state.mode.value = 'linear';
+  state.files.c_gb = new AuditFile(['LOCUS audit 10 bp DNA circular\n//\n'], 'replacement.gb');
+  await runner.refreshCircularRecordOrder();
   assert.deepEqual(state.circularRecordDiscovery.canonicalRecordIdentities, []);
+  state.mode.value = 'circular';
+  await runner.refreshCircularRecordOrder();
+  assert.equal(state.circularRecordList.value[0].record_id, 'audit');
+  assert.equal(state.circularRecordList.value[0].recordKey, undefined);
+  state.mode.value = 'linear';
+  state.files.c_gb = null;
+  await runner.refreshCircularRecordOrder();
+  assert.deepEqual(state.circularRecordList.value, []);
+  assert.deepEqual(state.circularRecordDiscovery.canonicalRecordIdentities, []);
+  state.mode.value = 'circular';
+  state.files.c_gb = fallbackPrimary;
 
   state.form.multi_record_canvas = true;
   state.files.c_depth = null;


### PR DESCRIPTION
## Plain-language summary

Switching from Circular to Linear and back could leave a feature placement pointing to a missing record key, so Generate failed and the Feature Editor was empty. This change retains discovered canonical record keys for the same source and restores the editor from the retained Result's feature catalog when returning to its mode. Replacing or removing the source still invalidates its old identity and placement binding.

## Implementation and review

`run-analysis.js` keeps the discovered selector-to-key mapping in the existing `circularRecordDiscovery.canonicalRecordIdentities` owner. The existing source-object and paired-file checks still clear that mapping on replacement/removal. `watchers.js` uses the existing catalog projection when returning to the Result's mode; the Vue proxy is unwrapped before consulting the catalog's admission registry.

The superseded unconditional identity disposal and empty editor projection on return are removed. No new identity store, watcher, schema, placement translation, override rewriting, renderer exception, or dependency is introduced. Source replacement remains owned by `record-display-options.js`. Owner/path excess and compatibility burden do not increase; no architecture exception is requested. Reverting this commit restores the preceding behavior without persisted-data migration.

Product preflight: `IMPLEMENT_EXISTING_AUTHORITY`. The supported source-bound editing and draft/Result separation contracts, together with the explicit unchanged-source round-trip requirement for BUG-03, determine the outcome. No product option or authority change is proposed. The existing FAQ restriction on cross-mode placement translation remains applicable.

Human review is **REQUIRED** under `docs/internal/WEB_CHANGE_POLICY.md` and the architecture ratchet because this changes the identity lifecycle and the mode-return editor path. Automated Review CLEAR does not waive this requirement. Please leave this PR unmerged until maintainer review is supplied.

## Validation

- Reproduced ungenerated and committed Human mitochondrial TRNF Outward lane 1 failures on `1ebcad197a93685e981c17d58e2f3927ddb67974` before production edits; no-placement, replacement and removal controls established the boundary.
- Added real-control Chromium regressions for both placement states, source/record/feature/placement identity, editor availability, Generate, Undo/Redo, dirty Save/fresh Load, replacement/removal, and no-placement round trips in both modes. Generated SVG structures must equal an independently generated unswitched draft, including every SVG attribute.
- Extended the existing discovery regression to cover identity retention and invalidation during inactive Circular mode, alongside the existing coalescing and stale-discovery checks.
- Local validation: 17 focused JavaScript suites; 639 Python placement/session/request/planning tests; 137 architecture contracts; Web change policy and `git diff --check`.
- Related browser coverage includes SESSION 02B placement capability, keyboard history, record discovery and SESSION 00 chloroplast placement. Browser computation uses local assets and the prepared browser wheel; external requests are blocked.

Production and test diffs were reviewed separately. No documentation, Gallery artifact, LOSAT, version, or release changes are included.
