### PR TITLE
Keep mobile feature controls reachable

### DIFF
--- a/docs/internal/session05a14/PROOF.json
+++ b/docs/internal/session05a14/PROOF.json
@@ -1,0 +1,329 @@
+{
+  "failingBase": "550540ef7f1bc9132c22162aa314617dd48096ca",
+  "failingTree": "62643107805b61586ea55affa179356ee664ce5a",
+  "integration": "pending maintainer review and publication authorization",
+  "evidenceRoot": "/tmp/gbdraw-session05a14-evidence",
+  "logs": {
+    "red-confirmed.log": {
+      "sha256": "fd1bf6ff56e77e1a168029170d8319cf632b72dce13b8c5089a5cf31e39bbe20",
+      "bytes": 1704117
+    },
+    "review-final.log": {
+      "sha256": "e764d90cf21ba0b927eac5242e5fe0f074561fd678833a24c54ca70917411e77",
+      "bytes": 1525
+    },
+    "final-browser.log": {
+      "sha256": "5ddec5365cd88367ac6f004cead5459743b845dcdc5da67a5e97b996f0686ce8",
+      "bytes": 5196
+    },
+    "final-node-corrected.log": {
+      "sha256": "b4de32169a6d599b1bde10b715f669525dde04bb36ed99208d15b6f86cae9920",
+      "bytes": 122839
+    },
+    "review-final-node.log": {
+      "sha256": "54152b0953ffdfa90895014a85e6dcbc2c813f5521952697d377725ecaa9cfb5",
+      "bytes": 2216
+    },
+    "architecture-final.log": {
+      "sha256": "8bcc3adf16b420dd1d25b4c76c71d21b78858b516510e5574400cc4bd3d45c7e",
+      "bytes": 27565
+    },
+    "web-policy-final.log": {
+      "sha256": "d1f24642a7d6a821fe4b65d15786719d0fe8d065177d83495027c07d7924e9b8",
+      "bytes": 6580
+    },
+    "pr-smoke.log": {
+      "sha256": "0fd6bdc2966afe3af020bcd9d813450e6dc82e15309bfbaecd31e361bad05f68",
+      "bytes": 1762
+    },
+    "gallery.log": {
+      "sha256": "cc61f149df707f8b87abb47240127416a93187854288b7c9ab68caa243dbd2c8",
+      "bytes": 1549
+    },
+    "python-browser-escalated.log": {
+      "sha256": "755988c361cb2fffd10ba7cae7f34554f322c64c460c8d2b415bd984f6bb2ac1",
+      "bytes": 20757
+    },
+    "python-cli-replay-current.log": {
+      "sha256": "b0e51d6e2719c704bddc50955e5249e75114ffdc70b584cbd4af844660b25669",
+      "bytes": 506
+    },
+    "packaged-browser.log": {
+      "sha256": "838d968053f845101dd8abe5dc8c99af54e0c28cc573a906ee36318e5d738ec0",
+      "bytes": 623
+    },
+    "final-original-journeys.log": {
+      "sha256": "59a05b7ed40b8681dd658ecb6235d8fd1df325c7a5f60db50e8b91c13210dc87",
+      "bytes": 24312
+    },
+    "review-original-journeys.log": {
+      "sha256": "20ee76c98f2df5c89f25b65b15d15271ec3c04a5d14f81769a74e5b4f79ea221",
+      "bytes": 6373
+    },
+    "web-policy-review-final.log": {
+      "sha256": "532755d54e7ae8c3242b9b76ebf8a18b1af3a93219d5e3a5a7a9dff1e440a271",
+      "bytes": 6580
+    },
+    "first-pr-node.log": {
+      "sha256": "298dcddc41e8f334e6faa73db24541d6e2d5bdb68ca953bc3f8f05dc578708f3",
+      "bytes": 1311
+    },
+    "pr-language-01.log": {
+      "sha256": "ca3e53671982f60a47fec7e11e92d63a5e4b061163a3a509ba7199b29cee10c1",
+      "bytes": 26
+    },
+    "pr-language-02.log": {
+      "sha256": "ca3e53671982f60a47fec7e11e92d63a5e4b061163a3a509ba7199b29cee10c1",
+      "bytes": 26
+    },
+    "pr-language-03.log": {
+      "sha256": "ca3e53671982f60a47fec7e11e92d63a5e4b061163a3a509ba7199b29cee10c1",
+      "bytes": 26
+    },
+    "first-pr.log": {
+      "sha256": "7e6344fb0889e722177161fb153b40cff3d72acd501b9f26edb28b5a79cfeb23",
+      "bytes": 1079
+    },
+    "second-pr.log": {
+      "sha256": "a5458375781b2c4b91392485936cfb294b1218cf284f448add2d5b0b6274f5a1",
+      "bytes": 195
+    },
+    "second-pr-node.log": {
+      "sha256": "db962377907876b2caea1aa15360a78f1559f9219ba751516bfbb49eb1432453",
+      "bytes": 1033
+    }
+  },
+  "journeys": {
+    "J09": {
+      "id": "J09",
+      "status": "PASS",
+      "error": null,
+      "steps": 102,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 106,
+      "authority_observations": 69,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "3c886ceba42809f66fe62b1ecfbbfe38a0c918da959592cf8dd2ce4569b83488",
+      "eventsSha256": "ec0399f34dc130cfc3354196ccc8414c6d52c5fa7b41b609deddf4265edf9b13",
+      "folder": "/tmp/gbdraw-session05a14-evidence/final-original-journeys/J09"
+    },
+    "J10": {
+      "id": "J10",
+      "status": "PASS",
+      "error": null,
+      "steps": 101,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 105,
+      "authority_observations": 68,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "2e797efd83ba63a24ecd4b714927862fbbfb32c400515d0578ac4b75a0be485b",
+      "eventsSha256": "78ae7dfd9af1786494e9f4748ba70e47e4fa705e7536becdf62c1aac15fca8e6",
+      "folder": "/tmp/gbdraw-session05a14-evidence/final-original-journeys/J10"
+    },
+    "J13": {
+      "id": "J13",
+      "status": "PASS",
+      "error": null,
+      "steps": 62,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 65,
+      "authority_observations": 44,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 4,
+      "programSha256": "b0e7abd3129f6c845cc3c946479513105a1d8163322d316b4c7d3dbf609d22f5",
+      "eventsSha256": "7101bc97252245e660e58120bc8ea3d1607e5bab8aa25da5832bc243b49819da",
+      "folder": "/tmp/gbdraw-session05a14-evidence/review-original-journeys/J13"
+    },
+    "J27": {
+      "id": "J27",
+      "status": "PASS",
+      "error": null,
+      "steps": 55,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 54,
+      "authority_observations": 35,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "ca3ba50e45b109d6b72f139991ad49327d757f008c26e611ac5a314507bb24b7",
+      "eventsSha256": "be190c0c6f64280afe677bbcf0e9199be6583867f68b356677012a319da5c7b5",
+      "folder": "/tmp/gbdraw-session05a14-evidence/final-original-journeys/J27"
+    },
+    "J28": {
+      "id": "J28",
+      "status": "PASS",
+      "error": null,
+      "steps": 50,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 51,
+      "authority_observations": 32,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "88c77c8e0abcc6367fb2c38cff6b0b0e190d946b92cff1abbb4de88735bb1e38",
+      "eventsSha256": "228a16e137c91e87d18246404e2513680f2c6fa62bdbf5fcf78cff20ec73758b",
+      "folder": "/tmp/gbdraw-session05a14-evidence/final-original-journeys/J28"
+    },
+    "J36": {
+      "id": "J36",
+      "status": "PASS",
+      "error": null,
+      "steps": 46,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 47,
+      "authority_observations": 27,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "6d7250cdaabd8eb4ac8fd6c9c8a07b5a06f7853b5fe8cbd267ba2f90f25b71b6",
+      "eventsSha256": "da17e28d543d244a02526bacf3717ab0b156b14e6eec6e81b56817c408eac548",
+      "folder": "/tmp/gbdraw-session05a14-evidence/final-original-journeys/J36"
+    },
+    "J43": {
+      "id": "J43",
+      "status": "PASS",
+      "error": null,
+      "steps": 42,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 42,
+      "authority_observations": 29,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "f874f9eea568aa030035e6c85f77c5aaa82183d4984a643fc663bdf5bc3707eb",
+      "eventsSha256": "2e2ddc3c7887d80cb95a557fcc136e0c34718425d8e0b081639d409dc0f9935a",
+      "folder": "/tmp/gbdraw-session05a14-evidence/review-original-journeys/J43"
+    },
+    "J44": {
+      "id": "J44",
+      "status": "PASS",
+      "error": null,
+      "steps": 42,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 43,
+      "authority_observations": 28,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "186792443a535f1b0702db742e43e8b29eb4588e1021bc8e9f8b330dab45b3c8",
+      "eventsSha256": "9a7503107fe451d24d3aec4244d0843233544a84a0d0505c6b2bcd31bfacce0a",
+      "folder": "/tmp/gbdraw-session05a14-evidence/review-original-journeys/J44"
+    },
+    "C01": {
+      "id": "C01",
+      "status": "PASS",
+      "error": null,
+      "steps": 71,
+      "console_errors": 0,
+      "page_errors": 0,
+      "external_requests": 0,
+      "observations": 0,
+      "blocked": 0,
+      "events": 75,
+      "authority_observations": 46,
+      "retired_checkpoints": [],
+      "nonTargetHistoryChecks": 0,
+      "programSha256": "32bd74b9dc33a2ece3007886ee48e5a8cf7db12dc0b30344666b2e0bfbb3ac17",
+      "eventsSha256": "50681dc544263ced65e50f22a941ad436686d72e3f6c2fcc9cdc5f32ed25b36b",
+      "folder": "/tmp/gbdraw-session05a14-evidence/final-original-journeys/C01"
+    }
+  },
+  "runnerInputs": {
+    "archive": "/mnt/c/Users/genom/GitHub/gbdraw/docs/internal/gbdraw_v014_session05a13_b_evidence_2026-09-12",
+    "sourceHashes": {
+      "audit.py": "d24c4627013cde32a57aa157c015788e1b4caabe5a7ac8265041f883bcea85f1",
+      "harness.py": "96f49c44fe172d7eeec374bc2e11d19b174daee9199961844ec2aac2ca2efb51",
+      "journeys.py": "0ec1adbac279ff7579985e416a269861e7006c6c2aef0c357bb635d84954eb07",
+      "audit-state.js": "e4525f9f4f56fdec788b8c3bb1141e1fa36da45488f22d00b8bc645b231b4cc8",
+      "disposition-adapters.py": "30a225fba3ce9bc23eee10dcaf4c1c39ecb8150021bbd4cc3ba93679b78c98a2",
+      "supplemental-controls.py": "f40b4355817ea4248bc630587d1d4537b3cc86b49d18e40133653eee6a83c827"
+    },
+    "comparatorSha256": "6479423d687796f0f616ae34084c08c1d4087d66bce583dbfe156ff27cb5ad2f",
+    "journeys": [
+      "J13",
+      "J43",
+      "J44"
+    ]
+  },
+  "packagedArtifact": {
+    "wheel": "/tmp/gbdraw-session05a14/dist/gbdraw-0.14.0-py3-none-any.whl",
+    "wheelSha256": "c5c6a41af4dfbe7503a68add438fcb229d197103f0fbb2fa249562f510d2bfcc",
+    "productionFileHashes": {
+      "gbdraw/web/index.html": "fd6484bdd9377c9136f406f30a59e7cdfbfa9809067578eee33dc0e8f362649a",
+      "gbdraw/web/js/app/app-setup.js": "ed42d6a8955d589c658d58f20757117d2e9fca603ff1daebf9c87d40c949ecb0",
+      "gbdraw/web/js/app/svg-styles.js": "d5053d400b861152b1898070ae6bf25ffd7bce33d2901023a8fc8458d932ec25",
+      "gbdraw/web/js/app/results.js": "634efe560ac87b539d9ecf12265fd8e27d4ed51d02ff3ca5b86a55e476f8733c",
+      "gbdraw/web/js/state.js": "ca473a70c00a79c4e32893bada2baab4b259725f3d597a5f65f50cf5472d13df",
+      "gbdraw/web/js/app/legend-layout/diagram-drag.js": "6050f70386863547decea5ea3d830b8678478d427434b9da614df8ad761abdef"
+    },
+    "analyticsScript": false
+  },
+  "productionFiles": {
+    "gbdraw/web/index.html": "fd6484bdd9377c9136f406f30a59e7cdfbfa9809067578eee33dc0e8f362649a",
+    "gbdraw/web/js/state.js": "ca473a70c00a79c4e32893bada2baab4b259725f3d597a5f65f50cf5472d13df",
+    "gbdraw/web/js/app/app-setup.js": "ed42d6a8955d589c658d58f20757117d2e9fca603ff1daebf9c87d40c949ecb0",
+    "gbdraw/web/js/app/results.js": "634efe560ac87b539d9ecf12265fd8e27d4ed51d02ff3ca5b86a55e476f8733c",
+    "gbdraw/web/js/app/svg-styles.js": "d5053d400b861152b1898070ae6bf25ffd7bce33d2901023a8fc8458d932ec25",
+    "gbdraw/web/js/app/legend-layout/diagram-drag.js": "6050f70386863547decea5ea3d830b8678478d427434b9da614df8ad761abdef"
+  },
+  "newTestFiles": {
+    "tests/web/visual-state-regressions.playwright.spec.js": "ce019af86fd74cf4d8a5a2b47c9322ca25d564d17fc028321d55078a8ed4f29c",
+    "tests/web/palette-history-preservation.playwright.spec.js": "c4a7e949ef54161d68d6b2366cdf3d77e829f84439293e1816852cca2d0e8268",
+    "tests/web/mobile-feature-popup.playwright.spec.js": "9621f9d57c9c33928849b11bb399e280e5911227dec583427073a00769a56ddf",
+    "tests/web/definition-replay-visual-state.playwright.spec.js": "55c61bd49619725553596a02e4df764fdefd29b850758be9af85400d09602ea7",
+    "tests/web/definition-layout-completion.test.mjs": "c68d73e0a8d04ab06e4168c523c63ecaa6c366abaefde627def7ce17ab4a9535",
+    "tests/web/svg-style-completion.test.mjs": "0bd41bc72bbef33884b8ca89eff087b8271a6d7b669077137aaa495a623dbdd5",
+    "tests/web/palette-history-preservation.test.mjs": "9b06a4ca74739bc4f780acc735bbdf6102c506dcbb09351f068911157a9ee4b3",
+    "tests/web/svg-visual-semantics.test.mjs": "8deb8bcad958e602357ee511092c05d469a46f9eb4d61e75a49b62683c11f2e3",
+    "tests/web/helpers/svg-visual-semantics.mjs": "6479423d687796f0f616ae34084c08c1d4087d66bce583dbfe156ff27cb5ad2f",
+    "tests/web/helpers/visual-state.cjs": "f1cc9b3e3846e5668d2e17aa8ac32e79bd5614fc72bf5867e59355bb2b3bf7ef",
+    "tests/web/helpers/svg-style-fixture.mjs": "621d444d540a287d467f62879e5eb43cd0459771e7bd6ec4acc9ff799020fbfa",
+    "tests/web/helpers/retained-visual-journeys.py": "c4d2f85c3d42366011612f72dbda4df241a4d0972dae5bc1c50d2b0d80395164"
+  },
+  "independentReviewCommits": {
+    "resultCompletion": "50a574fd",
+    "paletteHistory": "ae39e83c",
+    "resultBrowserCases": 7,
+    "resultOwnerComparatorChecks": 5,
+    "paletteBrowserCases": 1,
+    "paletteOwnerChecks": 5
+  },
+  "archiveImportHygiene": {
+    "disposableCachesRemoved": [
+      "harness.cpython-313.pyc",
+      "journeys.cpython-313.pyc"
+    ],
+    "bytecodeWritesDisabled": true,
+    "importCheck": "PASS: importing both retained modules created no archive __pycache__",
+    "productionAndBrowserOwnerTestFilesUnchangedFromTestedCommits": true
+  }
+}

