### PR TITLE
Await comparison changes in offline checks and Gallery captures

### DIFF
--- a/docs/internal/WEB_GALLERY_OPERATION_SCREENSHOT_REGISTER.md
+++ b/docs/internal/WEB_GALLERY_OPERATION_SCREENSHOT_REGISTER.md
@@ -1,9 +1,20 @@
 # Web Gallery operation screenshot register
 
-Last updated: 2026-09-09
+Last updated: 2026-09-11
 
 This register records task-specific decisions for Gallery operation media.
 Capture metadata remains the executable source of truth in each tutorial JSON.
+
+## Comparison commands in History (05A4-02)
+
+Keep the existing comparison-operation media, captions, values, and crops in
+the six Linear tutorials. Their capture scripts now await the comparison
+History transaction before setting LOSAT modes or reading its state. This
+changes execution ordering only; the declared screenshot state is unchanged.
+Replay verified all 23 affected operations. Visual comparison also found
+pre-existing image drift in additional comparison/collinear controls and the
+Vibrio selected-pair count. Those images are retained under this session's
+History-only scope; this entry does not accept them as a completed image refresh.
 
 ## Annotation TSV download reconciliation
 

--- a/gbdraw/web/gallery/tutorials/BGC0000708-BGC0000713.json
+++ b/gbdraw/web/gallery/tutorials/BGC0000708-BGC0000713.json
@@ -171,7 +171,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.adv.min_bitscore = 50; app.adv.evalue = '0.01'; app.adv.identity = 30; app.adv.alignment_length = 0;"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.adv.min_bitscore = 50; app.adv.evalue = '0.01'; app.adv.identity = 30; app.adv.alignment_length = 0; }"
               }
             ],
             "selector": "[data-linear-comparison-card]",
@@ -225,7 +225,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = 'auto';"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = 'auto'; }"
               },
               {
                 "type": "waitForFunction",
@@ -284,7 +284,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -323,7 +323,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); }"
               }
             ],
             "assertAppState": {
@@ -367,7 +367,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); }"
               }
             ],
             "assertAppState": {

--- a/gbdraw/web/gallery/tutorials/hepatoplasmataceae_collinear.json
+++ b/gbdraw/web/gallery/tutorials/hepatoplasmataceae_collinear.json
@@ -127,7 +127,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -160,7 +160,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = 'auto';"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = 'auto'; }"
               },
               {
                 "type": "waitForFunction",
@@ -244,7 +244,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -293,7 +293,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearColorMode = 'orientation_identity';"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearColorMode = 'orientation_identity'; }"
               }
             ],
             "assertAppState": {
@@ -324,7 +324,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearMaxDiagonalDrift = 0; app.losat.blastp.collinearMaxConflictsInMergeGap = 1;"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearMaxDiagonalDrift = 0; app.losat.blastp.collinearMaxConflictsInMergeGap = 1; }"
               },
               {
                 "type": "waitForFunction",

--- a/gbdraw/web/gallery/tutorials/hepatoplasmataceae_orthogroup.json
+++ b/gbdraw/web/gallery/tutorials/hepatoplasmataceae_orthogroup.json
@@ -130,7 +130,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -162,7 +162,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = 'auto';"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = 'auto'; }"
               },
               {
                 "type": "waitForFunction",
@@ -240,7 +240,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -280,7 +280,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.adv.min_bitscore = 50; app.adv.evalue = '1e-2'; app.adv.identity = 0; app.adv.alignment_length = 0;"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.adv.min_bitscore = 50; app.adv.evalue = '1e-2'; app.adv.identity = 0; app.adv.alignment_length = 0; }"
               }
             ],
             "selector": "[data-capture='linear-losat-settings']",

--- a/gbdraw/web/gallery/tutorials/lambda_basic_linear.json
+++ b/gbdraw/web/gallery/tutorials/lambda_basic_linear.json
@@ -142,7 +142,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('none');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('none'); }"
               }
             ],
             "selector": "[data-linear-comparison-card]",

--- a/gbdraw/web/gallery/tutorials/majanivirus_orthogroup.json
+++ b/gbdraw/web/gallery/tutorials/majanivirus_orthogroup.json
@@ -189,7 +189,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.adv.min_bitscore = 100; app.adv.evalue = '1e-3'; app.adv.identity = 20; app.adv.alignment_length = 0;"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.adv.min_bitscore = 100; app.adv.evalue = '1e-3'; app.adv.identity = 20; app.adv.alignment_length = 0; }"
               }
             ],
             "openDetails": ["Settings"],
@@ -250,7 +250,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -286,7 +286,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = '32';"
+                "script": "async () => { const app = window.__GBDRAW_APP__; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('orthogroup'); app.losat.executionMode = 'auto'; app.losat.totalThreadBudget = 'safe'; app.losat.parallelWorkers = undefined; app.losat.threadsPerJob = '32'; }"
               },
               {
                 "type": "waitForFunction",

--- a/gbdraw/web/gallery/tutorials/vibrio-harveyi-group-collinear.json
+++ b/gbdraw/web/gallery/tutorials/vibrio-harveyi-group-collinear.json
@@ -195,7 +195,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -236,7 +236,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear');"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); }"
               },
               {"type": "wait", "ms": 300}
             ],
