### PR TITLE
Remove obsolete generated legend entries after source replacement

### DIFF
--- a/docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md
+++ b/docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md
@@ -140,9 +140,11 @@ legend production changes.
 ## Legend implementation and verification
 
 `legend/entry-actions.js` remains the owner of editor legend extraction and its
-generated original-category inventory. Its existing extraction scan now
-reconciles `originalLegendOrder` with the admitted diagram instead of only
-initializing it once. Surviving categories retain their default relative order;
+generated original-category inventory. The existing Result binder requests
+inventory replacement for an accepted nonincremental Result; ordinary live
+extraction does not advance it. The same extraction scan reconciles
+`originalLegendOrder` with the admitted diagram instead of only initializing
+it once. Surviving categories retain their default relative order;
 explicitly deleted rows retain their restore intent. New generated categories
 are admitted into that same inventory. No second category cache or feature
 catalog is introduced.
@@ -162,6 +164,21 @@ binding control remains strict. Explicit deletion is idempotent while its
 category is absent and keeps the existing user-facing restore contract.
 `svg-result-ingestion.js` applies these plan capabilities using its existing
 lazy legend index; it adds no parsing or scan to an empty mutation plan.
+
+The G2 return control exposed a separate condition in that same candidate-plan
+owner: style replay iterated only current legend rows, so a saved category color
+was skipped on its first returning Generate. Style operations now come directly
+from the existing `legendColorOverrides`/`legendStrokeOverrides` maps and resolve
+against the admitted SVG without inventing entries. A dormant style may therefore
+require the existing mutation parse even when it finds no current category;
+the path without style intent and the empty-plan path remain unchanged.
+
+Supported generated-category rename uses `feature-editor/color-actions.js` and
+the existing specific-rule/feature-group intent. Its matcher rows survive B and
+name the category again when matching A features return. Category styles remain
+in their existing maps; deletion remains in `deletedLegendEntries` for Restore
+and continues to suppress the returning category. These representations and
+lifetimes are preserved rather than normalized into a new legend identity.
 
 This is `IMPLEMENT_EXISTING_AUTHORITY`: current generated-category membership,
 the existing manual Add/Restore contract, and the session's source-replacement
@@ -184,10 +201,17 @@ compatibility paths do not increase. Normal revert is sufficient for rollback.
 The retained M20 passes after the inventory correction. Added browser coverage
 exercises L1–L8, common category/different feature identity, manual rows,
 customized absent categories, rejected replacement, and Save/fresh Load.
+G1 compares the complete legend state and layout preferences plus digests of all
+Results, the mounted SVG, and canonical request across rejection. G2 returns to
+A after fresh loading B and verifies rename, an independent category color,
+and deletion on the first Generate. G3 verifies the explicitly owned row in B
+after Save/fresh Load and regeneration. No visibility-owner implementation or
+session format is changed by these boundary refinements.
 Deterministic tests cover inventory replacement, default-order retention,
 manual ownership, deleted-row intent, absent-category admission, and strict
 unchanged-source rejection. Local verification passes both original journeys,
-the two L1–L8/manual-row browser cases, seven visibility/composition browser
-controls, 405 fast Web contracts, and 137 architecture contracts. The policy
+all 35 selected browser cases covering L1–L8, G1–G3, V1–V8, and the closed
+05A2/05A4 neighbors; 29 focused legend/admission checks; 407 fast Web contracts;
+and 137 architecture contracts. The policy
 result is Gate PASS, Review CLEAR. Final exact-head and hosted results are
 recorded in the session handoff.

--- a/docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md
+++ b/docs/internal/SESSION05A8_R_SOURCE_RECONCILIATION.md
@@ -128,5 +128,66 @@ The trusted-base change gate passes; the added public operation requires human
 review under `WEB_CHANGE_POLICY.md`. Hosted and post-merge results are recorded
 in the session handoff rather than inferred from local checks. CI tiers,
 ten-case PR smoke budget, workflows, timeouts, Gallery artifacts, and unrelated
-05A4 findings remain unchanged. The independent 05A4-10 fix is pending the
-visibility PR's merge.
+05A4 findings remain unchanged.
+
+Visibility PR #510 was reviewed by the user at
+`d83f46fd86d9b42fdefa288afc5afce2ac44ce42`, passed all PR gates, and merged as
+`b67f9e505acd3a3a16320d6caa930bd30c1a2040`. Its final local head passed 403 fast
+Web contracts and all 33 selected browser cases. The independent legend branch
+starts at that fetched exact `dev`; retained M20 still fails there before
+legend production changes.
+
+## Legend implementation and verification
+
+`legend/entry-actions.js` remains the owner of editor legend extraction and its
+generated original-category inventory. Its existing extraction scan now
+reconciles `originalLegendOrder` with the admitted diagram instead of only
+initializing it once. Surviving categories retain their default relative order;
+explicitly deleted rows retain their restore intent. New generated categories
+are admitted into that same inventory. No second category cache or feature
+catalog is introduced.
+
+Manual additions use the existing `data-legend-owner="direct-editor"` marker
+at their creation, including when a later renderer produces the same caption.
+Extraction excludes those rows from the generated inventory, so they keep their
+manual lifetime across Generate and replacement. Renderer categories are keyed
+by caption, not biological feature ID: lambda and tobacco have disjoint feature
+identities yet legitimately share `CDS`.
+
+Source replacement can also remove a customized category. The existing source
+binding predicate, already wired for visibility, supplies one `sourceReplaced`
+fact to the candidate mutation planner. Old generated-category styles and
+renames may be absent in that replacement. The unchanged-source malformed
+binding control remains strict. Explicit deletion is idempotent while its
+category is absent and keeps the existing user-facing restore contract.
+`svg-result-ingestion.js` applies these plan capabilities using its existing
+lazy legend index; it adds no parsing or scan to an empty mutation plan.
+
+This is `IMPLEMENT_EXISTING_AUTHORITY`: current generated-category membership,
+the existing manual Add/Restore contract, and the session's source-replacement
+invariant determine these outcomes. Palette colors, valid category styles,
+legend position, font size, layout preferences, visibility rules, labels, and
+placement intent keep their existing owners. There are no persisted fields or
+reader/writer changes.
+
+The successful candidate's existing mounted binder updates the inventory, and
+the Generate rollback handle already captures all affected legend state. A
+rejected replacement therefore preserves the prior diagram and editor state;
+History restores the corresponding source, Result, and legend inventory.
+There is no watcher-order workaround or additional delay.
+
+The old initialize-only inventory update is replaced in place. Ownership and
+production paths remain Generate → existing source binding and candidate plan
+→ SVG admission → existing legend extraction; owner/path excess and persisted
+compatibility paths do not increase. Normal revert is sufficient for rollback.
+
+The retained M20 passes after the inventory correction. Added browser coverage
+exercises L1–L8, common category/different feature identity, manual rows,
+customized absent categories, rejected replacement, and Save/fresh Load.
+Deterministic tests cover inventory replacement, default-order retention,
+manual ownership, deleted-row intent, absent-category admission, and strict
+unchanged-source rejection. Local verification passes both original journeys,
+the two L1–L8/manual-row browser cases, seven visibility/composition browser
+controls, 405 fast Web contracts, and 137 architecture contracts. The policy
+result is Gate PASS, Review CLEAR. Final exact-head and hosted results are
+recorded in the session handoff.

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -1903,7 +1903,9 @@ export const createAppSetup = () => {
         phase: context.phase,
         rootGeneration: context.rootGeneration
       });
