### PR TITLE
Preserve preview binding and styling through mode and History changes

### DIFF
--- a/docs/internal/session05a14/INTEGRATION_FOLLOWUP.md
+++ b/docs/internal/session05a14/INTEGRATION_FOLLOWUP.md
@@ -1,0 +1,58 @@
+# Preserve restored previews after the 05A14 series
+
+The final integrated dev `884b0182df79ecbe1e4d32cdcdcd54084d4489c9`
+passed the six-family scoped acceptance, but its full Tests run 34691796434
+failed four additional cases. This corrective change addresses those failures.
+
+- Result replacement notified the preview watcher for both the new Result and
+  its template ref, requesting the same binder twice. Run that existing watcher
+  after Vue's render batch so each completed replacement requests one binding.
+- Mode profile changes triggered the live stroke watcher against a retained
+  Result. Batch this existing watcher after profile updates and exclude mode
+  transitions and suppressed restore operations. Ordinary stroke edits still
+  update the mounted SVG and saved Result.
+- Palette reconciliation treated split-feature outline paths as fill targets,
+  changing `fill="none"` to a palette color during file-replacement Undo.
+  Exclude the renderer's `__outline` paths in the existing fill predicate while
+  preserving their block identity for stroke edits. Transparent filled bodies
+  remain editable; connectors remain excluded.
+
+The no-op stroke setter experiment was discarded: it did not address the
+confirmed causes and adds no bytes to this patch. No assertions, test timeouts,
+CI routing, structural counters, smoke budget or generated wheel bytes change.
+No J08 implementation is included.
+
+## Product and architecture preflight
+
+Classification: `IMPLEMENT_EXISTING_AUTHORITY`. The base Web guidance requires
+immutable generated artifact replacement, automatic live-edit completion and
+preservation of saved Result versus active draft. The base Option Integrity
+contract's OIPC-C05/C06 protects valid intent and explicit replacement; Session
+compatibility keeps the last committed render distinct from per-mode drafts.
+No new default, compatibility retirement or alternative Product outcome is
+selected. The observed color/stroke corruption violates these existing outcomes.
+There is no unresolved evidence-dependent Product choice and no non-waivable
+constraint is relaxed. J08's separate settings-only behavior is unchanged.
+
+Owners and entry paths remain `setupWatchers` -> the existing preview runtime,
+`createSvgStyles` -> the existing Result persistence action, and the existing
+feature-DOM fill predicate. No reactive ref, watcher, export, module, fallback
+owner or canonical path is added. The superseded pre-render callback scheduling
+and overly broad fill predicate are replaced in place. Architecture Gate and
+Review results are retained with the exact candidate commit in the handoff proof;
+maintainer review remains required regardless of machine Review classification.
+
+## Verification
+
+The unchanged three functional failures pass on the corrective source. The
+unchanged saved-session performance case passes with one mount, one binder and
+one accepted readiness receipt per Generate, and no rejected duplicate request.
+New Circular and Linear controls cover repeated Generate, mode round trips and
+live stroke edits with selected/mounted/export coherence. The fill-target unit
+regression fails on the integrated-base helper and passes with the correction.
+The final 32-case neighbor run and exact source/commit hashes are recorded in the
+durable handoff. Existing failing tests are unchanged.
+
+These local results do not mark `884b0182...` or its failed dev CI as passing.
+The candidate is prepared for separate review. After authorized integration,
+refresh the required checks and acceptance against actual resulting dev.

--- a/gbdraw/web/js/app/feature-dom.js
+++ b/gbdraw/web/js/app/feature-dom.js
@@ -40,7 +40,10 @@ export const getFeaturePart = (element) => {
   return CONNECTOR_ID_SUFFIX_RE.test(elementId) ? FEATURE_PART_CONNECTOR : FEATURE_PART_BLOCK;
 };
 
-export const isFeatureFillTarget = (element) => getFeaturePart(element) === FEATURE_PART_BLOCK;
+export const isFeatureFillTarget = (element) => (
+  getFeaturePart(element) === FEATURE_PART_BLOCK
+  && !String(element?.getAttribute?.('id') || element?.id || '').endsWith('__outline')
+);
 
 export const filterFeatureFillTargets = (elements) =>
   Array.from(elements || []).filter(isFeatureFillTarget);

