### PR TITLE
Publish completed SVG edits and bind new Result geometry

### DIFF
--- a/docs/internal/session05a14/RESULT_COMPLETION.md
+++ b/docs/internal/session05a14/RESULT_COMPLETION.md
@@ -1,0 +1,98 @@
+# Result completion and layout corrections
+
+The candidate fixes B-01/A-01, B-04, B-05 and B-06 in the existing style,
+Result and composition owners. Palette fallback (B-02) and mobile popup access
+(B-03) are separate dependent review packages.
+
+The failing production witness is `550540ef7f1bc9132c22162aa314617dd48096ca`
+(tree `62643107805b61586ea55affa179356ee664ce5a`). Fetching origin before
+implementation and again before review preparation found the same dev SHA.
+All work took place in `/tmp/gbdraw-session05a14`; the user's dirty workspace
+was not edited. A/B evidence archives remain immutable.
+
+## Cause, correction and authority
+
+- **B-01/A-01 and B-04:** `svg-styles.js` returned after marking the mounted
+  Result dirty. History replay and depth visibility could finish with stale
+  `Result.content`. Its existing `persistSvgEdit` now always serializes and
+  replaces the selected Result synchronously. The dirty-only branch and its
+  caller parameter are removed. No request or draft History is rewritten.
+- **B-05:** after Web Load's delayed definition callback, composition correctly
+  changed the legend by 1 px / 0.5 px and canvas width by 1 px. A later Generate
+  could repeat the previous initial SVG bytes; the old Vue key and cached
+  mounted-content string then reused the edited DOM for a new Result. The
+  template now keys the mount by the existing committed artifact identity,
+  projected through `state.js`. Live edits retain that identity. Delayed
+  definition responses also check their scheduled revision, Result identity,
+  selected index and mounted root before applying changes.
+- **B-06:** incremental drag binding reused the previous SVG's scale baseline
+  (100) for a replacement SVG whose renderer-owned translation was 144.5.
+  `diagram-drag.js` now adopts the replacement element's geometry while
+  preserving same-element user offsets. It does not copy stale geometry into
+  the new preview.
+
+The base Web guidance's [live-edit boundary](../../../gbdraw/web/CLAUDE.md)
+requires the mounted target and current Result to update before an action
+completes, without using Save, Generate or drawer close as edit triggers.
+The existing Result ingestion identity and composition/drag ownership determine
+mounting and generated geometry. These corrections implement that authority;
+they do not select a new Product outcome or cite a candidate `BD-###`.
+
+Architecture review uses the ordinary non-increasing path: the same style,
+ingestion, definition and composition owners remain; no canonical store,
+compatibility reader, Worker, watcher, polling loop or privileged importer is
+added. The new computed value only projects existing ingestion identity through
+an already permitted import. The style owner keeps its existing serialization
+path and removes the alternate dirty-only completion. Architecture tests pass;
+the policy Gate passes and Review remains REQUIRED for the reactive declaration.
+A maintainer must supply that review.
+
+## Permanent evidence
+
+Before production edits, all ten browser reproductions failed at their intended
+actions in `red-confirmed.log` under `/tmp/gbdraw-session05a14-evidence`.
+The corresponding Result assertions now pass:
+
+| Family | Discoverable test | Original program | Original failed property |
+| --- | --- | --- | --- |
+| B-01/A-01 | `visual-state-regressions.playwright.spec.js`, Circular and Linear color Redo | J09, J10 | selected fill stayed stale after Redo |
+| B-04 | same file, Circular and Linear depth OFF/ON | J27, J28 | selected ancestor lacked mounted/exported `display="none"` |
+| B-05 | `definition-replay-visual-state.playwright.spec.js`, single and two-source composite | C01 | legend ancestor transform and root width differed after completed layout |
+| B-06 | `visual-state-regressions.playwright.spec.js`, rejected FASTA recovery and label regeneration | J36 | scale line and `5 kbp` parent translation differed by 44.5 px |
+
+`definition-layout-completion.test.mjs` controls the timer and Worker response,
+proving both legitimate delayed completion and stale-response rejection. Browser
+B-05 waits for the existing definition-completed event, not equality or a fixed
+700 ms delay. The fast CLI path is checked separately. The existing layout
+delay and test routing/timeouts are unchanged.
+
+`helpers/svg-visual-semantics.mjs` promotes B's visual projection into normal
+tests. It compares biological/rendered identities, multipart multiplicity,
+geometry/paint/text, depth/legend/scale nodes, ancestor transforms/style and
+root dimensions/viewBox. Deterministic controls reject the retained fill,
+display, 1 px / 0.5 px / 44.5 px, and missing/duplicate-part mutations. They also
+reject a coherently wrong non-target color independently of representation
+agreement. Numeric notation normalizes without rounding; only existing
+transient UI styling, default opacity 1, and missing-to-valid-catalog label
+binding enrichment receive narrow equivalence treatment.
+
+`helpers/visual-state.cjs` records completed selected/mounted SVG before export,
+then the actual public download and adjacent state separately. It never uses a
+repair action to observe completion. `helpers/retained-visual-journeys.py`
+imports this same projection and comparator into the immutable B statement
+runner. Original operation programs, failure retention, edit postconditions,
+per-Undo/Redo observations and export-boundary capture remain in use.
+
+Run the affected programs with a local server on port 4194:
+
+```bash
+python tests/web/helpers/retained-visual-journeys.py \
+  --archive /path/to/gbdraw_v014_session05a13_b_evidence_2026-09-12 \
+  --output /path/to/new-evidence --root "$PWD" \
+  --journeys J09 J10 J27 J28 J36 C01
+```
+
+The adapter disables bytecode cache writes and verifies original source and seed
+hashes before execution. It can
+serve the retained runner's other explicit journey IDs later; this remediation
+runs only the eight affected original journeys and supplemental C01.

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -4863,7 +4863,7 @@
                          @lostpointercapture="endPan"
                          @mouseleave="endPan">
                         <div v-if="svgContent" v-html="svgContent" ref="svgContainer"
