### PR TITLE
Allow 15 minutes for Web PR smoke checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -329,7 +329,7 @@ jobs:
       needs.ci-impact.result == 'success' &&
       contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-pr-smoke')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1060,7 +1060,7 @@ test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
   assert.match(webPrSmoke, /needs: ci-impact/);
   assert.match(webPrSmoke, /needs\.ci-impact\.result == 'success'/);
   assert.match(webPrSmoke, /requiredJobs, 'web-pr-smoke'/);
-  assert.match(webPrSmoke, /timeout-minutes: 10/);
+  assert.match(webPrSmoke, /timeout-minutes: 15/);
   assert.equal([...webPrSmoke.matchAll(/uses: actions\/checkout@/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/npm ci/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/playwright install --with-deps chromium/g)].length, 1);


### PR DESCRIPTION
## Plain-language summary

Allow the `Web PR smoke` job 15 minutes so browser checks can finish after dependency setup and the preceding contract suites. In PR #496, the existing 10-minute limit cancelled the job after fourteen successful browser cases, with no assertion failure reported.

## Change class

- [x] GOVERNANCE

## Purpose

Base: `origin/dev` at `1b08cff5e571cad6fed7be09674e8f8d6902aa05`.
Required checks: `Web base policy (trusted base)` and `PR / gate`.
This prerequisite is separate from runtime PR #496 because the trusted Web Change Policy separates runtime and CI authority changes.

## User-visible impact

Browser behavior and scientific output are unchanged. A slow CI smoke job can run for five additional minutes before cancellation.

## Changes

Change `.github/workflows/test.yml`, `jobs.web-pr-smoke.timeout-minutes`, from 10 to 15, and update the existing architecture contract to require that exact budget. Browser/recipe assertions, test selection, per-test timeouts, required statuses, checker implementation and branch protection retain their existing definitions.

## Verification

- Parsed both workflow documents and verified that this single numeric field is the complete workflow structural difference; whitespace check passes.
- The existing selective-plan architecture contract passes with the new exact 15-minute expectation. The first CI run exposed its old hard-coded 10-minute assertion; this corresponding contract update is now included. The local full architecture suite passes all **137 tests**; exact-head policy is **Gate PASS / Review REQUIRED**. Amended-head `PR / gate` and `Web base policy (trusted base)` pass. The Web smoke job completes all **20 tests in 9.1 minutes**, with **11 min 48 s** total job time; this confirms that the previous outer 10-minute budget was insufficient even for the base smoke selection.
- [Observed runtime job](https://github.com/satoshikawato/gbdraw/actions/runs/34370904709/job/102532351604): setup and earlier contract checks used 2 min 38 s; fourteen of twenty-two browser cases passed before the outer deadline cancelled execution. The two new smoke cases passed in 1 min 55 s and 4.5 s. All twenty-two have passing local evidence on that runtime head, including a focused correction of the local installed-Python environment for two unchanged replay cases.
- Required CI for this isolated prerequisite is shown on the PR checks tab. It verifies the base branch's smoke selection; runtime PR #496 will still need another required-CI run after this prerequisite reaches its base.

## Risk and review notes

This is not architecture-bearing. OE/PE/CB: N/A; no runtime owner, path, or compatibility format changes. The job's maximum runner use increases by five minutes. Review the job budget and separation from #496; this draft does not request an architecture waiver or authorize a merge.

## Rollback

Restore the job budget and its exact-value architecture assertion to 10. Browser/recipe tests and branch-protection definitions need no rollback.

## Conditional Product Impact

N/A: CI execution budget only; no product decision.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

## Conditional evidence

### GOVERNANCE

- Authority/evidence producers: `.github/workflows/test.yml` and its existing exact-budget assertion in `tests/web/architecture-contracts.test.mjs`.
- Checker implementation: none.
- Self-authorization separation: no runtime changes, checker changes, policy data or evidence-normalization changes; based directly on the existing dev head, independently of #496.
- Branch protection/rulesets: unchanged.
- Restore point: the budget and matching assertion can be reverted together independently of runtime PR #496.
