### PR TITLE
Discard obsolete feature visibility after source replacement

### DIFF
--- a/docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md
+++ b/docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md
@@ -1,0 +1,132 @@
+# Source replacement reconciliation (05A4-07 and 05A4-10)
+
+Starting `dev`: `cc16bd33dbb7f0fe79c4c68535d3e9eced30634d`.
+The remote was fetched and matched this SHA. Work uses a clean isolated worktree;
+the original dirty workspace is preserved.
+
+## Diagnosis before production changes
+
+Both retained reproducers fail on this exact source. The original M20 harness
+and journey module were copied with only their worktree root changed; its M13
+function matches the retained M13 sequence. Original fixtures, snapshots,
+downloaded SVGs/sessions, traces, and runtime logs are retained separately in
+`/tmp/gbdraw-session05a8-evidence`.
+
+- M13: load the mitochondrial Gallery session, Generate, hide `f24a47546`
+  (`s-rRNA`), upload the retained `tobacco.gb`, Generate, Save/fresh Load,
+  upload retained `mito.gb`, Generate. The override stays `{f24a47546: off}`;
+  manual visibility rules stay empty. The target is absent from tobacco's
+  catalog, remains dormant there, survives serialization, and hides the
+  mitochondrial feature on return (36 rendered features instead of 37).
+- M20: fresh Linear app, retained `lambda.gb`, labels All, Generate; replace
+  with retained `tobacco.gb`, Generate; replace with `lambda.gb`, Generate.
+  All 73 lambda feature geometries return, but the legend retains
+  `repeat_region`, `tRNA`, and `rRNA`. There are no custom legend entries,
+  color overrides, or added captions in this reproducer. Original order remains
+  `[CDS]` while the editor inventory includes tobacco's categories.
+- Both journeys maintain Result/mounted/export agreement and complete Save.
+  Neither reports console errors, page errors, or attempted external requests.
+
+These are **independent roots**, so fixes require sequential PRs. Visibility's
+candidate mutation planner skips missing rendered targets without pruning its
+durable override map; selector-cache preservation retains their rules. Legend
+extraction initializes `originalLegendOrder` only once; subsequent generated
+categories are then misclassified as manual additions by `candidate-render.js`.
+They do not share an existing reconciliation operation whose one correction
+would fix both defects.
+
+## Identity and lifetime
+
+Source bytes and ordinary/composite File views belong to
+`session-resource-backing.js`; the current `matchesSessionResourceDescriptor`
+operation includes 05A4-08's ordered composite/combined-resource equivalence.
+Ordinary native Files are bound by the successful run's object identity in
+`record-display-options.js`. Resource IDs and file names are not biological
+feature identity. Save/Load and CLI imports reconstruct those same supported
+backings; schema 1/2 binding readers and the current writer remain unchanged.
+
+Python `features/source.py` captures the original biological catalog before
+crop and visibility filtering, using `features/ids.py` identities (record ID,
+feature type, original ordered coordinates, strand, and duplicate ordinal).
+`services/feature-catalog.js` admits that catalog and its rendered projection.
+The existing feature hash utilities distinguish rendered record suffixes from
+the underlying identity. Mode navigation only projects the retained catalog;
+it is not a successful source replacement.
+
+The Generate caller uses `recordDisplayControls.isCurrentFeature` once per
+previous source record to distinguish retained bindings from replacement.
+Only a changed binding activates visibility reconciliation. Matching against
+the candidate's original catalog then preserves valid targets even when a new
+File has a different name. Hidden rendered instances use the visibility
+owner's existing cached hash selector when their old rendered row is absent.
+No identity bytes, descriptor comparison, or persistent index is duplicated.
+
+| State | Lifetime and disposition |
+| --- | --- |
+| `featureVisibilityOverrides` | Feature-bound individual intent; discard only absent biological targets after a successful Generate. |
+| `featureVisibilityManualRules` | Session-wide matcher rules, with explicit record/type/qualifier scope; preserve. An exact-product rule is a matcher, not one feature's identity. |
+| `featureVisibilitySelectorCache` | Generated-artifact-only selector projection; existing refresh follows reconciled overrides. |
+| `labelTextFeatureOverrides` | Feature-bound text intent; preserve its existing owner. |
+| `labelTextBulkOverrides` | Source-bound source-text matching; preserve its existing context reconciliation. |
+| `labelTextFeatureOverrideSources` | Feature-bound source-text context; preserve its existing owner. |
+| `labelVisibilityOverrides` | Feature-bound label intent; preserve its existing owner. |
+| `featureColorOverrides` | Feature-bound biological-key intent; existing candidate normalization already drops unmatched targets. |
+| `featurePlacementOverrides` | Record/feature-bound placement; preserve the recent source-backing capability contract. |
+| Catalog and feature selection | Generated-artifact-only catalog projection and mode-bound transient selection. |
+| Legend entries/original inventory | Generated-artifact-only category inventory, with separately owned user edits; diagnosis only in the first PR. |
+| Legend color/stroke/rename/delete edits | User intent keyed by category; do not treat every legend field as disposable. |
+| Layout preferences/legend typography | Session-wide preferences with existing mode-specific slots; preserve. |
+| Palette and color rules | Session-wide preferences/matchers; preserve. |
+| Generated legend metadata and saved Result | Generated-artifact-only; admitted, mounted, exported, and replayed through existing boundaries. |
+
+Classification for the individual visibility defect is
+`IMPLEMENT_EXISTING_AUTHORITY`: the supported “This feature” scope and the
+current request's authoritative biological catalog select the target. The
+user's explicit mode/source distinction agrees with the retained 05A2-01
+contract. Manual matcher lifetimes are not changed. No schema migration,
+source fingerprint, second catalog, or reset-all operation is justified.
+
+Generation already captures mutable editor intent in its rollback handle.
+Reconciliation must publish only with a successfully admitted replacement and
+must remain covered by that rollback and the existing History operation.
+The canonical render request continues to describe how its immutable Result
+was generated; active editor state determines the next Generate.
+
+## Visibility implementation and verification
+
+The visibility owner gains one reconciliation operation; Generate calls it
+after candidate admission, activation, readiness, and cancellation checks.
+It removes absent individual targets, refreshes the existing selector cache,
+then captures the generated artifact identity. Save and the History checkpoint
+therefore receive reconciled active intent. Existing rollback restores both
+the map and cache if commitment fails.
+
+The production path remains source binding (`record-display-options.js` and
+`session-resource-backing.js`) → admitted catalog (`feature-catalog.js`) →
+visibility owner (`feature-visibility.js`), coordinated by `run-analysis.js`
+and wired in `app-setup.js`. There was no previous visibility reconciliation
+path to retire. Owner/path excess and compatibility paths do not increase;
+no architecture exception or persisted-format change is introduced. Rollback
+is a normal revert with no data migration.
+
+Local evidence includes the retained original M13 before/after replay, all
+V1–V8 cases, 32 focused browser cases covering the closed neighboring defects,
+412 focused Python tests, 137 architecture contracts, and 402 fast Web
+contracts. The additional duplicate-feature control exposed an early candidate
+that pruned intent on unchanged-source regeneration; the source-binding check
+and existing selector cache correct it. The final browser set includes repeated
+Generate and a renamed File carrying the same duplicate target.
+
+Runtime checks block external requests in fresh browser contexts and use the
+locally prepared browser wheel. The original reproducer also compares mounted,
+Result, and exported SVG state and records console/page errors. An initial
+concurrent browser run lost its shared test server; the corrected run uses a
+separately owned local server. A sandbox Node run could not exercise subprocess
+contracts normally; executable evidence comes from the escalated rerun.
+
+The trusted-base change gate passes; the added public operation requires human
+review under `WEB_CHANGE_POLICY.md`. Hosted and post-merge results are recorded
+in the session handoff rather than inferred from local checks. CI tiers,
+ten-case PR smoke budget, workflows, timeouts, Gallery artifacts, and unrelated
+05A4 findings remain unchanged. The independent 05A4-10 fix is pending the
+visibility PR's merge.

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -1983,6 +1983,7 @@ export const createAppSetup = () => {
     restoreGeneratedArtifactRuntimeState
   } = createRunAnalysis({
     state,
+    isCurrentFeature: recordDisplayControls.isCurrentFeature,
     serializeCanonicalFiles: (comparisonPlanSnapshot, linearRecordCatalog = null) => (
       serializeActiveRenderFiles(state.mode.value, state, {
         comparisonPlan: comparisonPlanSnapshot,

--- a/gbdraw/web/js/app/feature-visibility.js
+++ b/gbdraw/web/js/app/feature-visibility.js
@@ -3,6 +3,7 @@ import {
   exactRegexValue,
   selectFeatureSelector
 } from './feature-selector.js';
+import { getFeatureGenerationHash } from './feature-utils.js';
 export { escapeRegexLiteral, exactRegexValue } from './feature-selector.js';
 
 const REQUIRED_COLUMNS = ['record_id', 'feature_type', 'qualifier', 'value', 'action'];
@@ -318,6 +319,32 @@ export const preserveFeatureVisibilitySelectorCacheForOverrides = (
   });
 
   return merged;
+};
+
+// Reconcile against the source catalog, including hidden/cropped features.
+// The source-binding owner decides whether a successful Generate replaced a source.
+export const reconcileFeatureVisibilityOverrides = (
+  overrides,
+  biologicalFeatures,
+  previousFeatures = [],
+  selectorCache = {}
+) => {
+  const keys = Object.keys(overrides || {});
+  if (keys.length === 0) return 0;
+  const currentIds = new Set((biologicalFeatures || []).map(getFeatureStableHashValue));
+  const previousById = new Map((previousFeatures || []).map(feature => [getFeatureId(feature), feature]));
+  let removed = 0;
+  keys.forEach(featureId => {
+    const previous = previousById.get(featureId);
+    const cached = getSelectorCacheEntry(selectorCache, featureId);
+    const sourceId = previous
+      ? getFeatureStableHashValue(previous)
+      : (cached?.qualifier === 'hash' ? cached.value : getFeatureGenerationHash({ svg_id: featureId }));
+    if (sourceId && currentIds.has(sourceId)) return;
+    delete overrides[featureId];
+    removed += 1;
+  });
+  return removed;
 };
 
 const buildRuleFromSelectorCacheEntry = (featureIdRaw, modeRaw, selectorCache) => {

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -57,7 +57,12 @@ import {
   normalizePaletteColors
 } from './color-utils.js';
 import { serializeSpecificRules } from './file-imports.js';
-import { serializeFeatureVisibilityRules } from './feature-visibility.js';
+import {
+  buildFeatureVisibilitySelectorCache,
+  preserveFeatureVisibilitySelectorCacheForOverrides,
+  reconcileFeatureVisibilityOverrides,
+  serializeFeatureVisibilityRules
+} from './feature-visibility.js';
 import {
   normalizeDefinitionLineStyleState
 } from './definition-line-style-state.js';
@@ -922,6 +927,7 @@ const mergeCircularRecordPositions = (records, currentPositions) => {
 };
 export const createRunAnalysis = ({
   state,
+  isCurrentFeature,
   serializeCanonicalFiles,
   canonicalSessionVersion,
   adoptCanonicalRenderArtifacts,
@@ -1754,6 +1760,9 @@ export const createRunAnalysis = ({
       ?? extractedFeatures.value;
     let workingBiologicalFeatures = committedArtifactHandle?.ownerSet?.biologicalFeatures
       ?? biologicalFeatures?.value;
+    const visibilitySourceChanged = !isReflow && Object.keys(featureVisibilityOverrides).length > 0
+      && [...new Map((workingBiologicalFeatures || []).map(feature => [feature.record_key, feature])).values()]
+        .some(feature => !isCurrentFeature(feature));
     let workingLosatCacheInfo = committedArtifactHandle?.ownerSet?.losatCacheInfo
       ?? losatCacheInfo.value;
     let workingSelectedOrthogroupId = selectedOrthogroupId.value;
@@ -4695,6 +4704,19 @@ export const createRunAnalysis = ({
           }
           await restoreCommittedArtifact();
           return { status: 'stale' };
+        }
+        const removedVisibilityTargets = visibilitySourceChanged && reconcileFeatureVisibilityOverrides(
+          featureVisibilityOverrides,
+          candidateBiologicalFeatures,
+          workingExtractedFeatures,
+          state.featureVisibilitySelectorCache
+        );
+        if (removedVisibilityTargets > 0) {
+          state.replaceFeatureVisibilitySelectorCacheOwner(preserveFeatureVisibilitySelectorCacheForOverrides(
+            buildFeatureVisibilitySelectorCache(candidateExtractedFeatures, candidateCommit.featureState.featureSelectorSafetyScope),
+            state.featureVisibilitySelectorCache,
+            featureVisibilityOverrides
+          ));
         }
         if (typeof setGeneratedArtifactIdentity === 'function') {
           setGeneratedArtifactIdentity(generationResponse.artifactIdentity, {

--- a/tests/web/feature-visibility-reconciliation.test.mjs
+++ b/tests/web/feature-visibility-reconciliation.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { reconcileFeatureVisibilityOverrides } from '../../gbdraw/web/js/app/feature-visibility.js';
+
+test('source replacement discards absent feature intent and cannot resurrect it on return', () => {
+  const overrides = { fa: 'off', fb: 'exclude_matching', shared: 'on' };
+  const sourceB = [{ svg_id: 'fb' }, { svg_id: 'shared' }];
+  assert.equal(reconcileFeatureVisibilityOverrides(overrides, sourceB), 1);
+  assert.deepEqual(overrides, { fb: 'exclude_matching', shared: 'on' });
+  const restored = JSON.parse(JSON.stringify(overrides));
+  reconcileFeatureVisibilityOverrides(restored, [{ svg_id: 'fa' }, { svg_id: 'shared' }]);
+  assert.deepEqual(restored, { shared: 'on' });
+});
+
+test('hidden, cropped, and unchanged semantic targets survive without a rendered path', () => {
+  const overrides = { hidden_record_2: 'off', croppedDisplay: 'on' };
+  const biological = [{ svg_id: 'hidden' }, { svg_id: 'original' }];
+  const previous = [{ svg_id: 'croppedDisplay', stable_svg_id: 'original' }];
+  assert.equal(reconcileFeatureVisibilityOverrides(overrides, biological, previous), 0);
+  assert.deepEqual(overrides, { hidden_record_2: 'off', croppedDisplay: 'on' });
+});
+
+test('a different biological target cannot inherit an old rendered ID', () => {
+  const overrides = { sameDisplay: 'off' };
+  reconcileFeatureVisibilityOverrides(overrides, [{ svg_id: 'newBiology' }], [
+    { svg_id: 'sameDisplay', stable_svg_id: 'oldBiology' }
+  ]);
+  assert.deepEqual(overrides, {});
+});
+
+test('hidden rendered instances retain the stable selector owned by the visibility cache', () => {
+  const overrides = { opaqueInstance: 'off' };
+  const cache = { opaqueInstance: { qualifier: 'hash', value: 'shared' } };
+  reconcileFeatureVisibilityOverrides(overrides, [{ svg_id: 'shared' }], [], cache);
+  assert.deepEqual(overrides, { opaqueInstance: 'off' });
+  reconcileFeatureVisibilityOverrides(overrides, [{ svg_id: 'different' }], [], cache);
+  assert.deepEqual(overrides, {});
+});
+
+test('no individual intent requires no source traversal', () => {
+  assert.equal(reconcileFeatureVisibilityOverrides({}, new Proxy([], {
+    get() { throw new Error('unnecessary catalog traversal'); }
+  })), 0);
+});

--- a/tests/web/feature-visibility.test.mjs
+++ b/tests/web/feature-visibility.test.mjs
@@ -19,6 +19,11 @@ await writeFile(
   await readFile(selectorSourcePath, 'utf8'),
   'utf8'
 );
+await writeFile(
+  join(tempDir, 'feature-utils.js'),
+  await readFile(join(repoRoot, 'gbdraw', 'web', 'js', 'app', 'feature-utils.js'), 'utf8'),
+  'utf8'
+);
 
 const {
   buildEditorFeatureVisibilityRule,

--- a/tests/web/history.test.mjs
+++ b/tests/web/history.test.mjs
@@ -35,6 +35,7 @@ for (const filename of [
 for (const filename of [
   'feature-selector.js',
   'feature-visibility.js',
+  'feature-utils.js',
   'layout-preferences.js',
   'plot-title-position.js'
 ]) {

--- a/tests/web/source-visibility-reconciliation.playwright.spec.js
+++ b/tests/web/source-visibility-reconciliation.playwright.spec.js
@@ -1,0 +1,176 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { gunzipSync } = require('node:zlib');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const { load, generate, switchMode, popup, closeEditor, download, snapshot } = require('./helpers/mode-transition.cjs');
+
+const seed = 'gbdraw/web/gallery/sessions/HmmtDNA_basic_circular.gbdraw-session.json';
+const tobacco = 'gbdraw/web/gallery/sessions/tobacco-chloroplast.gbdraw-session.json';
+const lambda = 'gbdraw/web/gallery/sessions/lambda_basic_linear.gbdraw-session.json';
+const source = async (file, name) => {
+  const session = JSON.parse(await fs.readFile(file, 'utf8'));
+  return { name, mimeType: 'text/plain', buffer: Buffer.from(
+    session.resources[session.renderRequest.records[0].source.resourceId].data, 'base64') };
+};
+const upload = async (page, file) => {
+  await page.getByLabel('GenBank/DDBJ File', { exact: true }).setInputFiles(file);
+  await expect.poll(() => page.evaluate(async () =>
+    (await import('./js/state.js')).state.circularRecordDiscovery.status)).not.toBe('loading');
+};
+const hide = async page => {
+  const target = await popup(page, 1);
+  await page.getByLabel('Feature visibility', { exact: true }).selectOption('off');
+  if (await page.getByRole('heading', { name: 'Feature Visibility Scope', exact: true }).isVisible()) {
+    await page.getByText('This feature', { exact: true }).click();
+  }
+  await closeEditor(page);
+  return target.featureId;
+};
+const history = async (page, action) => {
+  await page.getByRole('button', { name: action, exact: true }).click();
+  await expect.poll(() => page.evaluate(() => !window.__GBDRAW_HISTORY__.restoring.value
+    && !window.__GBDRAW_HISTORY__.capturing.value)).toBe(true);
+};
+
+test('V1-V5/V8 individual visibility is reconciled on accepted source replacement and History replay', async ({ browser }, testInfo) => {
+  test.setTimeout(1_800_000);
+  const page = await load(browser);
+  let fresh;
+  try {
+    await generate(page);
+    const id = await hide(page);
+    expect(id).toBe('f24a47546');
+    await generate(page);
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    await switchMode(page, 'linear');
+    await switchMode(page, 'circular');
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    await upload(page, await source(tobacco, 'tobacco.gb'));
+    // A remains the current Result until B is admitted.
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    await generate(page);
+    expect((await snapshot(page)).featureVisibility).toEqual({});
+    await history(page, 'Undo');
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    await history(page, 'Redo');
+    expect((await snapshot(page)).featureVisibility).toEqual({});
+    const file = testInfo.outputPath('source-B.gbdraw-session.json.gz');
+    const bytes = await download(page, 'Save Session', file);
+    expect(JSON.parse(gunzipSync(bytes)).features.featureVisibilityOverrides).toEqual({});
+    fresh = await load(browser, file);
+    expect((await snapshot(fresh)).featureVisibility).toEqual({});
+    await upload(fresh, await source(seed, 'mito-return.gb'));
+    await generate(fresh);
+    expect((await snapshot(fresh)).featureVisibility).toEqual({});
+    expect(await fresh.evaluate(id => window.__GBDRAW_APP__.extractedFeatures
+      .some(feature => feature.svg_id === id), id)).toBe(true);
+    expect(page.externalRequests).toEqual([]);
+    expect(fresh.externalRequests).toEqual([]);
+  } finally {
+    await page.context().close();
+    if (fresh) await fresh.context().close();
+  }
+});
+
+test('V6/V7 shared biological targets and manual matchers survive while rejected sources preserve A', async ({ browser }, testInfo) => {
+  test.setTimeout(1_800_000);
+  const page = await load(browser);
+  try {
+    await generate(page);
+    const id = await hide(page);
+    const a = await source(seed, 'renamed.gb');
+    const b = await source(lambda, 'lambda.gb');
+    await upload(page, { ...a, buffer: Buffer.concat([a.buffer, Buffer.from('\n'), b.buffer]) });
+    await generate(page);
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    // Use the existing manual-rule owner for a type-wide matcher.
+    await page.evaluate(() => {
+      const app = window.__GBDRAW_APP__;
+      app.addFeatureVisibilityRule();
+      for (const [field, value] of Object.entries({ featureType: 'CDS', qualifier: 'product', value: '.*', action: 'exclude_matching' })) {
+        app.setFeatureVisibilityRuleField(0, field, value);
+      }
+    });
+    const before = await snapshot(page);
+    await upload(page, { name: 'corrupt.gb', mimeType: 'text/plain', buffer: Buffer.from('invalid GenBank source') });
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.runAnalysis())).toEqual({ status: 'error' });
+    const failed = await snapshot(page);
+    expect(failed.featureVisibility).toEqual(before.featureVisibility);
+    expect(failed.visibilityRules).toEqual(before.visibilityRules);
+    expect(failed.result).toEqual(before.result);
+    expect(failed.request).toEqual(before.request);
+    await upload(page, await source(tobacco, 'tobacco.gb'));
+    await generate(page);
+    const accepted = await snapshot(page);
+    expect(accepted.featureVisibility).toEqual({});
+    expect(accepted.visibilityRules).toEqual(before.visibilityRules);
+    await fs.writeFile(testInfo.outputPath('manual-rule.json'), JSON.stringify(accepted.visibilityRules));
+    expect(page.externalRequests).toEqual([]);
+  } finally { await page.context().close(); }
+});
+
+test('composite source replacement and Web-CLI-Web replay do not restore discarded visibility', async ({ browser }, testInfo) => {
+  test.setTimeout(1_800_000);
+  const a = testInfo.outputPath('mito.gb');
+  const b = testInfo.outputPath('lambda.gb');
+  await fs.writeFile(a, (await source(seed, 'mito.gb')).buffer);
+  await fs.writeFile(b, (await source(lambda, 'lambda.gb')).buffer);
+  const cli = async (args, name) => {
+    const output = testInfo.outputPath(`${name}.gbdraw-session.json.gz`);
+    await promisify(execFile)('python', ['-m', 'gbdraw.cli', 'circular', ...args,
+      '-o', testInfo.outputPath(name), '--session_output', output], {
+      cwd: testInfo.outputDir, env: { ...process.env, PYTHONPATH: process.cwd() },
+      timeout: 1_800_000, maxBuffer: 1_000_000
+    });
+    return output;
+  };
+  const composite = await cli(['--gbk', a, b, '--multi_record_canvas', '--labels', 'out'], 'composite');
+  const page = await load(browser, composite);
+  let fresh;
+  try {
+    await generate(page);
+    const id = await hide(page);
+    await generate(page);
+    await switchMode(page, 'linear');
+    await switchMode(page, 'circular');
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    await upload(page, await source(tobacco, 'tobacco.gb'));
+    await generate(page);
+    expect((await snapshot(page)).featureVisibility).toEqual({});
+    const saved = testInfo.outputPath('replaced.gbdraw-session.json.gz');
+    await download(page, 'Save Session', saved);
+    const replayed = await cli(['--session', saved], 'replayed');
+    fresh = await load(browser, replayed);
+    expect((await snapshot(fresh)).featureVisibility).toEqual({});
+    await generate(fresh);
+    expect((await snapshot(fresh)).featureVisibility).toEqual({});
+    expect(page.externalRequests).toEqual([]);
+    expect(fresh.externalRequests).toEqual([]);
+  } finally {
+    await page.context().close();
+    if (fresh) await fresh.context().close();
+  }
+});
+
+test('repeated generation of an unchanged source preserves hidden duplicate feature intent', async ({ browser }) => {
+  test.setTimeout(1_800_000);
+  const page = await load(browser);
+  try {
+    const file = await source(seed, 'duplicate-rRNA.gb');
+    const text = file.buffer.toString('utf8');
+    const entry = text.match(/     rRNA\s[^]*?(?=\n     \S|\nORIGIN)/)[0];
+    await upload(page, { ...file, buffer: Buffer.from(text.replace(entry, `${entry}\n${entry}`)) });
+    await generate(page);
+    const id = await hide(page);
+    expect(id).toContain('__instance_');
+    await generate(page);
+    await generate(page);
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    // A new File view with the same supported semantic target is valid too.
+    await upload(page, { ...file, name: 'renamed-duplicates.gb', buffer: Buffer.from(text.replace(entry, `${entry}\n${entry}`)) });
+    await generate(page);
+    expect((await snapshot(page)).featureVisibility).toEqual({ [id]: 'off' });
+    expect(page.externalRequests).toEqual([]);
+  } finally { await page.context().close(); }
+});


### PR DESCRIPTION
## Plain-language summary

Remove individual Feature Visibility overrides when their biological targets are absent from a successfully generated replacement source. A hidden mitochondrial feature no longer remains in a tobacco session or becomes hidden again when the mitochondrial file is uploaded later. Hidden or cropped targets that still exist, mode round trips, manual matching rules, and failed replacement attempts retain their existing intent.

## Change class

- [x] STANDARD

## Purpose

Remediate `05A4-07` on `dev` at `cc16bd33dbb7f0fe79c4c68535d3e9eced30634d`. The retained `M13` journey reproduces the defect on that exact base. Diagnosis also reproduces `05A4-10`, but its independent legend-inventory cause requires a subsequent PR.

## User-visible impact

Successful source replacement removes obsolete individual visibility intent before the next Save or History checkpoint. Undo/Redo restores the corresponding intent, and a rejected source leaves the current diagram and visibility state intact.

## Changes

- Use the existing record/source binding predicate to distinguish replacement from unchanged-source regeneration, then reconcile individual overrides with the admitted, unfiltered biological catalog and existing visibility selector cache.
- Invoke it at the successful Generate boundary and refresh the existing selector cache before capturing the artifact identity.
- Add deterministic and full-functional browser regressions; record source/lifetime analysis in `docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md`.

## Verification

- Original retained `M13`: reproduced before the change; passes after it, including Save/fresh Load and source return, with no console errors, page errors, or external requests.
- New browser coverage: 4 passed, covering individual edits and regeneration; mode round trips; genuine replacement; Save/fresh Load; source return; shared biological target; manual type matcher; corrupt input rejection; History; composite source and Web/CLI replay; hidden duplicate targets on repeated Generate and renamed File replacement.
- Focused Python session, visibility, and multipart-label tests: 412 passed.
- Architecture contracts: 137 passed. Trusted-base change gate: PASS.
- Existing closed-neighbor browser controls plus the initial three new cases: 32 passed. Fast Web contracts: 402 passed; final focused visibility/History/Generate contracts: 13 passed.

## Risk and review notes

This is architecture-bearing: the existing `app/feature-visibility.js` owner gains a reconciliation operation called by the existing Generate transaction. `app-setup.js` supplies the existing `recordDisplayControls.isCurrentFeature` predicate; it is evaluated once per previous record only when individual visibility intent exists. The source identity, catalog, canonical request, Result admission, History rollback, and session readers keep their existing owners and paths; `OE`, `PE`, and `CB` do not increase. No previous reconciliation path exists to retire, and no reset-all helper, new source identity, extra catalog, compatibility path, or persisted field is introduced.

Gate: PASS. Review: REQUIRED for the added public operation. Production and test diffs were reviewed separately. Existing CI tiers, ten-case PR smoke budget, workflow timeouts, generated artifacts, and unrelated findings remain unchanged.

## Rollback

Revert this PR. No persisted format migration is needed.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Authority: the existing “This feature” scope, original biological catalog identity, mode-preservation contract, and explicit source-replacement invariant in SESSION 05A8-R.
- Manual matcher rules and other editor field lifetimes are preserved. The canonical request remains the recipe for its immutable Result; reconciled active intent governs subsequent generation.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