-                            :key="`svg-${mode}-${selectedResultIndex}-${results.length}`"
+                            :key="`svg-${mode}-${selectedResultIndex}-${svgResultIdentity}`"
                             :style="{transform: `translate(${canvasPan.x}px, ${canvasPan.y}px) scale(${zoom})`, transformOrigin: 'top center', transition: isPanning ? 'none' : 'transform 0.2s'}"
                             class="gbdraw-preview-surface shadow-xl bg-white m-auto origin-top">
                         </div>

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -223,6 +223,7 @@ export const createAppSetup = () => {
     pairwiseMatchFactors,
     matchSequenceRegistry,
     svgContent,
+    svgResultIdentity,
     zoom,
     layoutRepositionMode,
     isPanning,
@@ -1091,8 +1092,7 @@ export const createAppSetup = () => {
     state,
     watch,
     nextTick,
-    legendActions,
-    previewRuntime
+    legendActions
   });
   const featureSelection = createFeatureSelection({ state, onMounted, onUnmounted });
   const featureActions = createFeatureEditor({
@@ -3316,6 +3316,7 @@ export const createAppSetup = () => {
     runInfoCopyStatus,
     exactReplayCopyStatus,
     svgContent,
+    svgResultIdentity,
     zoom,
     layoutRepositionMode,
     isPanning,

--- a/gbdraw/web/js/app/legend-layout/diagram-drag.js
+++ b/gbdraw/web/js/app/legend-layout/diagram-drag.js
@@ -183,17 +183,23 @@ export const createDiagramDragActions = ({ state, history = null }) => {
       return;
     }
 
-    const hadLengthBarState = !!lengthBarElement.value;
+    const sameElement = lengthBarElement.value === nextLengthBar;
     lengthBarElement.value = nextLengthBar;
     lengthBarElement.value.style.opacity = '1';
     setElementCursor(lengthBarElement.value, isLayoutRepositionModeEnabled() ? 'grab' : '');
 
-    if (!preserveOffset || !hadLengthBarState) {
-      lengthBarOriginalTransform.value = parseTransform(nextLengthBar.getAttribute('transform'));
-    }
     if (!preserveOffset) {
       lengthBarUserOffset.x = 0;
       lengthBarUserOffset.y = 0;
+    }
+    if (!preserveOffset || !sameElement) {
+      // A replacement SVG already contains its own scale translation. Binding
+      // adopts that geometry; only a later drag applies an additional offset.
+      const current = parseTransform(nextLengthBar.getAttribute('transform'));
+      lengthBarOriginalTransform.value = {
+        x: current.x - lengthBarUserOffset.x,
+        y: current.y - lengthBarUserOffset.y
+      };
     }
     applyLengthBarTransform();
   };

--- a/gbdraw/web/js/app/results.js
+++ b/gbdraw/web/js/app/results.js
@@ -58,6 +58,7 @@ export const createResultsManager = ({
 }) => {
   const {
     svgContent,
+    svgResultIdentity,
     mode,
     shouldDeferCircularPreviewUpdates,
     svgContainer,
@@ -82,6 +83,7 @@ export const createResultsManager = ({
   const { refreshCompositionGeometry } = legendLayout;
 
   let definitionUpdateTimeout = null;
+  let definitionUpdateRevision = 0;
   const cloneColors = (colors) => ({ ...(colors || {}) });
   const getPaletteMap = () => {
     if (paletteDefinitions.value && Object.keys(paletteDefinitions.value).length > 0) {
@@ -124,6 +126,7 @@ export const createResultsManager = ({
   };
 
   const cancelDefinitionUpdate = () => {
+    definitionUpdateRevision += 1;
     if (definitionUpdateTimeout) {
       clearTimeout(definitionUpdateTimeout);
       definitionUpdateTimeout = null;
@@ -227,6 +230,14 @@ export const createResultsManager = ({
     if (!svg) return;
     if (mode.value === 'circular' && shouldDeferCircularPreviewUpdates.value) return;
 
+    const revision = definitionUpdateRevision;
+    const resultIndex = selectedResultIndex.value;
+    const resultIdentity = svgResultIdentity.value;
+    const isCurrent = () => revision === definitionUpdateRevision
+      && selectedResultIndex.value === resultIndex
+      && svgResultIdentity.value === resultIdentity
+      && svgContainer.value?.querySelector('svg') === svg;
+
     if (mode.value === 'circular') {
       const isMultiRecordCanvasOnSvg = isMultiRecordCanvasSvg(svg);
 
@@ -277,6 +288,7 @@ export const createResultsManager = ({
             keepFullDefinitionWithPlotTitle
           }
         );
+        if (!isCurrent()) return;
         const result = response.result;
 
         if (result.error) {

--- a/gbdraw/web/js/app/svg-styles.js
+++ b/gbdraw/web/js/app/svg-styles.js
@@ -45,7 +45,7 @@ const paletteColorKeysEqual = (left, right, keys) => keys.every(
   (key) => normalizeComparableColor(left?.[key]) === normalizeComparableColor(right?.[key])
 );
 
-export const createSvgStyles = ({ state, watch, nextTick, legendActions, previewRuntime = null }) => {
+export const createSvgStyles = ({ state, watch, nextTick, legendActions }) => {
   const {
     svgContent,
     extractedFeatures,
@@ -66,9 +66,8 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions, preview
 
   const { getAllFeatureLegendGroups } = legendActions;
 
-  const persistSvgEdit = (svg, reason) => {
+  const persistSvgEdit = (svg) => {
     skipCaptureBaseConfig.value = true;
-    if (previewRuntime?.markActiveResultDirty?.(reason)) return;
     const idx = selectedResultIndex.value;
     if (idx >= 0 && results.value.length > idx) {
       const nextResults = [...results.value];
@@ -360,7 +359,7 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions, preview
     }
 
     if (updatedCount > 0) {
-      persistSvgEdit(svg, 'palette-style');
+      persistSvgEdit(svg);
     }
   };
 
@@ -411,7 +410,7 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions, preview
     });
 
     if (updatedCount > 0) {
-      persistSvgEdit(svg, 'specific-rule-style');
+      persistSvgEdit(svg);
       console.log(`Applied specific rules: updated ${updatedCount} elements`);
     }
   };
@@ -549,7 +548,7 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions, preview
     }
 
     if (updatedCount > 0) {
-      persistSvgEdit(svg, 'diagram-style');
+      persistSvgEdit(svg);
       console.log(`Applied styles: updated ${updatedCount} elements`);
     }
   };
@@ -617,7 +616,7 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions, preview
     }
 
     if (updated) {
-      persistSvgEdit(svg, 'track-visibility');
+      persistSvgEdit(svg);
       console.log('Track visibility updated');
     }
   };

--- a/gbdraw/web/js/state.js
+++ b/gbdraw/web/js/state.js
@@ -18,7 +18,10 @@ import {
 } from './app/linear-comparisons.js';
 import { createModeProfileStateManager } from './mode-profiles.js';
 import { createDefaultFeatureRenderings } from './utils/feature-rendering.js';
-import { getCommittedSvgContent } from './services/svg-result-ingestion.js';
+import {
+  getCommittedSvgContent,
+  getCommittedSvgResultRuntimeIdentity
+} from './services/svg-result-ingestion.js';
 import { createImportedComparisonIntentState } from './services/imported-comparison-intent.js';
 import {
   createDefaultAdv,
@@ -56,6 +59,12 @@ const svgContent = computed(() => {
   if (results.value.length === 0) return null;
   return getCommittedSvgContent(results.value[selectedResultIndex.value]);
 });
+
+// Distinguish a new artifact even when its initial SVG bytes repeat a prior
+// artifact whose mounted DOM has since been edited. Live edits keep this ID.
+const svgResultIdentity = computed(() => (
+  getCommittedSvgResultRuntimeIdentity(results.value[selectedResultIndex.value])
+));
 
 const zoom = ref(1.0);
 const layoutRepositionMode = ref(false);
@@ -789,6 +798,7 @@ export const state = {
   pairwiseMatchFactors,
   matchSequenceRegistry,
   svgContent,
+  svgResultIdentity,
   zoom,
   layoutRepositionMode,
   isPanning,

--- a/tests/web/definition-layout-completion.test.mjs
+++ b/tests/web/definition-layout-completion.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { readFile } from 'node:fs/promises';
+import * as transforms from '../../gbdraw/web/js/app/legend-layout/transform-utils.js';
+
+// Load the existing owners with a controlled scheduler and Worker response.
+// All production control flow remains intact; only imported collaborators vary.
+const loadOwner = async (path, name, dependencies) => {
+  const source = (await readFile(new URL(`../../gbdraw/web/js/app/${path}`, import.meta.url), 'utf8'))
+    .replace(/import\s+\{([\s\S]*?)\}\s+from\s+['"][^'"]+['"];?/g, 'const {$1} = dependencies;')
+    .replace(/export const /g, 'const ');
+  return new Function('dependencies', 'setTimeout', 'clearTimeout', `${source}\nreturn ${name};`)(
+    dependencies, dependencies.setTimeout, dependencies.clearTimeout);
+};
+const ref = value => ({ value });
+const group = (id, transform) => {
+  const attrs = { id, transform };
+  return { id, attrs, style: { removeProperty() {} }, getAttribute: key => attrs[key] ?? null,
+    setAttribute: (key, value) => { attrs[key] = value; }, addEventListener() {}, removeEventListener() {} };
+};
+
+test('incremental rebind adopts the replacement scale geometry, retaining same-root user offsets', async () => {
+  const bar = group('length_bar', 'translate(0,100)');
+  let activeBar = bar;
+  const binding = { metadata: { primary: { automaticTranslation: [0, 0] }, title: null }, primary: { targets: [] }, title: { targets: [] } };
+  const root = { getAttribute: () => '1', getElementById: id => id === 'length_bar' ? activeBar : null,
+    addEventListener() {}, removeEventListener() {} };
+  const create = await loadOwner('legend-layout/diagram-drag.js', 'createDiagramDragActions', {
+    ...transforms, COMPOSITION_SCHEMA_ATTRIBUTE: 'schema', bindCompositionMetadata: () => binding,
+    compositionUserDeltas: () => ({ primary: [] })
+  });
+  const state = Object.fromEntries(['results','selectedResultIndex','diagramElements','diagramElementIds',
+    'diagramElementOriginalTransforms','diagramDragging','lengthBarElement','lengthBarOriginalTransform',
+    'plotTitleElement','plotTitleDragging','plotTitleAutoTransform','layoutRepositionMode','zoom','skipCaptureBaseConfig'].map(key => [key, ref(null)]));
+  for (const key of ['diagramOffset','diagramDragStart','lengthBarUserOffset','plotTitleDragStart','plotTitleUserOffset']) state[key] = { x: 0, y: 0 };
+  state.svgContainer = ref({ querySelector: () => root });
+  const actions = create({ state });
+  actions.setupDiagramDrag(false);
+  state.lengthBarUserOffset.y = 7;
+  bar.setAttribute('transform', 'translate(0,107)');
+  actions.setupDiagramDrag(true);
+  assert.equal(bar.getAttribute('transform'), 'translate(0,107)');
+  // A renderer-produced replacement already carries its own authoritative
+  // translation. Merely binding it cannot apply a prior root's baseline.
+  activeBar = group('length_bar', 'translate(0,144.5)');
+  state.lengthBarUserOffset.y = 0;
+  actions.setupDiagramDrag(true);
+  assert.equal(activeBar.getAttribute('transform'), 'translate(0,144.5)');
+});
+
+test('controlled definition callbacks complete for the active root and ignore superseded Results', async () => {
+  let callback;
+  let resolveHelper;
+  let mutations = 0;
+  const root = { getAttribute: () => null, querySelectorAll: () => [], getElementById: () => null };
+  let mounted = root;
+  const state = { svgContent: ref('<svg/>'), svgResultIdentity: ref(1), mode: ref('circular'), shouldDeferCircularPreviewUpdates: ref(false),
+    svgContainer: ref({ querySelector: () => mounted }), cInputType: ref('gb'), files: { c_gb: {} },
+    linearSeqs: [], form: {}, adv: {}, selectedResultIndex: ref(0), results: ref([{ content: 'old' }]), skipCaptureBaseConfig: ref(false) };
+  const create = await loadOwner('results.js', 'createResultsManager', {
+    setTimeout(fn) { callback = fn; return 1; }, clearTimeout() {},
+    isMultiRecordCanvasSvg: () => false, cloneFileBytesForTransfer: async () => new ArrayBuffer(0),
+    DIAGRAM_HELPER_OPERATIONS: { REGENERATE_DEFINITION_SVGS: 'definitions' },
+    runDiagramHelperOperation: () => new Promise(resolve => { resolveHelper = resolve; })
+  });
+  const owner = create({ state, legendLayout: { refreshCompositionGeometry() { mutations++; } } });
+  owner.scheduleDefinitionUpdate();
+  assert.equal(mutations, 0, 'fast path before the scheduled callback');
+  callback();
+  await new Promise(setImmediate);
+  assert.equal(typeof resolveHelper, 'function');
+  resolveHelper({ result: { definitions: [{ definition_group_id: 'unused' }] } });
+  await new Promise(setImmediate);
+  assert.equal(mutations, 1, 'the current root receives its legitimate delayed layout');
+  owner.scheduleDefinitionUpdate();
+  callback();
+  await new Promise(setImmediate);
+  mounted = { ...root };
+  state.results.value = [{ content: 'replacement' }];
+  state.svgResultIdentity.value = 2;
+  resolveHelper({ result: { definitions: [{ definition_group_id: 'unused' }] } });
+  await new Promise(setImmediate);
+  assert.equal(mutations, 1, 'superseded callback must not reflow the current root');
+  assert.equal(state.results.value[0].content, 'replacement');
+});

--- a/tests/web/definition-replay-visual-state.playwright.spec.js
+++ b/tests/web/definition-replay-visual-state.playwright.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('@playwright/test');
+const path = require('node:path');
+const fs = require('node:fs/promises');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+const { generate } = require('./helpers/mode-transition.cjs');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+const { capture, assertCoherent } = require('./helpers/visual-state.cjs');
+
+for (const composite of [false, true]) {
+  test(`B-05 current CLI ${composite ? 'two-source composite' : 'single'} replay after definition completion`, async ({ browser }, info) => {
+    test.setTimeout(300000);
+    const sources = ['tests/fixtures/sessions/cli-web-mito.gb', ...(composite ? ['tests/test_inputs/NC_001416.gb'] : [])].map(file => path.resolve(file));
+    let file = info.outputPath('cli.gbdraw-session.json.gz');
+    await promisify(execFile)('python', ['-m', 'gbdraw.cli', 'circular', '--gbk', ...sources,
+      '--track_type', 'middle', '--labels', 'out', ...(composite ? ['--multi_record_canvas'] : []),
+      '-o', info.outputPath('cli'), '--session_output', file], { env: { ...process.env, PYTHONPATH: process.cwd() } });
+    for (const phase of ['cli', 'web']) {
+      const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+      const page = await context.newPage();
+      await context.route('**/*', route => new URL(route.request().url()).hostname === '127.0.0.1' ? route.continue() : route.abort());
+      page.on('dialog', dialog => dialog.type() === 'prompt' ? dialog.accept('CLI replay') : dialog.accept());
+      let completed = 0;
+      page.on('console', message => { if (message.text() === 'Definition text updated') completed++; });
+      try {
+        await openApp(page);
+        await page.locator('input[accept^=".json,"]').setInputFiles(file);
+        await page.waitForFunction(() => !window.__GBDRAW_APP__.sessionImportPending && window.__GBDRAW_APP__.results.length > 0);
+        // This completion log is emitted by the existing definition owner after
+        // its Worker helper and composition update. No fixed 700 ms oracle and
+        // no polling selected/mounted equality.
+        if (phase === 'web') {
+          await expect.poll(() => completed, { timeout: 180000 }).toBeGreaterThan(0);
+          await assertCoherent(await capture(page, info, 'web-loaded-definition-completed'), 'loaded definition', true);
+        }
+        await generate(page);
+        await page.evaluate(async () => { await window.Vue.nextTick(); await new Promise(requestAnimationFrame); });
+        await assertCoherent(await capture(page, info, `${phase}-definition-completed`), phase, true);
+        if (phase === 'cli') {
+          const pending = page.waitForEvent('download');
+          expect(await page.evaluate(() => window.__GBDRAW_APP__.saveSessionWithTitle())).toMatchObject({ status: 'saved' });
+          file = info.outputPath('web.gbdraw-session.json.gz');
+          await (await pending).saveAs(file);
+        }
+      } finally { await page.context().close(); }
+    }
+  });
+}

--- a/tests/web/helpers/retained-visual-journeys.py
+++ b/tests/web/helpers/retained-visual-journeys.py
@@ -1,0 +1,144 @@
+"""Run retained SESSION 05A13-B programs with the permanent visual comparator.
+
+The immutable archive is an input, never copied or modified. The original
+statement runner keeps failed checkpoints and continues independent operations.
+Nonzero exit status prevents its diagnostic continuation from becoming a PASS.
+"""
+import argparse
+import gzip
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# Retained programs are immutable inputs, including their archive directory.
+sys.dont_write_bytecode = True
+
+from playwright.sync_api import sync_playwright
+
+HASHES = {
+    'audit.py': 'd24c4627013cde32a57aa157c015788e1b4caabe5a7ac8265041f883bcea85f1',
+    'harness.py': '96f49c44fe172d7eeec374bc2e11d19b174daee9199961844ec2aac2ca2efb51',
+    'journeys.py': '0ec1adbac279ff7579985e416a269861e7006c6c2aef0c357bb635d84954eb07',
+    'audit-state.js': 'e4525f9f4f56fdec788b8c3bb1141e1fa36da45488f22d00b8bc645b231b4cc8',
+    'disposition-adapters.py': '30a225fba3ce9bc23eee10dcaf4c1c39ecb8150021bbd4cc3ba93679b78c98a2',
+    'supplemental-controls.py': 'f40b4355817ea4248bc630587d1d4537b3cc86b49d18e40133653eee6a83c827',
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--archive', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--root', type=Path, default=Path.cwd())
+    parser.add_argument('--journeys', nargs='+', required=True)
+    args = parser.parse_args()
+    for name, expected in HASHES.items():
+        assert hashlib.sha256((args.archive / name).read_bytes()).hexdigest() == expected, name
+    for seed in json.loads((args.archive / 'seed-manifest.json').read_text()):
+        assert hashlib.sha256(Path(seed['path']).read_bytes()).hexdigest() == seed['sha256'], seed['seed']
+    args.output.mkdir(parents=True, exist_ok=True)
+    sys.path.insert(0, str(args.archive))
+    import harness
+    import journeys
+
+    # Keep the original interpreter and all journey statements. Replace only its
+    # comparator calls; both normal tests and this runner import the same helper.
+    source = (args.archive / 'audit.py').read_text()
+    for left, right in [('sm', 'mm'), ('bs', 'bm'), ('em', 'bs'), ('em', 'bm')]:
+        # Binding enrichment is directional: selected -> mounted/export.
+        expected, actual = (right, left) if left == 'em' else (left, right)
+        source = source.replace(f'if {left}!={right}:', f'if not self.visual_equal({expected},{actual},d):')
+    spec = importlib.util.spec_from_file_location('retained_audit', args.archive / 'audit.py')
+    audit = importlib.util.module_from_spec(spec)
+    exec(compile(source, str(args.archive / 'audit.py'), 'exec'), audit.__dict__)
+    state_source = audit.STATE
+    start = state_source.index(' const props=')
+    end = state_source.index(' if(contentOverride!==null)')
+    audit.STATE = state_source[:start] + " const {svgVisualSemantics:semantics}=await import('/tests/web/helpers/svg-visual-semantics.mjs');\n" + state_source[end:]
+
+    def visual_equal(self, left, right, state):
+        catalog = state.get('catalog') or {}
+        item = next((item for item in catalog.get('items', []) if item['resultIndex'] == state['selectedIndex']), {})
+        return self.page.evaluate("""async ({left,right,ids})=>{
+          const {compareVisualSemantics}=await import('/tests/web/helpers/svg-visual-semantics.mjs');
+          return compareVisualSemantics(left,right,{catalogIds:ids}).length===0;
+        }""", {'left': left, 'right': right, 'ids': [feature['svgId'] for feature in item.get('features', [])]})
+    audit.AuditJourney.visual_equal = visual_equal
+    original_edit = audit.AuditJourney.edit
+    original_observe = audit.AuditJourney.observe
+
+    def edit(self, kind, *params, **options):
+        target = original_edit(self, kind, *params, **options)
+        if self.jid == 'J13' and kind == 'placement':
+            self.placement_target = target['svg_id']
+        return target
+
+    def observe(self, reason):
+        state = original_observe(self, reason)
+        if self.jid != 'J13' or not state or not hasattr(self, 'placement_target'):
+            return state
+        if reason.startswith(('before Undo ', 'before Redo ', 'after Undo ', 'after Redo ')):
+            current = json.loads(gzip.decompress((self.folder / state['mounted_semantics']['path']).read_bytes()))
+            if reason.startswith('before '):
+                self.history_non_targets = current
+            else:
+                differences = self.page.evaluate("""async ({before,after,target})=>{
+                  const {nonTargetFeatures,compareVisualSemantics}=await import('/tests/web/helpers/svg-visual-semantics.mjs');
+                  return compareVisualSemantics(nonTargetFeatures(before,[target]),nonTargetFeatures(after,[target]));
+                }""", {'before': self.history_non_targets, 'after': current, 'target': self.placement_target})
+                self.record('non_target_preservation', 'OBSERVATION' if differences else 'PASS',
+                            reason=reason, differences=differences[:5])
+        return state
+
+    audit.AuditJourney.edit = edit
+    audit.AuditJourney.observe = observe
+    harness.ROOT = journeys.ROOT = args.root.resolve()
+    harness.OUT = audit.OUT = args.output.resolve()
+    harness.LINEAR_FILES = journeys.LINEAR_FILES = [harness.ROOT / 'examples' / name for name in ['MellatMJNV.gb', 'MeenMJNV.gb', 'LvMJNV.gb']]
+    # The retained harness uses port 4194 for its local-only request policy.
+    harness.INIT = harness.INIT.replace('window.__SWEEP__=', "window.__DEFINITION_COMPLETED__=0;const log=console.log;console.log=(...a)=>{if(a[0]==='Definition text updated')window.__DEFINITION_COMPLETED__++;log(...a)};window.__SWEEP__=")
+    original_load = audit.AuditJourney.load
+
+    def load(self, seed):
+        result = original_load(self, seed)
+        if self.jid == 'C01' and '-03-save' in str(seed):
+            self.page.wait_for_function('window.__DEFINITION_COMPLETED__ > 0', timeout=180000)
+            self.observe('Web Load definition callback completed before Generate')
+        return result
+    audit.AuditJourney.load = load
+    manifest = {'archive': str(args.archive.resolve()), 'sourceHashes': HASHES,
+                'comparatorSha256': hashlib.sha256((args.root / 'tests/web/helpers/svg-visual-semantics.mjs').read_bytes()).hexdigest(), 'journeys': args.journeys}
+    (args.output / 'runner-inputs.json').write_text(json.dumps(manifest, indent=2))
+    failed = []
+    with sync_playwright() as pw:
+        for jid in args.journeys:
+            if jid not in {f'J{i:02}' for i in range(1, 49)} | {'C01'}:
+                raise ValueError(jid)
+            browser = pw.chromium.launch(headless=True)
+            journey = audit.AuditJourney(browser, jid, {'width': 390, 'height': 844} if jid in ['J43', 'J44'] else None)
+            key = jid.lower()
+            fn = audit.supplements.get(key) or audit.adapters.get(key) or getattr(journeys, key, None) or getattr(harness, key)
+            # Original supplement OUT still references the immutable CLI fixtures.
+            program = audit.Program(journey, fn)
+            try:
+                program.run()
+                journey.observe('final')
+                journey.snap('final', True)
+                status = ('FAIL' if journey.observations else 'BLOCKED' if journey.blocked
+                          else 'PASS_WITH_DISPOSITION' if journey.checkpoints else 'PASS')
+            except Exception:
+                import traceback
+                journey.record('runner', 'HARNESS_ERROR', error=traceback.format_exc())
+                status = 'HARNESS_ERROR'
+            journey.finish(status)
+            if status not in ['PASS', 'PASS_WITH_DISPOSITION']:
+                failed.append(jid)
+            browser.close()
+    print(json.dumps({'failed': failed, 'completed': args.journeys}))
+    return bool(failed)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/web/helpers/svg-style-fixture.mjs
+++ b/tests/web/helpers/svg-style-fixture.mjs
@@ -1,0 +1,23 @@
+import { createSvgStyles } from '../../../gbdraw/web/js/app/svg-styles.js';
+
+const ref = value => ({ value });
+globalThis.XMLSerializer = class { serializeToString(svg) { return svg.snapshot(); } };
+export const fixture = (colors, rules) => {
+  const attrs = { id: 'f1', 'data-gbdraw-feature-id': 'f1', 'data-gbdraw-feature-part': 'block', fill: '#000000' };
+  const feature = { svg_id: 'f1', type: 'unlisted_type', start: 1, end: 10, qualifiers: { gene: ['sample'] } };
+  const path = { getAttribute: key => attrs[key] ?? null, setAttribute: (key, value) => { attrs[key] = value; } };
+  const depthAttrs = {};
+  const depth = { getAttribute: key => depthAttrs[key] ?? null,
+    setAttribute: (key, value) => { depthAttrs[key] = value; }, removeAttribute: key => { delete depthAttrs[key]; } };
+  const rootAttrs = { xmlns: 'http://www.w3.org/2000/svg', 'xmlns:xlink': 'http://www.w3.org/1999/xlink' };
+  const svg = { querySelectorAll: selector => selector.startsWith('g[') ? (selector.includes('depth') ? [depth] : []) : selector.includes('data-gbdraw-feature-id') ? [path] : [],
+    getElementById: () => null, getAttribute: key => rootAttrs[key] ?? null,
+    setAttribute: (key, value) => { rootAttrs[key] = value; }, removeAttribute: key => { delete rootAttrs[key]; }, cloneNode: () => svg,
+    snapshot: () => JSON.stringify({ fill: attrs.fill, depth: depthAttrs }) };
+  const state = { svgContent: ref('<svg/>'), extractedFeatures: ref([feature]), featuresBySvgId: ref(new Map([['f1', feature]])),
+    appliedPaletteColors: ref(colors), manualSpecificRules: rules, featureColorOverrides: {}, legendColorOverrides: {},
+    pairwiseMatchFactors: ref({}), results: ref([{ content: JSON.stringify({ fill: '#000000', depth: {} }) }]), selectedResultIndex: ref(0),
+    skipCaptureBaseConfig: ref(false), svgContainer: ref({ querySelector: () => svg }), adv: {}, mode: ref('circular'), form: { show_depth: true } };
+  const actions = createSvgStyles({ state, watch() {}, nextTick: fn => fn(), legendActions: { getAllFeatureLegendGroups: () => [] } });
+  return { actions, state, attrs, depthAttrs };
+};

--- a/tests/web/helpers/svg-visual-semantics.mjs
+++ b/tests/web/helpers/svg-visual-semantics.mjs
@@ -1,0 +1,76 @@
+// Promoted from SESSION 05A13-B audit-state.js. Same-browser numbers retain
+// their full precision; CLI/Wasm tolerance belongs to the separate CLI oracle.
+import { stripTransientPreviewState } from '../../../gbdraw/web/js/services/svg-serialization.js';
+
+const properties = ['x','y','x1','y1','x2','y2','cx','cy','r','rx','ry','width','height','d','points','transform','viewBox','fill','fill-opacity','fill-rule','stroke','stroke-width','stroke-opacity','stroke-dasharray','stroke-linecap','stroke-linejoin','opacity','display','visibility','font-family','font-size','font-weight','font-style','text-anchor','dominant-baseline','alignment-baseline','baseline-shift','letter-spacing','clip-path','mask','filter','marker-start','marker-mid','marker-end','href','xlink:href','offset','stop-color','stop-opacity','gradientUnits','gradientTransform','spreadMethod','preserveAspectRatio'];
+const numbers = new Set(['x','y','x1','y1','x2','y2','cx','cy','r','rx','ry','width','height','d','points','transform','viewBox','fill-opacity','stroke-width','stroke-opacity','stroke-dasharray','opacity','font-size','letter-spacing','offset','stop-opacity']);
+const normalize = (key, value) => numbers.has(key)
+  ? value.replace(/[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?/g, number => String(Number(number))) : value;
+const attributes = element => {
+  const attrs = Object.fromEntries(properties.map(key => [key, element.getAttribute(key)])
+    .filter(([, value]) => value !== null).map(([key, value]) => [key, normalize(key, value)]));
+  // Inline CSS has precedence over presentation attributes, including on groups.
+  for (const declaration of (element.getAttribute('style') || '').split(';').filter(value => value.trim())) {
+    const colon = declaration.indexOf(':');
+    const key = declaration.slice(0, colon).trim(), value = declaration.slice(colon + 1).trim();
+    if (key !== 'cursor') attrs[key] = normalize(key, value);
+  }
+  // Diagram drag adds opacity:1 to groups; this is the SVG default, unlike
+  // inherited visibility/paint or any real group transform.
+  if (attrs.opacity === '1') delete attrs.opacity;
+  return Object.fromEntries(Object.entries(attrs).sort(([a], [b]) => a.localeCompare(b)));
+};
+
+export const visualSemanticsFromRoot = root => {
+  const nodes = [root, ...root.querySelectorAll('path,text,tspan,textPath,circle,ellipse,rect,line,polyline,polygon,image,use,linearGradient,radialGradient,stop,style')];
+  return nodes.map(element => {
+    const ancestors = [];
+    for (let parent = element.parentElement; parent; parent = parent.parentElement) {
+      const attrs = attributes(parent);
+      if (Object.keys(attrs).length) ancestors.push(attrs);
+      if (parent === root) break;
+    }
+    return {
+      tag: element.localName,
+      feature: element.getAttribute('data-gbdraw-feature-id'),
+      rendered: element.getAttribute('data-gbdraw-rendered-feature-id'),
+      biological: element.getAttribute('data-gbdraw-stable-feature-id'),
+      record: element.getAttribute('data-gbdraw-record-id'),
+      part: element.getAttribute('data-gbdraw-feature-part'),
+      label: element.getAttribute('data-label-feature-id'),
+      text: ['text','tspan','textPath','style'].includes(element.localName) ? element.textContent : null,
+      attrs: attributes(element), ancestors
+    };
+  });
+};
+
+export const svgVisualSemantics = content => {
+  if (!content) return null;
+  const doc = new DOMParser().parseFromString(content, 'image/svg+xml');
+  if (doc.querySelector('parsererror')) throw new Error('Invalid SVG in visual comparison');
+  stripTransientPreviewState(doc.documentElement);
+  return visualSemanticsFromRoot(doc.documentElement);
+};
+
+export const compareVisualSemantics = (expected, actual, { catalogIds = [] } = {}) => {
+  const known = new Set(catalogIds);
+  if (!expected || !actual) return expected === actual ? [] : [{ property: 'presence' }];
+  const differences = [];
+  for (let index = 0; index < Math.max(expected.length, actual.length); index++) {
+    const before = expected[index], after = actual[index];
+    if (!before || !after) { differences.push({ index, before, after }); continue; }
+    const { label: oldBinding, ...oldVisual } = before;
+    const { label: newBinding, ...newVisual } = after;
+    // Only the established missing -> valid catalog binding enrichment is
+    // nonvisual. Removal, replacement, or a dangling binding is a failure.
+    const validEnrichment = !oldBinding && newBinding && known.has(newBinding);
+    if (JSON.stringify(oldVisual) !== JSON.stringify(newVisual)
+      || (oldBinding !== newBinding && !validEnrichment)) differences.push({ index, before, after });
+  }
+  return differences;
+};
+
+export const nonTargetFeatures = (semantics, targetIds = []) => {
+  const targets = new Set(targetIds);
+  return semantics.filter(node => node.feature && !targets.has(node.feature));
+};

--- a/tests/web/helpers/visual-state.cjs
+++ b/tests/web/helpers/visual-state.cjs
@@ -1,0 +1,95 @@
+const { expect } = require('@playwright/test');
+const fs = require('node:fs/promises');
+const { load: loadSeed, popup } = require('./mode-transition.cjs');
+
+const semantics = (page, content) => page.evaluate(async content => {
+  const { svgVisualSemantics } = await import('/tests/web/helpers/svg-visual-semantics.mjs');
+  return svgVisualSemantics(content);
+}, content);
+
+const capture = async (page, testInfo, name) => {
+  // No Save, Generate, flush or editor close. Capture action completion before
+  // invoking the public export handler, then capture its adjacent state.
+  const pending = page.waitForEvent('download');
+  const state = await page.evaluate(async () => {
+    const { state: s } = await import('./js/state.js');
+    const cap = () => ({ selected: s.results.value[s.selectedResultIndex.value]?.content || '',
+      mounted: s.svgContainer.value?.querySelector('svg')?.outerHTML || '',
+      catalogIds: s.featureCatalog.value?.items?.find(item => item.resultIndex === s.selectedResultIndex.value)
+        ?.features?.map(feature => feature.svgId) || [] });
+    const completed = cap();
+    await window.__GBDRAW_APP__.downloadSVG();
+    return { completed, boundary: cap() };
+  });
+  const file = testInfo.outputPath(`${name}.svg`);
+  await (await pending).saveAs(file);
+  const exported = await semantics(page, await fs.readFile(file, 'utf8'));
+  for (const phase of Object.values(state)) {
+    phase.selected = await semantics(page, phase.selected);
+    phase.mounted = await semantics(page, phase.mounted);
+  }
+  const observation = { ...state, exported };
+  await fs.writeFile(testInfo.outputPath(`${name}.json`), JSON.stringify(observation));
+  return observation;
+};
+const assertCoherent = async (observation, message, soft = false) => {
+  const { compareVisualSemantics } = await import('./svg-visual-semantics.mjs');
+  const check = soft ? expect.soft : expect;
+  for (const [phase, state] of Object.entries(observation).filter(([key]) => key !== 'exported')) {
+    const options = { catalogIds: state.catalogIds };
+    const differences = compareVisualSemantics(state.selected, state.mounted, options);
+    check(differences.slice(0, 5), `${message}: ${phase} selected/mounted`).toEqual([]);
+    if (phase === 'boundary') {
+      check(compareVisualSemantics(state.selected, observation.exported, options).slice(0, 5),
+        `${message}: download boundary selected/export`).toEqual([]);
+      check(compareVisualSemantics(state.mounted, observation.exported, options).slice(0, 5),
+        `${message}: download boundary mounted/export`).toEqual([]);
+    }
+  }
+};
+const assertNonTargetsPreserved = async (before, after, targetIds, message, soft = false) => {
+  const { nonTargetFeatures, compareVisualSemantics } = await import('./svg-visual-semantics.mjs');
+  (soft ? expect.soft : expect)(compareVisualSemantics(nonTargetFeatures(before, targetIds),
+    nonTargetFeatures(after, targetIds)).slice(0, 5), message).toEqual([]);
+};
+const load = async (...args) => { const page = await loadSeed(...args); page.setDefaultTimeout(20000); return page; };
+
+const settle = page => page.waitForFunction(() => !window.__GBDRAW_HISTORY__.restoring.value
+  && !window.__GBDRAW_HISTORY__.capturing.value && !window.__GBDRAW_APP__.processing && !window.__GBDRAW_APP__.featureStyleScopeDialog.show);
+const agree = async (page, info, name) => {
+  await settle(page);
+  const observation = await capture(page, info, name);
+  await assertCoherent(observation, name, true);
+  return observation;
+};
+const reveal = async locator => {
+  for (const details of await locator.locator('xpath=ancestor::details').all()) {
+    if (await details.getAttribute('open') === null) await details.locator(':scope > summary').click();
+  }
+  return locator;
+};
+const check = async (page, name, enabled) => {
+  await (await reveal(page.getByLabel(name, { exact: true }))).setChecked(enabled);
+  await settle(page);
+};
+const color = async page => {
+  const target = await popup(page);
+  await page.getByLabel('Feature fill color', { exact: true }).first().evaluate(element => {
+    element.value = '#c83366'; element.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await page.getByText('This feature only', { exact: true }).click();
+  await settle(page);
+  return target;
+};
+const label = async (page, text) => {
+  const input = page.locator('.feature-popup input[placeholder="Edit label text"]');
+  await input.fill(text);
+  await page.getByRole('button', { name: 'Apply Label', exact: true }).click();
+  if (await page.getByRole('heading', { name: 'Enable Labels', exact: true }).isVisible()) {
+    await page.getByRole('button', { name: /Show all labels/ }).click();
+  }
+  await settle(page);
+  expect(Object.values(await page.evaluate(async () => (await import('./js/state.js')).state.labelTextFeatureOverrides))).toContain(text);
+};
+
+module.exports = { semantics, capture, assertCoherent, assertNonTargetsPreserved, load, settle, agree, reveal, check, color, label };

--- a/tests/web/svg-style-completion.test.mjs
+++ b/tests/web/svg-style-completion.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { fixture } from './helpers/svg-style-fixture.mjs';
+
+const unmatched = { feat: 'CDS', qual: 'gene', val: 'absent', color: '#abcdef' };
+test('completed style action publishes selected Result without another user action', () => {
+  const { actions, state } = fixture({ default: '#d3d3d3', unlisted_type: '#abcdef' }, [unmatched]);
+  actions.applySpecificRulesToSvg();
+  assert.equal(JSON.parse(state.results.value[0].content).fill, '#abcdef');
+});
+test('depth OFF and ON publish parent visibility at the style owner', () => {
+  const { actions, state } = fixture({ default: '#d3d3d3' }, []);
+  for (const enabled of [false, true]) {
+    state.form.show_depth = enabled;
+    actions.applyTrackVisibility();
+    assert.equal(JSON.parse(state.results.value[0].content).depth.display, enabled ? undefined : 'none');
+  }
+});

--- a/tests/web/svg-visual-semantics.test.mjs
+++ b/tests/web/svg-visual-semantics.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { visualSemanticsFromRoot, compareVisualSemantics, nonTargetFeatures } from './helpers/svg-visual-semantics.mjs';
+
+// Minimal DOM-shaped fixture exercises the same projection as browser SVGs.
+const element = (localName, attrs = {}, children = [], textContent = '') => {
+  const node = { localName, textContent, getAttribute: key => attrs[key] ?? null,
+    querySelectorAll: () => children.flatMap(child => [child, ...child.querySelectorAll()])
+      .filter(child => child.localName !== 'g') };
+  children.forEach(child => { child.parentElement = node; });
+  return node;
+};
+const fixture = ({ fill = '#d3d3d3', depth = null, legend = 'translate(10,20)', scale = 'translate(0,100)', parts = 3, unrelated = '#d3d3d3', width = '1000', ancestorStyle = null } = {}) =>
+  visualSemanticsFromRoot(element('svg', { width, height: '800', viewBox: '0 0 1000 800' }, [
+    element('g', { transform: 'translate(1,2)', style: ancestorStyle }, [
+      ...Array.from({ length: parts }, () => element('path', { 'data-gbdraw-feature-id': 'target', 'data-gbdraw-feature-part': 'block', d: 'M0 0L1 1', fill })),
+      element('path', { 'data-gbdraw-feature-id': 'other', fill: unrelated })]),
+    element('g', { display: depth }, [element('path', { d: 'M0 0L10 10', fill: 'blue' })]),
+    element('g', { transform: legend }, [element('text', {}, [], 'CDS')]),
+    element('g', { transform: scale }, [element('line', { x1: '0', x2: '100' }), element('text', {}, [], '5 kbp')])
+  ]));
+const base = fixture();
+assert.deepEqual(compareVisualSemantics(base, fixture()), []);
+for (const change of [{ fill: '#ff0000' }, { depth: 'none' }, { legend: 'translate(11,20.5)' },
+  { scale: 'translate(0,144.5)' }, { parts: 2 }, { parts: 4 }, { width: '1001' },
+  { ancestorStyle: 'visibility: hidden; fill: red' }]) {
+  assert.ok(compareVisualSemantics(base, fixture(change)).length, JSON.stringify(change));
+}
+const wrong = fixture({ unrelated: '#cccccc' });
+assert.deepEqual(compareVisualSemantics(wrong, wrong), []);
+assert.ok(compareVisualSemantics(nonTargetFeatures(base, ['target']), nonTargetFeatures(wrong, ['target'])).length);
+assert.deepEqual(compareVisualSemantics(base, fixture({ legend: 'translate(10.0,2e1)' })), []);
+const enriched = structuredClone(base);
+enriched.at(-1).label = 'known';
+assert.ok(compareVisualSemantics(base, enriched).length);
+assert.deepEqual(compareVisualSemantics(base, enriched, { catalogIds: ['known'] }), []);
+assert.ok(compareVisualSemantics(enriched, base, { catalogIds: ['known'] }).length);
+console.log('visual comparator controls passed');

--- a/tests/web/visual-state-regressions.playwright.spec.js
+++ b/tests/web/visual-state-regressions.playwright.spec.js
@@ -1,0 +1,67 @@
+const { test, expect } = require('@playwright/test');
+const { seeds, generate, popup, closeEditor, switchMode } = require('./helpers/mode-transition.cjs');
+const { openApp } = require('./helpers/app-lifecycle.cjs');
+const { load, agree, reveal, check, color, label } = require('./helpers/visual-state.cjs');
+
+for (const mode of ['circular', 'linear']) {
+  test(`B-01 ${mode} color Redo publishes the completed SVG`, async ({ browser }, info) => {
+    test.setTimeout(300000);
+    const page = await load(browser, seeds[mode]);
+    try {
+      await generate(page);
+      const target = await color(page);
+      await agree(page, info, 'direct-color');
+      await closeEditor(page);
+      for (const action of ['Undo', 'Redo']) {
+        await page.getByRole('button', { name: action, exact: true }).click();
+        const observation = await agree(page, info, action);
+        if (action === 'Redo') {
+          const parts = observation.completed.mounted.filter(node => node.feature === target.featureId && node.part === 'block');
+          expect(parts.length).toBeGreaterThan(0);
+          expect(parts.every(node => node.attrs.fill === '#c83366')).toBe(true);
+        }
+      }
+    } finally { await page.context().close(); }
+  });
+}
+
+for (const mode of ['circular', 'linear']) {
+  test(`B-04 ${mode} depth OFF and ON publish parent visibility`, async ({ browser }, info) => {
+    test.setTimeout(300000);
+    const page = await load(browser, seeds[mode]);
+    try {
+      const length = mode === 'circular' ? 16569 : 48502;
+      const depth = Buffer.from(Array.from({ length: Math.ceil(length / 100) }, (_, i) => `${mode === 'circular' ? 'NC_012920.1' : 'NC_001416.1'}\t${i * 100 + 1}\t${20 + i % 10}\n`).join(''));
+      await (await reveal(page.getByLabel('Depth TSV', { exact: true }))).setInputFiles({ name: 'depth.tsv', mimeType: 'text/plain', buffer: depth });
+      await check(page, 'Show Depth', true); await generate(page);
+      for (const enabled of [false, true]) {
+        await check(page, 'Show Depth', enabled);
+        await agree(page, info, `depth-${enabled}`);
+        const displays = await page.locator('.origin-top svg g[id="depth"]').evaluateAll(groups => groups.map(group => group.getAttribute('display')));
+        expect(displays.length).toBeGreaterThan(0);
+        expect(displays.every(display => enabled ? display !== 'none' : display === 'none')).toBe(true);
+      }
+    } finally { await page.context().close(); }
+  });
+}
+
+test('B-06 J36 rejected FASTA recovery and label regeneration preserve scale geometry', async ({ page }, info) => {
+  test.setTimeout(300000);
+  page.on('dialog', dialog => dialog.dismiss());
+  await openApp(page);
+  await switchMode(page, 'linear');
+  await page.getByRole('radio', { name: 'GFF3 + FASTA', exact: true }).check();
+  await page.getByLabel('GFF3', { exact: true }).setInputFiles('gbdraw/web/tutorial-data/lambda-gff3/NC_001416.gff3');
+  const fasta = page.getByLabel('FASTA', { exact: true });
+  const valid = 'gbdraw/web/tutorial-data/lambda-gff3/NC_001416.fna';
+  await fasta.setInputFiles(valid); await generate(page);
+  await fasta.setInputFiles({ name: 'mismatch.fasta', mimeType: 'text/plain', buffer: Buffer.from('>wrong_record_identity\n' + 'ATGC'.repeat(100) + '\n') });
+  expect(await page.evaluate(() => window.__GBDRAW_APP__.runAnalysis())).toEqual({ status: 'error' });
+  await agree(page, info, 'rejected-input');
+  await fasta.setInputFiles(valid);
+  await popup(page); await label(page, 'JOURNEY_J36');
+  await agree(page, info, 'restored-label');
+  await closeEditor(page); await generate(page);
+  expect(await page.locator('.origin-top svg').textContent()).toContain('JOURNEY_J36');
+  await agree(page, info, 'regenerated-scale');
+});


### PR DESCRIPTION
## Plain-language summary

Feature-color Redo and depth visibility changes can leave the selected SVG stale, and replay or regeneration can attach the previous diagram's layout to a new Result. Publish completed style changes immediately, mount each new Result by its existing artifact identity, reject superseded definition responses, and preserve the renderer's replacement scale geometry.

## Changes and evidence

- Covers SESSION 05A14 B-01/A-01, B-04, B-05 and B-06 in the existing style, Result and composition owners.
- Promotes the retained visual comparator into normal tests, including ancestor geometry/visibility, legend, depth, scale, multipart identity and independent non-target preservation controls. Connects the same helper to the retained journey runner.
- Keeps completed-action observations separate from the actual SVG download boundary. Delayed replay tests wait for definition completion; owner tests control the timer and Worker response.
- Red tests were recorded on `550540ef7f1bc9132c22162aa314617dd48096ca`. The affected original J09/J10/J27/J28/J36 programs and single/composite C01 pass on the assembled candidate.

See `docs/internal/session05a14/RESULT_COMPLETION.md` for the owner analysis, immutable input references and reproduction command. Architecture tests and the Web policy Gate pass; the policy still requires maintainer Review for the derived identity declaration. CI routing, schemas and the ten-case PR smoke budget are unchanged.

This is the first review package. Palette fallback and mobile popup access are separate dependent changes. Maintainer approval and verification on the resulting dev remain pending. Publication authorization is not approval to merge.