@@ -279,7 +279,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearColorMode = 'orientation_identity';"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearColorMode = 'orientation_identity'; }"
               }
             ],
             "assertAppState": {
@@ -317,7 +317,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); const blastp = app.losat?.blastp; if (Number(blastp?.collinearMinAnchors) !== 3 || Number(blastp?.collinearMaxUnitGap) !== 2 || Number(blastp?.collinearMaxDiagonalDrift) !== 2 || blastp?.collinearColorMode !== 'orientation_identity' || blastp?.collinearSearchScope !== 'adjacent') throw new Error(`Restored collinear settings do not match the tutorial: ${JSON.stringify(blastp)}`);"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); const blastp = app.losat?.blastp; if (Number(blastp?.collinearMinAnchors) !== 3 || Number(blastp?.collinearMaxUnitGap) !== 2 || Number(blastp?.collinearMaxDiagonalDrift) !== 2 || blastp?.collinearColorMode !== 'orientation_identity' || blastp?.collinearSearchScope !== 'adjacent') throw new Error(`Restored collinear settings do not match the tutorial: ${JSON.stringify(blastp)}`); }"
               }
             ],
             "assertAppState": {
@@ -352,7 +352,7 @@
             "actions": [
               {
                 "type": "evaluate",
-                "script": "const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearMaxDiagonalDrift = 2;"
+                "script": "async () => { const app = window.__GBDRAW_APP__; app.sidebarWidth = 480; await app.setLinearComparisonGlobalAction('losat'); app.setLinearComparisonLosatMode('blastp'); app.setLinearComparisonLosatpMode('collinear'); app.losat.blastp.collinearMaxDiagonalDrift = 2; }"
               },
               {
                 "type": "waitForFunction",

--- a/tools/verify_gui_offline.py
+++ b/tools/verify_gui_offline.py
@@ -502,7 +502,7 @@ def _verify_exports(page) -> None:
 def _verify_linear_losat(page, left_gbk: str, right_gbk: str) -> None:
     setup_state = page.evaluate(
         """
-        ({ leftText, rightText }) => {
+        async ({ leftText, rightText }) => {
           const app = window.__GBDRAW_APP__;
           app.mode = 'linear';
           app.lInputType = 'gb';
@@ -519,7 +519,7 @@ def _verify_linear_losat(page, left_gbk: str, right_gbk: str) -> None:
             'gb',
             new File([rightText], 'SARS-CoV-1.gbk', { type: 'text/plain' })
           );
-          app.setLinearComparisonGlobalAction('losat');
+          await app.setLinearComparisonGlobalAction('losat');
           if (!app.setLinearComparisonLosatMode('blastn')) {
             throw new Error('Could not select the current Linear LOSAT nucleotide mode.');
           }


### PR DESCRIPTION
## Plain-language summary

The offline LOSAT check and Gallery capture recipes now wait for comparison changes before using the resulting state. This restores the offline generation check and keeps the declared Gallery comparison settings reproducible after comparison commands became undoable.

## Change class

- [x] STANDARD

## Purpose

Complete the direct-caller migration for 05A4-02 from PR #502.
PR base: `054a9b497d82e5c25722f511f5aaa763c7b0f676` (integrated dev after PR #503).

## Changes

- `tools/verify_gui_offline.py` awaits `setLinearComparisonGlobalAction` inside its browser setup callback before checking intent and starting generation.
- Six Linear tutorial JSON files await the same transaction in 23 capture scripts before setting LOSAT modes or reading comparison state. Each script returns its completion promise to Playwright.
- The operation register records that existing media, captions, values, and crops are retained.
- No application runtime code changes. The existing comparison mutation owner and History transaction from PR #502 remain the sole path.

## Verification

- On integrated dev `16196a6d94c6836ed3ed4358a480fbfcda241c1f`, the Browser CI job failed `test_offline_gui_linear_losat_generation_populates_cache`: setup inspected comparison mode `none` before the transaction completed.
- After awaiting completion, that offline browser test and all Gallery capture contract tests pass: 25 tests total.
- Strict Gallery metadata validation passes for all ready examples.
- All 23 changed capture recipes pass their existing app-state and visible-crop assertions with review images written only under `/tmp`. Ten affected Gallery/desktop/mobile/image-view browser tests also pass.
- Visual review confirms the requested modes and values. Existing image drift in additional comparison/collinear controls and the Vibrio pair count is recorded in the operation register and left outside the History-only scope; this PR does not claim a full image refresh.
- A repository-wide search confirms every direct JavaScript, Python-embedded, and Gallery-recipe caller awaits or returns the transaction promise. Vue event handlers retain their normal asynchronous dispatch.
- All four new History browser cases are discovered by required functional CI. No test assertion, timeout, media reference, or generated asset is changed.

## Risk and review notes

This is not architecture-bearing. Existing test and capture owners consume the established comparison transaction; they add no owner, canonical path, compatibility path, public API, schema, or dependency. Production application, test tooling, documentation metadata, and temporary generated images were reviewed separately.

Product classification: N/A. This changes verification/capture execution ordering while retaining its declared user-visible state. It does not introduce a normative behavior contract or Product decision. Other 05A4 defects remain outside scope.

## Rollback

Revert this commit to restore the previous unawaited capture and check calls.

## Conditional Product Impact

N/A: no runtime or normative Product Impact change.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
