### PR TITLE
Keep the Editor toggle accessible in narrow Previews

### DIFF
--- a/docs/internal/SESSION05A10_M_MOBILE_EDITOR_OVERLAY.md
+++ b/docs/internal/SESSION05A10_M_MOBILE_EDITOR_OVERLAY.md
@@ -1,0 +1,113 @@
+# 05A4-06: Mobile Editor overlay accessibility
+
+Starting `origin/dev`: `c9ba546a1a83d51f231853291c4944ca5228f860`.
+Work was isolated from the user's dirty checkout. Only 05A4-06 is in scope.
+
+## Original reproduction
+
+Before editing CSS, load the retained J43 `HmmtDNA_ATskew.gbdraw-session.json`
+or J44 `lambda_basic_linear.gbdraw-session.json` at exactly 390 × 844.
+Use the retained journey's `scrollIntoView({block: 'center'})` on the toggle.
+Both sessions reproduce the same geometry. Keyboard Enter was used only to
+measure the original open state because pointer activation was blocked.
+
+Coordinates below are `(left, top, width, height)` in CSS pixels, relative to
+the Result Preview rectangle; page scroll does not affect this comparison.
+
+| State | Preview size | Toggle | Preview controls | Drawer | Toggle center |
+| --- | --- | --- | --- | --- | --- |
+| Before, closed | 374 × 416 | (337, 274, 35, 60) | (10, 306, 354, 100) | (372, 2, 360, 412), hidden | Feature-search status intercepts |
+| Before, open | 374 × 416 | (-23, 274, 35, 60) | (10, 306, 354, 100) | (12, 2, 360, 412) | Outside Preview |
+| After, closed | 374 × 477.5 | (336, 10, 36, 60) | (10, 367.5, 354, 100) | (372, 2, 334, 473.5), hidden | Toggle descendant |
+| After, open | 374 × 477.5 | (2, 10, 36, 60) | (38, 367.5, 354, 100), behind drawer | (38, 2, 334, 473.5) | Toggle descendant |
+
+The original closed toggle/toolbar intersection is **27 × 28 = 756 px²**.
+The original open intersection is **2 × 28 = 56 px²**. Both become zero-area
+intersections. The new original-case test also fails against the unchanged
+starting HTML because the toggle center is blocked.
+
+## Cause and correction
+
+Several independent absolute overlays shared the same small Preview area:
+
+- The two-row toolbar grew into the toggle's fixed `bottom: 5rem` reservation.
+- The search panel, at z-index 30, intercepted the z-index 20 toggle center.
+- Translating the toggle by a 360 px drawer width exceeded the available
+  Preview width. The toolbar at z-index 20 also painted over the drawer at 10.
+- Hidden overflow could scroll horizontally during focus/scroll-into-view,
+  shifting the open drawer and toggle out of their intended bounds.
+
+`index.html` continues to own all layout. A container query uses the actual
+Preview pane width (up to 40rem), where the full toolbar needs to wrap, so it
+also covers the 844 × 390 landscape layout. Search occupies a scrollable grid
+row above the naturally sized toolbar. The toggle has a 2.25rem side lane at
+the top; drawer width is capped by both 360 px and the remaining Preview width.
+A local stacking context puts the narrow Preview overlays behind the open
+drawer. Their complete hit targets move behind its edge, without exposed
+button fragments. `overflow: clip` prevents programmatic horizontal scrolling
+of that region. The canvas-padding panel shares the search row without
+covering the persistent toolbar.
+
+Closed-drawer controls are all retained. The nearly full-width open drawer
+obscures its underlying toolbar; closing it restores access. This is the
+open-drawer exception specified in the task, not a new collapsed toolbar.
+The wider existing mobile rules still apply outside the compact container;
+the desktop overlay oracle is unchanged. Existing safe-area handling stays
+with the fixed Generate bar; no new platform-specific inset is needed.
+
+## Verification
+
+- J43 and J44 at 390 × 844, 375 × 667, 430 × 932, and 844 × 390: closed/open
+  geometry, positive-area overlap, hit testing, real controls, Editor list
+  scrolling, Enter/Space/Escape, title and ARIA preservation, mounted SVG
+  feature geometry/text, selected Result identity, and zero browser errors or
+  external requests. JSON geometry and screenshots are written to test output.
+- No Result, Circular → Linear → Circular, real GenBank source replacement,
+  desktop → mobile → desktop, exactly one drawer/toggle, and no inline toggle
+  geometry: one additional browser case.
+- Unchanged Issue #461 matrix: 1024 × 768, 1366 × 768, 1920 × 1080, and
+  2541 × 1409, with controls operable in both drawer states.
+- Neighboring browser suites: `mode-transition-editor-state`,
+  `mode-transition-result`, `multipart-label-regeneration`,
+  `composite-placement-regeneration`, `source-visibility-reconciliation`, and
+  `source-legend-reconciliation`, plus the rest of `right-drawer`.
+- Drawer and visibility unit tests; focused offline packaging tests; built
+  wheel browser verification at 390 × 844 and 1366 × 768, external networking
+  blocked, including cold and repeated generation.
+- PR smoke remains exactly **10 cases in 7 files**. New cases are selected by
+  full functional CI. No workflow, routing, or timeout policy changes.
+
+The test scrolls Preview into the usable space between the existing sticky
+header and fixed Generate bar before hit testing. This is test navigation,
+not a runtime geometry watcher. Reset layout's intentional layout/viewport
+changes are allowed; biological feature geometry and SVG text are preserved.
+
+Local detailed evidence is retained under
+`docs/internal/gbdraw_v014_session05a10_m_evidence_2026-09-12/` in the user's
+original checkout (outside this commit): original closed/open measurements,
+screenshots, execution logs, final geometry, and packaged verification.
+The tests regenerate the after screenshots and measurements in their output
+directory. No Gallery or reference screenshot is updated.
+
+## Product and architecture
+
+Product preflight: **IMPLEMENT_EXISTING_AUTHORITY**. The task's explicit
+operable-visible-toggle contract and `gbdraw/web/CLAUDE.md`'s reactive
+availability invariants select the outcome. The available actions, close and
+Escape transitions, Result authority, and saved intent remain intact. There
+is no unresolved alternative outcome, missing authority, or prohibited
+change; EVIDENCE_REQUIRED, PRODUCT_DECISION_REQUIRED, and NOT_ALLOWED do not
+apply. No new BD record or candidate authority is introduced.
+
+Architecture: ordinary non-increasing layout correction; this is not
+architecture-bearing. Layout remains in `index.html`; `right-drawer.js` still
+owns every visibility/tab transition. No semantic owner, canonical path,
+compatibility path, state, watcher, dependency, or resource signal is added.
+The geometry oracle remains in `right-drawer.playwright.spec.js`. Schemas,
+History, persistence, and scientific rendering are unchanged. Rollback is a
+revert of this single implementation commit.
+
+Other 05A4 findings are unchanged. The complete adversarial rerun, S11
+reacceptance, S12, and baseline/publication-candidate assignment are outside
+this change. Closure requires the exact merged dev checks and staging gates;
+local passing evidence alone does not establish that acceptance.

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -783,7 +783,9 @@
             white-space: nowrap;
         }
         .result-pane {
-            --right-drawer-width: min(100vw, 360px);
+            --right-drawer-max-width: 360px;
+            --right-drawer-width: min(100vw, var(--right-drawer-max-width));
+            container-type: inline-size;
         }
         .right-drawer {
             width: var(--right-drawer-width);
@@ -1031,6 +1033,72 @@
                 gap: 0.25rem 0.75rem !important;
                 font-size: 0.75rem !important;
                 line-height: 1.35 !important;
+            }
+        }
+
+        /* Narrow Preview: keep the Editor in a side lane and let search scroll
+           above the naturally wrapped controls, including in landscape. */
+        @container (max-width: 40rem) {
+            .result-pane > [aria-label="Result Preview"] {
+                min-height: 0;
+                overflow: clip;
+                --editor-toggle-width: 2.25rem;
+                --right-drawer-width: min(var(--right-drawer-max-width), calc(100% - var(--editor-toggle-width)));
+            }
+            [aria-label="Result Preview"] > .card-header {
+                padding-right: calc(var(--editor-toggle-width) + 0.75rem);
+            }
+            .preview-viewport {
+                display: grid;
+                grid-template-rows: minmax(0, 1fr) auto;
+                gap: 0.5rem;
+                padding: 0.5rem;
+                min-height: 0;
+                isolation: isolate;
+            }
+            .preview-feature-search {
+                position: relative;
+                grid-area: 1 / 1;
+                inset: auto !important;
+                width: auto;
+                min-height: 0;
+                max-height: 100% !important;
+                overflow: auto;
+                align-self: start;
+            }
+            .preview-viewport .preview-controls {
+                position: relative;
+                grid-area: 2 / 1;
+                inset: auto !important;
+                transform: none !important;
+                justify-content: center;
+                flex-wrap: wrap;
+            }
+            /* The open drawer covers the underlying controls in this narrow
+               region. Keep whole hit targets behind its edge. */
+            .preview-viewport .preview-controls--drawer-open,
+            .preview-viewport:has(.preview-controls--drawer-open) .preview-feature-search {
+                transform: translateX(max(calc(var(--editor-toggle-width) - 0.5rem), calc(100% - var(--right-drawer-max-width) + 0.5rem))) !important;
+            }
+            .preview-viewport .preview-canvas-padding {
+                position: relative;
+                grid-area: 1 / 1;
+                inset: auto;
+                transform: none;
+                place-self: end center;
+                max-height: 100%;
+                overflow: auto;
+                z-index: 31;
+            }
+            .drawer-toggle {
+                top: 0.5rem !important;
+                bottom: auto !important;
+                width: var(--editor-toggle-width);
+                transform: none !important;
+            }
+            .drawer-toggle[aria-expanded="true"] {
+                right: var(--right-drawer-width);
+                transform: none !important;
             }
         }
 
