### PR TITLE
Restore canonical requests when undoing Generate

### DIFF
--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -15,6 +15,7 @@ import {
   buildOrthogroupStateData,
   buildRunStateData,
   buildUiStateData,
+  canonicalRenderArtifactOwner,
   exportSession,
   getCommittedCanonicalSession,
   getCommittedCanonicalRenderRequest,
@@ -2018,8 +2019,14 @@ export const createAppSetup = () => {
     }
   });
   historySnapshots.setGeneratedArtifactRuntimeOwner({
-    capture: captureGeneratedArtifactRuntimeState,
-    restore: restoreGeneratedArtifactRuntimeState
+    capture: () => ({
+      ...captureGeneratedArtifactRuntimeState(),
+      canonical: canonicalRenderArtifactOwner.capture()
+    }),
+    restore: (snapshot, options) => {
+      canonicalRenderArtifactOwner.restore(snapshot.canonical);
+      return restoreGeneratedArtifactRuntimeState(snapshot, options);
+    }
   });
   const resultsManager = createResultsManager({
     state,

--- a/gbdraw/web/js/services/config.js
+++ b/gbdraw/web/js/services/config.js
@@ -2879,6 +2879,14 @@ export const getCommittedCanonicalRenderRequest = () => (
 
 export const getCommittedCanonicalSession = () => committedCanonicalSession;
 
+export const canonicalRenderArtifactOwner = Object.freeze({
+  capture: () => Object.freeze({ committedCanonicalSession, activeSessionResourceTable }),
+  restore: (snapshot) => {
+    committedCanonicalSession = snapshot.committedCanonicalSession;
+    activeSessionResourceTable = snapshot.activeSessionResourceTable;
+  }
+});
+
 const applyFiles = (filesData, { adoptCanonicalPayloads = false } = {}) => {
   state.matchSequenceRegistry?.reset?.();
   state.circularRecordList.value = [];

--- a/tests/web/history-canonical-owner.test.mjs
+++ b/tests/web/history-canonical-owner.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+globalThis.window = { Vue: {
+  ref: value => ({ value }), reactive: value => value,
+  computed: getter => ({ get value() { return getter(); } }), nextTick: async () => {}
+} };
+const { state } = await import('../../gbdraw/web/js/state.js');
+const {
+  adoptCanonicalRenderArtifacts, canonicalRenderArtifactOwner,
+  getCommittedCanonicalRenderRequest, buildConfigData, applyConfigData
+} = await import('../../gbdraw/web/js/services/config.js');
+const { createHistorySnapshotService } = await import('../../gbdraw/web/js/services/history-snapshot.js');
+const { createHistoryFileStore } = await import('../../gbdraw/web/js/services/history-files.js');
+const { createHistoryManager } = await import('../../gbdraw/web/js/services/history.js');
+
+const empty = canonicalRenderArtifactOwner.capture();
+const canonical = JSON.parse(await readFile(
+  'gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json', 'utf8'
+));
+adoptCanonicalRenderArtifacts(canonical, { adoptOwnedRequest: true });
+const a = canonicalRenderArtifactOwner.capture();
+assert(Object.isFrozen(a));
+assert.strictEqual(a.committedCanonicalSession.renderRequest, getCommittedCanonicalRenderRequest());
+state.form.labels_mode = 'out';
+state.results.value = [{ name: 'a.svg', content: '<svg id="a"/>' }];
+const snapshots = createHistorySnapshotService({
+  state, fileStore: createHistoryFileStore(), buildConfigData, applyConfigData
+});
+snapshots.setGeneratedArtifactRuntimeOwner(canonicalRenderArtifactOwner);
+const history = createHistoryManager({
+  buildIntent: snapshots.buildHistoryIntent, applyIntent: snapshots.applyHistoryIntent,
+  buildCheckpoint: () => assert.fail('Generate must not clone a full checkpoint'),
+  applyCheckpoint: () => assert.fail('Generate must restore its owner handle'),
+  captureGeneratedArtifactHandle: snapshots.captureGeneratedArtifactHandle,
+  restoreGeneratedArtifactHandle: snapshots.restoreGeneratedArtifactHandle,
+  compareGeneratedArtifactHandles: snapshots.compareGeneratedArtifactHandles
+});
+await history.initializeIntentBaseline();
+await history.runUndoable('Change labels', () => { state.form.labels_mode = 'none'; });
+const next = structuredClone(canonical);
+next.renderRequest.diagramOptions.configOverrides['labels.circular.scope'] = 'none';
+await history.runUndoableArtifactReplacement('Generate diagram', () => {
+  adoptCanonicalRenderArtifacts(next, { adoptOwnedRequest: true });
+  state.results.value = [{ name: 'b.svg', content: '<svg id="b"/>' }];
+});
+const b = canonicalRenderArtifactOwner.capture();
+assert.notStrictEqual(b.activeSessionResourceTable, a.activeSessionResourceTable);
+await history.undo();
+assert.strictEqual(getCommittedCanonicalRenderRequest(), a.committedCanonicalSession.renderRequest);
+assert.strictEqual(canonicalRenderArtifactOwner.capture().activeSessionResourceTable, a.activeSessionResourceTable);
+assert.equal(state.results.value[0].name, 'a.svg');
+assert.equal(state.form.labels_mode, 'none');
+await history.redo();
+assert.strictEqual(getCommittedCanonicalRenderRequest(), b.committedCanonicalSession.renderRequest);
+assert.strictEqual(canonicalRenderArtifactOwner.capture().activeSessionResourceTable, b.activeSessionResourceTable);
+assert.equal(state.results.value[0].name, 'b.svg');
+await history.undo();
+await history.undo();
+assert.equal(state.form.labels_mode, 'out');
+
+await assert.rejects(history.runUndoableArtifactReplacement('Failed Generate', () => {
+  adoptCanonicalRenderArtifacts(next, { adoptOwnedRequest: true });
+  throw new Error('finalization failed');
+}), /finalization failed/);
+assert.strictEqual(getCommittedCanonicalRenderRequest(), a.committedCanonicalSession.renderRequest);
+assert.strictEqual(canonicalRenderArtifactOwner.capture().activeSessionResourceTable, a.activeSessionResourceTable);
+canonicalRenderArtifactOwner.restore(empty);
+assert.equal(getCommittedCanonicalRenderRequest(), null);
+assert.equal(canonicalRenderArtifactOwner.capture().activeSessionResourceTable, null);
+state.results.value = [];
+await history.initializeIntentBaseline();
+await history.runUndoableArtifactReplacement('First Generate', () => {
+  adoptCanonicalRenderArtifacts(canonical, { adoptOwnedRequest: true });
+  state.results.value = [{ name: 'first.svg', content: '<svg/>' }];
+});
+await history.undo();
+assert.equal(getCommittedCanonicalRenderRequest(), null);
+assert.equal(canonicalRenderArtifactOwner.capture().activeSessionResourceTable, null);
+assert.equal(state.results.value.length, 0);
+await history.redo();
+assert.deepEqual(getCommittedCanonicalRenderRequest(), canonical.renderRequest);
+assert.equal(state.results.value[0].name, 'first.svg');
+console.log('Generated History restores canonical request/resource owners without consuming draft History.');

--- a/tests/web/history-generated-authority.playwright.spec.js
+++ b/tests/web/history-generated-authority.playwright.spec.js
@@ -1,0 +1,81 @@
+const { test, expect } = require('@playwright/test');
+const { createHash } = require('node:crypto');
+const { gunzipSync } = require('node:zlib');
+const { load, generate, snapshot, download } = require('./helpers/mode-transition.cjs');
+
+const hash = value => createHash('sha256').update(value).digest('hex');
+const inspect = async (page, testInfo, name) => {
+  const exported = await download(page, 'SVG', testInfo.outputPath(`${name}.svg`));
+  const current = await snapshot(page);
+  const editable = await page.evaluate(async () =>
+    (await import('./js/services/config.js')).buildConfigData());
+  const mounted = await page.evaluate(async () => {
+    const { state } = await import('./js/state.js');
+    const { serializeCleanSvg } = await import('./js/services/svg-serialization.js');
+    return serializeCleanSvg(state.svgContainer.value.querySelector('svg'));
+  });
+  const result = {
+    request: current.request, editable, markedMounted: current.markedMounted,
+    selected: hash(current.result), mounted: hash(mounted), exported: hash(exported)
+  };
+  await testInfo.attach(name, { body: JSON.stringify(result), contentType: 'application/json' });
+  return result;
+};
+const expectArtifact = (actual, expected) => {
+  expect.soft(actual.selected, 'selected Result').toBe(expected.selected);
+  expect.soft(actual.mounted, 'mounted SVG').toBe(expected.mounted);
+  expect.soft(actual.exported, 'exported SVG').toBe(expected.exported);
+  expect.soft(actual.markedMounted).toBe(true);
+  expect.soft(actual.request, 'committed canonical request').toEqual(expected.request);
+};
+
+test('Undo Generate restores request A and Result A while preserving draft B through Save and fresh Load', async ({ browser }, testInfo) => {
+  test.setTimeout(360000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    const a = await inspect(page, testInfo, 'a');
+    await page.locator('summary[aria-label="Labels"]').click();
+    const labels = page.locator('#circular-label-mode');
+    await labels.focus();
+    await labels.selectOption('none');
+    await labels.press('Tab');
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_HISTORY__.undoLabel())).toBe('Change setting');
+    await generate(page);
+    const b = await inspect(page, testInfo, 'b');
+    expect(b.request).not.toEqual(a.request);
+    expect(b.selected).not.toBe(a.selected);
+
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    const restored = await inspect(page, testInfo, 'undo');
+    expectArtifact(restored, a);
+    expect(restored.editable).toEqual(b.editable);
+    await expect(labels).toHaveValue('none');
+    await page.screenshot({ path: testInfo.outputPath('undo.png') });
+
+    const path = testInfo.outputPath('undo.gbdraw-session.json.gz');
+    const saved = JSON.parse(gunzipSync(await download(page, 'Save Session', path)));
+    expect.soft(saved.renderRequest).toEqual(a.request);
+    expect(saved.config.form.labels_mode).toBe('none');
+    const fresh = await load(browser, path);
+    try {
+      const loaded = await inspect(fresh, testInfo, 'fresh-load');
+      expectArtifact(loaded, a);
+      expect(loaded.editable).toEqual(b.editable);
+      await generate(fresh);
+      expectArtifact(await inspect(fresh, testInfo, 'fresh-generate'), b);
+      expect(fresh.externalRequests).toEqual([]);
+    } finally { await fresh.context().close(); }
+
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.redo());
+    const redone = await inspect(page, testInfo, 'redo');
+    expectArtifact(redone, b);
+    expect(redone.editable).toEqual(b.editable);
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    await page.evaluate(() => window.__GBDRAW_HISTORY__.undo());
+    await expect(labels).toHaveValue('out');
+    await generate(page);
+    expectArtifact(await inspect(page, testInfo, 'undo-setting-generate'), a);
+    expect(page.externalRequests).toEqual([]);
+  } finally { await page.context().close(); }
+});


### PR DESCRIPTION
## Plain-language summary

Undo Generate now restores the canonical request and session resources belonging to the previous Result. Saving after Undo therefore writes that Result's request. The editable settings remain as they were immediately before Generate, and their earlier History step can be undone separately.

For example, generate a labeled diagram A, change Label Mode to None, and generate B. Undo restores A's selected, mounted, and exported diagram and request while keeping the None draft. Save and fresh Load preserve this state; Generate produces B. Undoing the earlier setting instead restores the labeled draft and Generate reproduces A.

## Change class

- [x] STANDARD

## Purpose

Fix 05A4-05. Initial reproduction base: `0e5d70750bd6dd6ec07c778042b192b709db43ca`.
PR base: `29717d7e882702fca15d8d18604af799c065b6a9` (integrated dev after PR #504).
Required checks: `Web base policy (trusted base)` and `PR / gate`.

## Changes

- Root cause: the generated artifact handle already retained Result owners and mutable intent, but its runtime hook captured only Run Info state. The private canonical session and resource table in `config.js` remained at B after Undo. Both `getCommittedCanonicalRenderRequest` and Save read that stale session.
- Production: `gbdraw/web/js/services/config.js` exposes capture/restore on its existing canonical artifact owner. `gbdraw/web/js/app/app-setup.js` connects that owner to the established `setGeneratedArtifactRuntimeOwner` hook alongside Run Info.
- Canonical sessions and resource tables are retained by reference in the handle. There is no duplicate request cache, whole-application snapshot, new History mechanism, or timing workaround.
- Tests: `history-canonical-owner.test.mjs` verifies request/resource identity, Undo/Redo, independent draft History, failed-generation rollback, and first-generation Undo/Redo. `history-generated-authority.playwright.spec.js` independently checks selected Result, mounted SVG, exported SVG, complete editable config, runtime request, saved request, fresh Load, and both regeneration continuations.

## Verification

- On the exact starting base, the browser regression fails in three places: request after Undo, request in Save, and request after fresh Load. Each remains B while Result surfaces are A. The draft, Redo, and independent setting-Undo checks already pass.
- After the fix, 79 focused Node checks pass across History, session request/resources/save/load, and generation contracts. The final owner regression also covers the empty-to-first-Generate transition.
- Eighteen browser checks pass across the new regression, History inputs, mode-transition editor state, record identity, and Result/mounted/export behavior. A final focused run passes with a real Undo screenshot inspected: the None draft and labeled Result A are visible together.
- Browser checks block external requests. The generated test wheel is excluded from the commit.
- The new owner contract runs in fast PR JavaScript checks. The comprehensive Save/Load/regeneration browser regression runs in the full functional tier and exact-dev acceptance. It adds no new `@pr-smoke` case: the preceding 30-case smoke run completed all assertions but exhausted its 15-minute job budget during shutdown.

## Risk and review notes

This is architecture-bearing: an existing canonical owner participates in the existing generated artifact lifecycle. Semantic ownership stays in `config.js`; `app-setup.js` only wires capture/restore. There remains one History restoration path and one canonical session/resource owner. No owner is duplicated, no compatibility path is added, and there is no superseded path to retain. This is an ordinary non-increasing change, with no architecture exception or authority edit. Apply `architecture-change`; human review is required for the exported owner interface and lifecycle wiring.

Product preflight: `IMPLEMENT_EXISTING_AUTHORITY`. The supported independent form and Generate History steps select draft B / artifact A after Undo Generate. The Product Decision Owner explicitly clarified that the input History should restore B. No new decision record or normative contract is introduced. The draft is intentionally allowed to differ from the last generated Result; the Result and persisted canonical request must agree. Other 05A4 findings are outside this PR.

Base authority: `docs/REFERENCE/web-app.md` describes settings as committed only after successful generation and sessions as retaining both the committed request and newer editable state. Its Undo/Redo section supports traversing form changes. `gbdraw/web/CLAUDE.md` assigns canonical session/resource ownership to the existing config/session path. No candidate authority or newly invented behavior decision is used.

Production, tests, and generated assets were reviewed separately. No scientific output geometry or tracked reference changed.

## Rollback

Revert this commit to disconnect canonical artifact restoration from History.

## Conditional Product Impact

N/A: no registered Product Impact subject delta or unresolved outcome.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
