### PR TITLE
Fix the Vue warning on Circular option labels

### DIFF
--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -3362,6 +3362,7 @@ export const createAppSetup = () => {
     hasCircularDepthFiles,
     hasLinearDepthFiles,
     canShowDepthTrack,
+    enabledOptionClass,
     depthToggleOptionClass,
     depthTrackCountLabel,
     getDepthTrackLabel,

--- a/tests/web/depth-track-session.playwright.spec.js
+++ b/tests/web/depth-track-session.playwright.spec.js
@@ -262,6 +262,25 @@ test('Circular GFF3 mode exposes one annotation and one FASTA uploader', async (
   await expect(page.getByLabel('FASTA File', { exact: true })).toHaveCount(1);
 });
 
+test('Circular enabled options render without an undefined-property warning', { tag: '@pr-smoke' }, async ({ page }) => {
+  const warnings = [];
+  page.on('console', (message) => {
+    if (message.type() === 'warning' && message.text().includes('enabledOptionClass')) {
+      warnings.push(message.text());
+    }
+  });
+  await openApp(page, { waitForPalette: false });
+
+  for (const name of ['Separate Strands', 'Resolve Overlaps']) {
+    const checkbox = page.getByRole('checkbox', { name, exact: true });
+    await expect(checkbox).toBeEnabled();
+    const label = checkbox.locator('..');
+    await expect.soft(label).toHaveClass(/\btext-slate-700\b/);
+    await expect.soft(label).toHaveClass(/\bcursor-pointer\b/);
+  }
+  expect(warnings).toEqual([]);
+});
+
 test('Show Depth stays disabled until a depth TSV is uploaded', async ({ page }) => {
   await openApp(page, { waitForPalette: false });
 


### PR DESCRIPTION
## Plain-language summary

Circular's Separate Strands and Resolve Overlaps controls emit Vue warnings because their enabled style is missing from the setup bindings. This PR exposes the existing style constant so both labels receive their intended classes and render without that warning.

## Change class

- [x] STANDARD

## Purpose

Fix 05A2-03 only (P3, A / local), reproduced on exact remote `dev` at
`c7b681687e409a1813ffb88e7550abf3a13385b5`. Required admission checks are
`PR / gate` and `Web base policy (trusted base)`.

## User-visible impact

The two existing Circular checkbox labels receive `text-slate-700 cursor-pointer`.
Both controls already toggle their existing state correctly on the base; no
functional defect beyond the warning and missing styling is established.

## Changes

- Production: one added line in `gbdraw/web/js/app/app-setup.js`, returning the
  already-defined `enabledOptionClass`. The direct template bindings are at
  `gbdraw/web/index.html:2843` and `gbdraw/web/index.html:2850`. The returned object
  omitted the constant; the neighboring `disabledOptionClass` already works
  through the closure of the returned `depthToggleOptionClass` computed value.
- Test: add one focused `@pr-smoke` case to
  `tests/web/depth-track-session.playwright.spec.js`, asserting both controls are
  enabled, both expected label classes are present, and no console warning names
  `enabledOptionClass`. Other Vue warnings are outside this assertion.

## Verification

- Exact warning: `[Vue warn]: Property "enabledOptionClass" was accessed during render but is not defined on instance.` followed by `at <App>`.
- Three fresh 1600x1000 Chromium contexts and one fresh 390x844 context each
  reproduce **4 initial warnings / 14 after toggling and restoring both controls**
  on the base. Identical corrected-source runs each produce **0 / 0** warnings,
  the expected classes and successful state round trips. External requests are
  blocked; none are attempted, and no page errors occur.
- The new regression fails on the base on both absent classes and the targeted
  warning, then passes with the one-line correction.
- **16 focused browser tests pass**: the warning regression, five existing
  Circular/track neighbors and all ten accepted 05A2-01/02 mode-transition cases.
  The same ten cases pass before the correction. Their tests and production
  owners are unchanged.
- Eight focused Node suites pass before and after correction, covering setup
  wiring, session draft authority, Circular slots, slot display/validation,
  depth state, current option values and mode profiles.
- Web architecture/change-budget check: **Gate PASS / Review CLEAR**, ordinary
  profile, one production file and one added line; every inventory delta is zero.
- All **137 architecture contract tests pass**.
- The locally built browser wheel matches all 207 Python source members. No
  timeout, workflow, existing assertion or fixture is changed.

## Risk and review notes

This is not architecture-bearing. The existing setup owner supplies its existing
constant to its existing template consumers. No semantic owner, canonical or
compatibility path, module export, reactive owner, watcher, lifecycle or persisted
contract changes. `OE` / `PE` / `CB`: N/A. No architecture exception or
`architecture-change` label applies. Production and test diffs were reviewed
separately; documentation and generated artifacts are outside the diff.

## Rollback

Revert this commit.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION.
- Product preflight classification: N/A. Restoring the existing style binding
  introduces no unresolved material Product outcome or new supported behavior.
- The base Web contract assigns composition/dependency wiring to `app-setup.js`.
  No registered Product Impact delta, Product decision or new authority applies.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->

This session does not start the full 48-journey rerun or S11 reacceptance and does
not assign a replacement technical baseline. S11 reacceptance remains REQUIRED;
S12 remains BLOCKED; PUBLICATION_CANDIDATE_SHA remains UNASSIGNED.
