### PR TITLE
Shorten PR checks and separate release acceptance from dev CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,17 @@ on:
     branches: ["dev"]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   workflow_dispatch:
+    inputs:
+      tier:
+        description: Integrated dev validation or exhaustive release/S11 acceptance
+        type: choice
+        options: [dev, release]
+        default: dev
+        required: true
 
 concurrency:
   # Promotion accepts only the current remote dev tip, so older dev staging can be canceled.
-  group: tests-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  group: tests-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}-${{ inputs.tier || 'dev' }}
   cancel-in-progress: true
 
 jobs:
@@ -36,6 +43,9 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install locked CI test dependencies
+        run: npm ci
+
       - name: Test CI impact policy and adapters
         run: node --test tests/ci/*.test.mjs
 
@@ -45,6 +55,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: .ci-trusted-base
+          sparse-checkout: tools
           fetch-depth: 1
           persist-credentials: false
 
@@ -67,7 +78,7 @@ jobs:
         if: github.event_name != 'pull_request'
         id: dev_plan
         env:
-          CI_IMPACT_PROFILE: dev
+          CI_IMPACT_PROFILE: ${{ inputs.tier == 'release' && 'release' || 'dev' }}
           CI_IMPACT_EVENT_NAME: ${{ github.event_name }}
           CI_IMPACT_REPOSITORY: ${{ github.repository }}
           CI_IMPACT_CHANGE_BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.sha }}
@@ -315,10 +326,65 @@ jobs:
           -m "browser and not slow"
           --durations=30
 
+      - name: Run package build integration
+        run: >-
+          python -m pytest tests/test_web_packaging.py
+          -m "slow and not browser"
+          --durations=30
+
       - name: Run offline GUI browser contracts
         run: >-
           python -m pytest tests/test_web_packaging.py
           -m "slow and browser"
+          --durations=30
+
+  web-contracts-pr:
+    name: Web contracts (Python 3.11)
+    needs: ci-impact
+    if: >-
+      github.event_name == 'pull_request' && github.base_ref == 'dev' &&
+      needs.ci-impact.result == 'success' &&
+      (contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-contracts-pr') ||
+      contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-pr-smoke'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install Web contract dependencies
+        run: |
+          python -m pip install -e ".[dev]"
+          npm ci
+          python -m playwright install --with-deps chromium
+
+      - name: Prepare browser wheel
+        run: python tools/prepare_browser_wheel.py
+
+      - name: Run fast Web JavaScript contracts
+        run: >-
+          find tests/web -maxdepth 1 -type f
+          -name '*.test.mjs' ! -name 'architecture-contracts.test.mjs'
+          ! -name 'gallery-session-publication.test.mjs'
+          -print0 | xargs -0 node --test
+
+      - name: Run non-slow Python browser tests
+        run: >-
+          python -m pytest tests/
+          -m "browser and not slow"
           --durations=30
 
   web-pr-smoke:
@@ -329,7 +395,7 @@ jobs:
       needs.ci-impact.result == 'success' &&
       contains(fromJSON(needs.ci-impact.outputs.plan).requiredJobs, 'web-pr-smoke')
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -349,25 +415,12 @@ jobs:
 
       - name: Install Web PR smoke dependencies
         run: |
-          python -m pip install -e ".[dev]"
+          python -m pip install -e . build
           npm ci
           npx playwright install --with-deps chromium
 
       - name: Prepare browser wheel
         run: python tools/prepare_browser_wheel.py
-
-      - name: Run fast Web JavaScript contracts
-        run: >-
-          find tests/web -maxdepth 1 -type f
-          -name '*.test.mjs' ! -name 'architecture-contracts.test.mjs'
-          ! -name 'gallery-session-publication.test.mjs'
-          -print0 | xargs -0 node --test
-
-      - name: Run non-slow Python browser tests
-        run: >-
-          python -m pytest tests/
-          -m "browser and not slow"
-          --durations=30
 
       - name: Run Playwright PR smoke
         run: npm run test:web:pr-smoke
@@ -654,6 +707,7 @@ jobs:
       - recipes-standard
       - gallery
       - lint
+      - web-contracts-pr
       - web-pr-smoke
     if: >-
       always() &&
@@ -667,6 +721,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: .ci-trusted-base
+          sparse-checkout: tools
           fetch-depth: 1
           persist-credentials: false
 
@@ -694,7 +749,7 @@ jobs:
       - lint
       - losat-cache-browser-acceptance
     if: >-
-      always() &&
+      always() && inputs.tier != 'release' &&
       ((github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'))
     runs-on: ubuntu-latest
@@ -714,3 +769,49 @@ jobs:
           CI_IMPACT_EXPECTED_PROFILE: dev
           CI_IMPACT_EXPECTED_WORKFLOW_SHA: ${{ github.sha }}
         run: node tools/ci-impact.mjs gate
+
+  release-gate:
+    name: Release / gate
+    needs:
+      - ci-impact
+      - web-change-budget
+      - core
+      - recipes-standard
+      - gallery
+      - browser
+      - playwright-functional
+      - playwright-performance
+      - acceptance-supported-main
+      - slow-main
+      - lint
+      - losat-cache-browser-acceptance
+    if: >-
+      always() && github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/dev' && inputs.tier == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout protected dev CI policy
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate exhaustive release evidence
+        env:
+          CI_IMPACT_PLAN_JSON: ${{ needs.ci-impact.outputs.plan }}
+          CI_IMPACT_NEEDS_JSON: ${{ toJSON(needs) }}
+          CI_IMPACT_EXPECTED_PROFILE: release
+          CI_IMPACT_EXPECTED_WORKFLOW_SHA: ${{ github.sha }}
+        run: node tools/ci-impact.mjs gate
+
+      - name: Require exact candidate Gallery readiness
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          node tools/check-promotion-readiness.mjs workflow-evidence
+          --repository "$GITHUB_REPOSITORY"
+          --workflow-path .github/workflows/gallery-publication.yml
+          --aggregate-name "Gallery readiness / gate"
+          --head-sha "${{ github.sha }}"

--- a/docs/internal/CI_TIER_REDESIGN_2026-09-11.md
+++ b/docs/internal/CI_TIER_REDESIGN_2026-09-11.md
@@ -1,0 +1,212 @@
+# CI tier redesign measurements — 2026-09-11
+
+Starting `origin/dev`: `8d6c914ecf5bb12437e1c8370d35a28ea4b0af6a`.
+Scope: CI workflows, routing policy, tests/tags, and CI documentation only.
+No runtime production source, fixture, generated public figure, or release
+publication/source checker changed. Remaining 05A4 defects are unchanged.
+
+## Historical cost
+
+Source: GitHub Actions run/job/step timestamps, collected on 2026-09-11 for
+PRs #502–#505 (including earlier #503 attempts) and the four latest dev runs.
+The [per-job CSV](CI_TIER_TIMINGS_2026-09-11.csv) includes every non-skipped job
+in these Tests runs and the first redesign rollout, with direct evidence URLs. Partial/cancelled runs are identified;
+they are not counted as successful verification. Setup includes checkout and runtime
+setup; dependency time is the grouped install step; tests includes checks/planning;
+teardown includes uploads and post steps. Unattributed time captures runner overhead
+and timestamp rounding. Combined install steps do not expose exact independent
+pip/npm/Chromium or embedded wheel durations, so those are not falsely separated.
+Runner minutes are the sum of job wall durations, not rounded billed minutes.
+
+| PR | Successful Tests run | Web PR smoke | Playwright phase | Tests critical path | Tests runner minutes |
+| --- | --- | ---: | ---: | ---: | ---: |
+| #502 | [34543831540](https://github.com/satoshikawato/gbdraw/actions/runs/34543831540) | 14:47 | 12:10 | 17:17 | 31.75 |
+| #503 | [34548658285](https://github.com/satoshikawato/gbdraw/actions/runs/34548658285) | 13:21 | 10:59 | 15:46 | 30.63 |
+| #504 | [34550113922](https://github.com/satoshikawato/gbdraw/actions/runs/34550113922) | 14:06 | 11:37 | 16:23 | 31.00 |
+| #505 | [34551490388](https://github.com/satoshikawato/gbdraw/actions/runs/34551490388) | 14:22 | 11:49 | 16:31 | 30.23 |
+
+Each successful PR ran eight Tests jobs, plus the separate trusted-base check
+and three CodeQL language jobs (12 actual jobs total). Aggregate names and those
+four external jobs are preserved. Critical path above runs from the first Tests
+job start to PR gate completion, including inter-job scheduling; external checks
+are not added serially.
+
+Median phase seconds across sampled successful jobs (individual values and all
+matrix members remain in CSV):
+
+| Job | Setup | Dependencies | Wheel | Tests/checks | Teardown | Wall |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Web PR smoke | 34.5 | 40 | 2.5 | 771.5 | 1 | 854 |
+| Core PR | 30 | 14 | 0 | 203 | 0 | 253 |
+| Recipes standard | 30 | 18 | 0 | 89 | 0 | 138 |
+| Gallery | 29 | 14 | 0 | 210 | 0 | 254 |
+| Web change budget | 75 | 0 | 0 | 131 | 0 | 208 |
+| Browser | 26.5 | 42 | 2 | 154 | 1 | 229 |
+| Playwright functional shard 1/4 | 35 | 47.5 | 3 | 755.5 | 0 | 845 |
+| Playwright functional shard 2/4 | 30 | 41 | 2 | 239 | 0.5 | 312 |
+| Playwright functional shard 3/4 | 34 | 42 | 2 | 458.5 | 0.5 | 538 |
+| Playwright functional shard 4/4 | 25 | 45.5 | 2 | 549.5 | 0.5 | 629 |
+| Recipe acceptance 3.10 / 3.12 | 27.5 / 28.5 | 15.5 / 20 | 0 | 83.5 / 96.5 | 0 | 133.5 / 147 |
+| Gallery acceptance 3.10 / 3.12 | 30.5 / 27.5 | 18.5 / 20 | 0 | 214 / 200 | 1 / 0 | 266 / 244 |
+| Browser acceptance 3.10 / 3.12 | 33.5 / 27.5 | 44.5 / 45 | included in install | 49 / 54 | 1 / 0.5 | 126 / 130.5 |
+| Slow 3.10 / 3.11 / 3.12 | 32 / 28.5 / 29 | 18 / 18 / 19 | 2.5 / 3 / 3 | 74.5 / 71.5 / 77.5 | 1 / 0 / 0 | 129 / 120.5 / 131.5 |
+
+### Why passing smoke hit 15 minutes
+
+The original job serialized dependency installation, wheel preparation, roughly
+17–19 seconds of JS contracts, 48–52 seconds of Python browser tests, and about
+11–12 minutes of Playwright. Smoke had grown to 27 expanded cases at the starting
+SHA (28 in #502, 30 in early #503). The previous regex counted only top-level
+`tag: '@pr-smoke'` declarations, missing title tags, loops, and nested contracts.
+Several cases perform repeated Generate, History, Save/Load, or large Vibrio
+resource operations; they are integration regressions, not short boot probes.
+
+[Job 103097229281](https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229281)
+lasted 15:12 and logged **30 passed (12.6m)** immediately before cancellation.
+[Job 103102959643](https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959643)
+lasted 15:08. These runs exhausted the serialized job budget; assertion success
+could not rescue a cancelled required job. A separate 6:27 rerun was interrupted
+and is not counted as a timeout. The primary remedy removes serial work and
+reduces smoke selection. Its job timeout decreases from 15 to 10 minutes.
+
+### Unique failures and duplicated setup
+
+The successful heads of #502–#505 had no failing assertion in any required PR job.
+Earlier #503 PR gates failed because smoke was cancelled. Sampled dev Browser
+jobs [103096237619](https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237619)
+and [103110884127](https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884127)
+uniquely failed `test_offline_gui_linear_losat_generation_populates_cache` while
+core, recipes, Gallery, version-acceptance, slow, and all four functional shards
+passed. That Browser contract remains mandatory on dev. No unique failure was
+observed in those other jobs in this sample; that is not proof of redundancy.
+
+Pip/npm caches already existed. Web dependency installation usually cost 38–44
+seconds, and wheel preparation 2–3 seconds. Each functional shard repeats about
+40–48 seconds of setup dependencies, but sharing a 2–3-second wheel via an extra
+artifact job would add coordination/startup cost. No shared mutable state, wheel
+artifact pipeline, or Chromium cache is introduced. Splitting JS/Python contracts
+adds one roughly 75-second setup while removing their 65–70-second work from the
+browser critical path. Removing 17 browser journeys saves much more.
+
+Trusted-base checkouts previously cost about 25 seconds each in planning and the
+PR gate. Those two helpers require only `tools/`; their checkouts now use sparse
+checkout. This preserves exact base revisions and helper imports without copying
+candidate/runtime state. Actual savings are reported separately from projections.
+
+## Before / after
+
+| Measure | Before | After design / local evidence |
+| --- | --- | --- |
+| Web-only PR Tests jobs | Planner, architecture, core, recipes, Gallery, lint, serialized Web smoke, gate | Planner, architecture, Web contracts, Playwright smoke, gate |
+| Number of Tests jobs | 8 | 5 selective; 9 for this rollout/full-fallback PR |
+| Including trusted-base + three CodeQL jobs | 12 | 9 selective; 13 for rollout/full fallback |
+| Required browser cases | 27 | 10 |
+| Full functional browser inventory | 167 | 167, same cases after stripping smoke tags |
+| PR Tests wall | 15:46–17:17 | Projected 5–7 minutes, pending hosted measurement |
+| PR Tests runner minutes | 30.23–31.75 | Projected 10–13 selective; 20–24 full fallback |
+| Dev Tests jobs / runner minutes at starting SHA | 25 / 95.65 | 16 jobs; roughly 72 minutes plus retained package-build checks, projected |
+| Dev Tests wall at starting SHA | 16:49 | Same four full browser shards; approximately 15–20 minutes, projected |
+| Dev functional coverage | Core, recipes, Gallery, browser, LOSAT/cache, functional/performance Playwright, offline GUI | Retained; package builds stay on 3.11; multi-version core retained |
+| Supported-version and exhaustive slow acceptance | Every dev push | Explicit release profile; same matrices and commands mandatory under Release gate |
+| Release source and package publication checks | Existing exact source/admission/build/install path | Unchanged |
+
+The projection uses historical durations of **only the ten retained cases**:
+138.6 / 130.7 / 136.4 / 138.0 seconds in #502–#505, plus setup, planning, gate and
+scheduling. It does not use the faster local machine as a hosted-run prediction.
+Local Chromium on Linux/WSL, Playwright 1.61.1, zero retries: 10/10 passed with
+one worker in 87.09 seconds; two workers passed 30/30 over three repetitions in
+153.24 seconds total, with no skips or flakes. CI keeps one worker because the
+parallel experiment did not run repeatedly on GitHub-hosted hardware.
+
+Actual changed-path replays from the historical PRs (with successful exact-base
+staging evidence available):
+
+| PR | Affected capabilities | New Tests jobs including planner/gate |
+| --- | --- | ---: |
+| #502 | Web runtime + session + Gallery tests | 9; the independent capabilities jointly require every PR suite |
+| #503 | Session persistence and history tests | 8; Gallery deferred to dev |
+| #504 | Documentation + Gallery + packaging verifier | 9; packaging requires full coverage |
+| #505 | Web runtime + session/history | 8; Gallery deferred to dev |
+
+The five-job Web example is an editor/runtime change plus its normal Web tests.
+Session or packaging contributions must not disappear merely to reduce job count.
+All four historical replays benefit from the shorter browser critical path.
+
+### First hosted rollout measurement
+
+[Tests run 34563716800](https://github.com/satoshikawato/gbdraw/actions/runs/34563716800)
+on `8512e5650edebabf2b006ba312e9bdfc1fd70a97` passed all nine jobs in **6:20**,
+using **23.05 runner minutes**. The base's original full route was enforced:
+core, recipes, Gallery, lint, architecture, and browser smoke all ran, alongside
+the separated contracts. The independent trusted-base and CodeQL checks passed.
+
+Web smoke took **3:38**, with **2:20** in Playwright; contracts took **2:24**.
+Trusted helper checkout took **1 second** in both planner and PR gate. Core
+(4:13), rather than browser smoke, set the full-route test critical path.
+The full-route wall time fell about 62% against #505's 16:31. This measurement
+precedes the final code-plus-test routing refinement and evidence-only report
+update; final-head verification is recorded on the PR. Selective five-job timing
+and post-merge dev measurements must not be claimed as observed from this run.
+
+## Tests moved to later tiers
+
+The following 17 expanded browser cases leave PR smoke and remain mandatory in
+the full functional suite on dev and release. Their bodies and timeouts are
+unchanged:
+
+- `annotation-download.playwright.spec.js` — annotation TSV download/re-import and Python round-trip offline (1440px).
+- `annotation-download.playwright.spec.js` — annotation TSV download/re-import and Python round-trip offline (390px).
+- `composite-session-resources.playwright.spec.js` — Session export Vibrio composite resources survive minimal Save, fresh Load and Generate.
+- `contracts/active-result-edit-transaction.playwright.spec.js` — visible tRNA fill scope remains coherent through History, Session, Generate, and SVG export.
+- `draft-placement-capability.playwright.spec.js` — circular draft placement capability survives history and dirty session restore.
+- `draft-placement-capability.playwright.spec.js` — linear draft placement capability survives history and dirty session restore.
+- `history-inputs.playwright.spec.js` — Label Mode keyboard edit has one Undo step and survives generation and fresh Load.
+- `history-inputs.playwright.spec.js` — Label Mode pointer edit has one Undo step and survives generation and fresh Load.
+- `joint-display-placement.playwright.spec.js` — joint rotation placement and saved drafts in circular.
+- `joint-display-placement.playwright.spec.js` — joint rotation placement and saved drafts in linear.
+- `linear-typography.playwright.spec.js` — independent Linear typography follows linked, imported, and History journeys.
+- `mode-record-identity.playwright.spec.js` — committed Circular placement retains source identity through mode history and Save/Load.
+- `mode-record-identity.playwright.spec.js` — ungenerated Circular placement retains source identity through mode history and Save/Load.
+- `mode-transition-editor-state.playwright.spec.js` — circular label intent survives mode Undo/Redo and Save/Load/Generate.
+- `mode-transition-editor-state.playwright.spec.js` — linear label intent survives mode Undo/Redo and Save/Load/Generate.
+- `preview-navigation.playwright.spec.js` — background pan preserves screen displacement after text selection and zoom.
+- `preview-navigation.playwright.spec.js` — preview pan leaves feature and match gestures available.
+
+For a Web-subsystem PR (including its Web tests), the entire core, recipe, Gallery, and Python lint jobs
+also move to dev; their suites still run in PRs that affect those owners, and in
+full fallback. Python renderer PRs defer recipes/Gallery to dev. Session changes
+retain core and recipe contracts in PR; Gallery changes retain Gallery tests.
+The complete Python/browser contract suite stays in the parallel Web contracts
+job whenever browser smoke is required.
+
+Dev→release movement is explicit: `acceptance-supported-main` retains recipe,
+Gallery and non-slow browser tests on Python 3.10/3.12; `slow-main` retains every
+non-browser slow test on 3.10/3.11/3.12. The three package build tests also run on
+dev Python 3.11. Offline slow browser tests remain on dev and release Python 3.11.
+
+## Review evidence
+
+CI path classification and job requirements remain owned only by
+`tools/ci-impact-policy.mjs`; the adapter and workflows consume its result.
+The coarse strongest-class decision is replaced by the capability union in the
+same owner. No additional policy registry, runtime path, or persisted migration
+reader is added. Changed-scope owner excess, path excess and compatibility burden
+do not increase. Schema 1 remains executable only in the unchanged trusted PR
+base during rollout; the candidate helper accepts schema 2 only.
+
+Architecture/Product detectors, rules, privileged allowlists, accepted Product
+decisions, trusted-base workflow, release source gate, publication workflow and
+branch protection remain unchanged. Product outcome: no diagram/session/editor
+behavior change. This CI-governance change requires normal maintainer review;
+passing candidate tests is not that approval.
+
+Local validation: 58 CI policy/adapter/gate/inventory contracts; 137 architecture
+contracts; expanded functional inventory equality; smoke tags-only comparison;
+10-case smoke and three two-worker repetitions. Hosted results and the final
+integration state are recorded in the PR/handoff. S11 is not reaccepted here.
+
+The retained JS contract command passed 390 tests. Python browser checks passed
+23/24 initially; the replay failure used the globally installed older CLI
+(session 40 versus candidate 41). Installing this checkout in an isolated venv
+made that test pass without source edits. All three retained package-build
+integration tests passed (29.68 seconds). Generated artifacts remain uncommitted.

--- a/docs/internal/CI_TIER_TIMINGS_2026-09-11.csv
+++ b/docs/internal/CI_TIER_TIMINGS_2026-09-11.csv
@@ -1,0 +1,182 @@
+context,run_id,attempt,job_id,job,conclusion,setup_seconds,dependencies_seconds,wheel_seconds,tests_seconds,teardown_seconds,unattributed_seconds,wall_seconds,url
+PR #502,34543831540,1,103092062814,CI impact plan,success,104,0,0,0,1,3,108,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092062814
+PR #502,34543831540,1,103092460199,Gallery (Python 3.11),success,28,13,0,209,0,3,253,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092460199
+PR #502,34543831540,1,103092460225,Web change budget,success,84,0,0,129,1,4,218,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092460225
+PR #502,34543831540,1,103092460255,Core PR (Python 3.11),success,30,15,0,203,0,5,253,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092460255
+PR #502,34543831540,1,103092460259,Lint,success,32,1,0,1,0,5,39,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092460259
+PR #502,34543831540,1,103092460263,Web PR smoke,success,37,40,3,800,1,6,887,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092460263
+PR #502,34543831540,1,103092460308,Recipes standard (Python 3.11),success,27,14,0,71,0,3,115,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103092460308
+PR #502,34543831540,1,103095680139,PR / gate,success,27,0,0,1,0,4,32,https://github.com/satoshikawato/gbdraw/actions/runs/34543831540/job/103095680139
+PR #503,34548658285,1,103106685361,CI impact plan,success,104,0,0,0,1,2,107,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103106685361
+PR #503,34548658285,1,103107062148,Gallery (Python 3.11),success,28,13,0,210,1,2,254,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103107062148
+PR #503,34548658285,1,103107062180,Web change budget,success,78,0,0,136,0,3,217,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103107062180
+PR #503,34548658285,1,103107062192,Recipes standard (Python 3.11),success,29,18,0,89,1,3,140,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103107062192
+PR #503,34548658285,1,103107062211,Web PR smoke,success,34,38,2,724,1,2,801,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103107062211
+PR #503,34548658285,1,103107062229,Lint,success,30,2,0,0,1,3,36,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103107062229
+PR #503,34548658285,1,103107062230,Core PR (Python 3.11),success,30,14,0,203,1,4,252,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103107062230
+PR #503,34548658285,1,103109914715,PR / gate,success,27,0,0,0,1,3,31,https://github.com/satoshikawato/gbdraw/actions/runs/34548658285/job/103109914715
+PR #503,34547226783,1,103102560676,CI impact plan,success,104,0,0,1,1,4,110,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102560676
+PR #503,34547226783,1,103102959387,Core PR (Python 3.11),success,30,13,0,202,1,4,250,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959387
+PR #503,34547226783,1,103102959415,Web change budget,success,72,0,0,137,0,2,211,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959415
+PR #503,34547226783,1,103102959499,Gallery (Python 3.11),success,31,15,0,207,0,4,257,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959499
+PR #503,34547226783,1,103102959514,Recipes standard (Python 3.11),success,36,21,0,89,0,3,149,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959514
+PR #503,34547226783,1,103102959636,Lint,success,30,3,0,0,0,3,36,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959636
+PR #503,34547226783,1,103102959643,Web PR smoke,cancelled,42,43,3,814,0,6,908,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103102959643
+PR #503,34547226783,1,103106162123,PR / gate,failure,34,0,0,2,0,3,39,https://github.com/satoshikawato/gbdraw/actions/runs/34547226783/job/103106162123
+PR #503,34545278484,1,103096433241,CI impact plan,success,101,0,0,1,0,4,106,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103096433241
+PR #503,34545278484,1,103097229270,Core PR (Python 3.11),success,29,16,0,204,0,5,254,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229270
+PR #503,34545278484,1,103097229277,Gallery (Python 3.11),success,30,14,0,210,0,5,259,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229277
+PR #503,34545278484,1,103097229281,Web PR smoke,cancelled,36,40,3,830,0,3,912,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229281
+PR #503,34545278484,1,103097229287,Recipes standard (Python 3.11),success,35,18,0,79,0,4,136,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229287
+PR #503,34545278484,1,103097229303,Lint,success,30,1,0,1,0,3,35,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229303
+PR #503,34545278484,1,103097229322,Web change budget,success,75,0,0,130,0,2,207,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103097229322
+PR #503,34545278484,1,103100553328,PR / gate,failure,26,0,0,1,0,3,30,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103100553328
+PR #503,34545278484,2,103101026774,Web PR smoke,cancelled,39,42,2,300,1,3,387,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101026774
+PR #503,34545278484,2,103101026935,CI impact plan,success,101,0,0,1,0,4,106,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101026935
+PR #503,34545278484,2,103101027557,Recipes standard (Python 3.11),success,35,18,0,79,0,4,136,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101027557
+PR #503,34545278484,2,103101027772,Web change budget,success,75,0,0,130,0,2,207,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101027772
+PR #503,34545278484,2,103101027894,Lint,success,30,1,0,1,0,3,35,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101027894
+PR #503,34545278484,2,103101027968,Gallery (Python 3.11),success,30,14,0,210,0,5,259,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101027968
+PR #503,34545278484,2,103101059963,Core PR (Python 3.11),success,29,16,0,204,0,5,254,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103101059963
+PR #503,34545278484,2,103102435056,PR / gate,failure,27,0,0,3,0,2,32,https://github.com/satoshikawato/gbdraw/actions/runs/34545278484/job/103102435056
+PR #504,34550113922,1,103111045618,CI impact plan,success,98,0,0,1,1,2,102,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111045618
+PR #504,34550113922,1,103111709502,Gallery (Python 3.11),success,22,14,0,212,1,3,252,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111709502
+PR #504,34550113922,1,103111709556,Web change budget,success,73,0,0,131,1,2,207,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111709556
+PR #504,34550113922,1,103111709558,Core PR (Python 3.11),success,30,14,0,202,0,5,251,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111709558
+PR #504,34550113922,1,103111709560,Web PR smoke,success,33,40,3,766,0,4,846,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111709560
+PR #504,34550113922,1,103111709562,Recipes standard (Python 3.11),success,29,17,0,89,0,3,138,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111709562
+PR #504,34550113922,1,103111709598,Lint,success,30,2,0,0,0,3,35,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103111709598
+PR #504,34550113922,1,103114551631,PR / gate,success,25,0,0,1,0,3,29,https://github.com/satoshikawato/gbdraw/actions/runs/34550113922/job/103114551631
+PR #505,34551490388,1,103115688131,CI impact plan,success,87,0,0,0,1,3,91,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103115688131
+PR #505,34551490388,1,103116085017,Recipes standard (Python 3.11),success,30,17,0,89,0,4,140,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103116085017
+PR #505,34551490388,1,103116085051,Web change budget,success,75,0,0,131,0,2,208,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103116085051
+PR #505,34551490388,1,103116085076,Core PR (Python 3.11),success,30,13,0,205,0,5,253,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103116085076
+PR #505,34551490388,1,103116085167,Gallery (Python 3.11),success,29,14,0,150,1,2,196,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103116085167
+PR #505,34551490388,1,103116085175,Lint,success,28,2,0,0,0,3,33,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103116085175
+PR #505,34551490388,1,103116085632,Web PR smoke,success,35,44,2,777,1,3,862,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103116085632
+PR #505,34551490388,1,103118864282,PR / gate,success,26,0,0,1,0,4,31,https://github.com/satoshikawato/gbdraw/actions/runs/34551490388/job/103118864282
+PR #505,34551490020,1,103115157691,CI impact plan,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115157691
+PR #505,34551490020,1,103115160433,PR / gate,failure,12,0,0,1,0,2,15,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115160433
+PR #505,34551490020,1,103115160810,Browser (Python 3.11),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115160810
+PR #505,34551490020,1,103115160903,Playwright functional (shard ${{ matrix.shard }}/4),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115160903
+PR #505,34551490020,1,103115160912,LOSAT cache browser acceptance,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115160912
+PR #505,34551490020,1,103115161070,${{ matrix.surface }} acceptance (Python ${{ matrix.python-version }}),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161070
+PR #505,34551490020,1,103115161210,Web change budget,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161210
+PR #505,34551490020,1,103115161266,Gallery (Python 3.11),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161266
+PR #505,34551490020,1,103115161294,Recipes standard (Python 3.11),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161294
+PR #505,34551490020,1,103115161340,Core (Python ${{ matrix.python-version }}),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161340
+PR #505,34551490020,1,103115161363,Slow (Python ${{ matrix.python-version }}),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161363
+PR #505,34551490020,1,103115161378,Web PR smoke,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161378
+PR #505,34551490020,1,103115161389,Core PR (Python 3.11),cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161389
+PR #505,34551490020,1,103115161408,Dev staging / gate,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161408
+PR #505,34551490020,1,103115161410,Playwright performance,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161410
+PR #505,34551490020,1,103115161512,Lint,cancelled,0,0,0,0,0,0,0,https://github.com/satoshikawato/gbdraw/actions/runs/34551490020/job/103115161512
+dev,34552818001,1,103119071011,CI impact plan,success,73,0,0,0,0,3,76,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119071011
+dev,34552818001,1,103119324319,Recipes standard (Python 3.11),success,31,20,0,94,1,4,150,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324319
+dev,34552818001,1,103119324321,Browser (Python 3.11),success,19,43,2,154,1,4,223,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324321
+dev,34552818001,1,103119324336,Playwright performance,success,33,40,2,209,1,2,287,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324336
+dev,34552818001,1,103119324339,Web change budget,success,83,0,0,119,0,3,205,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324339
+dev,34552818001,1,103119324367,Core (Python 3.12),success,31,16,0,232,0,6,285,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324367
+dev,34552818001,1,103119324372,Gallery (Python 3.11),success,26,15,0,207,0,2,250,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324372
+dev,34552818001,1,103119324423,Core (Python 3.10),success,14,16,0,226,0,4,260,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324423
+dev,34552818001,1,103119324428,Core (Python 3.11),success,28,13,0,205,0,3,249,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324428
+dev,34552818001,1,103119324530,Slow (Python 3.10),success,33,16,2,75,1,2,129,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324530
+dev,34552818001,1,103119324561,LOSAT cache browser acceptance,success,41,35,2,91,1,4,174,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324561
+dev,34552818001,1,103119324588,Lint,success,30,1,0,0,1,3,35,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324588
+dev,34552818001,1,103119324595,Slow (Python 3.12),success,29,23,3,88,0,2,145,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324595
+dev,34552818001,1,103119324598,Playwright functional (shard 3/4),success,34,37,2,369,1,2,445,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324598
+dev,34552818001,1,103119324600,Playwright functional (shard 4/4),success,27,56,2,487,0,3,575,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324600
+dev,34552818001,1,103119324626,recipe acceptance (Python 3.10),success,18,14,0,73,0,4,109,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324626
+dev,34552818001,1,103119324631,browser acceptance (Python 3.10),success,33,44,0,49,1,3,130,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324631
+dev,34552818001,1,103119324642,browser acceptance (Python 3.12),success,23,46,0,56,0,4,129,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324642
+dev,34552818001,1,103119324643,gallery acceptance (Python 3.10),success,32,19,0,216,1,2,270,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324643
+dev,34552818001,1,103119324648,recipe acceptance (Python 3.12),success,27,20,0,96,0,2,145,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324648
+dev,34552818001,1,103119324677,gallery acceptance (Python 3.12),success,28,20,0,197,0,1,246,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324677
+dev,34552818001,1,103119324713,Playwright functional (shard 1/4),success,37,54,3,664,0,4,762,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324713
+dev,34552818001,1,103119324732,Playwright functional (shard 2/4),success,34,37,2,239,0,5,317,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324732
+dev,34552818001,1,103119324757,Slow (Python 3.11),success,28,19,3,59,0,2,111,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103119324757
+dev,34552818001,1,103122317999,Dev staging / gate,success,27,0,0,2,0,3,32,https://github.com/satoshikawato/gbdraw/actions/runs/34552818001/job/103122317999
+dev,34551383882,1,103114836498,CI impact plan,success,79,0,0,1,0,4,84,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103114836498
+dev,34551383882,1,103115117819,Browser (Python 3.11),success,34,41,2,154,1,3,235,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117819
+dev,34551383882,1,103115117849,Gallery (Python 3.11),success,14,13,0,181,1,2,211,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117849
+dev,34551383882,1,103115117856,Web change budget,success,73,0,0,131,1,2,207,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117856
+dev,34551383882,1,103115117894,Recipes standard (Python 3.11),success,13,18,0,105,0,2,138,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117894
+dev,34551383882,1,103115117910,Core (Python 3.11),success,28,13,0,203,1,3,248,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117910
+dev,34551383882,1,103115117912,Playwright performance,success,27,65,4,149,0,3,248,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117912
+dev,34551383882,1,103115117933,Core (Python 3.10),success,16,15,0,180,0,4,215,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115117933
+dev,34551383882,1,103115118014,Core (Python 3.12),success,28,17,0,229,1,4,279,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118014
+dev,34551383882,1,103115118055,Playwright functional (shard 4/4),success,30,40,2,622,1,2,697,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118055
+dev,34551383882,1,103115118084,Slow (Python 3.11),success,28,17,3,78,0,1,127,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118084
+dev,34551383882,1,103115118099,Slow (Python 3.12),success,28,19,3,81,0,4,135,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118099
+dev,34551383882,1,103115118100,Playwright functional (shard 3/4),success,34,42,2,512,0,4,594,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118100
+dev,34551383882,1,103115118107,LOSAT cache browser acceptance,success,32,43,3,120,0,3,201,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118107
+dev,34551383882,1,103115118117,Slow (Python 3.10),success,31,22,2,66,0,3,124,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118117
+dev,34551383882,1,103115118119,browser acceptance (Python 3.12),success,32,44,0,53,1,2,132,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118119
+dev,34551383882,1,103115118121,browser acceptance (Python 3.10),success,38,45,0,53,1,2,139,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118121
+dev,34551383882,1,103115118139,Playwright functional (shard 1/4),success,35,50,3,663,0,4,755,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118139
+dev,34551383882,1,103115118142,recipe acceptance (Python 3.12),success,30,19,0,97,0,3,149,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118142
+dev,34551383882,1,103115118161,recipe acceptance (Python 3.10),success,32,17,0,94,0,4,147,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118161
+dev,34551383882,1,103115118163,Playwright functional (shard 2/4),success,31,40,2,196,0,2,271,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118163
+dev,34551383882,1,103115118174,Lint,success,28,1,0,0,0,3,32,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118174
+dev,34551383882,1,103115118176,gallery acceptance (Python 3.10),success,29,19,0,237,1,2,288,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118176
+dev,34551383882,1,103115118185,gallery acceptance (Python 3.12),success,13,20,0,208,0,1,242,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103115118185
+dev,34551383882,1,103117584684,Dev staging / gate,success,25,0,0,0,0,4,29,https://github.com/satoshikawato/gbdraw/actions/runs/34551383882/job/103117584684
+dev,34549970407,1,103110607407,CI impact plan,success,74,0,0,0,1,2,77,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110607407
+dev,34549970407,1,103110884080,Gallery (Python 3.11),success,14,11,0,148,1,3,177,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884080
+dev,34549970407,1,103110884097,Recipes standard (Python 3.11),success,27,19,0,91,1,4,142,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884097
+dev,34549970407,1,103110884127,Browser (Python 3.11),failure,22,36,2,115,0,4,179,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884127
+dev,34549970407,1,103110884171,Core (Python 3.12),success,28,16,0,231,0,3,278,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884171
+dev,34549970407,1,103110884177,Core (Python 3.11),success,47,16,0,207,1,4,275,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884177
+dev,34549970407,1,103110884183,Lint,success,27,1,0,0,1,2,31,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884183
+dev,34549970407,1,103110884223,Core (Python 3.10),success,31,15,0,226,1,4,277,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884223
+dev,34549970407,1,103110884225,LOSAT cache browser acceptance,success,36,48,3,118,1,2,208,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884225
+dev,34549970407,1,103110884228,Playwright performance,success,25,46,2,174,0,4,251,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884228
+dev,34549970407,1,103110884229,Web change budget,success,63,0,0,102,1,2,168,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884229
+dev,34549970407,1,103110884350,Playwright functional (shard 3/4),success,36,42,4,482,1,4,569,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884350
+dev,34549970407,1,103110884353,Playwright functional (shard 2/4),success,21,42,2,239,1,2,307,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884353
+dev,34549970407,1,103110884354,Slow (Python 3.12),success,29,19,3,65,0,1,117,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884354
+dev,34549970407,1,103110884382,Slow (Python 3.11),success,31,19,3,82,1,3,139,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884382
+dev,34549970407,1,103110884396,gallery acceptance (Python 3.12),success,27,22,0,203,1,2,255,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884396
+dev,34549970407,1,103110884423,Slow (Python 3.10),success,16,19,3,89,1,1,129,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884423
+dev,34549970407,1,103110884424,browser acceptance (Python 3.12),success,37,48,0,54,0,3,142,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884424
+dev,34549970407,1,103110884426,Playwright functional (shard 1/4),success,26,45,4,863,0,3,941,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884426
+dev,34549970407,1,103110884429,gallery acceptance (Python 3.10),success,29,18,0,212,1,2,262,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884429
+dev,34549970407,1,103110884434,recipe acceptance (Python 3.10),success,25,20,0,98,0,4,147,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884434
+dev,34549970407,1,103110884442,Playwright functional (shard 4/4),success,23,43,2,494,1,3,566,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884442
+dev,34549970407,1,103110884451,recipe acceptance (Python 3.12),success,28,20,0,93,1,3,145,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884451
+dev,34549970407,1,103110884467,browser acceptance (Python 3.10),success,22,46,0,49,1,4,122,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103110884467
+dev,34549970407,1,103114058514,Dev staging / gate,failure,27,0,0,1,0,3,31,https://github.com/satoshikawato/gbdraw/actions/runs/34549970407/job/103114058514
+dev,34545113530,1,103095936660,CI impact plan,success,75,0,0,1,0,4,80,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103095936660
+dev,34545113530,1,103096237619,Browser (Python 3.11),failure,37,41,2,144,0,3,227,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237619
+dev,34545113530,1,103096237641,Recipes standard (Python 3.11),success,30,17,0,88,1,3,139,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237641
+dev,34545113530,1,103096237706,Gallery (Python 3.11),success,12,14,0,207,0,3,236,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237706
+dev,34545113530,1,103096237724,Core (Python 3.12),success,30,15,0,137,0,4,186,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237724
+dev,34545113530,1,103096237753,Web change budget,success,70,0,0,114,0,4,188,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237753
+dev,34545113530,1,103096237774,Playwright functional (shard 2/4),success,29,43,2,265,1,3,343,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237774
+dev,34545113530,1,103096237775,Core (Python 3.11),success,29,15,0,188,0,3,235,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237775
+dev,34545113530,1,103096237781,Core (Python 3.10),success,31,14,0,194,0,2,241,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237781
+dev,34545113530,1,103096237793,Playwright functional (shard 1/4),success,35,39,3,847,1,3,928,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237793
+dev,34545113530,1,103096237802,Playwright functional (shard 4/4),success,22,48,3,605,0,5,683,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237802
+dev,34545113530,1,103096237842,Playwright functional (shard 3/4),success,25,42,2,435,0,3,507,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237842
+dev,34545113530,1,103096237850,Lint,success,31,1,0,0,0,2,34,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237850
+dev,34545113530,1,103096237855,Playwright performance,success,37,45,2,183,1,2,270,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237855
+dev,34545113530,1,103096237872,LOSAT cache browser acceptance,success,48,60,3,121,1,6,239,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237872
+dev,34545113530,1,103096237969,recipe acceptance (Python 3.12),success,29,21,0,102,0,3,155,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237969
+dev,34545113530,1,103096237976,Slow (Python 3.11),success,29,14,2,65,0,4,114,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237976
+dev,34545113530,1,103096237978,Slow (Python 3.12),success,29,16,4,74,1,4,128,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237978
+dev,34545113530,1,103096237983,Slow (Python 3.10),success,33,17,3,74,1,3,131,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096237983
+dev,34545113530,1,103096238005,browser acceptance (Python 3.10),success,34,38,0,37,0,3,112,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096238005
+dev,34545113530,1,103096238008,recipe acceptance (Python 3.10),success,30,13,0,73,0,4,120,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096238008
+dev,34545113530,1,103096238016,gallery acceptance (Python 3.12),success,28,20,0,190,0,2,240,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096238016
+dev,34545113530,1,103096238049,browser acceptance (Python 3.12),success,18,43,0,54,1,2,118,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096238049
+dev,34545113530,1,103096238390,gallery acceptance (Python 3.10),success,32,18,0,176,0,4,230,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103096238390
+dev,34545113530,1,103099643847,Dev staging / gate,failure,26,0,0,3,0,3,32,https://github.com/satoshikawato/gbdraw/actions/runs/34545113530/job/103099643847
+PR #506 initial,34563716800,1,103151443630,CI impact plan,success,104,0,0,4,1,5,114,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151443630
+PR #506 initial,34563716800,1,103151783635,Web contracts (Python 3.11),success,33,47,2,58,0,4,144,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783635
+PR #506 initial,34563716800,1,103151783636,Core PR (Python 3.11),success,29,14,0,205,1,4,253,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783636
+PR #506 initial,34563716800,1,103151783639,Recipes standard (Python 3.11),success,35,21,0,73,0,2,131,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783639
+PR #506 initial,34563716800,1,103151783669,Gallery (Python 3.11),success,28,14,0,205,0,3,250,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783669
+PR #506 initial,34563716800,1,103151783674,Lint,success,27,1,0,1,0,3,32,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783674
+PR #506 initial,34563716800,1,103151783690,Web change budget,success,100,0,0,131,0,5,236,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783690
+PR #506 initial,34563716800,1,103151783698,Web PR smoke,success,34,37,2,140,1,4,218,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103151783698
+PR #506 initial,34563716800,1,103152525832,PR / gate,success,1,0,0,0,1,3,5,https://github.com/satoshikawato/gbdraw/actions/runs/34563716800/job/103152525832

--- a/docs/internal/SELECTIVE_CI.md
+++ b/docs/internal/SELECTIVE_CI.md
@@ -1,342 +1,153 @@
-# Selective CI impact planning
-
-Status: pull-request, `dev` staging, and Gallery readiness routing are active.
-
-## Purpose
-
-gbdraw classifies each change before deciding which existing CI jobs are needed. The
-classifier is deliberately coarse and conservative. It can avoid unrelated work only
-when the changed paths are clearly lightweight and the directly preceding trusted
-revision already has successful exact-SHA aggregate evidence.
-
-The `Tests` workflow routes pull-request jobs from a plan produced by the trusted base
-revision. Pushes to `dev` use the planner from the protected branch and inherit only
-successful evidence from the direct parent commit. The `Gallery publication` workflow
-uses the same protected-branch planner and direct-parent rule for its browser and
-performance jobs.
-
-## Impact classes
-
-The three impact classes, from least to most consequential, are:
-
-1. `metadata`: repository and development-support files that do not affect the
-   application, package, Web bundle, Gallery output, or public operating instructions.
-2. `documentation`: root Markdown files and files below `docs/`. These may participate
-   in documented-contract tests, so they are not treated as no-ops.
-3. `full`: runtime, tests, dependencies, build and packaging inputs, Web and Gallery
-   files, workflow and planner control files, and every unknown path.
-
-`tools/ci-impact-policy.mjs` is the only owner of the path allowlist and profile job
-registries. The initial metadata allowlist is:
-
-- `.agents/**`, `.claude/**`, `.codex/**`, and `.cursor/**`
-- `.github/pull_request_template.md`
-- `.dockerignore`, `.gitattributes`, and `.gitignore`
-- `CITATION.cff`, `LICENSE.txt`, and `LICENSE_LIBERATION_FONTS.txt`
-
-Root `*.md` files and `docs/**` are documentation. Everything else is full by default.
-For multiple paths, the strongest class wins:
-
-```text
-metadata < documentation < full
-```
-
-Rename and copy records classify both the old and new path. Deletes classify the old
-path. Unknown Git statuses, invalid paths, malformed or empty diffs, and missing Git
-objects all fail closed to `full`.
-
-## Plans and full fallback
-
-The planner emits one versioned `ImpactPlan` JSON object. It records the profile,
-impact, decision, stable basis code, change and workflow SHAs, required job IDs,
-changed-path count, and inherited evidence when present. Job IDs, not display names or
-human-readable reason text, form the routing contract.
-
-The policy defines three profiles:
-
-- `pr`: the `Tests` workflow for a pull request into `dev`
-- `dev`: the `Tests` workflow for a push to `dev`
-- `gallery`: the `Gallery publication` workflow for a push to `dev`
-
-## Active pull-request routing
-
-When the pull-request base has successful exact-SHA `Dev staging / gate` evidence, the
-`pr` profile selects these project-owned jobs:
-
-| Pull-request impact | Jobs that run |
-| --- | --- |
-| `metadata` | `CI impact plan`, `PR / gate` |
-| `documentation` | `CI impact plan`, `Recipes standard (Python 3.11)`, `PR / gate` |
-| `full` | `CI impact plan`, `Web change budget`, `Core PR (Python 3.11)`, `Recipes standard (Python 3.11)`, `Gallery (Python 3.11)`, `Lint`, `Web PR smoke`, `PR / gate` |
-
-Documentation changes run the recipe suite because it owns documented-contract,
-tutorial, CLI reference, and session compatibility checks. A full plan keeps the six
-existing pull-request test commands unchanged.
-
-`Web base policy (trusted base)` remains a separate required check. It evaluates Web
-change policy from `pull_request_target`; it does not select tests or replace
-`PR / gate`.
-
-A full-impact change always produces a full plan without calling the GitHub Actions
-API. Manual dispatch and a pull request carrying the `architecture-change` label also
-force a full plan.
-
-A metadata or documentation candidate can be selective only after inherited evidence
-is verified. Missing, queued, in-progress, failed, cancelled, or malformed evidence;
-API errors; and insufficient token access produce `decision=full` with
-`basis=INHERITED_EVIDENCE_UNAVAILABLE`. These operational failures do not crash the
-planner. Invalid inputs, malformed schemas, unsafe output writes, and programming errors
-remain control-plane failures and do not get hidden by a full fallback.
-
-## Active dev staging routing
-
-For a push to `dev`, the planner compares `github.event.before` with the current SHA.
-When the direct parent has successful exact-SHA `Dev staging / gate` evidence, the
-`dev` profile selects these project-owned jobs:
-
-| `dev` impact | Jobs that run |
-| --- | --- |
-| `metadata` | `CI impact plan`, `Dev staging / gate` |
-| `documentation` | `CI impact plan`, `Recipes standard (Python 3.11)`, `Dev staging / gate` |
-| `full` | `CI impact plan`, all 11 staging job IDs, `Dev staging / gate` |
-
-The 11 staging job IDs and their existing commands, matrices, timeouts, and artifact
-steps are unchanged. `workflow_dispatch` always produces a full plan.
-
-The direct-parent requirement handles rapid consecutive pushes. If a later push
-cancels the parent's run, or reaches the planner before the parent completes, the
-current run cannot inherit that evidence and runs the full staging profile. This keeps
-`cancel-in-progress: true` without admitting untested runtime changes.
-
-`Dev staging / gate` validates the plan and every result from the current workflow run
-with the protected branch's `tools/ci-impact.mjs`. It always creates aggregate evidence
-for the current SHA. The promotion verifier continues to require that exact current-SHA
-job; it does not accept the parent's job directly.
-
-## Active Gallery readiness routing
-
-For a push to `dev`, the Gallery planner compares `github.event.before` with the current
-SHA. When the direct parent has successful exact-SHA `Gallery readiness / gate`
-evidence, the `gallery` profile selects these jobs:
-
-| Gallery impact | Jobs that run |
-| --- | --- |
-| `metadata` | `CI impact plan`, `Gallery readiness / gate` |
-| `documentation` | `CI impact plan`, `Gallery readiness / gate` |
-| `full` | `CI impact plan`, `Gallery browser (common 9)`, `Gallery publication performance (projection)`, `Gallery readiness / gate` |
-
-Documentation tests remain in the `Tests` workflow's recipe suite. Public Markdown and
-files under `docs/` do not change the packaged Gallery sessions, Web bundle, browser
-generation path, or performance projection, so the Gallery profile does not rerun
-either Gallery test job for those changes.
-
-The blocking `browser` job runs the common 9 Gallery parity suite. The heavyweight
-Vibrio Generate test remains available as `test:web:vibrio-generate` and continues to
-run in the separate exact-SHA main verification workflow as stress and health evidence;
-it is not part of Gallery promotion readiness. The `browser` and `performance` job IDs
-retain their timeouts and performance baseline. Every `workflow_dispatch` run is full.
-When `complete_refresh=true`, the full performance job still runs its three-trial
-projection and complete-refresh gates.
-
-`Gallery readiness / gate` validates the Gallery plan and current-run job results with
-the protected branch's shared gate validator. A selective run therefore still creates
-successful aggregate evidence for the current SHA. Promotion continues to check that
-current-SHA job rather than the inherited parent job.
-
-## Direct evidence only
-
-Selective planning inherits evidence from exactly one revision:
-
-| Profile | Evidence revision | Workflow | Aggregate job |
-| --- | --- | --- | --- |
-| `pr` | pull-request base SHA | `.github/workflows/test.yml` | `Dev staging / gate` |
-| `dev` | `github.event.before` | `.github/workflows/test.yml` | `Dev staging / gate` |
-| `gallery` | `github.event.before` | `.github/workflows/gallery-publication.yml` | `Gallery readiness / gate` |
-
-The planner reuses `verifyWorkflowEvidence()` from
-`tools/check-promotion-readiness.mjs`. It does not copy GitHub API pagination or
-workflow/job identity logic.
-
-Only the direct base or parent is eligible because it proves that every unchanged
-surface in the current revision was covered immediately before the lightweight change.
-Searching for an older green run could cross an intervening unverified runtime change.
-If the direct run was cancelled by concurrency, is still running, or did not succeed,
-the current revision runs the full profile.
-
-## Stable aggregate checks
-
-The following display names are external admission contracts and stay fixed:
-
-- `PR / gate`
-- `Dev staging / gate`
-- `Gallery readiness / gate`
-- `Promotion / gate`
-
-Each workflow continues to start on every relevant event and creates its aggregate job
-for the current SHA. Pull-request, `dev` staging, and Gallery selection happen at job
-level. Keeping the aggregate names and current-SHA jobs stable avoids branch-protection
-changes and allows the existing promotion verifier to continue checking exact staging
-evidence.
-
-Workflow-level `paths` and `paths-ignore` filters are not used. Such filters can prevent
-a required check from being created, leaving a pull request pending, and would remove
-the current-SHA aggregate evidence required for promotion.
-
-## Pull-request trust boundary
-
-A pull request is untrusted input. Candidate code is tested, but it does not decide its
-own admission route. The workflow checks out the pull-request base SHA under
-`.ci-trusted-base` and runs that revision's `tools/ci-impact.mjs` for both planning and
-aggregate validation. The planner reads Git history from the candidate repository root.
-Candidate versions of `tools/ci-impact*.mjs` remain unit-test inputs only.
-
-The bootstrap pull request ran the candidate planner only because its base had no
-helper. That exception is no longer used. If the trusted base helper is absent,
-unusable, or emits an invalid plan, `ci-impact` or `PR / gate` fails instead of guessing
-a lightweight route. Changes below `.github/workflows/**`, `tools/ci-impact*.mjs`, and
-the CI planner tests classify as full.
-
-The `pull_request_target` workflow remains separate. It checks candidate Git data with
-trusted base code and never executes the candidate checkout.
-
-## Dev trust boundary
-
-Code merged to protected `dev` is the staging control plane. Push and manual-dispatch
-plans run the current checkout's helper. A change to a workflow, planner, policy, or
-planner test classifies as `full`, so the commit that changes routing must run the full
-staging and Gallery profiles before their aggregates can succeed.
-
-This trust boundary differs from pull requests, where the candidate helper is tested
-but the base revision decides the route. The Gallery workflow creates its own `gallery`
-plan and gate; it does not consume the `Tests` workflow's `dev` plan.
-
-## Aggregate validation
-
-The shared gate validator fails closed unless:
-
-- the plan schema, profile, required job list, and workflow SHA are valid;
-- `ci-impact` succeeded;
-- every required known job exists and succeeded;
-- every unrequired known job exists and either succeeded or was skipped; and
-- any additional job either succeeded or was skipped.
-
-An unexpected failure or cancellation remains blocking even for a job the plan did not
-require. Malformed plan or `needs` JSON is also blocking.
-
-`PR / gate` runs the validator from `.ci-trusted-base`. `Dev staging / gate` and
-`Gallery readiness / gate` run the same validator from the current protected-branch
-checkout with their expected profile and the current workflow SHA.
-
-## Rollout
-
-Selective CI uses four separately reviewed stages:
-
-1. Implemented: deterministic policy, adapter, validator, tests, documentation, and
-   shadow summary.
-2. Active: selective pull-request routing with the trusted base planner and validator.
-3. Active: evidence-aware selection for exact `dev` staging runs.
-4. Active: evidence-aware selection for exact Gallery readiness runs.
-
-Each stage keeps the aggregate check names stable and can be reverted independently.
-Reverting a routing stage restores the previous full-suite conditions without a
-repository-settings change.
-
-To roll back only Gallery selection, restore the `browser` and `performance` jobs to
-their unconditional event behavior and restore the fixed two-job readiness check.
-`Gallery readiness / gate` keeps the same display name, so repository settings do not
-need to change. The planner and the other two profiles can remain active.
-
-Selective CI does not alter `.github/workflows/deploy_web.yml`, Cloudflare deployment
-triggering, or GitHub's CodeQL setup. The main workflow retains browser verification
-only; Cloudflare Workers Builds is the sole production publisher. Those systems
-remain outside the impact planner.
-
-## Observability
-
-The `CI impact plan` summary includes:
-
-- profile, impact, decision, and stable basis;
-- change base/head and workflow SHAs;
-- changed-path count and a bounded, escaped path sample;
-- planned required job IDs;
-- inherited run and aggregate links when evidence succeeds; and
-- the fallback code and bounded reason when evidence is unavailable.
-
-The `pr`, `dev`, and `gallery` summaries state that routing is active and name the
-applicable trust boundary. Tokens are never included in the plan or summary and are
-redacted from CLI diagnostics.
-
-## Troubleshooting
-
-### A lightweight change produces a full plan
-
-Check `basis` in the `CI impact plan` summary.
-
-- `FULL_CHANGE`: at least one path is outside the two light allowlists.
-- `UNKNOWN_OR_INVALID_CHANGE`: the diff was empty, malformed, unavailable, or contained
-  an unsupported status/path.
-- `MANUAL_FULL_RUN`: manual dispatch is intentionally full.
-- `ARCHITECTURE_CHANGE`: the label intentionally forces full verification.
-- `INHERITED_EVIDENCE_UNAVAILABLE`: inspect the listed evidence code and the direct
-  base/parent workflow run. Do not substitute an older successful run.
-
-### The planner job fails
-
-Run the network-free focused tests first:
-
-```bash
-node --test tests/ci/*.test.mjs
-```
-
-Then verify that every required environment value is a correctly typed string and that
-base, head, and workflow SHAs are complete object IDs. A failure to write
-`GITHUB_OUTPUT` or `GITHUB_STEP_SUMMARY` is a control-plane error, not a reason to emit a
-selective plan.
-
-### The aggregate validator fails
-
-Compare the plan profile and workflow SHA with the gate environment. Confirm that every
-known job is present in `needs`, required jobs succeeded, and unrequired jobs did not
-fail or get cancelled unexpectedly. Do not weaken the validator to accept a missing or
-skipped required job.
-
-### Consecutive dev pushes run a full profile
-
-Inspect `basis` and the evidence failure in `CI impact plan`. If the direct parent's
-`Tests` or `Gallery publication` workflow is queued, running, cancelled, failed, or
-absent, the current push must use `INHERITED_EVIDENCE_UNAVAILABLE` and run the full
-profile for that workflow. Wait for a successful direct parent before using a
-lightweight commit when selective staging is important. Do not replace the direct
-parent with an older green SHA or disable concurrency.
-
-### Pull-request jobs are all skipped
-
-Open `CI impact plan` first. If the planner failed or its `plan` output is missing,
-`PR / gate` must fail even though the six test jobs are skipped. If the plan is valid,
-compare its `requiredJobs` array with each job's result in the aggregate summary.
-
-### The trusted helper cannot run
-
-Confirm that the pull-request base SHA contains `tools/ci-impact.mjs`,
-`tools/ci-impact-policy.mjs`, and `tools/check-promotion-readiness.mjs`. Do not run the
-candidate helper as a fallback. Restore the trusted base prerequisite or keep the
-control job failing.
-
-## Policy-extension review checklist
-
-Before making a path or profile less conservative, verify all of the following:
-
-- The structural reason that the path cannot change runtime, packaging, Web, Gallery,
-  public instructions, or another independently tested surface is documented.
-- Historical changes and failures support the proposed classification.
-- The unchanged surface is covered by the exact direct-parent/base evidence contract.
-- A current-revision test owns every changed surface that will no longer use the full
-  profile.
-- Rename, copy, delete, mixed-change, unknown-path, and API-failure cases still fall back
-  safely.
-- The policy remains in `tools/ci-impact-policy.mjs`; no duplicate YAML or JSON owner is
-  introduced.
-- Existing full-profile commands, aggregate names, and promotion evidence contracts are
-  unchanged.
-- Focused policy, CLI, gate, workflow architecture, and applicable full regression tests
-  pass without network access for unit coverage.
+# CI validation tiers and impact routing
+
+`tools/ci-impact-policy.mjs` owns path classification and required job registries.
+`tools/ci-impact.mjs` reads Git changes, verifies inherited evidence, and validates
+aggregate results. Workflows execute the selected jobs; they do not duplicate the
+classification rules.
+
+## Validation tiers
+
+| Tier | Trigger | Required coverage |
+| --- | --- | --- |
+| PR | Every PR into `dev` | Changed subsystem, cross-layer smoke, architecture/Product policy; Python 3.11 primary |
+| Integrated dev | Every push to `dev`; `Tests` dispatch with `tier=dev` | Core on Python 3.10/3.11/3.12; recipes, Gallery, browser/package integration, offline GUI, LOSAT cache, all functional Playwright in four shards, performance smoke on 3.11 |
+| Release / S11 | Explicit `Tests` dispatch on `dev` with `tier=release` | Every dev functional job, additional recipe/Gallery/browser acceptance on 3.10/3.12, exhaustive non-browser slow tests on all three versions, exact-candidate Gallery readiness |
+
+PR feedback targets 5–8 minutes. Integrated functional validation targets 15–20
+minutes where practical. S11 remains intentionally expensive. The separate
+`Gallery publication` workflow retains common-nine browser parity and its
+three-trial performance projection, with the complete-refresh budget available
+through its existing explicit dispatch. Deployment stress checks also remain.
+
+`Release / gate` is CI evidence for S11, not certification of the entire release
+process. S11 still requires its candidate freeze, package install/offline and
+cross-platform evidence, complete-refresh/performance budgets, and source checks.
+The tag publication workflow and `tools/check_release_source.py` are unchanged;
+passing a tier never authorizes tagging, publication, or deployment.
+
+### Python-version coverage
+
+The inexpensive core matrix remains on 3.10/3.11/3.12 because language support,
+TOML loading (`tomli` on 3.10), dependency resolution, and package/Python APIs can
+differ by host interpreter. Browser rendering itself uses the packaged Pyodide
+interpreter, not the runner's Python version. Host-version repetition still tests
+packaging and browser-test adapters, so exhaustive recipe/Gallery/browser version
+coverage remains mandatory in release acceptance. Python 3.11 already runs each
+of those surfaces in the shared functional jobs.
+
+All non-browser slow tests move to S11, except the three package-build integration
+checks in `test_web_packaging.py`, which also run in the dev Browser job. Offline
+GUI browser contracts remain on dev, including real Linear LOSAT generation;
+recent integrated runs found failures uniquely in that path.
+
+## Changed paths → capabilities → required jobs
+
+Plans contain the ordered union of affected `capabilities`. `impact` is the
+highest-ranked display label; it does not discard other capabilities. The job
+registry unions their contributions, then emits unique jobs in registry order.
+
+| Capability | Representative paths | Selective PR jobs |
+| --- | --- | --- |
+| `metadata` | Existing development-tool allowlist, `.gitignore`, citation/licenses | No test job |
+| `documentation` | Root Markdown and `docs/`, excluding policy authority | Recipes |
+| `python-core` | Known Python core/API/config/I/O owners and data | Architecture, core, lint, Web contracts, browser smoke |
+| `renderer` | Render/SVG/diagram/canvas/features/labels/layout owners | Architecture, core, lint, Web contracts, browser smoke |
+| `web-runtime` | `gbdraw/web/index.html`, first-party JS | Architecture, Web contracts, browser smoke |
+| `session-persistence` | Python session codecs; JS session/config/history owners | Architecture, core, recipes, lint, Web contracts, browser smoke |
+| `gallery` | Gallery inputs and their generator owners | Architecture, Gallery, Web contracts, browser smoke |
+| `losat-integration` | Comparison owners, LOSAT JS/workers/Wasm | Architecture, core, lint, Web contracts, browser smoke |
+| `tests-only` | Shared fixtures/harness and unclassified tests | Full PR tier |
+| `packaging` | Dependencies, manifests, vendored runtime, packaging tools | Full PR tier |
+| `ci-only` | Workflows, planner/tests, Playwright configuration, architecture/Product authority | Full PR tier |
+| `full` | Unknown or invalid paths | Full PR tier |
+
+The full PR job IDs are `web-change-budget`, `core-pr`, `recipes-standard`,
+`gallery`, `lint`, `web-contracts-pr`, and `web-pr-smoke`.
+
+`web-contracts-pr` groups the existing fast JS contracts and non-slow Python
+browser suite, which together took approximately 65–70 seconds historically.
+`web-pr-smoke` runs only the ten selected Playwright cases. They execute in
+parallel jobs instead of sharing one 15-minute serialized budget. Both jobs keep
+independent working directories, dependency installs, wheels, and browser state.
+The contracts job also runs when the trusted plan requires `web-pr-smoke`, so the
+pre-redesign base planner still requires all three original suites during rollout.
+
+Web unit/browser tests and their helpers route to the Web, session, Gallery, or
+LOSAT capability they exercise. Adding a normal Web regression therefore does not
+force a full PR route. Shared fixtures and unclassified tests remain conservative
+because they can affect several suites. Unknown production roots also remain full;
+recognizing known subsystem owners does not make arbitrary future paths safe.
+Renames/copies classify both endpoints, deletions classify their old path, and
+malformed/empty diffs or missing Git objects fail closed.
+
+### Evidence required for selection
+
+A narrower PR route requires successful exact-SHA `Dev staging / gate` evidence
+at the PR base. No older successful SHA can substitute. API failures, missing or
+unfinished runs, cancellation, and failed/malformed evidence select the complete
+PR tier. `architecture-change`, control-plane changes, dependencies, unknown
+paths, unclassified/shared test inputs, and explicit dispatches also require the full relevant tier.
+
+Every runtime/subsystem change runs complete integrated dev and Gallery coverage.
+Only metadata/documentation changes can inherit direct-parent staging evidence:
+metadata runs no test jobs, documentation runs recipes in `Tests`, and neither
+reruns Gallery publication when exact parent Gallery readiness is successful.
+Consecutive pushes whose direct parent is unfinished/cancelled run the full tier.
+
+## Smoke inventory and regression retention
+
+Smoke retains app/Worker boot and Circular generation, Linear multi-record
+rendering, mounted Feature/Label/Legend edits, export startup, Save/Load/Generate,
+Circular and Linear mode transitions, invalid-annotation preservation, and invalid
+composite-session rejection. Full functional discovery includes every smoke case.
+
+`tests/ci/playwright-inventory.test.mjs` uses Playwright's expanded `--list` output.
+It counts nested and parameterized cases and rejects fewer than 8 or more than 12;
+counting tag strings in source missed the earlier growth to 27 cases. No assertions,
+case bodies, test timeouts, or full-functional exclusions changed in this redesign.
+The exact relocated cases and before/after counts are in the
+[measurement report](CI_TIER_REDESIGN_2026-09-11.md).
+
+The smoke config retains one worker and zero retries. Three local two-worker
+repetitions passed, but these are not repeated GitHub runner evidence. One worker
+already meets the projected target, so CI does not adopt unverified parallelism.
+Full functional CI retains four shards and its existing retry policy.
+
+## Trust and aggregate checks
+
+PR planning and `PR / gate` execute the PR base's helper under `.ci-trusted-base`.
+Candidate helpers are test inputs only. A missing or invalid base helper fails;
+there is no candidate fallback. `Web base policy (trusted base)` remains a separate
+`pull_request_target` check that treats candidate files as Git data.
+
+The redesign PR therefore receives the old base's complete PR route. New selective
+routing can take effect only after reviewed integration into protected `dev`.
+Additional contract failures also block the old gate's unknown-job validation.
+No branch protection or required external status name changes.
+
+`PR / gate`, `Dev staging / gate`, `Gallery readiness / gate`, and `Promotion / gate`
+remain stable. `Release / gate` is separate and requires every release-profile
+job, including both exhaustive matrices, plus exact-candidate Gallery readiness.
+A release dispatch cannot emit ordinary `Dev staging / gate` success.
+
+Plans use schema 2 and include the capability union. The active helper validates
+its own exact schema, profile, workflow SHA, required job list, and inherited
+evidence. It rejects missing/skipped/failed/cancelled required jobs and unexpected
+failures in optional/additional jobs. Matrix aggregates must succeed. Workflows
+start on all relevant events and filter at job level; they never use workflow
+`paths` filters that could omit an aggregate.
+
+## Verification and rollback
+
+Install locked Node dependencies, then run `node --test tests/ci/*.test.mjs` and
+`node --test tests/web/architecture-contracts.test.mjs`. For browser execution,
+prepare the browser wheel and run `npm run test:web:pr-smoke`. Full functional
+coverage remains `npm run test:web:functional-full`.
+
+The [timing CSV](CI_TIER_TIMINGS_2026-09-11.csv) records each historical job's setup,
+dependency, wheel, test, teardown, and wall-clock times with direct job URLs.
+Plans report capabilities, required jobs, evidence links, and fallback reasons.
+
+Rollback this coherent CI change together: policy, adapter, workflow, smoke tags,
+and policy/inventory contracts. Preserve trusted-base evaluation and stable gate
+names. Restoring exhaustive matrices to dev changes cost, not release criteria.

--- a/tests/ci/ci-impact-cli.test.mjs
+++ b/tests/ci/ci-impact-cli.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { classifyPath } from '../../tools/ci-impact-policy.mjs';
 import { PromotionReadinessError } from '../../tools/check-promotion-readiness.mjs';
 import {
   buildImpactPlan,
@@ -216,7 +217,7 @@ test('Gallery-impacting surfaces select the full Gallery profile without evidenc
       verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
     });
     assert.equal(evidenceCalls, 0, path);
-    assert.equal(outcome.plan.impact, 'full', path);
+    assert.equal(outcome.plan.impact, classifyPath(path).impact, path);
     assert.equal(outcome.plan.decision, 'full', path);
     assert.equal(outcome.plan.basis, 'FULL_CHANGE', path);
     assert.deepEqual(outcome.plan.requiredJobs, ['browser', 'performance'], path);
@@ -236,7 +237,7 @@ test('dev control-plane changes run the full profile without inherited evidence'
       verifyWorkflowEvidenceImpl: async () => { evidenceCalls += 1; }
     });
     assert.equal(evidenceCalls, 0, path);
-    assert.equal(outcome.plan.impact, 'full', path);
+    assert.equal(outcome.plan.impact, classifyPath(path).impact, path);
     assert.equal(outcome.plan.decision, 'full', path);
     assert.equal(outcome.plan.basis, 'FULL_CHANGE', path);
   }
@@ -271,8 +272,6 @@ test('dev direct-parent staging failures force the current run to full', async (
       'browser',
       'playwright-functional',
       'playwright-performance',
-      'acceptance-supported-main',
-      'slow-main',
       'lint',
       'losat-cache-browser-acceptance'
     ], code);
@@ -398,6 +397,7 @@ test('evidence verifier failures fall back to the full profile', async () => {
     'recipes-standard',
     'gallery',
     'lint',
+    'web-contracts-pr',
     'web-pr-smoke'
   ]);
   assert.deepEqual(outcome.evidenceFailure, {
@@ -418,7 +418,7 @@ test('full changes never query inherited evidence', async () => {
     }
   });
   assert.equal(evidenceCalls, 0);
-  assert.equal(outcome.plan.impact, 'full');
+  assert.equal(outcome.plan.impact, 'ci-only');
   assert.equal(outcome.plan.basis, 'FULL_CHANGE');
 });
 
@@ -451,8 +451,6 @@ test('manual runs and architecture-change labels force full execution', async ()
       'browser',
       'playwright-functional',
       'playwright-performance',
-      'acceptance-supported-main',
-      'slow-main',
       'lint',
       'losat-cache-browser-acceptance'
     ]],
@@ -503,7 +501,7 @@ test('plan command writes one compact output line and escapes summary paths', as
   assert.equal(status, 0, stderr.value());
   const output = writes.get('/tmp/ci-impact-output');
   assert.equal(output.split('\n').filter(Boolean).length, 1);
-  assert.match(output, /^plan=\{"schemaVersion":1,/);
+  assert.match(output, /^plan=\{"schemaVersion":2,/);
   const summary = writes.get('/tmp/ci-impact-summary');
   assert.match(summary, /docs\/&lt;unsafe&gt;\\nname\.md/);
   assert.doesNotMatch(summary, /docs\/<unsafe>/);
@@ -628,6 +626,7 @@ test('workflow keeps trusted PR routing and activates protected dev routing', ()
     'recipes-standard',
     'gallery',
     'lint',
+    'web-contracts-pr',
     'web-pr-smoke'
   ]) {
     const job = workflowJob(jobId);
@@ -656,8 +655,6 @@ test('workflow keeps trusted PR routing and activates protected dev routing', ()
     'browser',
     'playwright-functional',
     'playwright-performance',
-    'acceptance-supported-main',
-    'slow-main',
     'lint',
     'losat-cache-browser-acceptance'
   ];
@@ -695,4 +692,54 @@ test('workflow keeps trusted PR routing and activates protected dev routing', ()
   assert.match(devGate, /CI_IMPACT_EXPECTED_WORKFLOW_SHA: \$\{\{ github\.sha \}\}/);
   assert.match(devGate, /run: node tools\/ci-impact\.mjs gate/);
   assert.doesNotMatch(devGate, /test "\$\{\{ needs\./);
+});
+
+test('web PR route inherits only exact base evidence and falls back to full on API failure', async () => {
+  for (const available of [true, false]) {
+    const outcome = await buildImpactPlan({
+      configuration: configuration(), token: 'test-token',
+      runGitImpl: () => gitResult('M', 'gbdraw/web/js/app/label-editor.js'),
+      verifyWorkflowEvidenceImpl: async ({ expectedHeadSha }) => {
+        assert.equal(expectedHeadSha, SHA.base);
+        if (!available) throw new PromotionReadinessError('API_REQUEST_FAILED', 'unavailable');
+        return successfulEvidence();
+      }
+    });
+    assert.equal(outcome.plan.decision, available ? 'selective' : 'full');
+    assert.equal(outcome.plan.requiredJobs.includes('core-pr'), !available);
+    assert.ok(outcome.plan.requiredJobs.includes('web-contracts-pr'));
+    assert.ok(outcome.plan.requiredJobs.includes('web-pr-smoke'));
+  }
+});
+
+test('release dispatch is exhaustive and cannot be inferred from a routine push', async () => {
+  const outcome = await buildImpactPlan({
+    configuration: configuration({ CI_IMPACT_PROFILE: 'release', CI_IMPACT_EVENT_NAME: 'workflow_dispatch' }),
+    runGitImpl: () => { throw new Error('manual release must not classify a diff'); },
+    verifyWorkflowEvidenceImpl: () => { throw new Error('manual release cannot inherit evidence'); }
+  });
+  assert.equal(outcome.plan.profile, 'release');
+  assert.equal(outcome.plan.basis, 'MANUAL_FULL_RUN');
+  assert.ok(outcome.plan.requiredJobs.includes('acceptance-supported-main'));
+  assert.ok(outcome.plan.requiredJobs.includes('slow-main'));
+  assert.throws(() => configuration({ CI_IMPACT_PROFILE: 'release', CI_IMPACT_EVENT_NAME: 'push' }), /explicit dispatch/);
+});
+
+test('release workflow binds exhaustive matrices and package/browser contracts to its gate', () => {
+  const workflow = readFileSync(resolve(REPOSITORY_ROOT, '.github/workflows/test.yml'), 'utf8');
+  const job = (id) => workflow.match(new RegExp(`\\n  ${id}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`))?.[0] || '';
+  const release = job('release-gate');
+  assert.match(release, /CI_IMPACT_EXPECTED_PROFILE: release/);
+  assert.match(release, /inputs\.tier == 'release'/);
+  for (const id of ['core', 'recipes-standard', 'gallery', 'browser', 'playwright-functional', 'playwright-performance', 'losat-cache-browser-acceptance', 'acceptance-supported-main', 'slow-main']) {
+    assert.ok(release.includes(`      - ${id}\n`), `release gate missing ${id}`);
+  }
+  assert.match(job('core'), /python-version: \["3.10", "3.11", "3.12"\]/);
+  assert.match(job('acceptance-supported-main'), /python-version: \["3.10", "3.12"\]/);
+  assert.match(job('acceptance-supported-main'), /surface: \["recipe", "gallery", "browser"\]/);
+  assert.match(job('slow-main'), /python-version: \["3.10", "3.11", "3.12"\]/);
+  assert.match(job('slow-main'), /-m "slow and not browser"/);
+  assert.match(job('browser'), /Run package build integration[\s\S]*-m "slow and not browser"/);
+  assert.match(job('browser'), /Run offline GUI browser contracts[\s\S]*-m "slow and browser"/);
+  assert.match(job('pr-gate'), /sparse-checkout: tools[\s\S]*node \.ci-trusted-base\/tools\/ci-impact.mjs gate/);
 });

--- a/tests/ci/ci-impact-gate.test.mjs
+++ b/tests/ci/ci-impact-gate.test.mjs
@@ -86,6 +86,7 @@ test('gate accepts metadata, documentation, and full PR routes', () => {
       'recipes-standard',
       'gallery',
       'lint',
+      'web-contracts-pr',
       'web-pr-smoke'
     ]
   ]);
@@ -122,8 +123,6 @@ test('gate accepts metadata, documentation, and full dev staging routes', () => 
       'browser',
       'playwright-functional',
       'playwright-performance',
-      'acceptance-supported-main',
-      'slow-main',
       'lint',
       'losat-cache-browser-acceptance'
     ]
@@ -180,7 +179,7 @@ test('Gallery gate rejects the wrong profile, workflow SHA, and schema', () => {
   for (const [candidate, expected, message] of [
     [impactPlan, { profile: 'dev', workflowSha: SHA.workflow }, /profile does not match/],
     [impactPlan, { profile: 'gallery', workflowSha: 'd'.repeat(40) }, /workflow SHA does not match/],
-    [{ ...impactPlan, schemaVersion: 2 }, {
+    [{ ...impactPlan, schemaVersion: 999 }, {
       profile: 'gallery', workflowSha: SHA.workflow
     }, /schema version is not supported/]
   ]) {
@@ -305,7 +304,7 @@ test('trusted gate rejects wrong profile, workflow SHA, and helper schema', () =
     expected: { profile: 'pr', workflowSha: 'd'.repeat(40) }
   }), /workflow SHA does not match/);
   assert.throws(() => validateGateResults({
-    plan: { ...impactPlan, schemaVersion: 2 },
+    plan: { ...impactPlan, schemaVersion: 999 },
     needs,
     knownJobs: knownJobsFor('pr'),
     expected: { profile: 'pr', workflowSha: SHA.workflow }
@@ -385,4 +384,16 @@ test('gate CLI emits a passing summary for a valid payload', async () => {
   assert.match(summary, /Gate result: pass/);
   assert.match(summary, /`recipes-standard`: `success` \(required\)/);
   assert.match(summary, /`gallery`: `skipped` \(not required\)/);
+});
+
+test('release aggregate rejects any skipped or failed exhaustive matrix', () => {
+  const release = plan({ profile: 'release', impact: 'full', decision: 'full', basis: 'MANUAL_FULL_RUN', inheritedEvidence: null });
+  assert.equal(validate(release, needsFor(release)).ok, true);
+  for (const jobId of release.requiredJobs) {
+    for (const result of ['skipped', 'failure', 'cancelled']) {
+      const needs = needsFor(release);
+      needs[jobId].result = result;
+      assert.throws(() => validate(release, needs), /required CI job did not succeed/);
+    }
+  }
 });

--- a/tests/ci/ci-impact-policy.test.mjs
+++ b/tests/ci/ci-impact-policy.test.mjs
@@ -66,30 +66,28 @@ test('root Markdown and docs tree are documentation', () => {
   assert.equal(classifyPath('README.MD').impact, 'full');
 });
 
-test('runtime, tests, workflows, dependencies, and unknown paths are full', () => {
-  for (const path of [
-    'gbdraw/core/sequence.py',
-    'tests/test_regression.py',
-    'tools/helper.mjs',
-    '.github/workflows/test.yml',
-    'pyproject.toml',
-    'setup.py',
-    'MANIFEST.in',
-    'package.json',
-    'package-lock.json',
-    'playwright.config.js',
-    'recipe/meta.yaml',
-    'examples/example.gb',
-    '_reproduced/result.svg',
-    'wrangler.toml',
-    'reports/result.json',
-    'future/unknown.file'
-  ]) {
-    assert.equal(classifyPath(path).impact, 'full', path);
-  }
+test('subsystem paths classify without making unknown production paths selective', () => {
+  for (const [path, impact] of [
+    ['gbdraw/core/sequence.py', 'python-core'],
+    ['gbdraw/render/drawers/linear/features.py', 'renderer'],
+    ['gbdraw/web/js/app/label-editor.js', 'web-runtime'],
+    ['gbdraw/session_request_codec.py', 'session-persistence'],
+    ['gbdraw/web/js/services/session-request.js', 'session-persistence'],
+    ['gbdraw/web/gallery/examples.json', 'gallery'],
+    ['gbdraw/web/js/services/losat.js', 'losat-integration'],
+    ['tests/test_regression.py', 'tests-only'],
+    ['.github/workflows/test.yml', 'ci-only'],
+    ['docs/internal/PRODUCT_IMPACT_RATCHET.md', 'ci-only'],
+    ['pyproject.toml', 'packaging'],
+    ['package-lock.json', 'packaging'],
+    ['tools/helper.mjs', 'full'],
+    ['gbdraw/future/new_engine.py', 'full'],
+    ['gbdraw/web/new-runtime.bin', 'full'],
+    ['future/unknown.file', 'full']
+  ]) assert.equal(classifyPath(path).impact, impact, path);
 });
 
-test('mixed changes use the strongest impact', () => {
+test('mixed changes preserve the capability union', () => {
   const metadata = classifyChanges([
     { status: 'M', paths: ['.gitignore'] },
     { status: 'A', paths: ['.agents/skills/new/SKILL.md'] }
@@ -106,7 +104,8 @@ test('mixed changes use the strongest impact', () => {
     { status: 'M', paths: ['docs/FAQ.md'] },
     { status: 'M', paths: ['gbdraw/cli.py'] }
   ]);
-  assert.equal(full.impact, 'full');
+  assert.equal(full.impact, 'python-core');
+  assert.deepEqual(full.capabilities, ['documentation', 'python-core']);
 });
 
 test('rename, copy, and delete classify every relevant path', () => {
@@ -152,6 +151,7 @@ test('profile job registries are exact and centralized', () => {
     'recipes-standard',
     'gallery',
     'lint',
+    'web-contracts-pr',
     'web-pr-smoke'
   ]);
   assert.deepEqual(knownJobsFor('pr'), [
@@ -160,6 +160,7 @@ test('profile job registries are exact and centralized', () => {
     'recipes-standard',
     'gallery',
     'lint',
+    'web-contracts-pr',
     'web-pr-smoke'
   ]);
   assert.deepEqual(knownJobsFor('dev'), [
@@ -170,8 +171,6 @@ test('profile job registries are exact and centralized', () => {
     'browser',
     'playwright-functional',
     'playwright-performance',
-    'acceptance-supported-main',
-    'slow-main',
     'lint',
     'losat-cache-browser-acceptance'
   ]);
@@ -200,7 +199,7 @@ test('impact plans are strict, policy-derived, and immutable', () => {
   const wrongJobs = { ...plan, requiredJobs: [] };
   assert.throws(() => validateImpactPlan(wrongJobs), /required jobs do not match policy/);
   assert.throws(
-    () => validateImpactPlan({ ...plan, schemaVersion: 2 }),
+    () => validateImpactPlan({ ...plan, schemaVersion: 999 }),
     /schema version is not supported/
   );
   assert.throws(
@@ -217,4 +216,70 @@ test('impact plans are strict, policy-derived, and immutable', () => {
     () => validateImpactPlan({ ...plan, unexpected: true }),
     /invalid schema/
   );
+});
+
+const jobsForPaths = (changes) => {
+  const classification = classifyChanges(changes);
+  return requiredJobsFor({ profile: 'pr', ...classification, decision: 'selective' });
+};
+
+test('representative PR routes require the changed subsystem and cross-layer smoke', () => {
+  for (const [path, expected] of [
+    ['README.md', ['recipes-standard']],
+    ['gbdraw/render/drawers/linear/features.py', ['web-change-budget', 'core-pr', 'lint', 'web-contracts-pr', 'web-pr-smoke']],
+    ['gbdraw/web/js/app/label-editor.js', ['web-change-budget', 'web-contracts-pr', 'web-pr-smoke']],
+    ['gbdraw/web/js/services/session-request.js', ['web-change-budget', 'core-pr', 'recipes-standard', 'lint', 'web-contracts-pr', 'web-pr-smoke']],
+    ['gbdraw/web/gallery/examples.json', ['web-change-budget', 'gallery', 'web-contracts-pr', 'web-pr-smoke']]
+  ]) assert.deepEqual(jobsForPaths([{ status: 'M', paths: [path] }]), expected, path);
+});
+
+test('mixed capabilities and both rename endpoints contribute independent required jobs', () => {
+  const paths = ['gbdraw/render/drawers/linear/features.py', 'gbdraw/web/gallery/examples.json'];
+  const expected = ['web-change-budget', 'core-pr', 'gallery', 'lint', 'web-contracts-pr', 'web-pr-smoke'];
+  for (const changes of [
+    paths.map((path) => ({ status: 'M', paths: [path] })),
+    [{ status: 'R100', paths }],
+    [{ status: 'C75', paths }]
+  ]) assert.deepEqual(jobsForPaths(changes), expected);
+  assert.ok(jobsForPaths([{ status: 'D', paths: [paths[0]] }]).includes('core-pr'));
+  assert.throws(() => jobsForPaths([{ status: 'R100', paths: [paths[0], 'future/engine.py'] }]), /full coverage/);
+  assert.throws(() => jobsForPaths([{ status: 'D', paths: ['gbdraw/unknown.py'] }]), /full coverage/);
+});
+
+test('control-plane, dependency, unknown and test-only changes cannot select partial coverage', () => {
+  for (const impact of ['ci-only', 'packaging', 'full', 'tests-only']) {
+    assert.throws(() => requiredJobsFor({ profile: 'pr', impact, decision: 'selective' }), /full coverage/);
+    assert.deepEqual(requiredJobsFor({ profile: 'pr', impact, decision: 'full' }), knownJobsFor('pr'));
+  }
+});
+
+test('release retains every dev functional job plus supported-version and slow acceptance', () => {
+  assert.deepEqual(knownJobsFor('release'), [...knownJobsFor('dev'), 'acceptance-supported-main', 'slow-main']);
+  assert.throws(() => requiredJobsFor({ profile: 'release', impact: 'documentation', decision: 'selective' }), /full coverage/);
+  assert.throws(() => requiredJobsFor({ profile: 'dev', impact: 'web-runtime', decision: 'selective' }), /full coverage/);
+});
+
+test('capability tampering cannot drop an independent contribution', () => {
+  const combined = selectivePlan({ impact: 'web-runtime', capabilities: ['documentation', 'web-runtime'] });
+  assert.deepEqual(combined.requiredJobs, ['web-change-budget', 'recipes-standard', 'web-contracts-pr', 'web-pr-smoke']);
+  for (const capabilities of [[], ['web-runtime', 'documentation'], ['documentation', 'documentation'], ['future']]) {
+    assert.throws(() => validateImpactPlan({ ...combined, capabilities }), /Capabilities/);
+  }
+  assert.throws(() => validateImpactPlan({ ...combined, requiredJobs: ['web-change-budget', 'web-contracts-pr', 'web-pr-smoke'] }), /required jobs/);
+});
+
+
+test('ordinary Web changes stay selective when accompanied by their regression tests', () => {
+  assert.deepEqual(jobsForPaths([
+    { status: 'M', paths: ['gbdraw/web/js/app/label-editor.js'] },
+    { status: 'A', paths: ['tests/web/label-editor.test.mjs'] },
+    { status: 'M', paths: ['tests/web/right-drawer.playwright.spec.js'] }
+  ]), ['web-change-budget', 'web-contracts-pr', 'web-pr-smoke']);
+  for (const path of ['tests/web/session-request.test.mjs', 'tests/web/contracts/current-session-lazy-materialization.playwright.spec.js']) {
+    assert.equal(classifyPath(path).impact, 'session-persistence', path);
+    assert.ok(jobsForPaths([{ status: 'M', paths: [path] }]).includes('core-pr'));
+  }
+  for (const path of ['tests/conftest.py', 'tests/test_inputs/example.gbk', 'tests/web/architecture-ratchet-fixtures.test.mjs']) {
+    assert.throws(() => jobsForPaths([{ status: 'M', paths: [path] }]), /full coverage/, path);
+  }
 });

--- a/tests/ci/playwright-inventory.test.mjs
+++ b/tests/ci/playwright-inventory.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const cli = require.resolve('@playwright/test/cli');
+const collect = (config) => {
+  const result = spawnSync(process.execPath, [cli, 'test', `--config=${config}`, '--list', '--reporter=json'], {
+    encoding: 'utf8', maxBuffer: 16 * 1024 * 1024
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.deepEqual(report.errors, []);
+  const visit = (suites) => suites.flatMap((suite) => [
+    ...(suite.specs || []).flatMap((spec) => spec.tests.map(() => `${spec.file}:${spec.title}`)),
+    ...visit(suite.suites || [])
+  ]);
+  return visit(report.suites);
+};
+
+test('expanded PR smoke has 8–12 cases and each remains in full functional acceptance', () => {
+  const smoke = collect('playwright.pr-smoke.config.js');
+  const full = new Set(collect('playwright.functional.config.js'));
+  assert.ok(smoke.length >= 8 && smoke.length <= 12, `collected ${smoke.length} PR cases`);
+  for (const title of smoke) assert.ok(full.has(title), `missing full regression: ${title}`);
+  for (const path of [
+    'mode-transition-editor-state.playwright.spec.js',
+    'mode-record-identity.playwright.spec.js',
+    'annotation-download.playwright.spec.js',
+    'contracts/active-result-edit-transaction.playwright.spec.js'
+  ]) assert.ok([...full].some((title) => title.startsWith(`${path}:`)), `missing moved regression: ${path}`);
+});

--- a/tests/web/annotation-download.playwright.spec.js
+++ b/tests/web/annotation-download.playwright.spec.js
@@ -29,7 +29,7 @@ const snapshot = (page) => page.evaluate(async () => {
 });
 
 for (const width of [1440, 390]) {
-  test(`@pr-smoke annotation TSV download/re-import and Python round-trip offline (${width}px)`, async ({ page, browser }, testInfo) => {
+  test(`annotation TSV download/re-import and Python round-trip offline (${width}px)`, async ({ page, browser }, testInfo) => {
     test.setTimeout(180000);
     await page.setViewportSize({ width, height: 960 });
     const external = [];

--- a/tests/web/architecture-contracts.test.mjs
+++ b/tests/web/architecture-contracts.test.mjs
@@ -1060,14 +1060,16 @@ test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
   assert.match(webPrSmoke, /needs: ci-impact/);
   assert.match(webPrSmoke, /needs\.ci-impact\.result == 'success'/);
   assert.match(webPrSmoke, /requiredJobs, 'web-pr-smoke'/);
-  assert.match(webPrSmoke, /timeout-minutes: 15/);
+  assert.match(webPrSmoke, /timeout-minutes: 10/);
   assert.equal([...webPrSmoke.matchAll(/uses: actions\/checkout@/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/npm ci/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/playwright install --with-deps chromium/g)].length, 1);
   assert.equal([...webPrSmoke.matchAll(/python tools\/prepare_browser_wheel\.py/g)].length, 1);
-  assert.match(webPrSmoke, /Run fast Web JavaScript contracts/);
-  assert.match(webPrSmoke, /! -name 'gallery-session-publication\.test\.mjs'/);
-  assert.match(webPrSmoke, /-m "browser and not slow"/);
+  const webContracts = workflowJob('web-contracts-pr');
+  assert.match(webContracts, /Run fast Web JavaScript contracts/);
+  assert.match(webContracts, /! -name 'gallery-session-publication\.test\.mjs'/);
+  assert.match(webContracts, /-m "browser and not slow"/);
+  assert.doesNotMatch(webPrSmoke, /Run fast Web JavaScript contracts|python -m pytest/);
   assert.match(webPrSmoke, /npm run test:web:pr-smoke/);
   assert.match(webPrSmoke, /if: failure\(\)[\s\S]+path: test-results\//);
   assert.doesNotMatch(
@@ -1087,6 +1089,7 @@ test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
     'recipes-standard',
     'gallery',
     'lint',
+    'web-contracts-pr',
     'web-pr-smoke'
   ]);
   assert.match(
@@ -1111,6 +1114,7 @@ test('PR-to-dev jobs and aggregate use the trusted selective plan', () => {
     'recipes-standard',
     'gallery',
     'lint',
+    'web-contracts-pr',
     'web-pr-smoke'
   ]) {
     const job = workflowJob(jobId);
@@ -1177,11 +1181,8 @@ test('PR smoke selection is explicit while the full functional inventory stays w
     /pass-with-no-tests/
   );
 
-  const selectedCount = PLAYWRIGHT_SPEC_SOURCES.reduce(
-    (count, source) => count + [...source.matchAll(/tag: ['"]@pr-smoke['"]/g)].length,
-    0
-  );
-  assert.ok(selectedCount >= 6 && selectedCount <= 10, `selected ${selectedCount} smoke tests`);
+  // Expanded Playwright discovery (including nested/parameterized tests) is checked
+  // by tests/ci/playwright-inventory.test.mjs, not a tag-source regex.
 });
 
 test('exact dev staging routes every job through the protected-branch plan', () => {
@@ -1193,8 +1194,6 @@ test('exact dev staging routes every job through the protected-branch plan', () 
     'browser',
     'playwright-functional',
     'playwright-performance',
-    'acceptance-supported-main',
-    'slow-main',
     'lint',
     'losat-cache-browser-acceptance'
   ];
@@ -1533,7 +1532,7 @@ test('dev staging Web checks scope only the newly integrated change', () => {
   );
 });
 
-test('supported-version and slow matrices cover exact dev staging', () => {
+test('supported-version and slow matrices are mandatory in explicit release acceptance', () => {
   for (const jobName of ['acceptance-supported-main', 'slow-main']) {
     const job = TEST_WORKFLOW.match(
       new RegExp(`\\n  ${jobName}:\\n[\\s\\S]*?(?=\\n  [a-z0-9-]+:\\n|$)`)
@@ -1548,6 +1547,12 @@ test('supported-version and slow matrices cover exact dev staging', () => {
       /github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/dev'/
     );
   }
+  const gate = workflowJob('release-gate');
+  assert.match(gate, /name: Release \/ gate/);
+  assert.match(gate, /inputs\.tier == 'release'/);
+  assert.match(gate, /CI_IMPACT_EXPECTED_PROFILE: release/);
+  assert.match(gate, /Require exact candidate Gallery readiness/);
+  assert.match(workflowJob('dev-staging-gate'), /inputs\.tier != 'release'/);
 });
 
 const CHANGE_BUDGET_CHECKER = join(REPOSITORY_ROOT, 'tools/check-web-change-budget.mjs');

--- a/tests/web/composite-session-resources.playwright.spec.js
+++ b/tests/web/composite-session-resources.playwright.spec.js
@@ -164,7 +164,7 @@ const prepareSeed = async (journey, testInfo) => {
 };
 
 for (const journey of ['minimal', 'grid-batch-grid']) {
-  test(`Session export Vibrio composite resources survive ${journey} Save, fresh Load and Generate${journey === 'minimal' ? ' @pr-smoke' : ''}`, async ({ browser }, testInfo) => {
+  test(`Session export Vibrio composite resources survive ${journey} Save, fresh Load and Generate`, async ({ browser }, testInfo) => {
     test.setTimeout(6 * generateTimeout + 6 * loadTimeout);
     const contexts = [];
     try {

--- a/tests/web/contracts/active-result-edit-transaction.playwright.spec.js
+++ b/tests/web/contracts/active-result-edit-transaction.playwright.spec.js
@@ -235,7 +235,7 @@ test.describe('active Result Feature fill transaction', () => {
     expect(await page.evaluate(() => window.__GBDRAW_APP__.errorLog || null)).toBeNull();
   };
 
-  test('visible tRNA fill scope remains coherent through History, Session, Generate, and SVG export', { tag: '@pr-smoke' }, async ({
+  test('visible tRNA fill scope remains coherent through History, Session, Generate, and SVG export', async ({
     page,
     browser
   }, testInfo) => {

--- a/tests/web/draft-placement-capability.playwright.spec.js
+++ b/tests/web/draft-placement-capability.playwright.spec.js
@@ -3,7 +3,7 @@ const fs = require('node:fs/promises');
 const { openApp } = require('./helpers/app-lifecycle.cjs');
 
 for (const mode of ['circular', 'linear']) {
-  test(`@pr-smoke ${mode} draft placement capability survives history and dirty session restore`, async ({ browser }, testInfo) => {
+  test(`${mode} draft placement capability survives history and dirty session restore`, async ({ browser }, testInfo) => {
     test.setTimeout(240000);
     const external = [];
     let context;

--- a/tests/web/history-inputs.playwright.spec.js
+++ b/tests/web/history-inputs.playwright.spec.js
@@ -45,7 +45,7 @@ const expectHistory = async (page, undo, redo, label) => {
 };
 
 for (const inputMethod of ['keyboard', 'pointer']) {
-  test(`Label Mode ${inputMethod} edit has one Undo step and survives generation and fresh Load @pr-smoke`, async ({
+  test(`Label Mode ${inputMethod} edit has one Undo step and survives generation and fresh Load`, async ({
     page, context, browser
   }, testInfo) => {
     test.setTimeout(300_000);

--- a/tests/web/joint-display-placement.playwright.spec.js
+++ b/tests/web/joint-display-placement.playwright.spec.js
@@ -68,7 +68,7 @@ ORIGIN
 `;
 
 for (const mode of ['circular', 'linear']) {
-  test(`@pr-smoke joint rotation placement and saved drafts in ${mode}`, async ({ page, browser }, testInfo) => {
+  test(`joint rotation placement and saved drafts in ${mode}`, async ({ page, browser }, testInfo) => {
     test.setTimeout(240000);
     await page.addInitScript(() => {
       window.__JOINT_LIFECYCLE__ = [];

--- a/tests/web/linear-typography.playwright.spec.js
+++ b/tests/web/linear-typography.playwright.spec.js
@@ -54,7 +54,7 @@ const focusAfterHistoryCapture = async (page, locator) => {
   }));
 };
 
-test('independent Linear typography follows linked, imported, and History journeys @pr-smoke', async ({ page }, testInfo) => {
+test('independent Linear typography follows linked, imported, and History journeys', async ({ page }, testInfo) => {
   test.setTimeout(300000);
   const genbank = readFileSync(genbankPath, 'utf8');
 

--- a/tests/web/mode-record-identity.playwright.spec.js
+++ b/tests/web/mode-record-identity.playwright.spec.js
@@ -67,7 +67,7 @@ const structure = (page, svg) => page.evaluate(svg => {
 }, svg);
 
 for (const committed of [false, true]) {
-  test(`@pr-smoke ${committed ? 'committed' : 'ungenerated'} Circular placement retains source identity through mode history and Save/Load`, async ({ browser }, testInfo) => {
+  test(`${committed ? 'committed' : 'ungenerated'} Circular placement retains source identity through mode history and Save/Load`, async ({ browser }, testInfo) => {
     test.setTimeout(360000);
     const pages = [];
     try {

--- a/tests/web/mode-transition-editor-state.playwright.spec.js
+++ b/tests/web/mode-transition-editor-state.playwright.spec.js
@@ -13,7 +13,7 @@ const labelIntent = state => ({ labels: state.labels, bulk: state.bulkLabels,
   sources: state.labelSources, visibility: state.visibility });
 
 for (const mode of ['circular', 'linear']) {
-  test(`@pr-smoke ${mode} label intent survives mode Undo/Redo and Save/Load/Generate`, async ({ browser }, testInfo) => {
+  test(`${mode} label intent survives mode Undo/Redo and Save/Load/Generate`, async ({ browser }, testInfo) => {
     test.setTimeout(360000);
     const page = await load(browser, seeds[mode]);
     let fresh;

--- a/tests/web/preview-navigation.playwright.spec.js
+++ b/tests/web/preview-navigation.playwright.spec.js
@@ -62,7 +62,7 @@ const expectTranslation = (before, after, dx, dy) => {
   expect(after.panning).toBe(false);
 };
 
-test('@pr-smoke background pan preserves screen displacement after text selection and zoom', async ({ page }, testInfo) => {
+test('background pan preserves screen displacement after text selection and zoom', async ({ page }, testInfo) => {
   test.setTimeout(180000);
   await openApp(page);
   page.on('dialog', (dialog) => dialog.dismiss());
@@ -112,7 +112,7 @@ test('@pr-smoke background pan preserves screen displacement after text selectio
   expect(await getDiagramWorkerActivity(page)).toMatchObject({ constructions: 0 });
 });
 
-test('@pr-smoke preview pan leaves feature and match gestures available', async ({ page }) => {
+test('preview pan leaves feature and match gestures available', async ({ page }) => {
   test.setTimeout(180000);
   // Keep the wide comparison's editing targets visible at its existing zoom anchor.
   await page.setViewportSize({ width: 2520, height: 1327 });

--- a/tools/ci-impact-policy.mjs
+++ b/tools/ci-impact-policy.mjs
@@ -1,69 +1,57 @@
 const freeze = (value) => Object.freeze(value);
 
-export const IMPACT_PLAN_SCHEMA_VERSION = 1;
+export const IMPACT_PLAN_SCHEMA_VERSION = 2;
 
+// Ordered only for the summary label. Routing unions every affected capability.
 export const IMPACT_CLASSES = freeze([
-  'metadata',
-  'documentation',
-  'full'
+  'metadata', 'documentation', 'tests-only', 'python-core', 'renderer',
+  'web-runtime', 'session-persistence', 'gallery', 'losat-integration',
+  'packaging', 'ci-only', 'full'
 ]);
-
 export const IMPACT_DECISIONS = freeze(['selective', 'full']);
-
 export const IMPACT_PLAN_BASES = freeze([
-  'FULL_CHANGE',
-  'UNKNOWN_OR_INVALID_CHANGE',
-  'MANUAL_FULL_RUN',
-  'ARCHITECTURE_CHANGE',
-  'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE',
-  'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE',
-  'INHERITED_EVIDENCE_UNAVAILABLE'
+  'FULL_CHANGE', 'UNKNOWN_OR_INVALID_CHANGE', 'MANUAL_FULL_RUN',
+  'ARCHITECTURE_CHANGE', 'LIGHT_CHANGE_WITH_DIRECT_BASE_EVIDENCE',
+  'LIGHT_CHANGE_WITH_DIRECT_PARENT_EVIDENCE', 'INHERITED_EVIDENCE_UNAVAILABLE'
 ]);
 
+const PR_JOBS = freeze([
+  'web-change-budget', 'core-pr', 'recipes-standard', 'gallery', 'lint',
+  'web-contracts-pr', 'web-pr-smoke'
+]);
+const DEV_JOBS = freeze([
+  'web-change-budget', 'core', 'recipes-standard', 'gallery', 'browser',
+  'playwright-functional', 'playwright-performance', 'lint',
+  'losat-cache-browser-acceptance'
+]);
 const PROFILE_REQUIRED_JOBS = freeze({
-  pr: freeze({
-    selective: freeze({
-      metadata: freeze([]),
-      documentation: freeze(['recipes-standard'])
-    }),
-    full: freeze([
-      'web-change-budget',
-      'core-pr',
-      'recipes-standard',
-      'gallery',
-      'lint',
-      'web-pr-smoke'
-    ])
-  }),
-  dev: freeze({
-    selective: freeze({
-      metadata: freeze([]),
-      documentation: freeze(['recipes-standard'])
-    }),
-    full: freeze([
-      'web-change-budget',
-      'core',
-      'recipes-standard',
-      'gallery',
-      'browser',
-      'playwright-functional',
-      'playwright-performance',
-      'acceptance-supported-main',
-      'slow-main',
-      'lint',
-      'losat-cache-browser-acceptance'
-    ])
-  }),
-  gallery: freeze({
-    selective: freeze({
-      metadata: freeze([]),
-      documentation: freeze([])
-    }),
-    full: freeze(['browser', 'performance'])
-  })
+  pr: PR_JOBS,
+  dev: DEV_JOBS,
+  release: freeze([...DEV_JOBS, 'acceptance-supported-main', 'slow-main']),
+  gallery: freeze(['browser', 'performance'])
+});
+const PR_CAPABILITY_JOBS = freeze({
+  metadata: freeze([]),
+  documentation: freeze(['recipes-standard']),
+  'tests-only': PR_JOBS,
+  'python-core': freeze(['web-change-budget', 'core-pr', 'lint', 'web-contracts-pr', 'web-pr-smoke']),
+  renderer: freeze(['web-change-budget', 'core-pr', 'lint', 'web-contracts-pr', 'web-pr-smoke']),
+  'web-runtime': freeze(['web-change-budget', 'web-contracts-pr', 'web-pr-smoke']),
+  'session-persistence': freeze(['web-change-budget', 'core-pr', 'recipes-standard', 'lint', 'web-contracts-pr', 'web-pr-smoke']),
+  gallery: freeze(['web-change-budget', 'gallery', 'web-contracts-pr', 'web-pr-smoke']),
+  'losat-integration': freeze(['web-change-budget', 'core-pr', 'lint', 'web-contracts-pr', 'web-pr-smoke']),
+  packaging: PR_JOBS,
+  'ci-only': PR_JOBS,
+  full: PR_JOBS
 });
 
-const IMPACT_WEIGHT = freeze({ metadata: 0, documentation: 1, full: 2 });
+// Runtime changes always receive comprehensive integrated-dev/Gallery validation.
+// Control-plane, dependency, and unknown changes cannot inherit a narrower route.
+export const requiresFullCoverage = (profile, capabilities) => profile === 'release'
+  || capabilities.some((capability) => ['full', 'ci-only', 'packaging', 'tests-only'].includes(capability))
+  || (profile !== 'pr' && capabilities.some((capability) => !['metadata', 'documentation'].includes(capability)));
+const orderedCapabilities = (capabilities) => IMPACT_CLASSES.filter((capability) => capabilities.includes(capability));
+const primaryImpact = (capabilities) => capabilities.at(-1);
 const FULL_OBJECT_ID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 const ROOT_MARKDOWN = /^[^/]+\.md$/;
 const METADATA_DIRECTORIES = freeze(['.agents', '.claude', '.codex', '.cursor']);
@@ -80,6 +68,7 @@ const PLAN_KEYS = freeze([
   'schemaVersion',
   'profile',
   'impact',
+  'capabilities',
   'decision',
   'basis',
   'changeBaseSha',
@@ -141,22 +130,59 @@ const isValidRepositoryPath = (path) => typeof path === 'string'
   && path.split('/').every((part) => part && part !== '.' && part !== '..');
 
 export const classifyPath = (path) => {
-  if (!isValidRepositoryPath(path)) {
-    return freeze({ path, impact: 'full', reason: 'INVALID_REPOSITORY_PATH' });
+  const classified = (impact, reason) => freeze({ path, impact, reason });
+  if (!isValidRepositoryPath(path)) return classified('full', 'INVALID_REPOSITORY_PATH');
+  // Policy documents are executable authority even though they are Markdown.
+  if (path.startsWith('.github/workflows/') || path.startsWith('tests/ci/')
+      || /^tools\/(?:ci-impact|check-web|web-(?:architecture|product|change)|check-promotion)/.test(path)
+      || /^tests\/web\/(?:architecture|product-impact|promotion-readiness).*\.test\.mjs$/.test(path)
+      || /^playwright.*\.config\.js$/.test(path)
+      || /^docs\/internal\/(?:WEB_CHANGE_POLICY|ARCHITECTURE_FITNESS_FUNCTION_RATCHET|PRODUCT_|OPTION_INTEGRITY_PRODUCT_CONTRACT|SELECTIVE_CI)/.test(path)) {
+    return classified('ci-only', 'CI_OR_POLICY_AUTHORITY');
   }
-  if (METADATA_FILES.has(path)) {
-    return freeze({ path, impact: 'metadata', reason: 'METADATA_FILE_ALLOWLIST' });
-  }
+  if (METADATA_FILES.has(path)) return classified('metadata', 'METADATA_FILE_ALLOWLIST');
   if (METADATA_DIRECTORIES.some((directory) => path.startsWith(`${directory}/`))) {
-    return freeze({ path, impact: 'metadata', reason: 'METADATA_DIRECTORY_ALLOWLIST' });
+    return classified('metadata', 'METADATA_DIRECTORY_ALLOWLIST');
   }
-  if (ROOT_MARKDOWN.test(path)) {
-    return freeze({ path, impact: 'documentation', reason: 'ROOT_MARKDOWN' });
+  if (ROOT_MARKDOWN.test(path)) return classified('documentation', 'ROOT_MARKDOWN');
+  if (path.startsWith('docs/')) return classified('documentation', 'DOCUMENTATION_TREE');
+  if (['pyproject.toml', 'setup.py', 'MANIFEST.in', 'package.json', 'package-lock.json',
+    'wrangler.toml', 'gbdraw/_build_support.py'].includes(path)
+      || path.startsWith('recipe/') || path.startsWith('gbdraw/web/vendor/')
+      || /^tools\/(?:prepare_browser_wheel|prepare_cloudflare_pages|verify_gui_offline|check_release_source)\.py$/.test(path)) {
+    return classified('packaging', 'PACKAGE_OR_DEPENDENCY_INPUT');
   }
-  if (path.startsWith('docs/')) {
-    return freeze({ path, impact: 'documentation', reason: 'DOCUMENTATION_TREE' });
+  if (path.startsWith('gbdraw/web/wasm/') || /^gbdraw\/web\/js\/.*losat[^/]*\.js$/.test(path)
+      || /^gbdraw\/(?:comparisons|losat)(?:\/|\.)/.test(path)) {
+    return classified('losat-integration', 'LOSAT_OWNER');
   }
-  return freeze({ path, impact: 'full', reason: 'FULL_BY_DEFAULT' });
+  if (path.startsWith('gbdraw/web/gallery/')
+      || /^tools\/(?:build_web_gallery|prepare_interactive_gallery_assets|refresh_gallery_sessions)\.py$/.test(path)) {
+    return classified('gallery', 'GALLERY_INPUT');
+  }
+  if (/^gbdraw\/(?:session[^/]*|api\/session)\.py$/.test(path)
+      || /^gbdraw\/web\/js\/(?:services\/(?:session[^/]*|config)|app\/(?:session[^/]*|history[^/]*))\.js$/.test(path)) {
+    return classified('session-persistence', 'SESSION_OWNER');
+  }
+  if (path === 'gbdraw/web/index.html' || /^gbdraw\/web\/js\/.*\.js$/.test(path)) {
+    return classified('web-runtime', 'WEB_SOURCE');
+  }
+  if (/^gbdraw\/(?:render|svg|diagrams|canvas|features|labels|legend|layout|tracks)\/.*\.py$/.test(path)) {
+    return classified('renderer', 'RENDERER_SOURCE');
+  }
+  if (/^gbdraw\/(?:api|config|configurators|core|io)\/.*\.py$/.test(path)
+      || /^gbdraw\/(?:__init__|cli|circular|linear)\.py$/.test(path)
+      || path.startsWith('gbdraw/data/')) {
+    return classified('python-core', 'PYTHON_SOURCE');
+  }
+  if (/^tests\/web\/.*(?:\.test\.mjs|\.playwright\.spec\.js|\.cjs)$/.test(path)) {
+    if (/\/(?:session|current-session|history)[^/]*\./.test(path)) return classified('session-persistence', 'SESSION_TEST');
+    if (/\/losat[^/]*\./.test(path)) return classified('losat-integration', 'LOSAT_TEST');
+    if (/\/gallery[^/]*\./.test(path)) return classified('gallery', 'GALLERY_TEST');
+    return classified('web-runtime', 'WEB_TEST');
+  }
+  if (path.startsWith('tests/')) return classified('tests-only', 'SHARED_OR_UNCLASSIFIED_TEST');
+  return classified('full', 'FULL_BY_DEFAULT');
 };
 
 const validScoredStatus = (status) => {
@@ -182,6 +208,7 @@ export const classifyChanges = (changes) => {
   if (!Array.isArray(changes) || changes.length === 0) {
     return freeze({
       impact: 'full',
+      capabilities: freeze(['full']),
       valid: false,
       changedPathCount: 0,
       paths: freeze([]),
@@ -195,6 +222,7 @@ export const classifyChanges = (changes) => {
     if (paths === null) {
       return freeze({
         impact: 'full',
+        capabilities: freeze(['full']),
         valid: false,
         changedPathCount: classifiedPaths.length,
         paths: freeze(classifiedPaths),
@@ -205,14 +233,10 @@ export const classifyChanges = (changes) => {
   }
 
   const invalidPath = classifiedPaths.some(({ reason }) => reason === 'INVALID_REPOSITORY_PATH');
-  const impact = classifiedPaths.reduce(
-    (current, entry) => IMPACT_WEIGHT[entry.impact] > IMPACT_WEIGHT[current]
-      ? entry.impact
-      : current,
-    'metadata'
-  );
+  const capabilities = invalidPath ? ['full'] : orderedCapabilities(classifiedPaths.map(({ impact }) => impact));
   return freeze({
-    impact: invalidPath ? 'full' : impact,
+    impact: primaryImpact(capabilities),
+    capabilities: freeze(capabilities),
     valid: !invalidPath,
     changedPathCount: classifiedPaths.length,
     paths: freeze(classifiedPaths),
@@ -220,24 +244,32 @@ export const classifyChanges = (changes) => {
   });
 };
 
-export const requiredJobsFor = ({ profile, impact, decision }) => {
+export const requiredJobsFor = ({ profile, impact, decision, capabilities = [impact] }) => {
   assertProfile(profile);
   assertImpact(impact);
   if (!IMPACT_DECISIONS.includes(decision)) {
     fail('UNKNOWN_DECISION', 'CI impact decision is not supported.', { decision });
   }
-  if (decision === 'selective' && impact === 'full') {
-    fail('INVALID_SELECTIVE_PLAN', 'A full impact cannot use selective execution.');
+  if (!Array.isArray(capabilities) || !capabilities.length
+      || capabilities.some((capability) => !IMPACT_CLASSES.includes(capability))
+      || JSON.stringify(orderedCapabilities(capabilities)) !== JSON.stringify(capabilities)
+      || primaryImpact(capabilities) !== impact) {
+    fail('INVALID_CAPABILITIES', 'Capabilities must be known, ordered, unique, and match the impact.');
   }
-  const jobs = decision === 'full'
-    ? PROFILE_REQUIRED_JOBS[profile].full
-    : PROFILE_REQUIRED_JOBS[profile].selective[impact];
-  return freeze([...jobs]);
+  if (decision === 'selective' && requiresFullCoverage(profile, capabilities)) {
+    fail('INVALID_SELECTIVE_PLAN', 'This impact requires full coverage.');
+  }
+  const all = PROFILE_REQUIRED_JOBS[profile];
+  if (decision === 'full') return freeze([...all]);
+  const selected = profile === 'pr'
+    ? capabilities.flatMap((capability) => PR_CAPABILITY_JOBS[capability])
+    : profile === 'dev' && capabilities.includes('documentation') ? ['recipes-standard'] : [];
+  return freeze(all.filter((job) => selected.includes(job)));
 };
 
 export const knownJobsFor = (profile) => {
   assertProfile(profile);
-  return freeze([...PROFILE_REQUIRED_JOBS[profile].full]);
+  return freeze([...PROFILE_REQUIRED_JOBS[profile]]);
 };
 
 const validateInheritedEvidence = (evidence, expectedHeadSha) => {
@@ -271,9 +303,12 @@ const validateBasis = (plan) => {
   ].includes(plan.basis)) {
     fail('BASIS_DECISION_MISMATCH', 'Full decision cannot claim inherited evidence.');
   }
-  if (['FULL_CHANGE', 'UNKNOWN_OR_INVALID_CHANGE', 'MANUAL_FULL_RUN'].includes(plan.basis)
+  if (['UNKNOWN_OR_INVALID_CHANGE', 'MANUAL_FULL_RUN'].includes(plan.basis)
       && plan.impact !== 'full') {
     fail('BASIS_IMPACT_MISMATCH', 'Full or invalid change basis requires full impact.');
+  }
+  if (plan.basis === 'FULL_CHANGE' && !requiresFullCoverage(plan.profile, plan.capabilities)) {
+    fail('BASIS_IMPACT_MISMATCH', 'Full change basis requires a full-coverage impact.');
   }
   if (plan.basis === 'INHERITED_EVIDENCE_UNAVAILABLE' && plan.impact === 'full') {
     fail('BASIS_IMPACT_MISMATCH', 'Evidence fallback requires a light impact candidate.');
@@ -340,6 +375,7 @@ export const createImpactPlan = (fields) => {
     schemaVersion: IMPACT_PLAN_SCHEMA_VERSION,
     profile: fields.profile,
     impact: fields.impact,
+    capabilities: freeze([...(fields.capabilities ?? [fields.impact])]),
     decision: fields.decision,
     basis: fields.basis,
     changeBaseSha: fields.changeBaseSha,

--- a/tools/ci-impact.mjs
+++ b/tools/ci-impact.mjs
@@ -14,10 +14,11 @@ import {
   createImpactPlan,
   isFullObjectId,
   knownJobsFor,
+  requiresFullCoverage,
   validateGateResults
 } from './ci-impact-policy.mjs';
 
-const SUPPORTED_PROFILES = new Set(['pr', 'dev', 'gallery']);
+const SUPPORTED_PROFILES = new Set(['pr', 'dev', 'gallery', 'release']);
 const SUPPORTED_EVENTS = new Set(['pull_request', 'push', 'workflow_dispatch']);
 const REPOSITORY_NAME = /^[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})\/[A-Za-z0-9](?:[A-Za-z0-9._-]{0,99})$/;
 const SUMMARY_PATH_LIMIT = 20;
@@ -97,6 +98,9 @@ export const readPlanConfiguration = (env, cwd = process.cwd()) => {
   }
   if ((profile === 'pr') !== (eventName === 'pull_request')) {
     fail('PROFILE_EVENT_MISMATCH', 'PR profile must match a pull_request event.');
+  }
+  if (profile === 'release' && eventName !== 'workflow_dispatch') {
+    fail('PROFILE_EVENT_MISMATCH', 'Release acceptance requires an explicit dispatch.');
   }
   if (!REPOSITORY_NAME.test(repository)) {
     fail('INVALID_REPOSITORY', 'CI_IMPACT_REPOSITORY must be OWNER/REPOSITORY.');
@@ -212,6 +216,7 @@ const readGitChanges = ({ configuration, runGitImpl }) => {
 const planFields = ({ configuration, classification, decision, basis, inheritedEvidence }) => ({
   profile: configuration.profile,
   impact: classification.impact,
+  capabilities: classification.capabilities,
   decision,
   basis,
   changeBaseSha: configuration.changeBaseSha,
@@ -223,6 +228,7 @@ const planFields = ({ configuration, classification, decision, basis, inheritedE
 
 const fullClassification = (reason) => Object.freeze({
   impact: 'full',
+  capabilities: Object.freeze(['full']),
   valid: false,
   changedPathCount: 0,
   paths: Object.freeze([]),
@@ -290,7 +296,7 @@ export const buildImpactPlan = async ({
     });
   }
 
-  if (!classification.valid || classification.impact === 'full') {
+  if (!classification.valid || requiresFullCoverage(configuration.profile, classification.capabilities)) {
     return Object.freeze({
       plan: createImpactPlan(planFields({
         configuration,
@@ -367,7 +373,7 @@ export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => 
   const requiredJobs = plan.requiredJobs.length ? plan.requiredJobs.map((job) => `\`${job}\``).join(', ') : 'none';
   const routing = plan.profile === 'pr'
     ? 'active; pull-request jobs use the trusted-base plan'
-    : plan.profile === 'dev'
+    : ['dev', 'release'].includes(plan.profile)
       ? 'active; dev staging jobs use the protected-branch plan'
       : 'active; Gallery readiness jobs use the protected-branch plan';
   const lines = [
@@ -375,6 +381,7 @@ export const formatPlanSummary = ({ plan, classification, evidenceFailure }) => 
     '',
     `- Profile: \`${plan.profile}\``,
     `- Impact: \`${plan.impact}\``,
+    `- Capabilities: ${plan.capabilities.join(', ')}`,
     `- Decision: \`${plan.decision}\``,
     `- Basis: \`${plan.basis}\``,
     `- Change base/head: \`${plan.changeBaseSha}\` / \`${plan.changeHeadSha}\``,


### PR DESCRIPTION
## Plain-language summary

Shorten pull-request feedback by selecting checks for the affected subsystem and reducing browser smoke from 27 cases to 10. JavaScript/Python browser contracts run alongside Playwright instead of sharing one 15-minute job. Full functional coverage remains on `dev`; supported-version acceptance and exhaustive slow tests run through an explicit release/S11 tier.

## Change class

- [x] GOVERNANCE

## Changes

- Replace the coarse path classification with a capability union in the existing CI policy owner. Unknown, dependency, CI-policy, and shared/unclassified test changes still select the full PR tier; selective PRs require exact successful base staging evidence.
- Keep all 167 full functional Playwright cases, the three-version core matrix, offline GUI/LOSAT/cache acceptance, package-build integration, recipes, Gallery, and performance checks on integrated `dev`.
- Preserve the existing supported-version and slow commands/matrices under `Release / gate`, including exact-candidate Gallery readiness. Release publication and source-admission checks are unchanged.
- Run the candidate's policy tests while the base revision continues to own PR planning and aggregate validation. Sparse trusted checkouts need only `tools/`.

## Evidence and verification

[Before/after measurements and every relocated browser case](docs/internal/CI_TIER_REDESIGN_2026-09-11.md) and [per-job historical timings](docs/internal/CI_TIER_TIMINGS_2026-09-11.csv) cover PRs #502–#505 and recent dev runs. Successful historical PR smoke jobs took 13:21–14:47; an earlier job logged all 30 cases passing immediately before cancellation at 15:12. Retained cases took 131–139 seconds on those hosted runners, supporting a 5–7-minute PR projection.

- 58 CI routing/adapter/gate/inventory tests; 137 architecture contracts; 390 fast JavaScript contracts.
- Retained package build integration: 3/3 passed. Python browser checks: 23 passed initially, with the remaining replay test passing after installing the correct candidate CLI in an isolated environment.
- Expanded full-functional inventory is identical before/after: 167 cases. Browser spec diffs remove smoke tags only.
- Local smoke: 10/10 passed in 87 seconds with one worker; three two-worker repetitions passed 30/30 in 153 seconds. CI keeps one worker pending repeated hosted evidence.
- The first hosted rollout passed all nine Tests jobs in **6:20**, using **23.05 runner minutes**; Web smoke took **3:38**, with **2:20** in Playwright. It received the trusted base's full PR route. Final-head checks follow the last code-plus-test classification refinement.

## Risk and review notes

Starting base: `dev` at `8d6c914ecf5bb12437e1c8370d35a28ea4b0af6a`.

Review is `REQUIRED` for CI governance. This is architecture-bearing only for CI routing: `tools/ci-impact-policy.mjs` remains the sole semantic owner; the adapter and workflows consume its decisions. Owner/path excess and compatibility burden do not increase; the coarse routing path is replaced in the same owner, with no candidate schema-1 compatibility reader. No Web runtime, renderer, session schema, editor behavior, Product authority, or remaining 05A4 defect is changed.

Authority/evidence-producer files: `.github/workflows/test.yml`, CI policy/tests, smoke tags, and CI documentation. Architecture/Product checker implementations, rule/decision registries, and `.github/workflows/web-base-policy.yml` are unchanged. Candidate workflow/policy edits do not replace `.ci-trusted-base` planning or gate validation. Required external checks and branch protection remain unchanged.

## Rollback

Revert this CI change as one unit, including routing, workflow, tags, and their contracts. Keep stable aggregate check names and trusted-base evaluation.

## Conditional Product Impact

N/A: no runtime or normative product-behavior change. S11 reacceptance remains not ready; S12 remains blocked; no replacement technical baseline or publication candidate is assigned.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
