### PR TITLE
Preserve label and visibility edits across diagram modes

### DIFF
--- a/gbdraw/web/js/app/feature-editor/label-actions.js
+++ b/gbdraw/web/js/app/feature-editor/label-actions.js
@@ -377,6 +377,7 @@ const hasFeatureScopedOverrideInSvg = (svg, ...overrideMaps) => {
 export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
   const {
     mode,
+    generatedMode,
     form,
     filterMode,
     manualWhitelist,
@@ -665,6 +666,9 @@ export const createFeatureLabelActions = ({ state, previewRuntime = null }) => {
     requiredFeatureIds = [],
     optionalFeatureIds = []
   } = {}) => {
+    // The retained Result can outlive its active mode. Keep its label intent
+    // dormant until its own mode can project and reconcile those identities.
+    if (generatedMode.value !== mode.value) return;
     if (!svgContainer.value) return;
     const svg = svgContainer.value.querySelector('svg');
     if (!svg) return;

--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -81,7 +81,6 @@ export const setupWatchers = ({
     suppressCircularMultiRecordDefaults,
     featureRecordIds,
     selectedFeatureRecordIdx,
-    featureVisibilityManualRules,
     featureVisibilityOverrides,
     replaceFeatureVisibilitySelectorCacheOwner,
     featurePanelTab,
@@ -94,11 +93,9 @@ export const setupWatchers = ({
     orthogroupDescriptionOverrides,
     selectedOrthogroupId,
     orthogroupSearch,
-    labelOverrideContextKey,
     labelTextBulkOverrides,
     labelTextFeatureOverrides,
     canonicalLabelOverrideRows,
-    labelTextFeatureOverrideSources,
     labelVisibilityOverrides,
     labelOverrideBuildWarning,
     isFeatureDrawerMounted,
@@ -423,18 +420,14 @@ export const setupWatchers = ({
       featureSelectorSafetyScope.value = features.featureSelectorSafetyScope || [];
       featureRecordIds.value = features.featureRecordIds || [];
       selectedFeatureRecordIdx.value = 0;
-      featureVisibilityManualRules.splice(0);
-      Object.keys(featureVisibilityOverrides).forEach((k) => delete featureVisibilityOverrides[k]);
+      // Mode inactivity clears projections, not durable label/visibility intent.
+      // The editor's existing identity reconciliation handles source replacement.
       if (typeof replaceFeatureVisibilitySelectorCacheOwner === 'function') {
         replaceFeatureVisibilitySelectorCacheOwner({});
       } else {
         replacePlainObject(state.featureVisibilitySelectorCache, {});
       }
       editableLabels.value = [];
-      Object.keys(labelTextFeatureOverrides).forEach((k) => delete labelTextFeatureOverrides[k]);
-      Object.keys(labelTextBulkOverrides).forEach((k) => delete labelTextBulkOverrides[k]);
-      Object.keys(labelTextFeatureOverrideSources).forEach((k) => delete labelTextFeatureOverrideSources[k]);
-      Object.keys(labelVisibilityOverrides).forEach((k) => delete labelVisibilityOverrides[k]);
       orthogroups.value = [];
       collinearGroups.value = [];
       featureOrthogroupIndex.value = new Map();
@@ -443,7 +436,6 @@ export const setupWatchers = ({
       orthogroupSearch.value = '';
       Object.keys(orthogroupNameOverrides).forEach((k) => delete orthogroupNameOverrides[k]);
       Object.keys(orthogroupDescriptionOverrides).forEach((k) => delete orthogroupDescriptionOverrides[k]);
-      labelOverrideContextKey.value = '';
       labelOverrideBuildWarning.value = '';
       labelLayoutDirtyReason.value = '';
       labelSearch.value = '';

--- a/tests/web/composite-session-resources.playwright.spec.js
+++ b/tests/web/composite-session-resources.playwright.spec.js
@@ -126,18 +126,54 @@ const save = async (page, testInfo, label) => {
   }
 };
 
+const prepareSeed = async (journey, testInfo) => {
+  const bytes = await fs.readFile(seed);
+  expect(hash(bytes)).toBe('11009dd28a1d98afa79e8b5d22b94217f61d9f53cb6353010095c983c3a9d90e');
+  const session = JSON.parse(gunzipSync(bytes));
+  if (journey !== 'minimal') return { file: seed, session };
+
+  // Three real plasmids exercise composite ordering and persistence in PR smoke.
+  // Keep the six-replicon Gallery fixture for grid/batch and CLI acceptance.
+  const records = session.renderRequest.records.slice(2, 5)
+    .map((record, index) => ({ ...record, recordKey: `record-${index + 1}` }));
+  const resourceIds = new Set(records.map(record => record.source.resourceId));
+  const title = 'Three Vibrio plasmids';
+  const input = testInfo.outputPath('three-plasmids-input.json');
+  const file = testInfo.outputPath('three-plasmids.gbdraw-session.json.gz');
+  await fs.writeFile(input, JSON.stringify({
+    format: session.format, version: session.version,
+    results: [], editorState: { featureCatalog: null },
+    ui: session.ui,
+    config: { ...session.config,
+      form: { ...session.config.form, plot_title: title },
+      adv: { ...session.config.adv, multi_record_positions: [] } },
+    renderRequest: { ...session.renderRequest, records,
+      layout: { ...session.renderRequest.layout, multiRecordPositions: [] },
+      diagramOptions: { ...session.renderRequest.diagramOptions, plotTitle: title } },
+    resources: Object.fromEntries(Object.entries(session.resources)
+      .filter(([id, resource]) => resource.kind !== 'genbank' || resourceIds.has(id)))
+  }));
+  // Materialize the matching SVG and catalog through the normal CLI writer.
+  const { stdout, stderr } = await promisify(execFile)('python', [
+    '-m', 'gbdraw.cli', 'circular', '--session', input,
+    '-o', testInfo.outputPath('three-plasmids'), '--session_output', file
+  ], { cwd: testInfo.outputDir, env: { ...process.env, PYTHONPATH: process.cwd() },
+    timeout: generateTimeout, maxBuffer: 1_000_000 });
+  await fs.writeFile(testInfo.outputPath('three-plasmids-cli.log'), stdout + stderr);
+  return { file, session: JSON.parse(gunzipSync(await fs.readFile(file))) };
+};
+
 for (const journey of ['minimal', 'grid-batch-grid']) {
   test(`Session export Vibrio composite resources survive ${journey} Save, fresh Load and Generate${journey === 'minimal' ? ' @pr-smoke' : ''}`, async ({ browser }, testInfo) => {
     test.setTimeout(6 * generateTimeout + 6 * loadTimeout);
     const contexts = [];
     try {
-      const { page, external } = await load(browser, seed, contexts);
+      const { file, session: seedSession } = await prepareSeed(journey, testInfo);
+      const recordCount = journey === 'minimal' ? 3 : 6;
+      const { page, external } = await load(browser, file, contexts);
       const original = await snapshot(page);
-      expect(original.request.records).toHaveLength(6);
-      expect(original.components).toHaveLength(6);
-      const seedBytes = await fs.readFile(seed);
-      expect(hash(seedBytes)).toBe('11009dd28a1d98afa79e8b5d22b94217f61d9f53cb6353010095c983c3a9d90e');
-      const seedSession = JSON.parse(gunzipSync(seedBytes));
+      expect(original.request.records).toHaveLength(recordCount);
+      expect(original.components).toHaveLength(recordCount);
       const seedIds = [...new Set(seedSession.renderRequest.records.map(r => r.source.resourceId))];
       expect(original.components.map(({ size, sha256 }) => ({ size, sha256 })))
         .toEqual(seedIds.map(id => resourceIdentity(seedSession.resources[id])));
@@ -149,19 +185,19 @@ for (const journey of ['minimal', 'grid-batch-grid']) {
       if (journey === 'grid-batch-grid') {
         await page.getByRole('checkbox', { name: 'Multi-Record Canvas', exact: true }).uncheck();
         await generate(page);
-        expect((await snapshot(page)).results).toHaveLength(6);
+        expect((await snapshot(page)).results).toHaveLength(recordCount);
         await page.getByRole('checkbox', { name: 'Multi-Record Canvas', exact: true }).check();
         await generate(page);
       }
       const generated = await snapshot(page);
-      expect(generated.records).toHaveLength(6);
+      expect(generated.records).toHaveLength(recordCount);
       expect(generated.results).toHaveLength(1);
       expect(generated.components).toEqual(original.components);
       const { saved, session, metrics } = await save(page, testInfo, 'generated');
       expect([session.version, session.webFiles.bindings.schema, session.renderRequest.schema]).toEqual([41, 2, 7]);
       const composite = session.webFiles.bindings.c_gb;
       expect(composite.kind).toBe('composite');
-      expect(composite.components).toHaveLength(6);
+      expect(composite.components).toHaveLength(recordCount);
       expect(composite.components.map(part => resourceIdentity(session.resources[part.resourceId])))
         .toEqual(original.components.map(({ size, sha256 }) => ({ size, sha256 })));
       expect(composite.components.map(({ resourceId, ...metadata }) => metadata))
@@ -169,7 +205,8 @@ for (const journey of ['minimal', 'grid-batch-grid']) {
       expect(metrics.filter(metric => ['base64EncodeCount', 'base64DecodeCount'].includes(metric.name)))
         .toEqual([]);
       const genomicSizes = Object.values(session.resources).filter(r => r.kind === 'genbank' || composite.components.some(c => session.resources[c.resourceId] === r)).map(r => r.size);
-      expect(genomicSizes.reduce((sum, n) => sum + n, 0)).toBe(34_912_520);
+      expect(genomicSizes.reduce((sum, n) => sum + n, 0))
+        .toBe(2 * original.components.reduce((sum, component) => sum + component.size, 0));
       const resources = Object.fromEntries(Object.entries(session.resources)
         .map(([id, descriptor]) => [id, resourceIdentity(descriptor)]));
       for (const [id, identity] of Object.entries(generated.resources)) expect(resources[id]).toEqual(identity);

--- a/tests/web/helpers/mode-transition.cjs
+++ b/tests/web/helpers/mode-transition.cjs
@@ -55,7 +55,7 @@ const popup = async (page, index = 0) => {
   await expect(page.locator('.feature-popup')).toBeVisible();
   return page.evaluate(() => {
     const feature = window.__GBDRAW_APP__.clickedFeature;
-    return { id: feature.id, featureId: feature.featureId, sourceText: feature.labelSourceText };
+    return { id: feature.id, featureId: feature.svg_id, sourceText: feature.labelSourceText };
   });
 };
 

--- a/tests/web/mode-transition-editor-state.playwright.spec.js
+++ b/tests/web/mode-transition-editor-state.playwright.spec.js
@@ -1,0 +1,169 @@
+const { test, expect } = require('@playwright/test');
+const { seeds, load, generate, switchMode, popup, closeEditor, download, snapshot } = require('./helpers/mode-transition.cjs');
+
+const rename = async (page, text) => {
+  const target = await popup(page);
+  await page.locator('.feature-popup input[placeholder="Edit label text"]').fill(text);
+  await page.getByRole('button', { name: 'Apply Label', exact: true }).click();
+  await closeEditor(page);
+  return target;
+};
+
+const labelIntent = state => ({ labels: state.labels, bulk: state.bulkLabels,
+  sources: state.labelSources, visibility: state.visibility });
+
+for (const mode of ['circular', 'linear']) {
+  test(`@pr-smoke ${mode} label intent survives mode Undo/Redo and Save/Load/Generate`, async ({ browser }, testInfo) => {
+    test.setTimeout(360000);
+    const page = await load(browser, seeds[mode]);
+    let fresh;
+    const text = 'MODE_RETAINED_LABEL';
+    try {
+      await generate(page);
+      await rename(page, text);
+      const edited = await snapshot(page);
+      expect(Object.values(edited.labels)).toContain(text);
+      expect(edited.mounted).toContain(text);
+      const temporary = mode === 'circular' ? 'linear' : 'circular';
+      await switchMode(page, temporary);
+      expect.soft(labelIntent(await snapshot(page))).toEqual(labelIntent(edited));
+      expect((await snapshot(page)).featureCount).toBe(0);
+      await switchMode(page, mode);
+      const check = async name => {
+        const returned = await snapshot(page);
+        await testInfo.attach(name, { body: JSON.stringify(returned), contentType: 'application/json' });
+        expect.soft(labelIntent(returned)).toEqual(labelIntent(edited));
+        expect.soft(returned.mounted).toContain(text);
+        expect.soft(returned.result).toContain(text);
+      };
+      await check('returned');
+      for (const action of ['Undo', 'Redo']) {
+        for (const expectedMode of [temporary, mode]) {
+          await page.getByRole('button', { name: action, exact: true }).click();
+          await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(expectedMode);
+          expect.soft(labelIntent(await snapshot(page))).toEqual(labelIntent(edited));
+        }
+        await check(action);
+      }
+      const file = testInfo.outputPath('roundtrip.gbdraw-session.json.gz');
+      await download(page, 'Save Session', file);
+      fresh = await load(browser, file);
+      expect.soft(labelIntent(await snapshot(fresh))).toEqual(labelIntent(edited));
+      await generate(fresh);
+      expect.soft((await snapshot(fresh)).mounted).toContain(text);
+      await generate(page);
+      expect.soft((await snapshot(page)).mounted).toContain(text);
+      expect(page.externalRequests).toEqual([]);
+      expect(fresh.externalRequests).toEqual([]);
+    } finally {
+      await page.context().close();
+      if (fresh) await fresh.context().close();
+    }
+  });
+}
+
+test('label visibility intent survives mode inactivity and regeneration', async ({ browser }, testInfo) => {
+  test.setTimeout(240000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    const target = await popup(page);
+    await expect(page.locator(`.origin-top text[data-label-feature-id="${target.featureId}"]`)).toBeVisible();
+    await page.locator('.feature-popup select').filter({ has: page.locator('option[value="on"]')
+      .filter({ hasText: 'On (force show, bypass filters)' }) }).selectOption('off');
+    await page.getByRole('button', { name: 'Apply Label', exact: true }).click();
+    await closeEditor(page);
+    const edited = await snapshot(page);
+    expect(Object.values(edited.visibility)).toEqual(['off']);
+    const visible = () => page.locator(`.origin-top text[data-label-feature-id="${target.featureId}"]`).isVisible();
+    expect(await visible()).toBe(false);
+    await switchMode(page, 'linear');
+    await switchMode(page, 'circular');
+    expect.soft((await snapshot(page)).visibility).toEqual(edited.visibility);
+    expect.soft(await visible()).toBe(false);
+    await generate(page);
+    expect.soft((await snapshot(page)).visibility).toEqual(edited.visibility);
+    expect.soft(await visible()).toBe(false);
+    await testInfo.attach('visibility-state', { body: JSON.stringify(await snapshot(page)), contentType: 'application/json' });
+  } finally { await page.context().close(); }
+});
+
+test('an applicable bulk label override remains dormant across mode navigation', async ({ browser }, testInfo) => {
+  test.setTimeout(240000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    await popup(page);
+    await closeEditor(page);
+    // Seed the existing bulk representation through the Session feature-state owner.
+    // Normal feature scope UI resolves matching labels into feature-specific keys.
+    await page.evaluate(async () => {
+      const { buildFeatureStateData, applyFeatureStateData } = await import('./js/services/config.js');
+      applyFeatureStateData({ ...buildFeatureStateData(),
+        labelTextBulkOverrides: { 'tRNA-Phe': 'BULK_RETAINED_LABEL' } });
+      window.__GBDRAW_APP__.syncLabelEditor();
+    });
+    const before = await snapshot(page);
+    expect(before.bulkLabels).toEqual({ 'tRNA-Phe': 'BULK_RETAINED_LABEL' });
+    expect(before.mounted).toContain('BULK_RETAINED_LABEL');
+    await switchMode(page, 'linear');
+    expect.soft((await snapshot(page)).bulkLabels).toEqual(before.bulkLabels);
+    await switchMode(page, 'circular');
+    expect.soft((await snapshot(page)).bulkLabels).toEqual(before.bulkLabels);
+    expect.soft((await snapshot(page)).mounted).toContain('BULK_RETAINED_LABEL');
+    await generate(page);
+    expect.soft((await snapshot(page)).mounted).toContain('BULK_RETAINED_LABEL');
+    await testInfo.attach('bulk-state', { body: JSON.stringify(await snapshot(page)), contentType: 'application/json' });
+  } finally { await page.context().close(); }
+});
+
+test('incompatible source replacement reconciles old label intent after a mode round trip', async ({ browser }) => {
+  test.setTimeout(240000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    await rename(page, 'SOURCE_A_ONLY_LABEL');
+    const edited = await snapshot(page);
+    await switchMode(page, 'linear');
+    await switchMode(page, 'circular');
+    expect.soft((await snapshot(page)).labels).toEqual(edited.labels);
+    await page.getByLabel('GenBank/DDBJ File', { exact: true }).setInputFiles('examples/MellatMJNV.gb');
+    await expect.poll(() => page.evaluate(async () =>
+      (await import('./js/state.js')).state.circularRecordDiscovery.status)).toBe('ready');
+    await generate(page);
+    const replaced = await snapshot(page);
+    expect(replaced.labels).toEqual({});
+    expect(replaced.mounted).not.toContain('SOURCE_A_ONLY_LABEL');
+    expect(replaced.result).not.toContain('SOURCE_A_ONLY_LABEL');
+  } finally { await page.context().close(); }
+});
+
+test('feature visibility overrides and qualifier rules survive mode navigation', async ({ browser }) => {
+  test.setTimeout(240000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    await popup(page);
+    await page.getByLabel('Feature visibility', { exact: true }).selectOption('off');
+    if (await page.getByRole('heading', { name: 'Feature Visibility Scope', exact: true }).isVisible()) {
+      await page.getByText('This feature', { exact: true }).click();
+    }
+    await closeEditor(page);
+    await popup(page, 1);
+    await page.getByLabel('Feature visibility', { exact: true }).selectOption('off');
+    await page.getByText(/^Exact product:/).click();
+    await closeEditor(page);
+    const before = await snapshot(page);
+    expect(Object.values(before.featureVisibility)).toEqual(['off']);
+    expect(before.visibilityRules).toHaveLength(1);
+    await switchMode(page, 'linear');
+    await switchMode(page, 'circular');
+    const after = await snapshot(page);
+    expect.soft(after.featureVisibility).toEqual(before.featureVisibility);
+    expect.soft(after.visibilityRules).toEqual(before.visibilityRules);
+    await generate(page);
+    const generated = await snapshot(page);
+    expect.soft(generated.featureVisibility).toEqual(before.featureVisibility);
+    expect.soft(generated.visibilityRules).toEqual(before.visibilityRules);
+  } finally { await page.context().close(); }
+});


### PR DESCRIPTION
## Plain-language summary

Switching between Circular and Linear could erase edited labels and visibility settings even when the underlying genome had not changed. This PR retains those edits while their diagram mode is inactive and restores the compatible editor projection when the user returns. Replacing the genome still uses the existing identity reconciliation to clear incompatible label overrides.

## Change class

- [x] STANDARD

## Purpose

Fix 05A2-01 against `dev` at `58dcd1c1359aa01ee68c8ce772989b9ea7d80f9a`, following the independently reviewed Result remount correction in #499. The initial M01/M02/M07 reproductions matched retained 05A2 observations exactly on the starting source `a4516af4703ab048a61845417fd405d416022dcf`.

## User-visible impact

Feature-specific label text, bulk label text, label visibility, feature visibility and qualifier rules survive a mode round trip, mode Undo/Redo, and Save/Load/Generate. The inactive mode may have no projected feature list. Navigation does not generate a diagram or copy the active draft into the committed Result.

## Changes

- `app/watchers.js` stops deleting durable label and visibility intent and the label reconciliation context during mode navigation. It still clears extracted/editor projections, selector caches, popups and other transient UI state.
- `app/feature-editor/label-actions.js` defers label synchronization when the retained Result's generated mode is inactive. This keeps bulk-only overrides from being mistaken for an incompatible source change. The existing label identity reconciler still owns genuine source replacement.
- Add six browser regressions and correct the shared test helper to return the actual SVG feature ID for a positive label-visibility assertion.
- Reduce the composite Session PR smoke input from six Vibrio replicons to three real plasmids, as requested in review. Build its matching SVG/catalog through the normal CLI writer. The six-source grid/batch and CLI sidecar tests retain the original Gallery fixture.

## Verification

- On the exact untouched starting source, all six new editor-state cases fail on deleted intent. The incompatible-source control still clears the old label after Generate; its before-fix failure is the preceding same-source navigation assertion.
- On the candidate, all 12 tests pass: six new editor-state tests, four independent Result/root/export regressions from #499, and two preview-navigation tests.
- Thirty existing mode/identity, History, feature-fill, depth/session and active-Result transaction browser cases pass. Two additional live Feature/Label editor cases pass.
- Nine focused Node suites pass, covering session draft/request authority, History, feature visibility/actions, label slots, PreviewRuntime and SVG Result ingestion.
- Both Circular and Linear label tests cover mode Undo/Redo, fresh Save/Load/Generate and repeated Generate. Other cases cover label visibility, bulk-only intent, feature visibility rules and incompatible genome replacement.
- Browser checks use fresh Chromium contexts, source-matching wheel bytes and blocked external requests. No timeout or CI configuration changes. The composite PR smoke keeps its ordering, byte identity, lazy decoding, Save/Load/Generate, replacement and mobile assertions with the smaller input.
- The approved runtime passes all 42 focused browser cases, two live editor/export neighbors and nine Node suites after evidence recovery. The reduced composite smoke passes locally in 26.2 seconds. Its three components contain 1,401,004 bytes instead of 17,456,260 bytes; full six-component acceptance remains in the existing detailed tests.

## Risk and review notes

Architecture classification: ordinary non-increasing, architecture-bearing owner correction; no exception applies. Durable intent stays with the current editor owners, the retained Result catalog supplies mode-local feature projections, and the existing label context reconciler handles source invalidation. Removing the mode watcher's competing deletion reduces responsibility overlap; no state store, identity namespace, cache, persistence schema, dependency or watcher is added. `OE`, `PE` and `CB` do not increase.

Gate: the deterministic Web architecture check passes with no inventory changes. Review: REQUIRED for the ownership correction; `architecture-change` applies. Production changes are confined to two files, with six added and ten removed lines. Human review approved the runtime at `b6a2b68ae6f863a1e8dc4eaad2b36660a2400439`; the subsequent requested test-data reduction leaves all production bytes unchanged. Documentation, generated artifacts, release/tag/publishing files and 05A2-03 are outside this diff.

## Rollback

Revert this PR's commit. The independently accepted SVG remount fix in #499 remains valid.

## Conditional Product Impact

- Role: IMPLEMENTATION.
- Preflight: IMPLEMENT_EXISTING_AUTHORITY. Base `OPTION_INTEGRITY_PRODUCT_CONTRACT.md` OIPC-C05/C06 preserves valid intent across mode inactivity and requires explicit clearing; the Web live-edit contract requires canonical edits to survive subsequent generation and persistence.
- Registered Product Impact delta: none. No unresolved Product choice, retired outcome or new compatibility contract.
- Residual scope: representative label and visibility identities in both modes; the bulk-only case seeds the existing representation through the Session feature-state owner, then exercises real browser navigation and Generate. This is focused remediation acceptance, not the full adversarial journey sweep or S11 reacceptance.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

05A2-03 remains OPEN, nonblocking for this remediation transaction. Historical S11 acceptance is retained, S11 reacceptance is REQUIRED, and no replacement technical baseline is assigned. S12 remains BLOCKED and PUBLICATION_CANDIDATE_SHA remains UNASSIGNED.

The initial CI smoke and one identical retry reached the existing 15-minute job limit after 22 and 24 passing cases. The test-data reduction addresses that measured overhead; no required gate is bypassed.