--- a/docs/internal/session05a14/REPORT.md
+++ b/docs/internal/session05a14/REPORT.md
@@ -1,0 +1,109 @@
+# SESSION 05A14 scoped remediation
+
+All six defect families are **CLOSED in the local candidate**, with permanent
+red/green tests and complete affected original programs. They are not yet
+integrated into dev. This is not a clean full-acceptance declaration.
+
+The unchanged failing witness, owner analysis, shared comparator and reproduction
+command are in [RESULT_COMPLETION.md](RESULT_COMPLETION.md). Compact file hashes,
+original-program hashes, operation counts, gate logs and package provenance are
+in [PROOF.json](PROOF.json). Raw evidence remains at
+`/tmp/gbdraw-session05a14-evidence`; historical A/B sources, fixtures and recorded evidence were not copied or
+modified. The original seed manifest is verified by hash before each retained run.
+
+| Defect | Status | Before correction | Permanent passing assertion | Complete original acceptance |
+| --- | --- | --- | --- | --- |
+| B-01 / A-01 | CLOSED | feature-color Redo left selected fill stale | Circular/Linear `color Redo publishes the completed SVG`; direct edit and every History checkpoint compare separately | J09, J10 PASS, including each of four Undo and four Redo steps and remaining operations |
+| B-02 / A-02 | CLOSED | placement History changed unrelated default fills to `#cccccc` | `placement History preserves every unrelated feature`; defaults, custom default, type and specific/hash precedence controls | J13 PASS; four independent non-target History checks PASS |
+| B-03 / A-03 | CLOSED | mobile Generate bar intercepted Apply Label pointer at 390x844 | Circular/Linear `mobile search Edit Apply Label accepts pointer input`; nonempty durable override, regenerated/restored text and control bounds | J43, J44 PASS through original pointer paths and downstream persistence/mode steps |
+| B-04 | CLOSED | depth ancestor visibility changed without selected Result publication | Circular/Linear `depth OFF and ON publish parent visibility`, observed before subsequent edits | J27, J28 PASS through intervening edits and persistence |
+| B-05 | CLOSED | delayed Web replay differed at legend by 1 px / 0.5 px and root width by 1 px | current-CLI single/composite replay after observable definition completion, plus fast control and controlled owner scheduler | supplemental C01 PASS, both single and two-source composite complete replays |
+| B-06 | CLOSED | replacement scale/5 kbp parent translated by 44.5 px | J36 rejected FASTA recovery and label regeneration compares selected/mounted/downloaded scale | J36 PASS with original rejection/recovery prefix and intended label confirmed |
+
+The common observer checks all scientific SVG nodes and relevant ancestors,
+rather than only biological paths. It retains completed-action observations
+before the actual export boundary, so later Save/Generate/export cannot erase an
+earlier failure. An unrelated feature assertion rejects coherently wrong output.
+This closes the old feature-only/group-blind, late-checkpoint and coherence-only
+gaps independently. There is no claim that the six cases share a cause or were
+introduced together.
+
+## Mobile correction
+
+The existing fixed feature/pairwise popups and their scope dialogs are teleported
+to the document body so preview containment cannot trap their stacking context.
+Their existing positioning constraints now supply the available height below
+the actual popup top. The mobile Generate bar stays below the popup/dialog
+stack, normal popup-body scrolling remains available, and long header/placement
+content is constrained within the popup. No forced pointer input, injected CSS,
+DOM click or Enter substitute is used for Apply Label.
+
+Final source and packaged screenshots were inspected at 390x844. Apply Label,
+Close and placement controls are visible and reachable in both modes. Existing
+Editor-toggle and preview navigation checks pass. This uses the existing popup,
+scroll and stacking owners; it adds no new state owner or interaction framework.
+
+## Verification and review packages
+
+The ten permanent browser cases first failed on unchanged production at their
+intended target actions (`red-confirmed.log`), then passed unchanged semantic
+assertions. The specifications were subsequently separated by review scope;
+all ten pass again in `review-final.log`.
+
+- Fast Node suite: 565 passed. After separating test files, the comparator and
+  style/palette/layout owner checks passed again.
+- Targeted and neighboring browser suite: 32 passed, protecting independent
+  draft B / Result A / committed request A, multipart labels, source-bound
+  intent, manual/category legends, scale, navigation and first-attempt recovery.
+- Original programs: eight journeys plus C01 PASS, zero failed or blocked
+  checkpoints. J13/J43/J44 were repeated after the final observer/layout refinements.
+- Independent review commits: the first passes its seven browser cases and five
+  owner/comparator checks without the palette/mobile changes; the second passes
+  its palette browser case and five precedence controls without the mobile change.
+- Existing PR smoke: 10 passed; Gallery publication parity: all 9 passed.
+- Python browser gate: 23 passed initially; the remaining downloaded CLI replay
+  passed with the candidate installed in an isolated environment. The first
+  attempt had selected the older global CLI (session 40 versus current 41).
+- Distribution wheel built successfully. Its six changed production files match
+  source hashes. Four package browser cases passed from cold contexts with
+  external requests blocked, covering desktop depth OFF/ON and mobile pointer
+  editing, Generate, Save and fresh Load. The package has no analytics script.
+- Architecture suite: 137 passed. Web policy Gate PASS; Review REQUIRED for the
+  derived identity declaration. No maintainer review is represented as complete.
+
+Review packages, in order:
+
+1. Publish completed SVG edits and bind new Result geometry: B-01/B-04/B-05/B-06,
+   carrying the shared comparator and retained-runner adapter.
+2. Preserve palette defaults during placement History: B-02, using that comparator.
+3. Keep mobile feature controls reachable: B-03, using the same comparator and
+   carrying this combined scoped report.
+
+CI routing, schemas, test-owned timeouts, the ten-case PR smoke budget, generated
+Gallery artifacts and reference SVGs are unchanged. Production, tests,
+documentation and ignored generated packages were reviewed separately. Earlier
+setup failures and interrupted exploratory runs remain in the evidence directory;
+they are not the red proof or final gate results. Two disposable Python bytecode
+cache files created by the initial retained import were removed; the adapter
+now disables bytecode writes before importing archive programs.
+
+## J08 decision and remaining acceptance
+
+The merged source/session contracts did not specify source-free Save behavior.
+The user answered the precise Product question in this session:
+
+> Save Session before any source file is loaded should preserve a settings-only session
+
+That choice is recorded separately. It is not an existing base-branch decision
+or a completed implementation. Source-free persistence and the corresponding
+contract/fixture work remain a separate follow-up, as required by the task.
+J08 is not waived and its historical failed checkpoint remains in the ledger.
+No rationale, retirement intent or accepted residual risk has been inferred.
+
+Publishing the prepared work branches/PRs and maintainer review remain pending.
+After integration, targeted and neighboring regressions and required dev/Gallery
+gates must run on the exact resulting dev. These local results do not substitute
+for those gates. The full 48-journey run, retired dense Q01 workloads, S11 and S12
+were not started; no technical/publication baseline SHA is assigned. The next
+acceptance phase is one strengthened retained run after integration, with S11
+only if its acceptance conditions are satisfied.

