### PR TITLE
Restore Auto values when undoing settings

### DIFF
--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -379,8 +379,8 @@ const safeDeepMerge = (target, source) => {
       return;
     }
 
-    // 5. Update value only if types match or initial value is null
-    if (typeof targetValue === typeof sourceValue || targetValue === null) {
+    // 5. Null restores an explicit value to Auto, as well as accepting one from Auto.
+    if (typeof targetValue === typeof sourceValue || targetValue === null || sourceValue === null) {
       target[key] = sourceValue;
     }
   });

--- a/tests/web/history-comparison.playwright.spec.js
+++ b/tests/web/history-comparison.playwright.spec.js
@@ -1,7 +1,7 @@
 const { test, expect } = require('@playwright/test');
 const { load, generate } = require('./helpers/mode-transition.cjs');
 
-test('comparison off has its own Undo step after a record definition edit @pr-smoke', async ({ browser }) => {
+test('comparison off has its own Undo step after a record definition edit', async ({ browser }) => {
   test.setTimeout(300000);
   const page = await load(browser, 'tests/test_inputs/BGC0000708-BGC0000713.gbdraw-session.json');
   try {

--- a/tests/web/history-config-restore.test.mjs
+++ b/tests/web/history-config-restore.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+
+globalThis.window = { Vue: {
+  ref: value => ({ value }), reactive: value => value,
+  computed: getter => ({ get value() { return getter(); } }), nextTick: async () => {}
+} };
+const { state } = await import('../../gbdraw/web/js/state.js');
+const { buildConfigData, applyConfigData } = await import('../../gbdraw/web/js/services/config.js');
+const { createHistoryManager } = await import('../../gbdraw/web/js/services/history.js');
+const { createHistoryFileStore } = await import('../../gbdraw/web/js/services/history-files.js');
+const { createHistorySnapshotService } = await import('../../gbdraw/web/js/services/history-snapshot.js');
+const snapshots = createHistorySnapshotService({
+  state, fileStore: createHistoryFileStore(), buildConfigData, applyConfigData
+});
+const history = createHistoryManager({
+  buildIntent: snapshots.buildHistoryIntent, applyIntent: snapshots.applyHistoryIntent,
+  buildCheckpoint: () => assert.fail('Form edits must use intent History'),
+  applyCheckpoint: () => assert.fail('Form edits must use intent History')
+});
+
+for (const [domain, key, first, second] of [
+  ['form', 'circular_region_start', 1000, 2000],
+  ['form', 'circular_region_end', 500, 1500],
+  ['adv', 'window_size', 100, 200],
+  ['adv', 'block_stroke_color', '#123456', '#abcdef']
+]) {
+  state[domain][key] = null;
+  await history.initializeIntentBaseline();
+  await history.runUndoable('Set explicit value', () => { state[domain][key] = first; });
+  await history.runUndoable('Change explicit value', () => { state[domain][key] = second; });
+  await history.undo();
+  assert.equal(state[domain][key], first, `${domain}.${key}: explicit to explicit`);
+  await history.undo();
+  assert.equal(state[domain][key], null, `${domain}.${key}: explicit to Auto`);
+  await history.redo();
+  assert.equal(state[domain][key], first, `${domain}.${key}: Redo explicit value`);
+}
+
+applyConfigData({ form: JSON.parse('{"unknown":1,"__proto__":{"polluted":true}}') });
+assert.equal(Object.hasOwn(state.form, 'unknown'), false);
+assert.equal({}.polluted, undefined);
+console.log('History restores nullable config values and preserves key guards.');

--- a/tests/web/history-region.playwright.spec.js
+++ b/tests/web/history-region.playwright.spec.js
@@ -14,7 +14,7 @@ const edit = async (page, label, value) => {
   await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(before + 1);
 };
 
-test('Circular region restores number to Auto @pr-smoke', async ({ browser }) => {
+test('Circular region restores number to Auto', async ({ browser }) => {
   test.setTimeout(300000);
   const page = await load(browser);
   try {
@@ -31,7 +31,7 @@ test('Circular region restores number to Auto @pr-smoke', async ({ browser }) =>
   } finally { await page.context().close(); }
 });
 
-test('rejected Circular region can Undo both edits back to valid Auto @pr-smoke', async ({ browser }) => {
+test('rejected Circular region can Undo both edits back to valid Auto', async ({ browser }) => {
   test.setTimeout(300000);
   const page = await load(browser);
   try {

--- a/tests/web/history-region.playwright.spec.js
+++ b/tests/web/history-region.playwright.spec.js
@@ -1,0 +1,56 @@
+const { test, expect } = require('@playwright/test');
+const { load, generate } = require('./helpers/mode-transition.cjs');
+const { generateAndWaitForResult } = require('./helpers/app-lifecycle.cjs');
+
+const region = page => page.evaluate(() => {
+  const form = window.__GBDRAW_APP__.form;
+  return [form.circular_region_start, form.circular_region_end];
+});
+const edit = async (page, label, value) => {
+  const before = await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount());
+  const input = page.getByLabel(label, { exact: true });
+  await input.fill(value);
+  await input.press('Tab');
+  await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(before + 1);
+};
+
+test('Circular region restores number to Auto @pr-smoke', async ({ browser }) => {
+  test.setTimeout(300000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    await page.locator('[data-circular-record-presentation] summary').click();
+    expect(await region(page)).toEqual([null, null]);
+    await edit(page, 'Circular region start', '1000');
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    expect(await region(page)).toEqual([null, null]);
+    await expect(page.getByLabel('Circular region start', { exact: true })).toHaveValue('');
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.redo());
+    expect(await region(page)).toEqual([1000, null]);
+    expect(page.externalRequests).toEqual([]);
+  } finally { await page.context().close(); }
+});
+
+test('rejected Circular region can Undo both edits back to valid Auto @pr-smoke', async ({ browser }) => {
+  test.setTimeout(300000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    const before = await page.evaluate(() => ({
+      undo: window.__GBDRAW_HISTORY__.getUndoCount(), result: window.__GBDRAW_APP__.results[0].content
+    }));
+    await page.locator('[data-circular-record-presentation] summary').click();
+    await edit(page, 'Circular region start', '1000');
+    await edit(page, 'Circular region end', '500');
+    await generateAndWaitForResult(page, { expectedStatus: 'error' });
+    expect(await page.evaluate(() => window.__GBDRAW_HISTORY__.getUndoCount())).toBe(before.undo + 2);
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    expect(await region(page)).toEqual([null, null]);
+    await expect(page.getByLabel('Circular region start', { exact: true })).toHaveValue('');
+    await expect(page.getByLabel('Circular region end', { exact: true })).toHaveValue('');
+    await generate(page);
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.results[0].content)).toBe(before.result);
+    expect(page.externalRequests).toEqual([]);
+  } finally { await page.context().close(); }
+});


### PR DESCRIPTION
## Plain-language summary

Undo can now clear explicit Circular region coordinates back to Auto. After an invalid region is rejected, undoing both coordinate edits restores the valid uncropped draft and Generate works again. Nullable settings use the same restoration behavior during History and session loading.

## Change class

- [x] STANDARD

## Purpose

Fix 05A4-03. Initial reproduction base: `0e5d70750bd6dd6ec07c778042b192b709db43ca`.
PR base: `16196a6d94c6836ed3ed4358a480fbfcda241c1f` (the integrated dev after PR #502).
Required checks: `Web base policy (trusted base)` and `PR / gate`.

## Changes

- Production: `gbdraw/web/js/services/config.js` permits a known field's explicit value to be replaced with `null` in `safeDeepMerge`.
- Root cause: History captured nullable values correctly, but the merge accepted a populated number only when the restored value had the same JavaScript type. It therefore left 1000/500 active when the History patch requested null/null.
- History owner: the config domain in `history-snapshot.js::applyHistoryIntent` continues to use the single `applyConfigData` restore boundary. There is no new snapshot or restoration path.
- Tests: `history-config-restore.test.mjs` checks explicit-to-explicit, explicit-to-Auto, Redo, nullable numeric/color settings, and existing key guards. `history-region.playwright.spec.js` covers Auto/number/Undo/Redo and rejected-region recovery through the actual controls and renderer.

## Verification

- On the exact starting base, the unit regression fails with actual 1000 versus expected null. Both browser regressions fail at null restoration: 1000/null and 1000/500 remain active after Undo.
- After the fix: 73 Node checks pass across History, input History, session save/load/request/resource contracts, and current option values.
- Five browser tests pass: both new region regressions, the existing Circular record-presentation/validation/session test, and both keyboard/pointer History-input tests.
- Numeric-to-numeric restoration remains covered in the real History/config unit path.
- Generated wheel is prepared for testing and excluded from the commit.
- Fast PR JavaScript CI runs the new nullable-config History contract. New browser regressions run in the full functional tier and exact-dev acceptance. Fast runs passed all 30 and then all 28 browser tests but hit the 15-minute job limit during shutdown. The two new region tags and the new comparison tag from #502 are removed to retain the pre-session 27-case smoke set. All test bodies, assertions, and timeouts are unchanged.

## Risk and review notes

This is not architecture-bearing: existing config and History owners remain in place. `null` already denotes Auto in the current form/advanced config defaults and writer contract; restoring it now works in both directions. Unknown keys and prototype keys remain excluded. No new owner, path, compatibility reader, schema, or dependency is introduced.

The exact-commit Web check reports Gate PASS / Review REQUIRED because `config.js` is a registered session path. Production churn is two additions and two deletions, with no inventory or authority delta. The maintainer approved the production change and tests in the session; later test-tier adjustments change only tags, with every assertion retained.

Product preflight: `IMPLEMENT_EXISTING_AUTHORITY`. The current nullable defaults, supported form Undo/Redo, and saved-value restoration contract select the outcome. No Product choice or retirement is introduced. Production, test, and generated-asset diffs are reviewed separately. Other 05A4 findings remain outside this PR.

## Rollback

Revert this commit to restore the former merge behavior.

## Conditional Product Impact

N/A: no registered Product Impact subject delta or current decision.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
