### PR TITLE
Add Dimensions citations badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Static Badge](https://img.shields.io/badge/gbdraw%20webapp-8A2BE2)](https://gbdraw.app/)
 [![DOI](https://img.shields.io/badge/DOI-10.64898/2026.04.07.716863-blue)](https://doi.org/10.64898/2026.04.07.716863)
+[![Dimensions citations](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmetrics-api.dimensions.ai%2Fdoi%2F10.64898%2F2026.04.07.716863&query=%24.times_cited&label=Dimensions%20citations&color=blue)](https://doi.org/10.64898/2026.04.07.716863)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/gbdraw/badges/version.svg)](https://anaconda.org/bioconda/gbdraw)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/gbdraw/badges/platforms.svg)](https://anaconda.org/bioconda/gbdraw)
 [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/gbdraw/README.html)
@@ -93,6 +94,7 @@ https://github.com/satoshikawato/gbdraw/issues
 ## How to cite
 
 If you use `gbdraw` in your research, please cite the preprint:
+[![Dimensions citations](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmetrics-api.dimensions.ai%2Fdoi%2F10.64898%2F2026.04.07.716863&query=%24.times_cited&label=Dimensions%20citations&color=blue)](https://doi.org/10.64898/2026.04.07.716863)
 
 ```text
 Kawato, S. (2026). gbdraw: a genome diagram generator for microbes and organelles. bioRxiv. https://doi.org/10.64898/2026.04.07.716863


### PR DESCRIPTION
## Plain-language summary

Add a Dimensions citation-count badge beside the existing README badges and beside the preprint citation. Both badges link to the gbdraw preprint, so readers can see its citation count and open the paper. The same README description is included in the source distribution and wheel metadata.

## Change class

- [x] STANDARD

## Purpose

E2 package-bearing editorial: `pyproject.toml` uses `README.md` as the package description.

- Exact base: `dev` at `458b16e43412a1447029c8034ac59163b1ba1117`.
- Final exact PR head: `2d5a6f1c7670bee0062d5d144d456fe81b4893f2`.
- Preserve PR #495 by reconstructing its two README additions as one commit on that base and retargeting it from `main` to `dev`.
- Required checks: `Web base policy (trusted base)` and `PR / gate`, with strict up-to-date checking. The existing trusted CI impact policy selects the applicable jobs; no checks, selection rules, or protection settings change.

## User-visible impact

Readers see the same linked Dimensions badge in the top badge group and near `How to cite`.

## Changes

- `README.md` only: two additions, zero deletions; the additions match the original PR patch.
- Both links use DOI `10.64898/2026.04.07.716863`.
- Shields requests `https://metrics-api.dimensions.ai/doi/10.64898/2026.04.07.716863` and selects `$.times_cited`.
- Zero production/runtime changes. No version or release-workflow changes.

## Verification

All local results below are from final head `2d5a6f1c7670bee0062d5d144d456fe81b4893f2`.

- DOI request: HTTP 200 after redirect to the gbdraw bioRxiv preprint. Dimensions: HTTP 200, matching DOI, `times_cited: 4`. Shields: HTTP 200, valid SVG labeled `Dimensions citations: 4` at verification time.
- README rendered with `readme_renderer.markdown`; both badge links and the citation heading and code block parse correctly. Removing only the two badge lines reproduces the baseline README.
- `python -m pytest tests/test_release_pipeline.py tests/test_web_packaging.py::test_project_docs_and_citation_metadata_include_preprint_doi -v`: 29 passed.
- Existing release build route: `python tools/prepare_browser_wheel.py`, then `python -m build --outdir <temporary-dist>`: sdist and wheel passed.
- `python -m twine check --strict <temporary-dist>/*`: both distributions passed.
- `python tools/verify_gui_offline.py inspect-distributions <temporary-dist>`: passed.
- Wheel, embedded browser wheel, and sdist metadata declare `gbdraw 0.14.0`, use `text/markdown`, and contain the final README description.
- Fresh venv wheel installation and `pip check`: passed. The existing `tests/utils/installed_package_smoke.py`, copied with `HmmtDNA.gbk` and run using isolated Python 3.13.3 outside the checkout, passed CLI version/help, circular/linear rendering, exact session replay, and both Python drawing APIs.
- `git diff --exit-code` after building: passed; generated browser wheel and evidence remain uncommitted.
- `gbdraw/` tree is identical at baseline and head: `5f5ad9866ae2577f559d6002788986a09df08497`. This includes session/schema, renderer, and LOSAT JavaScript/Wasm. Workflow, tool, test, and package-configuration objects are also identical. The complete tracked delta is `README.md` only.

## Risk and review notes

- Gate result: local package verification passed; final-head hosted checks must pass before merge.
- Review result: `CLEAR`; the original two-line editorial patch is preserved, and the entire technical source is unchanged.
- This is not architecture-bearing.
- Architecture baseline and changed-scope conclusion: N/A.
- Product impact: N/A.
- The external citation count can change; it is not a fixed package value.
- `TECHNICAL_BASELINE_SHA=458b16e43412a1447029c8034ac59163b1ba1117` remains unchanged. S12 is not started, and `PUBLICATION_CANDIDATE_SHA` is not assigned.

## Rollback

Revert the README badge commit `2d5a6f1c7670bee0062d5d144d456fe81b4893f2`.

## Conditional Product Impact

- Product-impact role: N/A.
- Product preflight classification: N/A.
- Affected concerns, effects, authority, decision evidence, and behavior contracts: N/A.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"2d5a6f1c7670bee0062d5d144d456fe81b4893f2","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