-      legendActions.extractLegendEntries();
+      legendActions.extractLegendEntries({
+        replaceGeneratedInventory: !context.bindingOptions.isIncrementalEdit
+      });
     },
     bindComposition(context) {
       if (context.bindingOptions.trustedRestore) return;

--- a/gbdraw/web/js/app/candidate-render.js
+++ b/gbdraw/web/js/app/candidate-render.js
@@ -110,6 +110,7 @@ const compilePlanBundle = ({
   legendEntries = [],
   deletedLegendEntries = [],
   originalLegendOrder = [],
+  sourceReplaced = false,
   addedLegendCaptions = [],
   legendColorOverrides = {},
   legendStrokeOverrides = {},
@@ -233,6 +234,7 @@ const compilePlanBundle = ({
       addToResults(operationsByResult, allResultIndexes, 'legendRenames', {
         from: entry.originalCaption,
         to: entry.caption,
+        allowMissing: sourceReplaced,
         xPos: entry.xPos,
         yPos: entry.yPos
       });
@@ -241,7 +243,7 @@ const compilePlanBundle = ({
     const legendRenderedIds = entry.featureIds.length > 0
       ? entry.featureIds
       : [...(renderedIdsByDirectCaption.get(entry.caption) || [])];
-    const allowMissing = rendererDerivedCaptions.has(entry.caption)
+    const allowMissing = (sourceReplaced && isOriginal) || rendererDerivedCaptions.has(entry.caption)
       && (
         legendRenderedIds.length === 0
         || legendRenderedIds.every((renderedId) => hiddenRenderedIds.has(renderedId))
@@ -298,7 +300,9 @@ const compilePlanBundle = ({
   });
 
   deletedCaptions.forEach((caption) => {
-    addToResults(operationsByResult, allResultIndexes, 'legendDeletes', { caption });
+    // Explicit deletions remain valid while their category is absent, including
+    // subsequent Generate calls after a source replacement.
+    addToResults(operationsByResult, allResultIndexes, 'legendDeletes', { caption, allowMissing: true });
   });
 
   if (typeof transformSvg === 'function') {

--- a/gbdraw/web/js/app/candidate-render.js
+++ b/gbdraw/web/js/app/candidate-render.js
@@ -239,48 +239,6 @@ const compilePlanBundle = ({
         yPos: entry.yPos
       });
     }
-    const targetCaption = isOriginal ? entry.originalCaption : entry.caption;
-    const legendRenderedIds = entry.featureIds.length > 0
-      ? entry.featureIds
-      : [...(renderedIdsByDirectCaption.get(entry.caption) || [])];
-    const allowMissing = (sourceReplaced && isOriginal) || rendererDerivedCaptions.has(entry.caption)
-      && (
-        legendRenderedIds.length === 0
-        || legendRenderedIds.every((renderedId) => hiddenRenderedIds.has(renderedId))
-      );
-    if (
-      hasOwn(legendColorOverrides, entry.caption)
-      && !deletedCaptions.has(entry.originalCaption)
-    ) {
-      const color = normalizePaint(legendColorOverrides[entry.caption], 'legend color');
-      if (color) {
-        addToResults(operationsByResult, allResultIndexes, 'legendFills', {
-          caption: targetCaption,
-          color,
-          allowMissing
-        });
-      }
-    }
-    const stroke = legendStrokeOverrides?.[entry.caption];
-    if (stroke && typeof stroke === 'object' && !deletedCaptions.has(entry.originalCaption)) {
-      const strokeColor = hasOwn(stroke, 'strokeColor')
-        ? normalizePaint(stroke.strokeColor, 'legend stroke color')
-        : '';
-      const strokeWidth = hasOwn(stroke, 'strokeWidth')
-        ? normalizeStrokeWidth(stroke.strokeWidth)
-        : null;
-      if (strokeColor || strokeWidth !== null) {
-        addToResults(operationsByResult, allResultIndexes, 'legendStrokes', {
-          caption: targetCaption,
-          strokeColor,
-          strokeWidth,
-          allowMissing,
-          renderedIds: legendRenderedIds.filter((renderedId) => (
-            renderedResultIndexes(catalogAdmission, renderedId).size > 0
-          ))
-        });
-      }
-    }
     if (
       originalCaptions.size > 0
       && !isOriginal
@@ -296,6 +254,37 @@ const compilePlanBundle = ({
           yPos: entry.yPos
         });
       }
+    }
+  });
+
+  // Category style preferences outlive the current generated entry projection.
+  // Apply a returning category's preference without synthesizing a manual row.
+  const entriesByCaption = new Map(currentEntries.map(entry => [entry.caption, entry]));
+  const styledCaptions = new Set([...Object.keys(legendColorOverrides), ...Object.keys(legendStrokeOverrides)]);
+  styledCaptions.forEach(caption => {
+    const entry = entriesByCaption.get(caption);
+    const originalCaption = entry?.originalCaption || caption;
+    if (deletedCaptions.has(originalCaption)) return;
+    const isOriginal = originalCaptions.has(originalCaption);
+    const targetCaption = isOriginal ? originalCaption : caption;
+    const legendRenderedIds = entry?.featureIds.length > 0
+      ? entry.featureIds : [...(renderedIdsByDirectCaption.get(caption) || [])];
+    const allowMissing = !entry || (sourceReplaced && isOriginal) || (rendererDerivedCaptions.has(caption)
+      && (legendRenderedIds.length === 0 || legendRenderedIds.every(id => hiddenRenderedIds.has(id))));
+    if (hasOwn(legendColorOverrides, caption)) {
+      const color = normalizePaint(legendColorOverrides[caption], 'legend color');
+      if (color) addToResults(operationsByResult, allResultIndexes, 'legendFills', {
+        caption: targetCaption, color, allowMissing
+      });
+    }
+    const stroke = legendStrokeOverrides[caption];
+    if (stroke && typeof stroke === 'object') {
+      const strokeColor = hasOwn(stroke, 'strokeColor') ? normalizePaint(stroke.strokeColor, 'legend stroke color') : '';
+      const strokeWidth = hasOwn(stroke, 'strokeWidth') ? normalizeStrokeWidth(stroke.strokeWidth) : null;
+      if (strokeColor || strokeWidth !== null) addToResults(operationsByResult, allResultIndexes, 'legendStrokes', {
+        caption: targetCaption, strokeColor, strokeWidth, allowMissing,
+        renderedIds: legendRenderedIds.filter(id => renderedResultIndexes(catalogAdmission, id).size > 0)
+      });
     }
   });
 

--- a/gbdraw/web/js/app/legend/entry-actions.js
+++ b/gbdraw/web/js/app/legend/entry-actions.js
@@ -763,7 +763,7 @@ export const createLegendEntryActions = ({
     }
   };
 
-  const extractLegendEntries = () => {
+  const extractLegendEntries = ({ replaceGeneratedInventory = false } = {}) => {
     if (!svgContainer.value) {
       legendEntries.value = [];
       return;
@@ -849,16 +849,18 @@ export const createLegendEntryActions = ({
 
     legendEntries.value = visuallySortedEntries;
 
-    // Keep the default order for surviving categories and user-deleted rows,
-    // while replacing the generated inventory as the effective diagram changes.
-    const retainedCaptions = new Set([
-      ...generatedCaptions,
-      ...deletedLegendEntries.value.map(entry => entry.originalCaption || entry.caption)
-    ]);
-    originalLegendOrder.value = [...new Set([
-      ...originalLegendOrder.value.filter(caption => retainedCaptions.has(caption)),
-      ...visuallySortedEntries.map(entry => entry.originalCaption).filter(caption => generatedCaptions.has(caption))
-    ])];
+    if (replaceGeneratedInventory || originalLegendOrder.value.length === 0) {
+      // Keep default order and deletion intent; live editor extraction alone
+      // must not advance the accepted generated inventory.
+      const retainedCaptions = new Set([
+        ...generatedCaptions,
+        ...deletedLegendEntries.value.map(entry => entry.originalCaption || entry.caption)
+      ]);
+      originalLegendOrder.value = [...new Set([
+        ...originalLegendOrder.value.filter(caption => retainedCaptions.has(caption)),
+        ...visuallySortedEntries.map(entry => entry.originalCaption).filter(caption => generatedCaptions.has(caption))
+      ])];
+    }
 
     if (Object.keys(originalLegendColors.value).length === 0 && visuallySortedEntries.length > 0) {
       visuallySortedEntries.forEach((entry) => {

--- a/gbdraw/web/js/app/legend/entry-actions.js
+++ b/gbdraw/web/js/app/legend/entry-actions.js
@@ -782,6 +782,7 @@ export const createLegendEntryActions = ({
     }
 
     const entries = [];
+    const generatedCaptions = new Set();
 
     const entryGroups = targetGroup.querySelectorAll('g[data-legend-key]');
 
@@ -819,6 +820,9 @@ export const createLegendEntryActions = ({
       const showStroke = existingEntry?.showStroke || false;
       const existingFeatureIds = existingEntry?.featureIds || [];
       const originalCaption = existingEntry?.originalCaption || caption;
+      if (entryGroup.getAttribute('data-legend-owner') !== 'direct-editor') {
+        generatedCaptions.add(originalCaption);
+      }
 
       entries.push({
         caption,
@@ -845,9 +849,16 @@ export const createLegendEntryActions = ({
 
     legendEntries.value = visuallySortedEntries;
 
-    if (originalLegendOrder.value.length === 0 && visuallySortedEntries.length > 0) {
-      originalLegendOrder.value = visuallySortedEntries.map((e) => e.caption);
-    }
+    // Keep the default order for surviving categories and user-deleted rows,
+    // while replacing the generated inventory as the effective diagram changes.
+    const retainedCaptions = new Set([
+      ...generatedCaptions,
+      ...deletedLegendEntries.value.map(entry => entry.originalCaption || entry.caption)
+    ]);
+    originalLegendOrder.value = [...new Set([
+      ...originalLegendOrder.value.filter(caption => retainedCaptions.has(caption)),
+      ...visuallySortedEntries.map(entry => entry.originalCaption).filter(caption => generatedCaptions.has(caption))
+    ])];
 
     if (Object.keys(originalLegendColors.value).length === 0 && visuallySortedEntries.length > 0) {
       visuallySortedEntries.forEach((entry) => {
@@ -956,7 +967,7 @@ export const createLegendEntryActions = ({
   const addNewLegendEntry = async () => {
     if (!newLegendCaption.value.trim()) return;
 
-    const added = await addLegendEntry(newLegendCaption.value.trim(), newLegendColor.value);
+    const added = await addLegendEntry(newLegendCaption.value.trim(), newLegendColor.value, { owner: 'direct-editor' });
     if (added) {
       newLegendCaption.value = '';
       newLegendColor.value = '#808080';

--- a/gbdraw/web/js/app/run-analysis.js
+++ b/gbdraw/web/js/app/run-analysis.js
@@ -1760,7 +1760,10 @@ export const createRunAnalysis = ({
       ?? extractedFeatures.value;
     let workingBiologicalFeatures = committedArtifactHandle?.ownerSet?.biologicalFeatures
       ?? biologicalFeatures?.value;
-    const visibilitySourceChanged = !isReflow && Object.keys(featureVisibilityOverrides).length > 0
+    const hasSourceBoundEditorIntent = Object.keys(featureVisibilityOverrides).length > 0
+      || Object.keys(legendColorOverrides).length > 0 || Object.keys(legendStrokeOverrides).length > 0
+      || legendEntries.value.some(entry => entry.originalCaption && entry.originalCaption !== entry.caption);
+    const sourceReplaced = !isReflow && hasSourceBoundEditorIntent
       && [...new Map((workingBiologicalFeatures || []).map(feature => [feature.record_key, feature])).values()]
         .some(feature => !isCurrentFeature(feature));
     let workingLosatCacheInfo = committedArtifactHandle?.ownerSet?.losatCacheInfo
@@ -4459,6 +4462,7 @@ export const createRunAnalysis = ({
             'run-analysis sanitize and reapply editor overrides',
             () => prepareCandidateCommit({
               generationResponse,
+              sourceReplaced,
               catalogAdmission: candidateCatalogAdmission,
               results: res,
               catalog: candidateCatalog,
@@ -4705,7 +4709,7 @@ export const createRunAnalysis = ({
           await restoreCommittedArtifact();
           return { status: 'stale' };
         }
-        const removedVisibilityTargets = visibilitySourceChanged && reconcileFeatureVisibilityOverrides(
+        const removedVisibilityTargets = sourceReplaced && reconcileFeatureVisibilityOverrides(
           featureVisibilityOverrides,
           candidateBiologicalFeatures,
           workingExtractedFeatures,

--- a/gbdraw/web/js/services/svg-result-ingestion.js
+++ b/gbdraw/web/js/services/svg-result-ingestion.js
@@ -452,14 +452,14 @@ const applyLegendOperations = (index, operations) => {
       if (strokeWidth !== null) setAttributeIfDifferent(swatch, 'stroke-width', strokeWidth);
     });
   });
-  operations.legendRenames.forEach(({ from, to, xPos, yPos }) => {
-    requireLegendEntries(index, from).forEach((entry) => {
+  operations.legendRenames.forEach(({ from, to, xPos, yPos, allowMissing }) => {
+    requireLegendEntries(index, from, { allowMissing }).forEach((entry) => {
       updateLegendCaption(entry, to);
       moveLegendEntryToAnchor(entry, xPos, yPos);
     });
   });
-  operations.legendDeletes.forEach(({ caption }) => {
-    requireLegendEntries(index, caption).forEach((entry) => entry.remove());
+  operations.legendDeletes.forEach(({ caption, allowMissing }) => {
+    requireLegendEntries(index, caption, { allowMissing }).forEach((entry) => entry.remove());
   });
   operations.legendAdds.forEach(({ caption, color, xPos, yPos }) => {
     const { entries, groups } = index.legends();
@@ -469,6 +469,7 @@ const applyLegendOperations = (index, operations) => {
         const swatch = legendSwatch(entry);
         if (!swatch) throw new Error('Current SVG has no Legend swatch template.');
         setAttributeIfDifferent(swatch, 'fill', color);
+        entry.setAttribute('data-legend-owner', 'direct-editor');
         moveLegendEntryToAnchor(entry, xPos, yPos);
       });
       return;

--- a/tests/web/legend-sync.test.mjs
+++ b/tests/web/legend-sync.test.mjs
@@ -375,4 +375,27 @@ const mockLegendEntry = (caption, color, x) => {
   assert.equal(strokeActions.reconcileStrokeOverrides({
     changes: [{ path: ['editorState', 'legend', 'entries', '0', 'caption'] }]
   }), false);
+
+  // The generated inventory follows the current diagram, independently of
+  // explicitly owned rows and the default order of surviving categories.
+  state.legendEntries.value = [];
+  state.originalLegendOrder.value = ['Alpha', 'Beta'];
+  state.deletedLegendEntries.value = [{ caption: 'Deleted', originalCaption: 'Deleted' }];
+  state.originalLegendOrder.value.push('Deleted');
+  featureLegend.children.forEach(entry => { entry.parentElement = null; });
+  featureLegend.children = [];
+  featureLegend.appendChild(mockLegendEntry('Gamma', '#334455', 0));
+  featureLegend.appendChild(mockLegendEntry('Beta', '#445566', 70));
+  const manual = mockLegendEntry('Manual', '#884422', 140);
+  manual.setAttribute('data-legend-owner', 'direct-editor');
+  featureLegend.appendChild(manual);
+  actions.extractLegendEntries();
+  assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted', 'Gamma']);
+  assert.deepEqual(state.legendEntries.value.map(e => e.caption), ['Gamma', 'Beta', 'Manual']);
+  actions.extractLegendEntries();
+  assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted', 'Gamma']);
+  featureLegend.children[0].remove();
+  actions.extractLegendEntries();
+  assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted']);
+  assert.deepEqual(state.legendEntries.value.map(e => e.caption), ['Beta', 'Manual']);
 }

--- a/tests/web/legend-sync.test.mjs
+++ b/tests/web/legend-sync.test.mjs
@@ -83,7 +83,7 @@ assert.match(configSource, /skipCaptureBaseConfig\.value = true;\s+state\.skipPo
 const sessionLegendSyncSource = appSetupSource.match(
   /adoptLegend\(context\)[\s\S]*?\n    bindComposition/
 )?.[0] || '';
-assert.match(sessionLegendSyncSource, /extractLegendEntries\(\)/);
+assert.match(sessionLegendSyncSource, /extractLegendEntries\(\{\s*replaceGeneratedInventory: !context\.bindingOptions\.isIncrementalEdit/);
 assert.doesNotMatch(sessionLegendSyncSource, /initPyodide|addLegendEntry|removeLegendEntry/);
 assert.doesNotMatch(appSetupSource, /restoreLoadedSessionLegendEntries/);
 assert.match(configSource, /entries: normalizeSessionLegendEntries\(legend\.entries\)/);
@@ -390,12 +390,16 @@ const mockLegendEntry = (caption, color, x) => {
   manual.setAttribute('data-legend-owner', 'direct-editor');
   featureLegend.appendChild(manual);
   actions.extractLegendEntries();
+  assert.deepEqual(state.originalLegendOrder.value, ['Alpha', 'Beta', 'Deleted']);
+  actions.extractLegendEntries({ replaceGeneratedInventory: true });
   assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted', 'Gamma']);
   assert.deepEqual(state.legendEntries.value.map(e => e.caption), ['Gamma', 'Beta', 'Manual']);
   actions.extractLegendEntries();
   assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted', 'Gamma']);
   featureLegend.children[0].remove();
   actions.extractLegendEntries();
+  assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted', 'Gamma']);
+  actions.extractLegendEntries({ replaceGeneratedInventory: true });
   assert.deepEqual(state.originalLegendOrder.value, ['Beta', 'Deleted']);
   assert.deepEqual(state.legendEntries.value.map(e => e.caption), ['Beta', 'Manual']);
 }

--- a/tests/web/source-legend-reconciliation.playwright.spec.js
+++ b/tests/web/source-legend-reconciliation.playwright.spec.js
@@ -1,0 +1,146 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { load, generate, switchMode, download } = require('./helpers/mode-transition.cjs');
+
+const seeds = {
+  lambda: 'gbdraw/web/gallery/sessions/lambda_basic_linear.gbdraw-session.json',
+  tobacco: 'gbdraw/web/gallery/sessions/tobacco-chloroplast.gbdraw-session.json'
+};
+const upload = async (page, name, linear = true) => {
+  const session = JSON.parse(await fs.readFile(seeds[name], 'utf8'));
+  const input = linear ? page.getByTestId('linear-genbank-1') : page.getByLabel('GenBank/DDBJ File', { exact: true });
+  await input.setInputFiles({ name: `${name}.gb`, mimeType: 'text/plain', buffer: Buffer.from(
+    session.resources[session.renderRequest.records[0].source.resourceId].data, 'base64') });
+};
+const inspect = page => page.evaluate(async () => {
+  const { state: s } = await import('./js/state.js');
+  const { getVisibleFeatureLegendGroup } = await import('./js/app/legend/utils.js');
+  const captions = svg => [...(getVisibleFeatureLegendGroup(svg)?.querySelectorAll('g[data-legend-key]') || [])]
+    .map(e => ({ caption: e.getAttribute('data-legend-key'), color: e.querySelector('path[fill]')?.getAttribute('fill') }))
+    .sort((a, b) => a.caption.localeCompare(b.caption));
+  const result = s.results.value[s.selectedResultIndex.value].content;
+  const svg = new DOMParser().parseFromString(result, 'image/svg+xml').documentElement;
+  return JSON.parse(JSON.stringify({
+    entries: s.legendEntries.value.map(e => e.caption).sort(), original: s.originalLegendOrder.value,
+    result: captions(svg), mounted: captions(s.svgContainer.value.querySelector('svg')),
+    side: s.form.legend, fontSize: s.adv.legend_font_size, preferences: s.layoutPreferences.legend,
+    palette: s.selectedPalette.value, colors: s.currentColors.value,
+    featureIds: s.extractedFeatures.value.map(f => f.stable_feature_id),
+    overrides: s.legendColorOverrides, deleted: s.deletedLegendEntries.value
+  }));
+});
+const expectEntries = async (page, expected) => {
+  const current = await inspect(page);
+  expect(current.entries).toEqual([...expected].sort());
+  expect(current.result.map(e => e.caption).sort()).toEqual([...expected].sort());
+  expect(current.mounted).toEqual(current.result);
+  return current;
+};
+const reveal = async locator => {
+  for (const details of await locator.locator('xpath=ancestor::details').all()) {
+    if (await details.getAttribute('open') === null) await details.locator(':scope > summary').click();
+  }
+  return locator;
+};
+
+test('L1-L8 generated legend categories reconcile while valid category and layout preferences survive', async ({ browser }, testInfo) => {
+  test.setTimeout(1_800_000);
+  const page = await load(browser, seeds.lambda);
+  page.setDefaultTimeout(180_000);
+  let fresh;
+  try {
+    await generate(page);
+    const a = await expectEntries(page, ['CDS']);
+    const palette = page.getByLabel('Palette', { exact: true });
+    const alternatives = await palette.locator('option').evaluateAll(options => options.map(o => o.value));
+    await (await reveal(palette)).selectOption(alternatives.find(value => value !== a.palette));
+    await (await reveal(page.locator('#legend-position'))).selectOption('left');
+    await page.evaluate(() => {
+      const app = window.__GBDRAW_APP__;
+      app.adv.legend_font_size = 18;
+      app.updateLegendEntryColor(app.legendEntries.findIndex(e => e.caption === 'CDS'), '#123456');
+    });
+    await generate(page);
+    const edited = await inspect(page);
+    await upload(page, 'tobacco');
+    await generate(page);
+    const b = await expectEntries(page, ['CDS', 'repeat_region', 'rRNA', 'tRNA']);
+    expect(b.featureIds.some(id => a.featureIds.includes(id))).toBe(false);
+    expect(b.result.find(e => e.caption === 'CDS').color).toBe('#123456');
+    for (const key of ['side', 'fontSize', 'preferences', 'palette', 'colors']) expect(b[key]).toEqual(edited[key]);
+    await switchMode(page, 'circular');
+    await switchMode(page, 'linear');
+    expect((await inspect(page)).overrides).toEqual(b.overrides);
+    await generate(page);
+    await upload(page, 'lambda');
+    await generate(page);
+    const returned = await expectEntries(page, ['CDS']);
+    for (const [action, captions] of [['Undo', b.entries], ['Redo', returned.entries]]) {
+      await page.getByRole('button', { name: action, exact: true }).click();
+      await expect.poll(() => page.evaluate(() => !window.__GBDRAW_HISTORY__.restoring.value
+        && !window.__GBDRAW_HISTORY__.capturing.value)).toBe(true);
+      await expectEntries(page, captions);
+    }
+    await generate(page);
+    expect((await inspect(page)).result).toEqual(returned.result);
+    const saved = testInfo.outputPath('legend-replacement.gbdraw-session.json.gz');
+    await download(page, 'Save Session', saved);
+    fresh = await load(browser, saved);
+    await expectEntries(fresh, ['CDS']);
+    await generate(fresh);
+    expect((await expectEntries(fresh, ['CDS'])).result).toEqual(returned.result);
+    expect(page.externalRequests).toEqual([]);
+    expect(fresh.externalRequests).toEqual([]);
+  } finally {
+    await page.context().close();
+    if (fresh) await fresh.context().close();
+  }
+});
+
+test('manual legend rows survive replacement and absent customized categories do not reject a valid source', async ({ browser }, testInfo) => {
+  test.setTimeout(1_800_000);
+  const page = await load(browser);
+  page.setDefaultTimeout(180_000);
+  let fresh;
+  try {
+    await upload(page, 'tobacco', false);
+    await generate(page);
+    await page.evaluate(async () => {
+      const app = window.__GBDRAW_APP__;
+      app.newLegendCaption = 'Retained annotation';
+      app.newLegendColor = '#884422';
+      await app.addNewLegendEntry();
+    });
+    await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.legendEntries.some(e => e.caption === 'Retained annotation'))).toBe(true);
+    await page.evaluate(async () => {
+      const app = window.__GBDRAW_APP__;
+      app.updateLegendEntryColor(app.legendEntries.findIndex(e => e.caption === 'rRNA'), '#abcdef');
+      await app.renameLegendEntry(app.legendEntries.findIndex(e => e.caption === 'rRNA'), 'Ribosomal RNA');
+      app.deleteLegendEntry(app.legendEntries.findIndex(e => e.caption === 'tRNA'));
+    });
+    await generate(page);
+    const a = await inspect(page);
+    expect(a.entries).toContain('Retained annotation');
+    expect(a.original).not.toContain('Retained annotation');
+    const input = page.getByLabel('GenBank/DDBJ File', { exact: true });
+    await input.setInputFiles({ name: 'corrupt.gb', mimeType: 'text/plain', buffer: Buffer.from('not a GenBank record') });
+    expect(await page.evaluate(() => window.__GBDRAW_APP__.runAnalysis())).toEqual({ status: 'error' });
+    expect(await inspect(page)).toEqual(a);
+    await upload(page, 'lambda', false);
+    await generate(page);
+    const expected = ['CDS', 'GC content', 'GC skew (+)', 'GC skew (-)', 'Retained annotation'];
+    await expectEntries(page, expected);
+    await generate(page);
+    await expectEntries(page, expected);
+    const saved = testInfo.outputPath('manual-legend.gbdraw-session.json.gz');
+    await download(page, 'Save Session', saved);
+    fresh = await load(browser, saved);
+    await generate(fresh);
+    await expectEntries(fresh, expected);
+    expect(page.externalRequests).toEqual([]);
+    expect(fresh.externalRequests).toEqual([]);
+  } finally {
+    await page.context().close();
+    if (fresh) await fresh.context().close();
+  }
+});

--- a/tests/web/source-legend-reconciliation.playwright.spec.js
+++ b/tests/web/source-legend-reconciliation.playwright.spec.js
@@ -14,7 +14,11 @@ const upload = async (page, name, linear = true) => {
 };
 const inspect = page => page.evaluate(async () => {
   const { state: s } = await import('./js/state.js');
+  const { getCommittedCanonicalRenderRequest } = await import('./js/services/config.js');
   const { getVisibleFeatureLegendGroup } = await import('./js/app/legend/utils.js');
+  const digest = async value => [...new Uint8Array(await crypto.subtle.digest('SHA-256',
+    new TextEncoder().encode(typeof value === 'string' ? value : JSON.stringify(value))))]
+    .map(byte => byte.toString(16).padStart(2, '0')).join('');
   const captions = svg => [...(getVisibleFeatureLegendGroup(svg)?.querySelectorAll('g[data-legend-key]') || [])]
     .map(e => ({ caption: e.getAttribute('data-legend-key'), color: e.querySelector('path[fill]')?.getAttribute('fill') }))
     .sort((a, b) => a.caption.localeCompare(b.caption));
@@ -22,8 +26,15 @@ const inspect = page => page.evaluate(async () => {
   const svg = new DOMParser().parseFromString(result, 'image/svg+xml').documentElement;
   return JSON.parse(JSON.stringify({
     entries: s.legendEntries.value.map(e => e.caption).sort(), original: s.originalLegendOrder.value,
+    entryState: s.legendEntries.value, originalColors: s.originalLegendColors.value,
+    manualRules: s.manualSpecificRules, strokes: s.legendStrokeOverrides,
+    selectedResult: s.selectedResultIndex.value,
+    resultsDigest: await digest(s.results.value),
+    mountedDigest: await digest(s.svgContainer.value.querySelector('svg').outerHTML),
+    requestDigest: await digest(getCommittedCanonicalRenderRequest()),
     result: captions(svg), mounted: captions(s.svgContainer.value.querySelector('svg')),
     side: s.form.legend, fontSize: s.adv.legend_font_size, preferences: s.layoutPreferences.legend,
+    layoutPreferences: s.layoutPreferences,
     palette: s.selectedPalette.value, colors: s.currentColors.value,
     featureIds: s.extractedFeatures.value.map(f => f.stable_feature_id),
     overrides: s.legendColorOverrides, deleted: s.deletedLegendEntries.value
@@ -97,7 +108,7 @@ test('L1-L8 generated legend categories reconcile while valid category and layou
   }
 });
 
-test('manual legend rows survive replacement and absent customized categories do not reject a valid source', async ({ browser }, testInfo) => {
+test('G1-G3 rejected candidates preserve A and dormant category intent and manual rows survive A-B-A replay', async ({ browser }, testInfo) => {
   test.setTimeout(1_800_000);
   const page = await load(browser);
   page.setDefaultTimeout(180_000);
@@ -114,6 +125,7 @@ test('manual legend rows survive replacement and absent customized categories do
     await expect.poll(() => page.evaluate(() => window.__GBDRAW_APP__.legendEntries.some(e => e.caption === 'Retained annotation'))).toBe(true);
     await page.evaluate(async () => {
       const app = window.__GBDRAW_APP__;
+      app.updateLegendEntryColor(app.legendEntries.findIndex(e => e.caption === 'repeat_region'), '#224466');
       app.updateLegendEntryColor(app.legendEntries.findIndex(e => e.caption === 'rRNA'), '#abcdef');
       await app.renameLegendEntry(app.legendEntries.findIndex(e => e.caption === 'rRNA'), 'Ribosomal RNA');
       app.deleteLegendEntry(app.legendEntries.findIndex(e => e.caption === 'tRNA'));
@@ -125,11 +137,12 @@ test('manual legend rows survive replacement and absent customized categories do
     const input = page.getByLabel('GenBank/DDBJ File', { exact: true });
     await input.setInputFiles({ name: 'corrupt.gb', mimeType: 'text/plain', buffer: Buffer.from('not a GenBank record') });
     expect(await page.evaluate(() => window.__GBDRAW_APP__.runAnalysis())).toEqual({ status: 'error' });
-    expect(await inspect(page)).toEqual(a);
+    const rejected = await inspect(page);
+    expect(rejected).toEqual(a);
     await upload(page, 'lambda', false);
     await generate(page);
     const expected = ['CDS', 'GC content', 'GC skew (+)', 'GC skew (-)', 'Retained annotation'];
-    await expectEntries(page, expected);
+    const b = await expectEntries(page, expected);
     await generate(page);
     await expectEntries(page, expected);
     const saved = testInfo.outputPath('manual-legend.gbdraw-session.json.gz');
@@ -137,6 +150,17 @@ test('manual legend rows survive replacement and absent customized categories do
     fresh = await load(browser, saved);
     await generate(fresh);
     await expectEntries(fresh, expected);
+    await upload(fresh, 'tobacco', false);
+    await generate(fresh);
+    const returned = await inspect(fresh);
+    expect(returned.entries).toContain('Retained annotation');
+    expect(returned.entries).toContain('Ribosomal RNA');
+    expect(returned.entries).not.toContain('rRNA');
+    expect(returned.entries).not.toContain('tRNA');
+    expect(returned.result.find(e => e.caption === 'repeat_region').color).toBe('#224466');
+    expect(returned.result.find(e => e.caption === 'Ribosomal RNA').color).toBe('#abcdef');
+    expect(returned.deleted).toEqual(a.deleted);
+    await fs.writeFile(testInfo.outputPath('G1-G3.json'), JSON.stringify({ a, rejected, b, returned }, null, 2));
     expect(page.externalRequests).toEqual([]);
     expect(fresh.externalRequests).toEqual([]);
   } finally {

--- a/tests/web/svg-result-ingestion.test.mjs
+++ b/tests/web/svg-result-ingestion.test.mjs
@@ -538,6 +538,42 @@ test('explicit category deletion stays idempotent while the category is absent',
   }));
 });
 
+test('a dormant category style applies on its first returning Result without creating a manual row', () => {
+  const { response, admission } = currentFixture();
+  const plan = compileDirectEditorMutationPlan({
+    catalogAdmission: admission,
+    legendEntries: [], originalLegendOrder: [],
+    legendColorOverrides: { CDS: '#224466' }
+  });
+  assert.equal(plan.operationsByResult[0].legendAdds.length, 0);
+  const results = admitCurrentGeneratedResults(response, {
+    catalogAdmission: admission, mutationPlan: plan,
+    sanitizer: { sanitize: value => value }, parser: FakeDomParser
+  });
+  assert.match(results[0].content, /fill="#224466"/);
+});
+
+test('category absence capabilities never admit ambiguous Legend bindings', () => {
+  class DuplicateLegendParser extends FakeDomParser {
+    parseFromString(...args) {
+      const document = super.parseFromString(...args);
+      const group = document.documentElement.querySelector('#feature_legend');
+      group.appendChild(group.children[0].cloneNode(true));
+      return document;
+    }
+  }
+  for (const sourceReplaced of [false, true]) {
+    const { response, admission } = currentFixture();
+    const plan = compileDirectEditorMutationPlan({
+      ...planOptions.Legend(admission), sourceReplaced
+    });
+    assert.throws(() => admitCurrentGeneratedResults(response, {
+      catalogAdmission: admission, mutationPlan: plan,
+      sanitizer: { sanitize: value => value }, parser: DuplicateLegendParser
+    }), /ambiguous Legend binding/);
+  }
+});
+
 test('Label replay is deferred until mounted identity binding', () => {
   const { response, admission } = currentFixture('<svg>missing-label</svg>');
   const plan = compileDirectEditorMutationPlan(planOptions.Label(admission));

--- a/tests/web/svg-result-ingestion.test.mjs
+++ b/tests/web/svg-result-ingestion.test.mjs
@@ -459,6 +459,7 @@ test('a requested Legend addition reuses an exact renderer-produced caption', ()
   });
   assert.equal((results[0].content.match(/data-legend-key="CDS"/g) || []).length, 1);
   assert.match(results[0].content, /fill="#556677"/);
+  assert.match(results[0].content, /data-legend-owner="direct-editor"/);
 });
 
 test('a renderer-derived Legend style may be absent when no current binding remains', () => {
@@ -503,6 +504,38 @@ test('an unexplained missing Legend binding remains rejected', () => {
     }),
     /missing a Legend binding/
   );
+});
+
+test('source replacement may retire styled, renamed, or deleted generated Legend categories', () => {
+  const { response, admission } = currentFixture('<svg>missing-legend</svg>');
+  const plan = compileDirectEditorMutationPlan({
+    ...planOptions.Legend(admission),
+    sourceReplaced: true,
+    legendEntries: [{ caption: 'Genes', originalCaption: 'CDS', color: '#334455' }],
+    originalLegendOrder: ['CDS', 'rRNA'],
+    deletedLegendEntries: [{ caption: 'rRNA', originalCaption: 'rRNA' }],
+    legendColorOverrides: { Genes: '#334455' },
+    legendStrokeOverrides: { Genes: { strokeColor: '#445566', strokeWidth: 3 } }
+  });
+  assert.doesNotThrow(() => admitCurrentGeneratedResults(response, {
+    catalogAdmission: admission,
+    mutationPlan: plan,
+    sanitizer: { sanitize: value => value },
+    parser: FakeDomParser
+  }));
+});
+
+test('explicit category deletion stays idempotent while the category is absent', () => {
+  const { response, admission } = currentFixture('<svg>missing-legend</svg>');
+  const plan = compileDirectEditorMutationPlan({
+    catalogAdmission: admission,
+    originalLegendOrder: ['rRNA'],
+    deletedLegendEntries: [{ caption: 'rRNA', originalCaption: 'rRNA' }]
+  });
+  assert.doesNotThrow(() => admitCurrentGeneratedResults(response, {
+    catalogAdmission: admission, mutationPlan: plan,
+    sanitizer: { sanitize: value => value }, parser: FakeDomParser
+  }));
 });
 
 test('Label replay is deferred until mounted identity binding', () => {


### PR DESCRIPTION
## Plain-language summary

Remove obsolete generated legend categories when the diagram’s source changes. Replacing lambda with tobacco and then lambda again now returns to the lambda legend without retaining tobacco’s RNA and repeat entries. Manual legend rows, category preferences, palette choices, position, and typography survive replacement. A temporarily absent category receives its saved style on the first Generate after it returns.

## Change class

- [x] STANDARD

## Purpose

Fix `05A4-10` independently of the visibility defect fixed in #510. This branch starts at the resulting exact `dev`, `b67f9e505acd3a3a16320d6caa930bd30c1a2040`; retained M20 still reproduces the legend defect there before this change.

## User-visible impact

Generated categories follow the current diagram. Explicitly added rows remain manual, even if a later source generates the same caption. Old category styles and renames do not reject a valid replacement that lacks their targets. Explicit deletions remain idempotent while a category is absent and retain their existing restore intent.

## Changes

- Reconcile the existing original-category inventory at accepted Result binding, preserving the default relative order of surviving categories and the record of user deletions.
- Mark manual additions with the existing `direct-editor` ownership marker.
- Reuse the existing source-binding decision for category edits in the candidate mutation plan; apply its absent-target capabilities through the existing SVG admission index.
- Compile category styles from their existing durable maps, independently of the current entry projection, so temporary absence does not postpone style replay.
- Add deterministic and full-functional regressions and extend the source/lifetime diagnosis note.

## Verification

- Retained original M13 and M20: PASS; zero console errors, page errors, or external requests, with mounted/Result/export agreement.
- L1–L8 and G1–G3 cover complete failed-candidate state preservation, category rename/color/deletion through A→B→A, manual rows through fresh Load, and Undo/Redo.
- Fast Web contracts: 407 passed, including inventory replacement, manual ownership, idempotent deletion, and the unchanged-source missing-binding rejection control.
- Selected browser controls: 35 passed, covering L1–L8, G1–G3, visibility, multipart labels, composite placement, CLI/Web replay, mode transitions, and History neighbors. Focused legend/admission checks: 29 passed. Architecture contracts: 137 passed. Trusted-base change gate: PASS, Review: CLEAR.

## Risk and review notes

Legend extraction, source identity, candidate planning, and SVG admission keep their existing owners and paths. The initialize-only inventory update is replaced in place; no second source identity, category cache, catalog, schema, or compatibility path is introduced. Empty mutation plans gain no SVG parse or legend scan. Existing CI tiers, the ten-case PR smoke budget, workflow timeouts, and generated Gallery artifacts are unchanged.

Gate: PASS. Review: CLEAR. Production and test diffs were reviewed separately. Unrelated 05A4 findings remain unchanged.

## Rollback

Revert this PR. No persisted data migration is needed.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Authority: current generated-category membership, the existing manual Add/Restore contract, and SESSION 05A8-R’s source-replacement invariant.
- Category membership follows renderer captions, not biological feature IDs. The common-CDS/different-feature control preserves this distinction. Mode navigation preserves durable editor intent, and rejected replacement preserves the prior artifact and legend state.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
