### PR TITLE
Restore comparison commands as separate Undo steps

### DIFF
--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -1750,7 +1750,7 @@
                                     >Clear comparison</button>
                                 </div>
                             </div>
-                            <div role="group" aria-label="Set all adjacent comparisons" data-capture="linear-blast-source" class="linear-comparison-actions">
+                            <div role="group" aria-label="Set all adjacent comparisons" data-history-managed data-capture="linear-blast-source" class="linear-comparison-actions">
                                 <button type="button" aria-label="Set no comparison" @click="setLinearComparisonGlobalAction('none')" :class="linearComparisonGlobalAction === 'none' ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'" class="btn rounded-lg border text-xs font-bold shadow-sm">No comparison</button>
                                 <button type="button" aria-label="Run LOSAT for all adjacent pairs" @click="setLinearComparisonGlobalAction('losat')" :class="linearComparisonGlobalAction === 'losat' ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'" class="btn rounded-lg border text-xs font-bold shadow-sm">Run LOSAT</button>
                                 <button type="button" aria-label="Use uploaded BLAST TSV for all adjacent pairs" @click="setLinearComparisonGlobalAction('upload')" :class="linearComparisonGlobalAction === 'upload' ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-50'" class="btn rounded-lg border text-xs font-bold shadow-sm">Upload BLAST TSV</button>

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -476,11 +476,11 @@ export const createAppSetup = () => {
     if (invalidate) invalidateLinearComparisonArtifacts();
   };
 