--- a/gbdraw/web/index.html
+++ b/gbdraw/web/index.html
@@ -940,7 +940,7 @@
                 background: rgba(255, 255, 255, 0.96) !important;
                 border-top: 1px solid #e2e8f0 !important;
                 box-shadow: 0 -12px 28px rgba(15, 23, 42, 0.12) !important;
-                z-index: 60 !important;
+                z-index: 40 !important;
             }
 
             .generate-bar .btn {
@@ -4869,6 +4869,7 @@
                         </div>
                     </div>
 
+                    <Teleport to="body">
                     <!-- Feature Editor Popup -->
                     <div v-if="clickedFeature"
                          ref="featurePopupRef"
@@ -4881,8 +4882,8 @@
                          ]"
                          :style="featurePopupStyle">
                         <div class="flex items-start gap-2 mb-3 pb-3 border-b border-slate-100">
-                            <div class="w-4 h-4 rounded mt-1" :style="{ backgroundColor: clickedFeature.color }"></div>
-                            <div class="min-w-0">
+                            <div class="w-4 h-4 rounded mt-1 shrink-0" :style="{ backgroundColor: clickedFeature.color }"></div>
+                            <div class="min-w-0 flex-1">
                                 <div class="text-base font-bold text-slate-700 truncate max-w-[260px]">{{ clickedFeature.label }}</div>
                                 <div class="text-xs text-slate-500 mt-0.5">Location: {{ clickedFeatureLocation }}</div>
                                 <div v-if="clickedFeature.orthogroupId" class="text-xs text-slate-500 mt-0.5">
