### PR TITLE
Preserve composite feature placement through regeneration

### DIFF
--- a/docs/internal/SESSION05A7_E_COMPOSITE_PLACEMENT_REMEDIATION.md
+++ b/docs/internal/SESSION05A7_E_COMPOSITE_PLACEMENT_REMEDIATION.md
@@ -1,0 +1,110 @@
+# SESSION 05A7-E: composite placement remediation
+
+PR B starts at exact `origin/dev` `bed447b813d07581764b92373da62bcf464e8517`,
+the squash merge of PR #508 after final-head human review. The user's original
+worktree remains untouched. This PR addresses only 05A4-08.
+
+## Original failure and independence
+
+Both defects reproduced before any production changes on
+`ac1bb944cd26441cf7552823769a54ced7c53881`. The retained two-source
+mitochondrial/lambda composite and full 11-record Vibrio Circular construction
+lost every placement option after Generate with unchanged source/configuration.
+PR A repaired the multipart label and left this placement failure intact.
+The PR B base also fails the new composite transition contract while its single
+record browser control passes. The roots are independent.
+
+Generate changes the committed source representation: separate component
+resources become one concatenated GenBank resource. The UI retains the same
+composite file view. `record-display-options.js::matchesSavedSource` compared
+each component payload with the concatenated payload. That could never prove
+current-source identity, so `isCurrentFeature` rejected every placement including
+Auto. The catalog, record identities, feature type/strand, track preset, and
+Separate Strands state were not lost or reinterpreted. Save retains the ordered
+component bindings, so the same comparison also failed after a fresh Load.
+
+## Existing owner correction
+
+`session-resource-backing.js` already owns immutable ordinary and composite file
+views, ordered component bytes, and their LF concatenation rule. Its new
+`matchesSessionResourceDescriptor` operation verifies the committed descriptor
+against either an original component or the complete ordered composite bytes.
+`record-display-options.js` delegates its former payload comparison to that owner.
+The exact source object and paired-source guards stay in the record display
+owner; a real new File/view cannot inherit an old feature's capability.
+
+The comparison checks declared sizes, all bytes, order, repeated/empty components,
+CRLF and appended LF boundaries. On a successful whole-composite comparison,
+the existing backing's descriptor slot references that immutable serialized
+representation. Repeated checks reuse the verified descriptor and retain no
+decoded content. This adds no Result/editor cache, second catalog, placement
+owner, identity namespace, or persisted metadata. Component file bindings and
+source metadata remain unchanged. The old editor-local payload comparison is
+removed. Native File behavior and ordinary resource matching are retained.
+
+`placement-actions.js` remains the capability/action owner. Capability follows
+the draft feature slot, using the same track-slot resolver as request projection.
+`valueFor` reads the current placement override independently. The popup renders
+`choices`, and `setPlacement` rejects unavailable choices through that same
+predicate. Middle permits Auto/Main/Outward/Inward; tuckin and spreadout permit
+Auto/Main. An existing outward value does not make an unsupported lane available.
+
+An initial two-line candidate used the existing payload-owner association and
+fixed Generate, but its privileged import was disallowed and its ephemeral
+association did not survive fresh Load. That candidate was removed. No allowlist,
+CI policy, compatibility field, or schema was changed to admit it.
+
+## Architecture and Product evidence
+
+Ordinary non-increasing correction: the source-backing owner gains one operation;
+the editor delegates its source payload comparison there. There is one canonical
+source comparison path and one placement capability owner. No parallel owner,
+compatibility reader, production module, reactive state, or watcher is retained
+or introduced. Privileged permissions and import fan-out do not increase; no
+first-party cycles are added. The new public export requires ordinary human
+review, not an architecture exception. Rollback is a revert of this PR.
+
+Product classification: `IMPLEMENT_EXISTING_AUTHORITY`. The base Web live-edit
+and reactive availability contracts in `gbdraw/web/CLAUDE.md` require accepted
+editing to remain generatable, enabled rendering and action admission to share
+a predicate, and editing to remain bound to current source data. The fix preserves
+that affordance across Generate, Save/Load, and mode changes; it selects no new
+placement semantics or persisted compatibility outcome. The original failing
+reproductions and the existing slot owner establish the implementation defect.
+No unresolved Product choice requires EVIDENCE_REQUIRED or PRODUCT_DECISION_REQUIRED,
+and the final correction needs no forbidden architecture or persistence exception.
+
+Session 41, request 7, feature catalog 3, and file-binding schema 2 remain unchanged.
+PR smoke remains ten cases. The new browser test is discovered only by the existing
+full-functional selection; CI policy and generated Gallery artifacts are unchanged.
+
+## Regression coverage
+
+- `record-display-options.test.mjs`: exact component-to-combined transition through
+  the real file view and placement actions, same-name/same-byte replacement rejection,
+  and unsupported draft lanes independently of the selected value.
+- `session-resource-backing.test.mjs`: exact composition, order, empty/repeated parts,
+  LF/CRLF boundaries, mismatched same-length bytes, replacement, and no repeated decoding
+  after successful verification or decoded-content release.
+- `composite-placement-regeneration.playwright.spec.js`: P1 single, P2 composite,
+  P3 repeat Generate, P4 label plus placement, P5 Save/fresh Load/Generate, P6 mode
+  round trip, P7 actual same-byte File replacement, P8 preset/Separate Strands matrix.
+  It compares semantic enabled sets, current value, DOM options, invalid-action
+  rejection and renderer placement targets, preserving both records and their order.
+
+The real CLI writer constructs the two-source test session from the existing
+Gallery source sessions. Cold browser contexts block external requests and require
+no page errors. The retained original full 11-record Vibrio construction remains a
+separate acceptance case; it is not reduced to the two-source regression fixture.
+
+Evidence lives under `/tmp/gbdraw-session05a7-e-evidence/`. Initial policy and P5
+failures are retained as diagnosis and are excluded from passing evidence. The
+large-source allocation measurement motivated comparing decoded binary strings
+without unnecessary Uint8Array construction. Chromium verifies all 71,480,904 bytes
+in 154–170 ms across three trials; 1,000 subsequent checks take 0.2–0.4 ms. These are
+local source-comparison measurements, not a new performance baseline or an output
+cache. The existing performance and exact-dev staging gates remain authoritative.
+
+Deterministic verification: 37 focused source/placement contracts, 398 fast Web
+contracts, and 137 architecture contracts pass. The local final Web checker reports
+Gate PASS / Review REQUIRED solely for the new source-backing public operation.