@@ -4499,7 +4567,7 @@
                     <p>Current changes were not applied.</p>
                 </div>
 
-                <div v-show="resultPanelTab === 'preview'" class="relative flex-grow overflow-hidden bg-slate-50/30">
+                <div v-show="resultPanelTab === 'preview'" class="preview-viewport relative flex-grow overflow-hidden bg-slate-50/30">
 
                     <div v-if="svgContent"
                          :class="['preview-feature-search', { 'is-invalid': previewFeatureSearchError }]"
@@ -4751,7 +4819,7 @@
 
                     <!-- Canvas padding controls panel -->
                     <div v-if="showCanvasControls && svgContent"
-                         class="absolute bottom-20 left-1/2 -translate-x-1/2 bg-white shadow-lg rounded-lg p-3 z-20 border border-slate-200 w-48">
+                         class="preview-canvas-padding absolute bottom-20 left-1/2 -translate-x-1/2 bg-white shadow-lg rounded-lg p-3 z-20 border border-slate-200 w-48">
                         <div class="flex items-center justify-between mb-2">
                             <span class="text-xs font-bold text-slate-700">Canvas Padding</span>
                             <button @click="resetCanvasPadding" class="text-[10px] text-blue-600 hover:text-blue-800">Reset</button>

--- a/tests/web/right-drawer.playwright.spec.js
+++ b/tests/web/right-drawer.playwright.spec.js
@@ -1,4 +1,6 @@
 const { test, expect } = require('@playwright/test');