@@ -4900,12 +4901,12 @@
                                    :title="canEditFeatureColor(clickedFeature.feat) ? 'Change fill color' : 'No stable identifier available'"
                                    aria-label="Feature fill color"
                                    :class="['w-8 h-8 cursor-pointer border-2 border-slate-200 rounded-lg shrink-0', canEditFeatureColor(clickedFeature.feat) ? '' : 'opacity-50 cursor-not-allowed']">
-                            <button @click="clickedFeature = null" class="text-slate-400 hover:text-slate-600 ml-auto text-xl" aria-label="Close feature popup">
+                            <button @click="clickedFeature = null" class="text-slate-400 hover:text-slate-600 ml-auto text-xl shrink-0" aria-label="Close feature popup">
                                 <i class="ph ph-x"></i>
                             </button>
                         </div>
                         <label class="block text-xs mb-2">Feature placement
-                            <select data-history-managed aria-label="Feature placement" :value="featurePlacementActions.valueFor(clickedFeature.feat)" @change="featurePlacementActions.setPlacement([clickedFeature.feat], $event.target.value)" class="rounded border p-1">
+                            <select data-history-managed aria-label="Feature placement" :value="featurePlacementActions.valueFor(clickedFeature.feat)" @change="featurePlacementActions.setPlacement([clickedFeature.feat], $event.target.value)" class="rounded border p-1 max-w-full">
                                 <option v-for="choice in featurePlacementActions.choices([clickedFeature.feat])" :key="choice.value" :value="choice.value" :disabled="!choice.enabled">{{ choice.label }}{{ choice.reason ? ' — ' + choice.reason : '' }}</option>
                             </select>
                             <span class="block text-slate-500">Applied on the next successful Generate.</span>