--- a/gbdraw/web/js/app/record-display-options.js
+++ b/gbdraw/web/js/app/record-display-options.js
@@ -1,6 +1,6 @@
 // Source-bound editable rotation intent. The request service owns serialization.
 import { resolveDisambiguatedRecordSelection } from './record-options.js';
-import { getSessionResourceSource } from '../services/file-content-cache.js';
+import { matchesSessionResourceDescriptor } from '../services/session-resource-backing.js';
 
 export const recordDisplayKey = ({ scope, sourceUid, selector }) => {
   if (!['circular', 'linear'].includes(scope) || !sourceUid || !/^#[1-9]\d*$/.test(selector)) {
@@ -122,11 +122,8 @@ export const createRecordDisplayControls = ({ state, computed, watch, linearReco
     Object.assign(draft, patch);
   });
   const matchesSavedSource = (file, resourceId) => {
-    const binding = getSessionResourceSource(file);
-    if (!binding) return true; // Native Files are bound by the successful run's object identity.
     const expected = getCommittedSession()?.resources?.[resourceId];
-    return (binding.descriptors || [binding]).some(({ descriptor }) => expected
-      && descriptor?.encoding === expected.encoding && descriptor?.data === expected.data);
+    return matchesSessionResourceDescriptor(file, expected);
   };
   const recordForKey = (key) => getCommittedRequest()?.records.find((record) => record.recordKey === key
     || (record.cardinality === 'all' && key.startsWith(`${record.recordKey}:`)

--- a/gbdraw/web/js/services/session-resource-backing.js
+++ b/gbdraw/web/js/services/session-resource-backing.js
@@ -338,6 +338,46 @@ export const isSessionResourceFileView = (file) => Boolean(
   && fileViewBackings.has(file)
 );
 
+export const matchesSessionResourceDescriptor = (file, descriptor) => {
+  const backing = fileViewBackings.get(file);
+  // Native Files remain bound by the successful run's object identity.
+  if (!backing || backing.dirty) return true;
+  if (!descriptor) return false;
+  const matches = (entry) => entry?.encoding === descriptor.encoding
+    && entry?.data === descriptor.data;
+  if (matches(backing.descriptor)) return true;
+  if (!backing.sourceBackings) return false;
+  if (backing.sourceBackings.some((part) => matches(part.descriptor))) return true;
+  if (descriptor.encoding !== 'base64' || descriptor.size !== backing.size) return false;
+
+  const decode = (entry) => {
+    recordStructuralMetric('base64DecodeCount', 1, {
+      resourceId: entry.resourceId, resourceName: entry.name
+    });
+    const binary = atob(entry.descriptor.data);
+    recordStructuralMetric('decodedByteCount', binary.length, {
+      resourceId: entry.resourceId, resourceName: entry.name
+    });
+    return binary;
+  };
+  const combined = decode({ ...backing, descriptor });
+  if (combined.length !== descriptor.size) return false;
+  let offset = 0;
+  for (const part of backing.sourceBackings) {
+    const binary = decode(part);
+    if (binary.length !== part.size || !combined.startsWith(binary, offset)) return false;
+    offset += binary.length;
+    if (binary.length && binary.charCodeAt(binary.length - 1) !== LF_BYTE) {
+      if (combined.charCodeAt(offset++) !== LF_BYTE) return false;
+    }
+  }
+  if (offset !== combined.length) return false;
+  // The immutable composite's existing descriptor slot can now reference its
+  // verified serialized representation, without retaining decoded content.
+  backing.descriptor = descriptor;
+  return true;
+};
+
 export const sessionResourceSource = (file) => {
   const backing = fileViewBackings.get(file);
   if (!backing || backing.dirty) return null;

--- a/tests/web/composite-placement-regeneration.playwright.spec.js
+++ b/tests/web/composite-placement-regeneration.playwright.spec.js
@@ -1,0 +1,188 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+
+const singleSeed = 'gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json';
+const allPlacements = ['auto', 'main', 'outward', 'inward'];
+
+const compositeSeed = async (testInfo) => {
+  const single = JSON.parse(await fs.readFile(singleSeed, 'utf8'));
+  const lambda = JSON.parse(await fs.readFile('gbdraw/web/gallery/sessions/lambda_basic_linear.gbdraw-session.json', 'utf8'));
+  const second = { ...lambda.renderRequest.records[0], recordKey: 'record-2',
+    source: { kind: 'genbank', resourceId: 'record-2-genbank' } };
+  const input = testInfo.outputPath('two-source-input.json');
+  const output = testInfo.outputPath('two-source.gbdraw-session.json.gz');
+  await fs.writeFile(input, JSON.stringify({ format: single.format, version: single.version,
+    results: [], editorState: { featureCatalog: null }, ui: { ...single.ui, generatedMultiRecordCanvas: true },
+    config: { ...single.config, form: { ...single.config.form, multi_record_canvas: true } },
+    renderRequest: { ...single.renderRequest, grouping: 'grid',
+      records: [...single.renderRequest.records, second], layout: { multiRecordSizeMode: 'auto',
+        multiRecordMinRadiusRatio: 0.55, multiRecordColumnGapRatio: 0.1, multiRecordRowGapRatio: 0.05,
+        multiRecordPositions: null } },
+    resources: { ...single.resources, 'record-2-genbank': lambda.resources[lambda.renderRequest.records[0].source.resourceId] } }));
+  // The normal writer creates matching SVG, feature metadata and current file bindings.
+  const { stdout, stderr } = await promisify(execFile)('python', ['-m', 'gbdraw.cli', 'circular',
+    '--session', input, '-o', testInfo.outputPath('two-source'), '--session_output', output],
+  { cwd: testInfo.outputDir, env: { ...process.env, PYTHONPATH: process.cwd() },
+    timeout: 1_800_000, maxBuffer: 1_000_000 });
+  await fs.writeFile(testInfo.outputPath('seed-cli.log'), stdout + stderr);
+  return output;
+};
+
+for (const composite of [false, true]) {
+  test(`Circular ${composite ? 'composite P2-P8' : 'single P1'} placement capability survives generation`, async ({ browser }, testInfo) => {
+    test.setTimeout(1_800_000);
+    let context;
+    let page;
+    const external = [];
+    const errors = [];
+    const load = async (file) => {
+      if (context) await context.close();
+      context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+      await context.route('**/*', (route) => {
+        if (new URL(route.request().url()).hostname === '127.0.0.1') return route.continue();
+        external.push(route.request().url());
+        return route.abort();
+      });
+      page = await context.newPage();
+      page.on('pageerror', (error) => errors.push(error.message));
+      page.on('dialog', (dialog) => dialog.type() === 'prompt' ? dialog.accept('Composite placement') : dialog.accept());
+      await openApp(page);
+      await page.locator('input[accept^=".json,"]').setInputFiles(file);
+      await expect.poll(() => page.evaluate(() => !window.__GBDRAW_APP__.sessionImportPending
+        && window.__GBDRAW_APP__.extractedFeatures.length > 0), { timeout: 180000 }).toBe(true);
+    };
+    const features = () => page.evaluate(() => {
+      const items = window.__GBDRAW_APP__.extractedFeatures;
+      return [...new Set(items.map((feature) => feature.record_key))]
+        .map((key) => items.find((feature) => feature.record_key === key && feature.type === 'CDS'));
+    });
+    const generate = async () => {
+      expect(await page.evaluate(() => window.__GBDRAW_APP__.runAnalysis())).toEqual({ status: 'ok' });
+      await expect.poll(() => page.evaluate(async () => {
+        const { state } = await import('./js/state.js');
+        return (await import('./js/services/svg-result-ingestion.js'))
+          .isCommittedSvgResultMounted(state.results.value[state.selectedResultIndex.value]);
+      })).toBe(true);
+    };
+    const close = () => page.getByRole('button', { name: 'Close feature popup', exact: true }).click();
+    const open = async (feature) => {
+      await page.evaluate((feature) => window.__GBDRAW_APP__.openFeatureEditorFromList(feature), feature);
+      return page.getByLabel('Feature placement', { exact: true });
+    };
+    const check = async (stage, enabled = allPlacements, targets = null) => {
+      const selected = targets || await features();
+      expect(selected).toHaveLength(composite ? 2 : 1);
+      for (const feature of selected) {
+        const control = await open(feature);
+        const semantic = await page.evaluate((feature) => {
+          const actions = window.__GBDRAW_APP__.featurePlacementActions;
+          return { choices: actions.choices([feature]), value: actions.valueFor(feature) };
+        }, feature);
+        expect(semantic.choices.filter((choice) => choice.enabled).map((choice) => choice.value)).toEqual(enabled);
+        expect(await control.evaluate((node) => [...node.options].filter((option) => !option.disabled)
+          .map((option) => option.value))).toEqual(enabled);
+        await expect(control).toHaveValue(semantic.value);
+        for (const invalid of allPlacements.filter((value) => !enabled.includes(value))) {
+          const rejected = await page.evaluate(({ feature, invalid }) => {
+            try { window.__GBDRAW_APP__.featurePlacementActions.setPlacement([feature], invalid); return false; }
+            catch (error) { return error.message.includes('Unavailable'); }
+          }, { feature, invalid });
+          expect(rejected).toBe(true);
+        }
+        await close();
+      }
+      const state = await page.evaluate(async () => {
+        const { state } = await import('./js/state.js');
+        const config = await import('./js/services/config.js');
+        const { getSessionResourceSource } = await import('./js/services/file-content-cache.js');
+        const session = config.getCommittedCanonicalSession();
+        const binding = getSessionResourceSource(state.files.c_gb);
+        return { records: state.circularRecordList.value, request: session.renderRequest,
+          resources: Object.fromEntries(Object.entries(session.resources).map(([id, descriptor]) => [id, { size: descriptor.size, name: descriptor.name }])),
+          source: { name: state.files.c_gb.name, size: state.files.c_gb.size,
+            components: binding?.descriptors?.map((part) => part.resourceId) || [] },
+          form: config.buildConfigData().form, geometry: state.trackSlotResolvedGeometry.value,
+          catalog: state.featureCatalog.value, placements: state.featurePlacementOverrides };
+      });
+      await fs.writeFile(testInfo.outputPath(`${stage}.json`), JSON.stringify({ selected, enabled, ...state }, null, 2));
+      return { ...state, recordOrder: selected.map((feature) => [feature.record_key, feature.record_id]) };
+    };
+    try {
+      await load(composite ? await compositeSeed(testInfo) : singleSeed);
+      const original = await check('P1-P2-before');
+      if (composite) expect(original.source.components).toHaveLength(2);
+      await generate();
+      const generated = await check('P1-P2-after');
+      expect(generated.recordOrder).toEqual(original.recordOrder);
+      if (composite) {
+        await generate();
+        await check('P3-second-Generate');
+        const target = (await features())[0];
+        const placement = await open(target);
+        await placement.selectOption('outward');
+        await page.locator('.feature-popup input[placeholder="Edit label text"]').fill('COMPOSITE_RETAINED_LABEL');
+        await page.getByRole('button', { name: 'Apply Label', exact: true }).click();
+        await close();
+        await generate();
+        const edited = await check('P4-feature-edit');
+        expect(Object.values(edited.placements)).toHaveLength(1);
+        expect(await page.evaluate(() => window.__GBDRAW_APP__.results[0].content)).toContain('COMPOSITE_RETAINED_LABEL');
+        const download = page.waitForEvent('download');
+        await page.getByRole('button', { name: 'Save Session', exact: true }).click();
+        const saved = testInfo.outputPath('P5-saved.gbdraw-session.json.gz');
+        await (await download).saveAs(saved);
+        await load(saved);
+        expect((await check('P5-loaded')).placements).toEqual(edited.placements);
+        await generate();
+        expect((await check('P5-generated')).placements).toEqual(edited.placements);
+        for (const mode of ['Linear', 'Circular']) {
+          await page.getByRole('button', { name: mode, exact: true }).click();
+          await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.mode)).toBe(mode.toLowerCase());
+        }
+        expect((await check('P6-returned')).placements).toEqual(edited.placements);
+        await generate();
+        expect((await check('P6-generated')).placements).toEqual(edited.placements);
+
+        // P8: capability follows draft track semantics, even while the selected value differs.
+        for (const separate of [false, true]) {
+          await page.getByRole('checkbox', { name: 'Separate Strands', exact: true }).setChecked(separate);
+          for (const preset of ['tuckin', 'spreadout', 'middle']) {
+            await page.locator('#circular-track-preset').selectOption(preset);
+            const valid = preset === 'middle' ? allPlacements : ['auto', 'main'];
+            await check(`P8-${separate}-${preset}-draft`, valid);
+            // Clear the now-unsupported outward intent through the existing Auto action.
+            const control = await open((await features())[0]);
+            await control.selectOption('auto');
+            await close();
+            await generate();
+            const rendered = await check(`P8-${separate}-${preset}-generated`, valid);
+            expect(rendered.geometry.records.every((record) =>
+              JSON.stringify(record.featurePlacementTargets.map((placement) => placement.side || placement.kind))
+              === JSON.stringify(valid.filter((value) => value !== 'auto')))).toBe(true);
+          }
+        }
+        // P7: an actual new File is a replacement even with identical name and bytes.
+        const old = await features();
+        const source = await page.evaluate(async () => {
+          const { state } = await import('./js/state.js');
+          return { name: state.files.c_gb.name, mimeType: state.files.c_gb.type,
+            bytes: [...await (await import('./js/services/file-content-cache.js')).readFileBytes(state.files.c_gb)] };
+        });
+        await page.getByLabel('GenBank/DDBJ File', { exact: true }).setInputFiles({
+          name: source.name, mimeType: source.mimeType, buffer: Buffer.from(source.bytes) });
+        await expect.poll(() => page.evaluate(async () => (await import('./js/state.js'))
+          .state.circularRecordDiscovery.status)).toBe('ready');
+        expect((await check('P7-replaced-before-Generate', [], old)).placements).toEqual({});
+        await generate();
+        await check('P7-replaced-after-Generate');
+      }
+      expect(errors).toEqual([]);
+      expect(external).toEqual([]);
+    } finally {
+      if (context) await context.close();
+    }
+  });
+}

--- a/tests/web/record-display-options.test.mjs
+++ b/tests/web/record-display-options.test.mjs
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
-  buildRecordDisplayRows, parseRecordDisplayStart, reconcileRecordDisplayDrafts,
+  buildRecordDisplayRows, createRecordDisplayControls, parseRecordDisplayStart, reconcileRecordDisplayDrafts,
   recordDisplaySurface, selectedFeatureDisplayStart
 } from '../../gbdraw/web/js/app/record-display-options.js';
 import { parseSequenceRecordText } from '../../gbdraw/web/js/app/record-discovery.js';
+
+import { createFeaturePlacementActions } from '../../gbdraw/web/js/app/feature-editor/placement-actions.js';
+import { createDefaultForm, createDefaultAdv } from '../../gbdraw/web/js/services/session-active-config-contract.js';
+import { adoptCurrentSessionResources, createCombinedSessionResourceFileView } from '../../gbdraw/web/js/services/session-resource-backing.js';
+import { readFileBytes } from '../../gbdraw/web/js/services/file-content-cache.js';
 
 const source = {};
 const records = [
@@ -82,4 +87,74 @@ test('shortcuts reject stale, unbound, cross-record, empty, and unknown/mixed-st
     { selectedFeatures: [{ ...feature, location_parts: [] }] },
     { selectedFeatures: [{ ...feature, location_parts: [{ start: 5, end: 10, strand: '-' }] }] }
   ]) assert.throws(() => selectedFeatureDisplayStart({ ...args, ...changed }));
+});
+
+const descriptor = (name, text) => ({ kind: 'genbank', name, type: 'text/plain',
+  lastModified: 0, size: Buffer.byteLength(text), encoding: 'base64', data: btoa(text) });
+const compositeControls = () => {
+  const resources = Object.fromEntries(['first', 'second'].map((id) => [id,
+    descriptor(`${id}.gb`, `LOCUS       ${id} 100 bp DNA circular\n//\n`)]));
+  const table = adoptCurrentSessionResources(resources);
+  const components = Object.keys(resources).map((resourceId) => ({ resourceId }));
+  const makeFile = () => createCombinedSessionResourceFileView(table, components);
+  const file = makeFile();
+  let committed = { resources, renderRequest: { mode: 'circular', records: components.map(({ resourceId }, i) => ({
+    recordKey: `record-${i + 1}`, cardinality: 'exactly_one', source: { kind: 'genbank', resourceId },
+    selector: null })) } };
+  const state = { mode: { value: 'circular' }, cInputType: { value: 'gb' },
+    lInputType: { value: 'gb' }, files: { c_gb: file }, linearSeqs: [],
+    form: createDefaultForm(), adv: createDefaultAdv('circular'),
+    recordDisplayDrafts: [], featurePlacementOverrides: {},
+    circularRecordList: { value: components.map(({ resourceId }, i) => ({
+      record_id: resourceId, record_length: 100, selector: `#${i + 1}`, detectedTopology: 'circular' })) },
+    featureCatalog: { value: { items: [{ recordKeys: ['record-1', 'record-2'] }] } } };
+  state.form.track_type = 'middle';
+  const getCommittedRequest = () => committed.renderRequest;
+  const history = { runUndoable: (_label, fn) => fn() };
+  const controls = createRecordDisplayControls({ state, computed: (fn) => ({ get value() { return fn(); } }),
+    watch: () => {}, linearRecordSelector: { recordsFor: () => [] }, history,
+    getCommittedRequest, getCommittedSession: () => committed });
+  const actions = createFeaturePlacementActions({ state, history, getCommittedRequest,
+    isCurrentFeature: controls.isCurrentFeature });
+  const feature = { record_key: 'record-2', biological_feature_id: 'logical-feature' };
+  return { state, actions, feature, file, makeFile,
+    enabled: () => actions.choices([feature]).filter((choice) => choice.enabled).map((choice) => choice.value),
+    commitCombined: async () => {
+      const bytes = await readFileBytes(file);
+      const combined = { ...descriptor(file.name, ''), size: bytes.byteLength,
+        data: Buffer.from(bytes).toString('base64') };
+      committed = { resources: { combined }, renderRequest: { ...committed.renderRequest,
+        records: committed.renderRequest.records.map((record, i) => ({ ...record,
+          source: { kind: 'genbank', resourceId: 'combined' }, selector: { kind: 'recordIndex', index: i } })) } };
+    } };
+};
+
+test('same composite retains semantic capability when the committed resource becomes combined', async () => {
+  const model = compositeControls();
+  const all = ['auto', 'main', 'outward', 'inward'];
+  assert.deepEqual(model.enabled(), all);
+  model.actions.setPlacement([model.feature], 'main');
+  assert.equal(model.actions.valueFor(model.feature), 'main');
+  await model.commitCombined();
+  assert.deepEqual(model.enabled(), all);
+  assert.equal(model.actions.valueFor(model.feature), 'main');
+});
+
+test('same-name, same-content source replacement does not retain old feature capability', () => {
+  const model = compositeControls();
+  assert.equal(model.enabled().length, 4);
+  model.state.files.c_gb = model.makeFile();
+  assert.equal(model.state.files.c_gb.name, model.file.name);
+  assert.notEqual(model.state.files.c_gb, model.file);
+  assert.deepEqual(model.enabled(), []);
+  assert.throws(() => model.actions.setPlacement([model.feature], 'main'), /Unavailable/);
+});
+
+test('unsupported draft lanes remain unavailable independently of current placement value', () => {
+  const model = compositeControls();
+  model.actions.setPlacement([model.feature], 'outward');
+  model.state.form.track_type = 'tuckin';
+  assert.equal(model.actions.valueFor(model.feature), 'outward');
+  assert.deepEqual(model.enabled(), ['auto', 'main']);
+  assert.throws(() => model.actions.setPlacement([model.feature], 'inward'), /Unavailable/);
 });