--- a/gbdraw/web/js/app/svg-styles.js
+++ b/gbdraw/web/js/app/svg-styles.js
@@ -11,6 +11,7 @@ import {
   getFeatureIdentity
 } from './feature-editor/svg-actions.js';
 import {
+  FEATURE_PART_BLOCK,
   FEATURE_PART_CONNECTOR,
   getFeaturePart,
   isFeatureFillTarget
@@ -427,7 +428,8 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions }) => {
     let updatedCount = 0;
 
     if (adv.block_stroke_color || adv.block_stroke_width !== null) {
-      const featurePaths = Array.from(svg.querySelectorAll(FEATURE_SELECTOR)).filter(isFeatureFillTarget);
+      const featurePaths = Array.from(svg.querySelectorAll(FEATURE_SELECTOR))
+        .filter((element) => getFeaturePart(element) === FEATURE_PART_BLOCK);
       featurePaths.forEach((path) => {
         if (adv.block_stroke_color) {
           path.setAttribute('stroke', adv.block_stroke_color);
@@ -654,6 +656,7 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions }) => {
 
   watch(
     () => [
+      mode.value,
       adv.block_stroke_color,
       adv.block_stroke_width,
       adv.line_stroke_color,
@@ -663,9 +666,12 @@ export const createSvgStyles = ({ state, watch, nextTick, legendActions }) => {
       adv.scale_stroke_color,
       adv.scale_stroke_width
     ],
-    () => {
+    (values, previousValues) => {
+      // Mode profiles and artifact restores retain the saved Result unchanged.
+      if (values[0] !== previousValues[0] || state.semanticFileWatchersSuppressed?.value) return;
       applyStylesToSvg();
-    }
+    },
+    { flush: 'post' }
   );
 
   watch(

--- a/gbdraw/web/js/app/watchers.js
+++ b/gbdraw/web/js/app/watchers.js
@@ -304,6 +304,7 @@ export const setupWatchers = ({
     }
   );
 
+  // Batch Result and template-ref changes after the replacement root is mounted.
   watch([svgContent, svgContainer, () => results.value[selectedResultIndex.value]], () => {
     const isIncrementalEdit = Boolean(skipCaptureBaseConfig.value);
     skipCaptureBaseConfig.value = false;
@@ -343,7 +344,7 @@ export const setupWatchers = ({
         console.error('Could not bind the mounted SVG Result.', error);
       }
     });
-  });
+  }, { flush: 'post' });
 
   // Persisting the current live DOM changes Result text but deliberately leaves the
   // mounted root in place. Consume the old remount-only flags at that boundary.

--- a/tests/web/feature-fill-targets.test.mjs
+++ b/tests/web/feature-fill-targets.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  FEATURE_PART_BLOCK, filterFeatureFillTargets, getFeaturePart
+} from '../../gbdraw/web/js/app/feature-dom.js';
+
+const element = (id, part, fill) => ({
+  getAttribute: key => ({ id, 'data-gbdraw-feature-part': part, fill })[key] ?? null
+});
+
+test('fill edits exclude outline-only and connector paths while preserving transparent blocks', () => {
+  const block = element('f1__part1', 'block', 'none');
+  const outline = element('f1__part1__outline', 'block', 'none');
+  const connector = element('f1__line1', 'connector', 'none');
+  assert.deepEqual(filterFeatureFillTargets([block, outline, connector]), [block]);
+  assert.equal(getFeaturePart(outline), FEATURE_PART_BLOCK, 'outlines remain targets for block stroke edits');
+});

--- a/tests/web/preview-bind-coalescing.playwright.spec.js
+++ b/tests/web/preview-bind-coalescing.playwright.spec.js
@@ -1,0 +1,51 @@
+const { test, expect } = require('@playwright/test');
+const { load, seeds, generate, switchMode } = require('./helpers/mode-transition.cjs');
+const { capture, assertCoherent } = require('./helpers/visual-state.cjs');
+
+for (const mode of ['circular', 'linear']) {
+  test(`${mode} replacement previews bind once and keep stroke editing after mode switches`, async ({ browser }, info) => {
+    test.setTimeout(240000);
+    const page = await load(browser, seeds[mode]);
+    try {
+      await page.evaluate(() => {
+        window.__BIND_METRICS__ = {};
+        window.__GBDRAW_TEST_HOOKS__.onStructuralMetric = ({ name, value }) => {
+          window.__BIND_METRICS__[name] = (window.__BIND_METRICS__[name] || 0) + value;
+        };
+      });
+      for (let run = 1; run <= 2; run++) {
+        await page.evaluate(() => { window.__BIND_METRICS__ = {}; });
+        await generate(page);
+        const metrics = await page.evaluate(() => {
+          const count = name => window.__BIND_METRICS__[name] || 0;
+          return {
+            mounts: count('previewMountAdoptionCount'),
+            binds: count('previewBinderInvocationCount'),
+            duplicates: count('previewDuplicateBindRejectedCount'),
+            accepted: count('previewReadyReceiptAcceptedCount')
+          };
+        });
+        expect.soft(metrics, `Generate ${run} must complete one fresh bind without duplicate requests`)
+          .toEqual({ mounts: 1, binds: 1, duplicates: 0, accepted: 1 });
+        await assertCoherent(await capture(page, info, `generate-${run}`), `Generate ${run}`, true);
+      }
+      const before = await page.evaluate(() => window.__GBDRAW_APP__.results[0].content);
+      await switchMode(page, mode === 'circular' ? 'linear' : 'circular');
+      await switchMode(page, mode);
+      expect(await page.evaluate(() => window.__GBDRAW_APP__.results[0].content)).toBe(before);
+      await page.locator('summary[aria-label="Features"]').click();
+      await page.getByLabel('Block Stroke Width', { exact: true }).fill('3');
+      await expect.poll(() => page.evaluate(() => {
+        const app = window.__GBDRAW_APP__;
+        const stored = new DOMParser().parseFromString(app.results[0].content, 'image/svg+xml');
+        const mounted = app.svgContainer.querySelector('svg');
+        return [stored, mounted].map(svg => {
+          const blocks = [...svg.querySelectorAll('[data-gbdraw-feature-part="block"]')];
+          return blocks.length > 0 && blocks.every(el => el.getAttribute('stroke-width') === '3');
+        });
+      })).toEqual([true, true]);
+      await assertCoherent(await capture(page, info, 'stroke-after-mode-return'), 'live stroke edit', true);
+      expect(page.externalRequests).toEqual([]);
+    } finally { await page.context().close(); }
+  });
+}


### PR DESCRIPTION
## Plain-language summary

Generate can request preview preparation twice, while mode switches and file-replacement Undo can change the saved SVG's line colors or fill outline-only paths. Batch the existing preview and stroke callbacks after Vue finishes updating the view, and exclude outline-only paths from fill edits. The saved Result survives these transitions, and ordinary stroke controls continue to update both the preview and exported SVG.

## Scope

This is one corrective PR for failures in the final dev CI after #515, #516 and #517, based on `884b0182df79ecbe1e4d32cdcdcd54084d4489c9`. It changes three existing runtime modules, adds two focused test files and records the integration findings in `docs/internal/session05a14/INTEGRATION_FOLLOWUP.md`.

- The existing preview watcher requests one binding for each replacement root.
- The existing stroke watcher distinguishes live edits from mode profiles and suppressed restoration.
- The shared fill-target predicate preserves split-feature outlines; the existing block stroke selector still includes them.

No CI routing, assertions, timeouts, structural counters, ten-case smoke budget or generated packages change. J08 remains a separate implementation with the already-selected settings-only Save Session behavior.

## Validation

The unchanged three functional failures pass locally, as does the unchanged saved-session performance case from [Tests run 34691796434](https://github.com/satoshikawato/gbdraw/actions/runs/34691796434). New tests cover one mount/bind/readiness receipt per Generate in both modes, mode round trips, live stroke controls, selected/mounted/export coherence, and preservation of outline-only fill. The new binder checks fail on the integrated source; the fill-target assertion fails on its base helper. The final local 32-case neighbor run and nine owner tests are recorded in the handoff evidence.

The full dev run remains failed at its original SHA. These local results support this new candidate, not a passing claim for that old dev. Required PR checks and acceptance on the eventual integrated dev must be refreshed after publication and review.

## Review

Product preflight is `IMPLEMENT_EXISTING_AUTHORITY`: preserve saved Results and per-mode drafts, with no new default, compatibility retirement or Product choice. Existing preview, style and feature-DOM owners and their entry paths are retained; no watcher, reactive ref, export, module or fallback owner is added. The exact-head architecture checker reports Gate PASS and Review CLEAR. Maintainer review remains required.