@@ -6007,6 +6008,7 @@
                         </div>
                     </div>
 
+                    </Teleport>
                 </div>
 
                 <div v-show="resultPanelTab === 'run-info'" class="run-info-panel flex-grow overflow-auto bg-white p-4 custom-scrollbar">

--- a/gbdraw/web/js/app/app-setup.js
+++ b/gbdraw/web/js/app/app-setup.js
@@ -2609,7 +2609,8 @@ export const createAppSetup = () => {
   const featurePopupStyle = computed(() => {
     const style = {
       top: `${clickedFeaturePos.y}px`,
-      left: `${clickedFeaturePos.x}px`
+      left: `${clickedFeaturePos.x}px`,
+      maxHeight: `${getFeaturePopupConstraints().maxHeight}px`
     };
     if (featurePopupSize.width > 0) {
       style.width = `${featurePopupSize.width}px`;
@@ -2638,7 +2639,8 @@ export const createAppSetup = () => {
   const pairwiseMatchPopupStyle = computed(() => {
     const style = {
       top: `${clickedPairwiseMatchPos.y}px`,
-      left: `${clickedPairwiseMatchPos.x}px`
+      left: `${clickedPairwiseMatchPos.x}px`,
+      maxHeight: `${getPairwiseMatchPopupConstraints().maxHeight}px`
     };
     if (pairwiseMatchPopupSize.width > 0) {
       style.width = `${pairwiseMatchPopupSize.width}px`;

--- a/tests/web/mobile-feature-popup.playwright.spec.js
+++ b/tests/web/mobile-feature-popup.playwright.spec.js
@@ -1,0 +1,41 @@
+const { test, expect } = require('@playwright/test');
+const { seeds, generate, popup, closeEditor, download } = require('./helpers/mode-transition.cjs');
+const { load, agree, label } = require('./helpers/visual-state.cjs');
+
+for (const mode of ['circular', 'linear']) {
+  test(`B-03 ${mode} mobile search Edit Apply Label accepts pointer input`, async ({ browser }, info) => {
+    test.setTimeout(300000);
+    const page = await load(browser, mode === 'circular'
+      ? 'gbdraw/web/gallery/sessions/HmmtDNA_ATskew.gbdraw-session.json' : seeds.linear, { width: 390, height: 844 });
+    try {
+      if (mode === 'circular') {
+        await popup(page); await closeEditor(page);
+        const search = page.getByRole('searchbox', { name: 'Search features', exact: true });
+        await search.fill('tRNA'); await search.press('Enter');
+        await page.getByRole('button', { name: 'Open active feature', exact: true }).click();
+        await closeEditor(page);
+      }
+      await popup(page);
+      await page.screenshot({ path: info.outputPath('popup-before.png') });
+      await label(page, `MOBILE_${mode}`);
+      for (const selector of ['[aria-label="Close feature popup"]', '[aria-label="Feature placement"]']) {
+        const box = await page.locator('.feature-popup').locator(selector).boundingBox();
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width).toBeLessThanOrEqual(390);
+      }
+      await agree(page, info, 'pointer-label-applied');
+      await page.screenshot({ path: info.outputPath('popup-after.png') });
+      await closeEditor(page);
+      await generate(page);
+      page.removeAllListeners('dialog');
+      page.on('dialog', dialog => dialog.type() === 'prompt' ? dialog.accept('Mobile edit') : dialog.accept());
+      const file = info.outputPath('edited.gbdraw-session.json.gz');
+      await download(page, 'Save Session', file);
+      const restored = await load(browser, file, { width: 390, height: 844 });
+      try {
+        expect(await restored.locator('.origin-top svg').textContent()).toContain(`MOBILE_${mode}`);
+        await agree(restored, info, 'restored');
+      } finally { await restored.context().close(); }
+    } finally { await page.context().close(); }
+  });
+}


### PR DESCRIPTION
## Plain-language summary

At a 390×844 viewport, the Generate bar can intercept Apply Label in the feature popup. Move the existing popups and scope dialogs outside preview containment, keep them above the mobile Generate bar, and constrain their height and long controls so users can apply labels and close the popup normally.

## Changes and evidence

- Covers B-03/A-03 using the original Circular and Linear pointer paths, with no force click, injected CSS or keyboard substitute.
- Confirms nonempty label overrides, regenerated/restored text and visible control bounds. Complete original J43 and J44 programs pass through their persistence and mode steps.
- Final source and packaged screenshots were inspected. Four package browser cases pass with external requests blocked; neighboring Editor-toggle and preview navigation checks also pass.
- Includes the combined scoped report and hashed proof records in `docs/internal/session05a14/REPORT.md` and `PROOF.json`.

PRs #515 and #516 are integrated into dev at `e4bda164c70877446172b992700a9cfedce8e24d`. This PR targets that actual dev and contains only its five-file popup/test/report delta. The old parent/head were `de92b346e6d9f67c5dde07696e6a5216a89a3256` / `a3db1b8b9dfc7b21d888bcac3e1e9cb306966ed3`; the transplanted head is `e8d31e04d6ab09453792bfbaf489780887a54aa8`. The before/after own patches are byte-identical (`git range-diff` reports `=`), both base trees match, and both complete head trees match. Only parent/committer metadata changed; no production, test, documentation, CI, assertion or timeout bytes changed. Already-integrated ancestor changes were not replayed.

The maintainer approved the prepared implementation and explicitly authorized sequential dev integration. The transplant preserves that implementation byte-for-byte. Required dev admission checks are refreshed for this exact head; merge remains conditional on those checks and applicable review policy. The assembled candidate's prior ten new browser cases and 32 targeted/neighboring cases remain recorded separately from acceptance on the eventual exact integrated dev.

J08 is separate: the user selected settings-only saving before any source is loaded. This patch records that choice without implementing or waiving source-free persistence. After six-family integration and acceptance, J08 must be implemented and accepted separately before one strengthened full 48-journey run. S11 follows only if acceptance conditions are satisfied. Q01 remains deferred/non-blocking under its existing decision; its retired dense-label workloads are not rerun. Technical and publication baseline SHAs remain unassigned. This PR does not start S11, S12 or release publication.