--- a/tests/web/session-resource-backing.test.mjs
+++ b/tests/web/session-resource-backing.test.mjs
@@ -16,6 +16,8 @@ const {
   adoptCurrentSessionResources,
   createCombinedSessionResourceFileView,
   createSessionResourceFileView,
+  matchesSessionResourceDescriptor,
+  releaseSessionResourceContent,
   readSessionResourceBytes,
   readSessionResourceText
 } = await import('../../gbdraw/web/js/services/session-resource-backing.js');
@@ -426,4 +428,34 @@ test('same-length adopted, alternate-encoded and new candidates decode/hash at m
   assert.equal(metricTotal('base64EncodeCount'), 1);
   assert.equal(metricTotal('resourceIdentityHashCount'), 5);
   for (const id of ['alpha', 'beta', 'differentId']) assert.equal(metricTotal('resourceByteReadCount', id), 1);
+});
+
+
+test('composite descriptor matching preserves order, LF boundaries and immutable backing identity', () => {
+  const resources = {
+    empty: encodedDescriptor('empty.gb', ''),
+    alpha: encodedDescriptor('alpha.gb', 'a'),
+    beta: encodedDescriptor('beta.gb', 'b\r\n')
+  };
+  const components = ['alpha', 'empty', 'beta', 'alpha'].map(resourceId => ({ resourceId }));
+  const view = createCombinedSessionResourceFileView(adoptCurrentSessionResources(resources), components);
+  assert.equal(matchesSessionResourceDescriptor(view, resources.alpha), true);
+  for (const text of ['a\nb\r\nc\n', 'b\r\na\na\n', 'ab\r\na\n', 'a\nb\r\na']) {
+    assert.equal(matchesSessionResourceDescriptor(view, encodedDescriptor('combined.gb', text)), false);
+  }
+  const combined = encodedDescriptor('combined.gb', 'a\nb\r\na\n');
+  resetMetrics();
+  assert.equal(matchesSessionResourceDescriptor(view, combined), true);
+  assert.equal(metricTotal('base64DecodeCount'), 5);
+  const decoded = metricTotal('decodedByteCount');
+  releaseSessionResourceContent(view);
+  for (let index = 0; index < 20; index += 1) {
+    assert.equal(matchesSessionResourceDescriptor(view, { ...combined, name: 'renamed.gb' }), true);
+  }
+  assert.equal(metricTotal('base64DecodeCount'), 5, 'verified descriptor matching needs no repeated decoding');
+  assert.equal(metricTotal('decodedByteCount'), decoded);
+  assert.equal(matchesSessionResourceDescriptor(view, encodedDescriptor('combined.gb', 'a\nb\r\nc\n')), false);
+  const replaced = createCombinedSessionResourceFileView(adoptCurrentSessionResources({ ...resources,
+    alpha: encodedDescriptor('alpha.gb', 'c') }), components);
+  assert.equal(matchesSessionResourceDescriptor(replaced, combined), false);
 });