+const { writeFileSync } = require('node:fs');
+const { semantics, switchMode } = require('./helpers/mode-transition.cjs');
 
 const loadGallerySession = async (page, filename) => page.evaluate(async (name) => {
   const response = await fetch(`/gbdraw/web/gallery/sessions/${name}`);
@@ -77,7 +79,18 @@ const readOverlayGeometry = (page) => page.evaluate(() => {
   if (!preview || !toggle || !controls || !zoomControls || !drawer) {
     throw new Error('Issue #461 overlay controls are not mounted.');
   }
+  const overlays = [toggle, drawer, controls, zoomControls, ...controls.querySelectorAll('button')];
   return {
+    viewport: { width: innerWidth, height: innerHeight, pageWidth: document.documentElement.scrollWidth },
+    media: { max760: matchMedia('(max-width: 760px)').matches, mobile: matchMedia('(max-width: 768px)').matches,
+      compactPreview: preview.parentElement.clientWidth <= 640 },
+    hitTargets: overlays.map((element) => {
+      const box = element.getBoundingClientRect();
+      const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+      return { name: element.getAttribute('aria-label') || element.title || element.className,
+        zIndex: getComputedStyle(element).zIndex,
+        hit: hit ? { tag: hit.tagName, className: hit.getAttribute('class'), text: hit.textContent.trim().slice(0, 80) } : null };
+    }),
     preview: rect(preview),
     toggle: rect(toggle),
     controls: rect(controls),
@@ -180,6 +193,16 @@ const exercisePreviewControls = async (page) => {
 };
 
 test.beforeEach(async ({ page }) => {
+  page.overlayDiagnostics = { pageErrors: [], consoleErrors: [], externalRequests: [] };
+  page.on('pageerror', (error) => page.overlayDiagnostics.pageErrors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') page.overlayDiagnostics.consoleErrors.push(message.text());
+  });
+  await page.route('**/*', (route) => {
+    if (new URL(route.request().url()).hostname === '127.0.0.1') return route.continue();
+    page.overlayDiagnostics.externalRequests.push(route.request().url());
+    return route.abort();
+  });
   page.on('dialog', (dialog) => dialog.accept());
   await page.goto('/gbdraw/web/index.html', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(() => window.__GBDRAW_APP__);
@@ -225,6 +248,206 @@ for (const viewport of ISSUE_461_VIEWPORTS) {
     expect(await readSettledPreviewSurface(page)).toEqual(initialSurface);
   });
 }
+
+const MOBILE_VIEWPORTS = [
+  { id: 'MOB1', width: 390, height: 844 },
+  { id: 'MOB2', width: 375, height: 667 },
+  { id: 'MOB3', width: 430, height: 932 },
+  { id: 'MOB4', width: 844, height: 390 }
+];
+
+const centerPreview = async (page) => {
+  await waitForSettledDrawer(page);
+  await page.getByRole('region', { name: 'Result Preview' }).evaluate(async (preview) => {
+    await document.fonts.ready;
+    await Promise.all(preview.getAnimations().map((animation) => animation.finished.catch(() => {})));
+    preview.scrollIntoView({ block: 'center' });
+    // Center the journey's Preview in the space between the sticky header and
+    // fixed mobile Generate bar, as a user scrolling to the Result would.
+    const header = document.querySelector('.app-header').getBoundingClientRect();
+    const generate = document.querySelector('.generate-bar');
+    const bottom = getComputedStyle(generate).position === 'fixed'
+      ? generate.getBoundingClientRect().top : innerHeight;
+    const box = preview.getBoundingClientRect();
+    window.scrollBy(0, (box.top + box.bottom - header.bottom - bottom) / 2);
+  });
+};
+
+const assertMobileGeometry = (geometry, drawerOpen) => {
+  const { preview, toggle, drawer, viewport } = geometry;
+  expect(viewport.pageWidth).toBeLessThanOrEqual(viewport.width);
+  expect(toggle.left).toBeGreaterThanOrEqual(Math.max(0, preview.left));
+  expect(toggle.right).toBeLessThanOrEqual(Math.min(viewport.width, preview.right));
+  expect(toggle.top).toBeGreaterThanOrEqual(Math.max(0, preview.top));
+  expect(toggle.bottom).toBeLessThanOrEqual(Math.min(viewport.height, preview.bottom));
+  expect(geometry.toggleReceivesPointerAtCenter, 'Editor toggle center is blocked').toBe(true);
+  expect(boxOverlap(toggle, geometry.controls).intersects).toBe(false);
+  for (const button of geometry.controlButtons) {
+    expect(boxOverlap(toggle, button.box).intersects, button.name).toBe(false);
+  }
+  if (!drawerOpen) {
+    assertOverlayGeometry(geometry, 'mobile closed', false);
+    return;
+  }
+  expect(drawer.left).toBeGreaterThanOrEqual(Math.max(0, preview.left));
+  expect(drawer.right).toBeLessThanOrEqual(Math.min(viewport.width, preview.right));
+  expect(drawer.top).toBeGreaterThanOrEqual(0);
+  expect(drawer.bottom).toBeLessThanOrEqual(viewport.height);
+  expect(boxOverlap(toggle, drawer).intersects).toBe(false);
+  for (const button of geometry.controlButtons) {
+    // At these narrow widths the drawer obscures the underlying toolbar. A
+    // partially exposed button with a blocked center would still be a defect.
+    if (boxOverlap(button.box, drawer).intersects) {
+      expect(button.box.left, `${button.name} exposed beside drawer`).toBeGreaterThanOrEqual(drawer.left);
+      expect(button.box.top).toBeGreaterThanOrEqual(drawer.top);
+      expect(button.box.bottom).toBeLessThanOrEqual(drawer.bottom);
+      expect(button.receivesPointerAtCenter).toBe(false);
+    } else {
+      expect(button.receivesPointerAtCenter, `${button.name} exposed but blocked`).toBe(true);
+    }
+  }
+};
+
+const assertNoOverlayErrors = (page) => expect(page.overlayDiagnostics).toEqual({
+  pageErrors: [], consoleErrors: [], externalRequests: []
+});
+
+for (const viewport of MOBILE_VIEWPORTS) {
+  for (const [journey, filename] of [
+    ['J43', 'HmmtDNA_ATskew.gbdraw-session.json'],
+    ['J44', 'lambda_basic_linear.gbdraw-session.json']
+  ]) {
+    test(`mobile Editor overlays ${viewport.id} ${journey}`, async ({ page }, testInfo) => {
+      test.setTimeout(180000);
+      await page.setViewportSize(viewport);
+      await expect(page.locator('.drawer-toggle')).toHaveCount(0);
+      expect((await loadGallerySession(page, filename)).status).toBe('ok');
+      const toggle = page.locator('.drawer-toggle');
+      const drawer = page.locator('.right-drawer');
+      const initialAccessibility = await toggle.ariaSnapshot();
+      const identity = () => page.evaluate(() => ({
+        index: window.__GBDRAW_APP__.selectedResultIndex,
+        names: window.__GBDRAW_APP__.results.map((result) => result.name)
+      }));
+      const content = () => page.locator('.gbdraw-preview-surface svg').evaluate((svg) => svg.outerHTML);
+      const beforeIdentity = await identity();
+      const beforeSemantics = await semantics(page, await content());
+      const text = () => page.locator('.gbdraw-preview-surface svg text').allTextContents();
+      const beforeText = await text();
+      const capture = async (state) => {
+        await centerPreview(page);
+        const geometry = await readOverlayGeometry(page);
+        const path = testInfo.outputPath(`${state}-geometry.json`);
+        writeFileSync(path, JSON.stringify(geometry, null, 2));
+        await testInfo.attach(`${state}-geometry`, { path, contentType: 'application/json' });
+        await page.screenshot({ path: testInfo.outputPath(`${viewport.id}-${journey}-${state}.png`) });
+        assertMobileGeometry(geometry, state === 'open');
+      };
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await expect(toggle).toHaveAttribute('title', 'Open editor');
+      await capture('closed');
+      await exercisePreviewControls(page);
+      await page.getByRole('button', { name: 'Toggle layout edit mode', exact: true }).click();
+      await expect(page.getByRole('button', { name: 'Toggle layout edit mode', exact: true })).toHaveAttribute('aria-pressed', 'true');
+      await page.getByRole('button', { name: 'Toggle layout edit mode', exact: true }).click();
+      await page.getByRole('button', { name: 'Zoom in', exact: true }).click();
+      await page.getByRole('button', { name: 'Reset layout', exact: true }).click();
+      await expect(page.getByRole('button', { name: 'Reset zoom', exact: true })).toHaveText('100%');
+      expect(await identity()).toEqual(beforeIdentity);
+      expect(await semantics(page, await content())).toEqual(beforeSemantics);
+      await centerPreview(page);
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      await expect(drawer).toHaveAttribute('aria-hidden', 'false');
+      await expect(toggle).toHaveAttribute('title', 'Close editor');
+      await capture('open');
+      // Exercise the real scrollable Features list, not just its overflow style.
+      const scroll = await drawer.locator('.overflow-y-auto').evaluateAll((elements) => {
+        const list = elements.find((element) => element.scrollHeight > element.clientHeight);
+        if (!list) throw new Error('Expected a scrollable Editor feature list');
+        list.scrollTop = list.scrollHeight;
+        return list.scrollTop;
+      });
+      expect(scroll).toBeGreaterThan(0);
+      await drawer.getByRole('button', { name: 'Close editor', exact: true }).click();
+      await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+      await toggle.focus();
+      await expect(toggle).toBeFocused();
+      await page.keyboard.press('Enter');
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      await page.keyboard.press('Escape');
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      await toggle.focus();
+      await page.keyboard.press('Space');
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+      await waitForSettledDrawer(page);
+      await toggle.click();
+      await expect(drawer).toHaveAttribute('aria-hidden', 'true');
+      await centerPreview(page);
+      assertMobileGeometry(await readOverlayGeometry(page), false);
+      expect(await identity()).toEqual(beforeIdentity);
+      expect(await semantics(page, await content())).toEqual(beforeSemantics);
+      expect(await text()).toEqual(beforeText);
+      expect(await toggle.ariaSnapshot()).toEqual(initialAccessibility);
+      writeFileSync(testInfo.outputPath('diagnostics.json'), JSON.stringify(page.overlayDiagnostics, null, 2));
+      assertNoOverlayErrors(page);
+    });
+  }
+}
+
+test('mobile overlays preserve mode, source replacement, and resize behavior', async ({ page }) => {
+  test.setTimeout(180000);
+  await page.setViewportSize({ width: 1366, height: 768 });
+  await expect(page.locator('.drawer-toggle')).toHaveCount(0);
+  expect((await loadGallerySession(page, 'HmmtDNA_ATskew.gbdraw-session.json')).status).toBe('ok');
+  const toggle = page.locator('.drawer-toggle');
+  for (const viewport of [{ width: 1366, height: 768 }, MOBILE_VIEWPORTS[0], { width: 1366, height: 768 }]) {
+    await page.setViewportSize(viewport);
+    await expect(toggle).toHaveCount(1);
+    await expect(page.locator('.right-drawer')).toHaveCount(1);
+    for (const open of [false, true]) {
+      if (open) await toggle.click();
+      await centerPreview(page);
+      const geometry = await readOverlayGeometry(page);
+      if (viewport.width === 390) assertMobileGeometry(geometry, open);
+      else assertOverlayGeometry(geometry, 'resized desktop', open);
+    }
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(await toggle.getAttribute('style')).toBeNull();
+  }
+  await page.setViewportSize(MOBILE_VIEWPORTS[0]);
+  for (const mode of ['linear', 'circular']) {
+    await switchMode(page, mode);
+    await expect(toggle).toHaveCount(1);
+    await centerPreview(page);
+    assertMobileGeometry(await readOverlayGeometry(page), false);
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await waitForSettledDrawer(page);
+    await toggle.click();
+  }
+  // Replace the actual input bytes through the upload control while retaining
+  // the established last-Result availability semantics.
+  const replacement = await page.evaluate(async () => {
+    const session = await (await fetch('/gbdraw/web/gallery/sessions/lambda_basic_linear.gbdraw-session.json')).json();
+    const resource = session.resources[session.renderRequest.records[0].source.resourceId];
+    return atob(resource.data);
+  });
+  await page.getByLabel('GenBank/DDBJ File', { exact: true }).setInputFiles({
+    name: 'lambda-replacement.gb', mimeType: 'text/plain', buffer: Buffer.from(replacement)
+  });
+  await expect.poll(() => page.evaluate(async () => (await import('./js/state.js')).state.circularRecordDiscovery.status)).not.toBe('loading');
+  await expect(toggle).toHaveCount(1);
+  await expect(page.locator('.right-drawer')).toHaveCount(1);
+  await centerPreview(page);
+  assertMobileGeometry(await readOverlayGeometry(page), false);
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  await page.locator('.right-drawer').getByRole('button', { name: 'Close editor', exact: true }).click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  assertNoOverlayErrors(page);
+});
 
 test('a remembered unavailable Similarity groups tab reopens as Features', async ({
   page


### PR DESCRIPTION
## Plain-language summary

Keep the Editor toggle usable in narrow Result Previews, including 390 × 844 mobile screens. Search and Preview controls now have separate layout rows, and the toggle stays inside Preview when the drawer opens. All closed-drawer controls remain available; the open narrow drawer covers the underlying toolbar without leaving blocked button fragments exposed.

## Change class

- [x] STANDARD

## Purpose

Fix only 05A4-06 from exact `dev` `c9ba546a1a83d51f231853291c4944ca5228f860`. Required admission checks remain `Web base policy (trusted base)` and `PR / gate`.

The original J43 `HmmtDNA_ATskew` and J44 `lambda_basic_linear` sessions reproduce the defect at 390 × 844 before any CSS changes. Closed, the 35 × 60 px toggle intersects the wrapped toolbar by **27 × 28 px**, and `elementFromPoint(toggle center)` returns the feature-search status. Open, the toggle starts at **x = -15 px** and is clipped outside Preview; the toolbar paints over the drawer.

## User-visible impact

In narrow Preview panes, the Editor toggle remains visible and responds to pointer and keyboard input. Zoom in/reset/out, Reset layout, Layout edit, and Canvas padding remain available with the drawer closed. The nearly full-width open drawer obscures its underlying controls, as allowed by the existing mobile interaction contract; closing it restores access.

## Changes

- Use a container query up to 40rem, based on available Preview width, covering portrait and landscape without device-specific offsets.
- Give search a scrollable grid row above the naturally wrapped toolbar and reserve a 2.25rem toggle lane. Bound drawer width by 360 px and the available Preview width.
- Keep underlying overlays behind the open drawer and prevent hidden horizontal scrolling from shifting the drawer edge.
- Extend the existing rectangle-overlap and pointer-hit oracle in `right-drawer.playwright.spec.js`. Add nine full-functional cases; preserve the existing desktop assertions and exactly ten PR smoke cases.

At 390 × 844, the final toggle is `(344, 216.578, 36, 60)` closed and `(10, 216.578, 36, 60)` open; drawer width is 334 px. Toggle/toolbar overlap is zero in both states. The center hits the toggle or its icon; all closed-toolbar button centers receive pointer input. Coordinates relative to Preview, root cause, and reproduction details are in `docs/internal/SESSION05A10_M_MOBILE_EDITOR_OVERLAY.md`.

## Verification

- Final geometry/interaction run: **13 passed**. Both retained sessions at 390 × 844, 375 × 667, 430 × 932, 844 × 390; unchanged 1024 × 768, 1366 × 768, 1920 × 1080, 2541 × 1409 matrix; no-Result, mode/source replacement, resize, and uniqueness controls.
- Neighboring editor regressions: **33 passed**, covering mode/editor durable intent, Result remount/export, multipart labels, placement, source visibility, and legend reconciliation, plus existing drawer behavior.
- Actual open/close, zoom, canvas-padding, layout-edit/reset, Editor scrolling, Enter/Space/Escape; title/ARIA, selected Result, feature geometry and SVG text preserved. No page/console errors or external requests in mobile cases.
- New original-case regression fails on the unchanged starting HTML because the toggle center is blocked.
- Drawer/visibility Node tests: **2 passed**; focused offline packaging tests: **4 passed**. Built-wheel mobile/desktop browser checks pass with external requests blocked, including repeated generation.
- Before/after screenshots and JSON measurements retained locally; tests write after screenshots and geometry to their output directory. Gallery/reference images are unchanged.

## Risk and review notes

- Local Web policy: `Gate: PASS`, `Review: CLEAR`. Trusted PR checks still apply to this exact head.
- This is not architecture-bearing: ordinary non-increasing layout correction. `index.html` remains the layout owner; `right-drawer.js` retains all state transitions. No JavaScript state, watcher, runtime dependency, compatibility path, schema, History, or persistence changes.
- Production, test, documentation, and generated-artifact diffs were reviewed separately. Generated wheels and browser evidence are not committed.
- Other 05A4 findings remain unchanged. Full adversarial rerun and technical/publication baseline assignments are outside scope.

## Rollback

Revert this single implementation commit.

## Conditional Product Impact

- Product-impact role: IMPLEMENTATION
- Product preflight classification: IMPLEMENT_EXISTING_AUTHORITY
- Authority: explicit operability contract in the task and the base `gbdraw/web/CLAUDE.md` reactive availability invariants. No affordance retirement or unresolved product choice.
- Contracts: existing desktop overlay oracle plus the mobile geometry, hit-testing, interaction, and negative controls above.

<!-- gbdraw-product-impact-decision:start -->
{"schemaVersion":1,"headSha":"","decisions":[]}
<!-- gbdraw-product-impact-decision:end -->
