### PR TITLE
Update session binding schema expectation after schema-2 writer

### DIFF
--- a/tests/web/depth-track-session.playwright.spec.js
+++ b/tests/web/depth-track-session.playwright.spec.js
@@ -1585,7 +1585,7 @@ ORIGIN
   expect(exportedSession.version).toBe(41);
   expect(exportedSession).not.toHaveProperty('files');
   expect(exportedSession.webFiles).toEqual(expect.any(Object));
-  expect(exportedSession.webFiles.bindings.schema).toBe(1);
+  expect(exportedSession.webFiles.bindings.schema).toBe(2);
   expect(exportedSession.webFiles.bindings.c_gb.name).toBe('layout-preferences.gbk');
   expect(exportedSession.webFiles.bindings.linearSeqs[0].gb.name).toBe(
     'inactive-linear-layout.gbk'


### PR DESCRIPTION
## Plain-language summary

Update the session round-trip test to expect `webFiles.bindings.schema === 2` in newly exported sessions. Merged PR #496 intentionally advanced the Web binding writer to schema 2, and post-merge full functional CI exposed one stale schema-1 test expectation. The exact previously failing test now passes through all its later assertions, including fresh-page import and restoration. Production code is unchanged; this correction does not change compatibility or architecture.

## Validation

- `v40 layout preferences and mode profiles survive fresh-page export and import`: **PASS**, including exported binding metadata, resource deduplication, inactive drafts, layout preferences, mode profiles, and the independent `config.modeProfiles.schema === 1` assertion.
- `tests/web/depth-track-session.playwright.spec.js`: **20 passed**, with no skipped tests or retries.
- Both runs used `playwright.functional.config.js`; the containing file ran with one worker.
- Diff review: one test file, one expectation changed from `1` to `2`; no production, documentation, generated-artifact, or CI-policy changes.