### PR DESCRIPTION
## Plain-language summary

Generate could disable every feature placement option for an unchanged Circular composite because the editor compared its separate source files with the newly combined resource. The existing file backing now verifies the full combined content and keeps the same source editable through Generate, Save/Load, and mode changes. Actual source replacement still invalidates old feature editing, and unsupported placements remain unavailable.

## Reproducer and root cause

Exact base: `bed447b813d07581764b92373da62bcf464e8517`, the merge of #508. Both original defects were reproduced before any production edits on `ac1bb944cd26441cf7552823769a54ced7c53881`. The label repair in #508 left this placement failure unchanged.

Load the retained two-resource mitochondrial/lambda Circular composite, inspect placement choices, Generate, and inspect the same feature. Auto, Main, Outward and Inward all became disabled. The original full 11-record Vibrio construction reproduced the same failure, with its records and order intact.

Generate replaces component resources with one concatenated GenBank resource while the UI keeps the original composite file view. The editor's current-source predicate compared each component payload with that combined payload and rejected it. The catalog and track semantics remained valid. Saved sessions retain their ordered component file bindings, so the same comparison also failed after a fresh Load.

## Existing owners changed

- `session-resource-backing.js` adds `matchesSessionResourceDescriptor` beside the existing ordinary/composite file view owner. It verifies either an original component or the complete ordered composite, including exact bytes, declared sizes, repeated/empty components and LF/CRLF boundaries.
- `record-display-options.js` delegates its former payload comparison to that owner. Its exact source-object and paired-source guards remain authoritative for real replacement.