-  const mutateLinearComparisonPlan = (mutator) => {
+  const mutateLinearComparisonPlan = (mutator) => history.runUndoable('Change comparisons', () => {
     const next = normalizeLinearComparisonPlan(linearComparisonPlan);
     mutator(next);
     replaceLinearComparisonPlan(next);
-  };
+  });
 
   const effectiveLinearComparisonLayout = () => (
     linearRecordLayoutEnabled.value ? linearRecordRows : []
@@ -616,7 +616,7 @@ export const createAppSetup = () => {
 
   const setLinearComparisonGlobalAction = (action) => {
     const normalized = String(action || '').trim().toLowerCase();
-    mutateLinearComparisonPlan((next) => {
+    return mutateLinearComparisonPlan((next) => {
       if (normalized === 'none') {
         next.mode = LINEAR_COMPARISON_MODES.NONE;
         return;

--- a/tests/web/comparison-ui.playwright.spec.js
+++ b/tests/web/comparison-ui.playwright.spec.js
@@ -517,11 +517,11 @@ test('preserved imported comparison generates only after explicit inheritance', 
 
 test('LOSAT and LOSATP modes own their controls and mixed plans require explicit topology change', async ({ page }) => {
   await openLinear(page);
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
     app.addLinearSeq();
     app.addLinearSeq();
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
   });
   await comparisonSettings(page).locator('summary').click();
   const losatMode = page.getByRole('group', { name: 'LOSAT Mode' });
@@ -676,10 +676,10 @@ test('LOSAT and LOSATP modes own their controls and mixed plans require explicit
 
 test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and filters', async ({ page }) => {
   await openLinear(page);
-  const transitions = await page.evaluate(() => {
+  const transitions = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
     app.addLinearSeq();
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastn');
     app.losat.blastn.task = 'dc-megablast';
     Object.assign(app.losat.blastp, {
@@ -783,7 +783,7 @@ test('LOSAT and LOSATP mode setters preserve inactive drafts, appearance, and fi
 test('comparison controls drive appearance and current Session round trips', async ({ page }) => {
   test.setTimeout(600000);
   await openLinear(page);
-  await page.evaluate((records) => {
+  await page.evaluate(async (records) => {
     const app = window.__GBDRAW_APP__;
     if (app.linearSeqs.length < 2) app.addLinearSeq();
     records.forEach((content, index) => app.setLinearSeqPrimaryFile(
@@ -801,7 +801,7 @@ test('comparison controls drive appearance and current Session round trips', asy
       show_depth: false,
       show_labels_linear: 'none'
     });
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastp');
     app.setLinearComparisonLosatpMode('pairwise');
   }, [makeGenbank('Ui04A', 'atg'), makeGenbank('Ui04B', 'gct')]);
@@ -909,9 +909,9 @@ test('comparison controls drive appearance and current Session round trips', asy
   expect(taller.style).toBe('curve');
   expect(taller.path).not.toBe(curve.path);
 
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastp');
     app.setLinearComparisonLosatpMode('collinear');
     app.sessionTitle = 'ui04-comparison-controls';
@@ -1010,7 +1010,7 @@ test('structured comparison errors open and focus their owning disclosure', asyn
   await configureRecords();
   const missingUpload = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     const edgeKey = app.linearComparisonResolution.edges[0].edgeKey;
     app.setLinearComparisonGapAction(edgeKey, 'upload');
     document.querySelector('[data-linear-comparison-disclosure="selected-pairs"]')?.removeAttribute('open');
@@ -1040,7 +1040,7 @@ test('structured comparison errors open and focus their owning disclosure', asyn
   await configureRecords();
   const selectedCollinear = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastp');
     app.setLinearComparisonLosatpMode('collinear');
     const edgeKey = app.linearComparisonResolution.edges[0].edgeKey;

--- a/tests/web/composition-layout-real.playwright.spec.js
+++ b/tests/web/composition-layout-real.playwright.spec.js
@@ -67,7 +67,7 @@ const renderRealDiagram = async (
     } else {
       app.lInputType = 'gb';
       app.setLinearSeqPrimaryFile(0, 'gb', input);
-      app.setLinearComparisonGlobalAction('none');
+      await app.setLinearComparisonGlobalAction('none');
       app.setLinearTrackSlotsEnabled(false);
     }
     await window.Vue.nextTick();

--- a/tests/web/gallery-session-regeneration.playwright.spec.js
+++ b/tests/web/gallery-session-regeneration.playwright.spec.js
@@ -58,7 +58,7 @@ test('uncached protein LOSAT helpers and render share one lazy Worker runtime', 
     const { state } = await import('/gbdraw/web/js/state.js');
     state.losatCache.value.clear();
     state.losatDerivedCache.value.clear();
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastp');
     app.setLinearComparisonLosatpMode('pairwise');
     return {

--- a/tests/web/generation-feedback.playwright.spec.js
+++ b/tests/web/generation-feedback.playwright.spec.js
@@ -163,7 +163,7 @@ test('Linear comparison preparation, real search counts, cache reuse, and no-com
     for (let i = 0; i < 2; i += 1) {
       app.setLinearSeqPrimaryFile(i, 'gb', new File([content], `record-${i}.gbk`, { type: 'text/plain' }));
     }
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     await window.Vue.nextTick();
   }, source);
   await generate(page).click();

--- a/tests/web/history-comparison.playwright.spec.js
+++ b/tests/web/history-comparison.playwright.spec.js
@@ -1,0 +1,43 @@
+const { test, expect } = require('@playwright/test');
+const { load, generate } = require('./helpers/mode-transition.cjs');
+
+test('comparison off has its own Undo step after a record definition edit @pr-smoke', async ({ browser }) => {
+  test.setTimeout(300000);
+  const page = await load(browser, 'tests/test_inputs/BGC0000708-BGC0000713.gbdraw-session.json');
+  try {
+    await generate(page);
+    const baseline = await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount());
+    await page.getByRole('button', { name: 'Record options for sequence 2', exact: true }).click();
+    const definition = page.getByLabel('Definition for sequence 2', { exact: true });
+    await definition.fill('HISTORY_RECORD_TWO');
+    await definition.press('Tab');
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(baseline + 1);
+    const before = await page.evaluate(async () => ({
+      plan: (await import('./js/services/config.js')).buildConfigData().linearComparisonPlan,
+      result: window.__GBDRAW_APP__.results[0].content
+    }));
+    await page.getByRole('button', { name: 'Set no comparison', exact: true }).click();
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.linearComparisonPlan.mode)).toBe('none');
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(baseline + 2);
+    await page.getByRole('button', { name: 'Undo', exact: true }).click();
+    await expect.poll(() => page.evaluate(async () =>
+      (await import('./js/services/config.js')).buildConfigData().linearComparisonPlan)).toEqual(before.plan);
+    await expect(definition).toHaveValue('HISTORY_RECORD_TWO');
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.results[0].content)).toBe(before.result);
+    await page.getByRole('button', { name: 'Redo', exact: true }).click();
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.linearComparisonPlan.mode)).toBe('none');
+    await expect(definition).toHaveValue('HISTORY_RECORD_TWO');
+    await page.getByRole('button', { name: 'Set no comparison', exact: true }).click();
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(baseline + 2);
+    const losat = page.getByRole('button', { name: 'Run LOSAT for all adjacent pairs', exact: true });
+    await losat.focus();
+    await losat.press('Enter');
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(baseline + 3);
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.linearComparisonPlan.mode)).toBe('none');
+    await expect(definition).toHaveValue('HISTORY_RECORD_TWO');
+    expect(page.externalRequests).toEqual([]);
+  } finally {
+    await page.context().close();
+  }
+});

--- a/tests/web/linear-multi-record.playwright.spec.js
+++ b/tests/web/linear-multi-record.playwright.spec.js
@@ -315,7 +315,7 @@ test('Pairwise pointer feedback commits selection and preserves keyboard focus',
 test('Linear record rows and N-to-M comparison batches remain keyed by sequence uid', async ({ page }) => {
   await openApp(page, { waitForPalette: false });
 
-  const setup = await page.evaluate(() => {
+  const setup = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     app.addLinearSeq();
@@ -331,7 +331,7 @@ test('Linear record rows and N-to-M comparison batches remain keyed by sequence 
     app.setLinearRecordRow(app.linearSeqs[1].uid, 1);
     app.setLinearRecordRow(app.linearSeqs[2].uid, 2);
     app.setLinearRecordRow(app.linearSeqs[3].uid, 2);
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     return {
       uids: app.linearSeqs.map((item) => item.uid),
       tokens: app.linearLayoutTokens,
@@ -429,14 +429,14 @@ test('Linear records precede comparison pairs in DOM and keyboard order at narro
   await page.setViewportSize({ width: 390, height: 844 });
   await openApp(page, { waitForPalette: false });
 
-  const uids = await page.evaluate(() => {
+  const uids = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     while (app.linearSeqs.length < 5) app.addLinearSeq();
     app.linearSeqs.forEach((sequence, index) => {
       sequence.definition = `Timeline record ${index + 1}`;
     });
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     return app.linearSeqs.map((sequence) => sequence.uid);
   });
   const edgeKeys = uids.slice(0, -1).map((uid, index) => `${uid}->${uids[index + 1]}`);
@@ -595,7 +595,7 @@ test('Linear region controls do not overlap at supported sidebar widths', async 
 test('Selected pairs focuses Add and repairs an unplaced draft in its boundary', async ({ page }) => {
   await openApp(page, { waitForPalette: false });
 
-  const uids = await page.evaluate(() => {
+  const uids = await page.evaluate(async () => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     app.addLinearSeq();
@@ -603,7 +603,7 @@ test('Selected pairs focuses Add and repairs an unplaced draft in its boundary',
     app.linearSeqs.forEach((sequence, index) => {
       sequence.definition = `Advanced record ${index + 1}`;
     });
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.clearSelectedLinearComparisons();
     return app.linearSeqs.map((sequence) => sequence.uid);
   });
@@ -725,7 +725,7 @@ test('Normalize Record Lengths rejects a shared Linear row and remains recoverab
   test.setTimeout(300000);
   await installDiagramRequestObserver(page);
   await openApp(page, { waitForPalette: false });
-  const sharedRowUids = await page.evaluate((records) => {
+  const sharedRowUids = await page.evaluate(async (records) => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     app.lInputType = 'gb';
@@ -744,7 +744,7 @@ test('Normalize Record Lengths rejects a shared Linear row and remains recoverab
       show_labels_linear: 'none',
       normalize_length: true
     });
-    app.setLinearComparisonGlobalAction('none');
+    await app.setLinearComparisonGlobalAction('none');
     app.setLinearRecordLayoutEnabled(true);
     app.setLinearRecordRow(app.linearSeqs[0].uid, 1);
     app.setLinearRecordRow(app.linearSeqs[1].uid, 1);
@@ -839,7 +839,7 @@ test('No comparison completes a real render without touching dormant comparison 
       included: true, fileActive: true, losatFilenameActive: true,
       source: 'upload', file: dormant, losatFilename: 'dormant-losat-name.tsv'
     });
-    app.setLinearComparisonGlobalAction('none');
+    await app.setLinearComparisonGlobalAction('none');
     const rawCache = new Map([['dormant-cache', { text: 'must remain unread' }]]);
     const nativeGet = rawCache.get.bind(rawCache);
     window.__GBDRAW_CACHE_LOOKUPS__ = 0;
@@ -954,7 +954,7 @@ test('Automatic Linear renders every record from one GenBank source and survives
   await openApp(page);
 
   const sourceName = 'automatic-multi-record.gbk';
-  await page.evaluate(({ content, name }) => {
+  await page.evaluate(async ({ content, name }) => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     app.lInputType = 'gb';
@@ -975,7 +975,7 @@ test('Automatic Linear renders every record from one GenBank source and survives
       show_depth: false,
       show_labels_linear: 'none'
     });
-    app.setLinearComparisonGlobalAction('none');
+    await app.setLinearComparisonGlobalAction('none');
     app.sessionTitle = 'automatic-multi-record';
   }, {
     content: makeComparisonGenbank('AutomaticA', 'atg') +
@@ -1313,7 +1313,7 @@ test('Sparse upload and mixed selected renders keep snapshots and raw cache iden
     };
   });
   await openApp(page, { waitForPalette: false });
-  const [uidA, uidB, uidC] = await page.evaluate((records) => {
+  const [uidA, uidB, uidC] = await page.evaluate(async (records) => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     app.lInputType = 'gb';
@@ -1326,7 +1326,7 @@ test('Sparse upload and mixed selected renders keep snapshots and raw cache iden
       legend: 'bottom', show_gc: false, show_skew: false,
       show_depth: false, show_labels_linear: 'none'
     });
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastp');
     app.setLinearComparisonLosatpMode('collinear');
     app.setLinearComparisonLosatMode('blastn');
@@ -1434,8 +1434,8 @@ test('Sparse upload and mixed selected renders keep snapshots and raw cache iden
 
   await page.evaluate(() => { window.__GBDRAW_MIXED_RUN__ = window.__GBDRAW_APP__.runAnalysis(); });
   await page.waitForFunction(() => window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ === 1);
-  await page.evaluate(() => {
-    window.__GBDRAW_APP__.setLinearComparisonGlobalAction('none');
+  await page.evaluate(async () => {
+    await window.__GBDRAW_APP__.setLinearComparisonGlobalAction('none');
     window.__GBDRAW_RELEASE_LOSAT__();
   });
   const firstMixed = await page.evaluate(async () => {
@@ -2367,7 +2367,7 @@ test('derived protein options reach Generate without changing raw search identit
   });
   await openApp(page, { waitForPalette: false });
 
-  await page.evaluate((records) => {
+  await page.evaluate(async (records) => {
     const app = window.__GBDRAW_APP__;
     app.mode = 'linear';
     app.lInputType = 'gb';
@@ -2387,7 +2387,7 @@ test('derived protein options reach Generate without changing raw search identit
       show_depth: false,
       show_labels_linear: 'none'
     });
-    app.setLinearComparisonGlobalAction('losat');
+    await app.setLinearComparisonGlobalAction('losat');
     app.setLinearComparisonLosatMode('blastp');
     app.setLinearComparisonLosatpMode('collinear');
     app.losat.executionMode = 'serial';


### PR DESCRIPTION
## Plain-language summary

Changing all adjacent comparisons now creates its own Undo step. After editing a record definition and choosing No comparison, Undo restores the comparison plan while keeping the definition edit. The three comparison commands use their existing mutation owner and History transaction.

## Change class

- [x] STANDARD

## Purpose

Fix 05A4-02 on base `dev` at `0e5d70750bd6dd6ec07c778042b192b709db43ca`.
Required checks are `Web base policy (trusted base)` and `PR / gate`.

## Changes

- Production: `gbdraw/web/js/app/app-setup.js` runs the existing comparison mutation through `history.runUndoable` and returns its completion promise. `gbdraw/web/index.html` marks that command group as managed by the owner.
- Root cause: the generic pointer/focus adapter can share a pending input transaction with a comparison button; focus-out closes that transaction, leaving the comparison change without its own committed entry.
- History owner: `mutateLinearComparisonPlan` changes the plan and invalidates derived comparison artifacts; `services/history.js` and `services/history-snapshot.js` already capture and restore its config/file intent domains.
- Tests: add `history-comparison.playwright.spec.js` for off/Undo/Redo, preserving the previous definition and Result, no-op activation, and keyboard activation. Direct test callers await the comparison transaction before inspecting or changing its output.

## Verification

- Exact-base regression fails: expected 3 Undo entries after No comparison, received 2.
- Fixed regression passes, including keyboard and repeated no-op commands.
- 30 comparison, Linear multi-record, and generation-feedback browser tests pass.
- Both existing keyboard/pointer History-input browser tests pass, including Save/fresh Load/Generate.
- 16 focused Node checks pass across History, History inputs, comparison UI, and comparison plan tests.
- Local Web change gate: `PASS`; executable review: `CLEAR`.
- Browser wheel prepared with `python tools/prepare_browser_wheel.py --no-build-isolation`; generated wheel is not included.

## Risk and review notes

This is not architecture-bearing: the comparison mutation, intent snapshot, request/session projection, and single History stack keep their existing owners. The existing mutation now participates in its transaction; no owner, canonical path, compatibility path, or dependency is added. Production and test diffs were reviewed separately. Comparison actions are asynchronous History operations, so direct callers must await completion.

Product preflight: `IMPLEMENT_EXISTING_AUTHORITY`, preserving the supported form-edit Undo/Redo contract in `docs/REFERENCE/web-app.md`. No repository authority defines the comparison command as non-undoable; disclosure-only state remains excluded as documented in the comparison UI plan. No Product option is retired. This PR does not address 05A4-03, 05A4-05, or other 05A4 findings.

## Rollback

Revert this commit to restore the previous comparison command handling and caller tests.

## Conditional Product Impact

N/A: no registered Product Impact subject delta or current decision.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
