### PR TITLE
Remount edited Results when switching diagram modes

### DIFF
--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -307,7 +307,7 @@ export const setupWatchers = ({
     }
   );
 
-  watch([svgContent, () => results.value[selectedResultIndex.value]], () => {
+  watch([svgContent, svgContainer, () => results.value[selectedResultIndex.value]], () => {
     const isIncrementalEdit = Boolean(skipCaptureBaseConfig.value);
     skipCaptureBaseConfig.value = false;
     skipPositionReapply.value = false;
@@ -405,6 +405,10 @@ export const setupWatchers = ({
     () => {
       if (semanticFileWatchersSuppressed.value) return;
       cancelDefinitionUpdate();
+
+      // Vue replaces the mode-keyed container. Release its frozen live-edit
+      // payload first so the new root materializes the selected Result content.
+      previewRuntime?.clearActiveRuntime?.();
 
       if (typeof resetPreviewViewport === 'function') {
         resetPreviewViewport();

--- a/tests/web/helpers/mode-transition.cjs
+++ b/tests/web/helpers/mode-transition.cjs
@@ -1,0 +1,108 @@
+const { expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { openApp } = require('./app-lifecycle.cjs');
+
+const seeds = {
+  circular: 'gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json',
+  linear: 'gbdraw/web/gallery/sessions/lambda_basic_linear.gbdraw-session.json'
+};
+
+const load = async (browser, file = seeds.circular, viewport = { width: 1600, height: 1000 }) => {
+  const context = await browser.newContext({ viewport });
+  const page = await context.newPage();
+  page.externalRequests = [];
+  await context.route('**/*', route => {
+    if (new URL(route.request().url()).hostname === '127.0.0.1') return route.continue();
+    page.externalRequests.push(route.request().url());
+    return route.abort();
+  });
+  await page.addInitScript(() => {
+    window.__MODE_EVENTS__ = [];
+    window.__GBDRAW_TEST_HOOKS__ = {
+      onSessionLifecycleEvent: event => window.__MODE_EVENTS__.push(event)
+    };
+  });
+  page.on('dialog', dialog => dialog.type() === 'confirm' && dialog.message().startsWith('Download ')
+    ? dialog.accept() : dialog.dismiss());
+  await openApp(page);
+  await page.locator('input[accept^=".json,"]').setInputFiles(file);
+  await expect.poll(() => page.evaluate(() => !window.__GBDRAW_APP__.sessionImportPending
+    && window.__GBDRAW_APP__.extractedFeatures.length > 0), { timeout: 180000 }).toBe(true);
+  return page;
+};
+
+const generate = async page => {
+  const key = await page.evaluate(async () => (await import('./js/state.js')).state.resultGenerationKey.value);
+  await page.getByRole('button', { name: 'Generate Diagram', exact: true }).click();
+  await expect.poll(() => page.evaluate(async () => {
+    const { state } = await import('./js/state.js');
+    return { key: state.resultGenerationKey.value, processing: state.processing.value, error: state.errorLog.value };
+  }), { timeout: 180000 }).toEqual({ key: key + 1, processing: false, error: null });
+};
+
+const switchMode = async (page, mode) => {
+  await page.getByRole('button', { name: mode === 'circular' ? 'Circular' : 'Linear', exact: true }).click();
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(mode);
+  await expect.poll(() => page.evaluate(async () =>
+    (await import('./js/state.js')).state.circularRecordDiscovery.status)).not.toBe('loading');
+  // Settle the Vue render and its asynchronous preview binder, without a time delay.
+  await page.evaluate(async () => { await window.Vue.nextTick(); });
+};
+
+const popup = async (page, index = 0) => {
+  if (!await page.locator('.right-drawer').isVisible()) await page.locator('.drawer-toggle').click();
+  await page.locator('.right-drawer').getByRole('button', { name: 'Edit', exact: true }).nth(index).click();
+  await expect(page.locator('.feature-popup')).toBeVisible();
+  return page.evaluate(() => {
+    const feature = window.__GBDRAW_APP__.clickedFeature;
+    return { id: feature.id, featureId: feature.featureId, sourceText: feature.labelSourceText };
+  });
+};
+
+const closeEditor = async page => {
+  if (await page.locator('.feature-popup').isVisible()) {
+    await page.getByRole('button', { name: 'Close feature popup', exact: true }).click();
+  }
+  if (await page.locator('.right-drawer').isVisible()) await page.locator('.drawer-toggle').click();
+};
+
+const download = async (page, button, path) => {
+  const pending = page.waitForEvent('download');
+  await page.getByRole('button', { name: button, exact: true }).click();
+  await (await pending).saveAs(path);
+  return fs.readFile(path);
+};
+
+const snapshot = page => page.evaluate(async () => {
+  const { state: s } = await import('./js/state.js');
+  const ingestion = await import('./js/services/svg-result-ingestion.js');
+  const { getCommittedCanonicalRenderRequest } = await import('./js/services/config.js');
+  const root = s.svgContainer.value.querySelector('svg');
+  const result = s.results.value[s.selectedResultIndex.value];
+  return {
+    mode: s.mode.value, generation: s.resultGenerationKey.value,
+    labels: { ...s.labelTextFeatureOverrides }, bulkLabels: { ...s.labelTextBulkOverrides },
+    labelSources: { ...s.labelTextFeatureOverrideSources }, visibility: { ...s.labelVisibilityOverrides },
+    featureVisibility: { ...s.featureVisibilityOverrides }, visibilityRules: [...s.featureVisibilityManualRules],
+    colors: { ...s.featureColorOverrides }, rules: s.manualSpecificRules.map(rule => ({ ...rule, fromFile: Boolean(rule.fromFile) })),
+    context: s.labelOverrideContextKey.value, featureCount: s.extractedFeatures.value.length,
+    resultIdentity: ingestion.getCommittedSvgResultRuntimeIdentity(result),
+    markedMounted: ingestion.isCommittedSvgResultMounted(result),
+    result: result.content, payload: s.svgContent.value, mounted: root.outerHTML,
+    sameRoot: root === window.__MODE_EDITED_ROOT__,
+    mountEvents: window.__MODE_EVENTS__.filter(e => e.name === 'preview.mount-observed'),
+    request: getCommittedCanonicalRenderRequest()
+  };
+});
+
+const semantics = (page, content) => page.evaluate(content => {
+  const root = new DOMParser().parseFromString(content, 'image/svg+xml').documentElement;
+  return [...root.querySelectorAll('[data-gbdraw-feature-id]')].map(element => ({
+    id: element.getAttribute('data-gbdraw-feature-id'),
+    part: element.getAttribute('data-gbdraw-feature-part'),
+    d: element.getAttribute('d'), fill: element.getAttribute('fill'),
+    stroke: element.getAttribute('stroke'), display: element.getAttribute('display')
+  }));
+}, content);
+
+module.exports = { seeds, load, generate, switchMode, popup, closeEditor, download, snapshot, semantics };

--- a/tests/web/mode-transition-result.playwright.spec.js
+++ b/tests/web/mode-transition-result.playwright.spec.js
@@ -1,0 +1,125 @@
+const { test, expect } = require('@playwright/test');
+const { seeds, load, generate, switchMode, popup, closeEditor, download, snapshot, semantics } = require('./helpers/mode-transition.cjs');
+
+const color = async (page, value, index = 0) => {
+  const target = await popup(page, index);
+  await page.getByLabel('Feature fill color', { exact: true }).first().evaluate((element, value) => {
+    element.value = value;
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+  await page.getByText('This feature only', { exact: true }).click();
+  await closeEditor(page);
+  return target;
+};
+
+const agree = async (page, expected, testInfo, name) => {
+  const state = await snapshot(page);
+  const exported = (await download(page, 'SVG', testInfo.outputPath(`${name}.svg`))).toString();
+  await testInfo.attach(`${name}-state`, { body: JSON.stringify(state), contentType: 'application/json' });
+  expect.soft(state.colors).toEqual(expected.colors);
+  expect.soft(state.rules).toEqual(expected.rules);
+  expect.soft(await semantics(page, state.result)).toEqual(await semantics(page, expected.result));
+  expect.soft(await semantics(page, state.mounted)).toEqual(await semantics(page, expected.result));
+  expect.soft(await semantics(page, exported)).toEqual(await semantics(page, expected.result));
+  expect.soft(state.markedMounted).toBe(true);
+  return state;
+};
+
+for (const mode of ['circular', 'linear']) {
+  test(`@pr-smoke ${mode} color Result agrees with a fresh mode root and export before regeneration`, async ({ browser }, testInfo) => {
+    test.setTimeout(240000);
+    const page = await load(browser, seeds[mode]);
+    try {
+      await generate(page);
+      const original = await snapshot(page);
+      await color(page, '#c83366');
+      const edited = await snapshot(page);
+      expect(edited.result).toContain('#c83366');
+      expect(edited.mounted).toContain('#c83366');
+      expect(edited.resultIdentity).toBe(original.resultIdentity);
+      await page.evaluate(() => { window.__MODE_EDITED_ROOT__ = document.querySelector('.origin-top svg'); });
+      await switchMode(page, mode === 'circular' ? 'linear' : 'circular');
+      if (mode === 'circular') {
+        const scale = page.getByLabel('Show Coordinate Scale (Linear)', { exact: true });
+        for (const details of await scale.locator('xpath=ancestor::details').all()) {
+          if (await details.getAttribute('open') === null) await details.locator(':scope > summary').click();
+        }
+        await scale.uncheck();
+        expect((await snapshot(page)).request).toEqual(edited.request);
+      }
+      await agree(page, edited, testInfo, 'inactive');
+      await switchMode(page, mode);
+      const returned = await agree(page, edited, testInfo, 'returned');
+      expect(returned.sameRoot).toBe(false);
+      expect(returned.resultIdentity).toBe(edited.resultIdentity);
+      expect(returned.generation).toBe(edited.generation);
+      expect.soft(returned.mountEvents.at(-1).rootGeneration).toBeGreaterThan(edited.mountEvents.at(-1).rootGeneration);
+      expect.soft(returned.mountEvents.at(-1).bindSequence).toBeGreaterThan(edited.mountEvents.at(-1).bindSequence);
+      expect(page.externalRequests).toEqual([]);
+    } finally { await page.context().close(); }
+  });
+}
+
+test('incremental color edits survive mode history, dirty draft, and fresh Save/Load/export', async ({ browser }, testInfo) => {
+  test.setTimeout(360000);
+  const page = await load(browser);
+  let fresh;
+  try {
+    await generate(page);
+    await color(page, '#c83366');
+    await color(page, '#267b91', 1);
+    const edited = await snapshot(page);
+    expect(edited.result).toContain('#c83366');
+    expect(edited.result).toContain('#267b91');
+    const savedBefore = testInfo.outputPath('before.gbdraw-session.json.gz');
+    await download(page, 'Save Session', savedBefore);
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    const undone = await snapshot(page);
+    expect(undone.colors).not.toEqual(edited.colors);
+    await switchMode(page, 'linear');
+    await switchMode(page, 'circular');
+    await agree(page, undone, testInfo, 'after-edit-undo');
+    for (const mode of ['linear', 'circular']) {
+      await page.getByRole('button', { name: 'Undo', exact: true }).click();
+      await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(mode);
+    }
+    await agree(page, undone, testInfo, 'after-mode-undo');
+    // Reload the two-edit checkpoint; Generate must not be needed to restore it.
+    fresh = await load(browser, savedBefore);
+    await agree(fresh, edited, testInfo, 'saved-before-loaded');
+    await switchMode(fresh, 'linear');
+    await switchMode(fresh, 'circular');
+    await agree(fresh, edited, testInfo, 'two-edits-returned');
+    const savedAfter = testInfo.outputPath('after.gbdraw-session.json.gz');
+    await download(fresh, 'Save Session', savedAfter);
+    await fresh.context().close();
+    fresh = await load(browser, savedAfter);
+    await agree(fresh, edited, testInfo, 'saved-after-loaded');
+    await generate(fresh);
+    await agree(fresh, edited, testInfo, 'regenerated');
+    expect(fresh.externalRequests).toEqual([]);
+  } finally {
+    await page.context().close();
+    if (fresh) await fresh.context().close();
+  }
+});
+
+test('unedited Result and same-mode navigation keep feature presentation unchanged', async ({ browser }, testInfo) => {
+  test.setTimeout(240000);
+  for (const mode of ['circular', 'linear']) {
+    const page = await load(browser, seeds[mode]);
+    try {
+      await generate(page);
+      const original = await snapshot(page);
+      await page.evaluate(() => { window.__MODE_EDITED_ROOT__ = document.querySelector('.origin-top svg'); });
+      await switchMode(page, mode);
+      expect((await snapshot(page)).sameRoot).toBe(true);
+      await switchMode(page, mode === 'circular' ? 'linear' : 'circular');
+      await switchMode(page, mode);
+      const returned = await agree(page, original, testInfo, `unedited-${mode}`);
+      expect(returned.sameRoot).toBe(false);
+      expect(returned.resultIdentity).toBe(original.resultIdentity);
+      expect(returned.generation).toBe(original.generation);
+    } finally { await page.context().close(); }
+  }
+});


### PR DESCRIPTION
## Plain-language summary

Switching between Circular and Linear after recoloring a feature could display and export the original color even though the saved Result contained the edit. This PR makes the replacement preview use the selected Result and binds its new SVG root before further interaction. Label intent deletion remains a separate follow-up fix.

## Change class

- [x] STANDARD

## Purpose

Fix 05A2-02 against `dev` at `a4516af4703ab048a61845417fd405d416022dcf`. The retained M08/M09 color reproductions were rerun before production edits and matched the previous observations exactly. M01/M02/M07 independently confirmed the separate label and visibility defect.

## User-visible impact

After a mode round trip, recolored features retain their current appearance in the preview and downloaded SVG. Save/Load and export preserve the edited artifact without requiring Generate. Mode navigation does not generate a new diagram or merge the active draft into the committed request.

## Changes

`app/watchers.js` releases the existing PreviewRuntime before Vue replaces the mode-keyed container and includes `svgContainer` in the existing mounted-Result watcher. The unmounted Result supplies the replacement content; the existing binder adopts the actual new root. The fixed payload used during edits remains limited to keeping the current DOM root stable.

## Verification

- Exact starting source: new Result browser suite failed 3 tests and passed the unedited control before the fix; all 4 pass afterward.
- Independent oracles cover editor intent, selected Result identity/content, actual root replacement, root/bind sequence, and downloaded SVG semantics in both directions.
- Multiple edits, untouched features, mode and edit Undo, Save before/after navigation, fresh Load/export, repeated Generate, and active-draft separation are covered.
- Focused browser acceptance: all 36 tests pass, including the new regressions and existing mode/identity, feature fill, History, depth/session and preview transaction suites (4.8 minutes).
- Preview runtime, SVG Result ingestion, feature visibility/actions and History Node suites: 6 files pass; label-slot and Result-normalization suites also pass.
- Browser checks use fresh Chromium contexts, a source-matching browser wheel and blocked external requests. No existing tests or timeouts were weakened.

## Risk and review notes

This is architecture-bearing: it corrects lifecycle sequencing at the existing PreviewRuntime and Vue mount boundary. Classification is ordinary non-increasing; no architecture exception applies. The selected Result remains the rematerialization authority, the current DOM remains the live editing surface, and the existing flush commits its edits. No owner, cache, persistence schema, identity namespace, compatibility path or dependency is added; `OE`, `PE` and `CB` do not increase. The obsolete unobserved mode-remount path is removed in this change.

Gate: the deterministic Web architecture check passes. Review: REQUIRED for the lifecycle correction; `architecture-change` applies. No release, tag, publishing or Gallery artifact files change.

## Rollback

Revert this PR's commit; it is independent of the later label-intent remediation.

## Conditional Product Impact

- Role: IMPLEMENTATION.
- Preflight: IMPLEMENT_EXISTING_AUTHORITY. The base Web live-edit contract requires current Result and mounted-target agreement; `OPTION_INTEGRITY_PRODUCT_CONTRACT.md` OIPC-C04/C06 requires artifact agreement and explicit clearing. There is no unresolved Product choice, retirement or new persisted contract.
- Registered Product Impact delta: none. Existing request construction and admission owners remain unchanged.
- Residual scope: tests cover SVG export and representative Circular/Linear sessions. This does not claim a full release journey sweep or fix 05A2-01.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

05A2-03 remains OPEN, nonblocking for this remediation transaction. This E3 merge requires S11 reacceptance while retaining the historical acceptance record. No replacement technical baseline is assigned; S12 remains BLOCKED and PUBLICATION_CANDIDATE_SHA remains UNASSIGNED.