After complete verification, the existing immutable backing's descriptor slot references the matching serialized descriptor. It retains no decoded content and needs no repeated decoding. The placement action owner still derives valid choices from the current draft slot; the selected override value is separate, and the popup and action admission use the same capability predicate.

## Verification

- P1–P8 browser coverage checks single and composite sources, repeat Generate, label plus placement edits, Save/fresh Load, mode round trips, actual same-name/same-byte File replacement, and all Circular preset/Separate Strands combinations.
- The browser checks compare semantic capability sets, selected values, enabled UI options, invalid-action rejection, generated track targets, and record order. They use the normal CLI session writer with the existing source fixtures and block external requests.
- The retained two-source and all-11-record originals pass after the correction, including Save/Load and repeat Generate. The label-only and placement-plus-label multipart originals also pass as cross controls.
- Browser controls: 33 passed. The frozen-head P1–P8 and Circular warning/Auto selection was then verified separately: 5 passed.
- Focused source/placement contracts: 37 passed. Fast Web JavaScript contracts: 398 passed. Architecture contracts: 137 passed. New browser cases enter the existing full functional suite; PR smoke remains ten cases.
- Negative controls reject reordered or different composite bytes, real source replacement, and unavailable lanes even when the current override selects such a lane. Existing History, durable editor intent, Result/mounted/export and CLI/Web compatibility controls are included in the browser verification.
- In Chromium, first verification of the full 71,480,904-byte Vibrio source took 154–170 ms in three local trials; 1,000 subsequent checks took 0.2–0.4 ms. These measurements do not establish a new baseline.

Architecture: ordinary non-increasing correction at the existing source-backing owner, with the former editor-local comparison removed. There is no new catalog, placement owner, identity namespace, production module, reactive owner, watcher, compatibility reader, or Result/editor cache. Privileged permissions and import fan-out are unchanged. Local policy: Gate PASS / Review REQUIRED for the new public source-backing operation; ordinary final-head human review is required.

Product: `IMPLEMENT_EXISTING_AUTHORITY`, supported by the base Web live-edit and reactive availability contracts. Valid editing remains available for unchanged source/configuration; invalid placements and replacement-source rejection remain enforced. No unresolved placement semantics or Product choice is introduced.

Schema disposition: unchanged session 41, request 7, catalog 3, and file-binding schema 2. CI policy, generated Gallery artifacts, and geometry references are unchanged. Rollback is a revert of this PR.

See `docs/internal/SESSION05A7_E_COMPOSITE_PLACEMENT_REMEDIATION.md` for the owner trace, excluded diagnostic attempts, and retained evidence. This PR addresses only 05A4-08 and assigns no technical baseline or publication candidate.
