### PR TITLE
Preserve palette defaults during placement History

### DIFF
--- a/docs/internal/session05a14/PALETTE_HISTORY.md
+++ b/docs/internal/session05a14/PALETTE_HISTORY.md
@@ -1,0 +1,27 @@
+# Preserve unrelated feature colors during placement History
+
+B-02/A-02 is an output-correctness defect separate from Result synchronization.
+On base `550540ef7f1bc9132c22162aa314617dd48096ca`, the permanent placement
+History test observed unrelated `rep_origin` fills change from the active
+palette default `#d3d3d3` to `#cccccc`. All three SVG representations could
+agree on that wrong color; coherence alone could not reject it.
+
+`svg-styles.js` now resolves an unmatched type through the existing applied
+palette's `default` entry in palette application and specific-rule replay.
+The existing palette normalization/loader remains the color authority. Explicit
+type colors, specific rules and hash-rule precedence remain intact; there is
+no species, feature-ID or color-value special case and no additional owner.
+
+`palette-history-preservation.test.mjs` covers the palette default, another
+custom default, explicit type color, matching specific rule and hash precedence.
+`palette-history-preservation.playwright.spec.js` compares every non-target
+feature after each placement Undo/Redo, including identity, paint, visibility
+and geometry. It reuses the first review package's visual comparator. Its red
+proof predates production edits and its unchanged preservation assertion passes
+with this correction.
+
+The full original J13 program also passes placement, label edit, mode changes,
+each History step and regeneration. The retained adapter additionally applies
+the same non-target assertion at every individual J13 Undo and Redo, independent
+of selected/mounted/download agreement. Immutable source/seed references and
+common reproduction instructions are in [RESULT_COMPLETION.md](RESULT_COMPLETION.md).

--- a/gbdraw/web/js/app/svg-styles.js
+++ b/gbdraw/web/js/app/svg-styles.js
@@ -114,7 +114,7 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions }) => {
       const feat = featureLookup.get(svgId);
       if (!feat) return;
 
-      const paletteColor = colors[feat.type];
+      const paletteColor = colors[feat.type] || colors.default;
       if (!paletteColor) return;
 
       const hasSpecificRule = manualSpecificRules.some((rule) => ruleMatchesFeature(feat, rule));
@@ -399,7 +399,9 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions }) => {
 
       const elements = getFeatureFillElements(svg, feat.svg_id, featureElementIndex);
       if (elements.length > 0) {
-        const newColor = matchingRule ? matchingRule.color : appliedPaletteColors.value[feat.type] || '#cccccc';
+        const newColor = matchingRule
+          ? matchingRule.color
+          : appliedPaletteColors.value[feat.type] || appliedPaletteColors.value.default;
         elements.forEach((el) => {
           if (el.getAttribute('fill') !== newColor) {
             el.setAttribute('fill', newColor);

--- a/tests/web/palette-history-preservation.playwright.spec.js
+++ b/tests/web/palette-history-preservation.playwright.spec.js
@@ -1,0 +1,26 @@
+const { test } = require('@playwright/test');
+const { generate, closeEditor } = require('./helpers/mode-transition.cjs');
+const { load, agree, assertNonTargetsPreserved } = require('./helpers/visual-state.cjs');
+
+test('B-02 placement History preserves every unrelated feature', async ({ browser }, info) => {
+  test.setTimeout(300000);
+  const page = await load(browser, 'gbdraw/web/gallery/sessions/tobacco-chloroplast.gbdraw-session.json');
+  try {
+    await generate(page);
+    const before = await agree(page, info, 'before-placement');
+    await page.evaluate(() => {
+      const app = window.__GBDRAW_APP__;
+      app.openFeatureEditorFromList(app.extractedFeatures.find(feature => feature.qualifiers.gene?.[0] === 'rps12'
+        && feature.qualifiers.locus_tag?.[0] === 'NitaCp049'));
+    });
+    const target = await page.evaluate(() => window.__GBDRAW_APP__.clickedFeature.svg_id);
+    await page.getByLabel('Feature placement', { exact: true }).selectOption('outward');
+    await closeEditor(page);
+    for (const action of ['Undo', 'Redo']) {
+      await page.getByRole('button', { name: action, exact: true }).click();
+      const observation = await agree(page, info, action);
+      await assertNonTargetsPreserved(before.completed.mounted, observation.completed.mounted, [target],
+        `${action}: placement must not recolor or hide unrelated features`, true);
+    }
+  } finally { await page.context().close(); }
+});

--- a/tests/web/palette-history-preservation.test.mjs
+++ b/tests/web/palette-history-preservation.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { fixture } from './helpers/svg-style-fixture.mjs';
+
+const unmatched = { feat: 'CDS', qual: 'gene', val: 'absent', color: '#abcdef' };
+for (const [name, colors, rules, expected] of [
+  ['palette default', { default: '#d3d3d3' }, [unmatched], '#d3d3d3'],
+  ['custom default', { default: '#123456' }, [unmatched], '#123456'],
+  ['explicit type', { default: '#123456', unlisted_type: '#654321' }, [unmatched], '#654321'],
+  ['specific rule', { default: '#123456', unlisted_type: '#654321' }, [{ feat: 'unlisted_type', qual: 'gene', val: 'sample', color: '#aabbcc' }], '#aabbcc'],
+  ['hash rule precedence', { default: '#123456' }, [{ feat: 'unlisted_type', qual: 'gene', val: 'sample', color: '#aabbcc' }, { feat: 'unlisted_type', qual: 'hash', val: 'f1', color: '#778899' }], '#778899']
+]) {
+  test(`specific-rule replay uses ${name}`, () => {
+    const { actions, attrs } = fixture(colors, rules);
+    actions.applySpecificRulesToSvg();
+    assert.equal(attrs.fill, expected);
+  });
+}


### PR DESCRIPTION
## Plain-language summary

Placement Undo and Redo can recolor unrelated features to a hardcoded gray. Use the applied palette's default for unmatched feature types so placement History preserves their colors, while explicit type colors and specific-rule precedence continue to apply.

## Changes and evidence

- Covers B-02/A-02 separately from SVG synchronization.
- Tests the palette default, a custom default, an explicit type color, a specific rule and hash-rule precedence.
- Reuses the preceding PR's visual comparator to check non-target features independently of selected/mounted/export agreement. The original J13 program and all four independent History preservation checks pass.

See `docs/internal/session05a14/PALETTE_HISTORY.md`. The permanent regression failed on `550540ef7f1bc9132c22162aa314617dd48096ca` and passes with the correction. PR #515 is integrated into dev at `dfe2dff2f707e30524931221ca2f3a3b55b8b192`. This PR now targets that actual dev and contains only its four-file palette delta. The old parent/head were `6300e5c1ce6d80949862f1f6f1b797a30d3962d3` / `de92b346e6d9f67c5dde07696e6a5216a89a3256`; the transplanted head is `119befe8fec9bd8295b1395bd2a9a0fba7861eac`. The before/after own patches are byte-identical (`git range-diff` reports `=`), both base trees match, and both complete head trees match. Only parent/committer metadata changed; no production, test, documentation, CI, assertion or timeout bytes changed. Already-integrated Result changes were not replayed.

The maintainer approved the prepared implementation and explicitly authorized sequential integration into dev. The transplant preserves that implementation byte-for-byte. Required dev admission checks are refreshed for this exact head; merge remains conditional on those checks and the applicable review policy.
