### PR TITLE
Keep LOSAT acceptance aligned with current Session contracts

### DIFF
--- a/docs/internal/session05a15-j08/LOSAT_ACCEPTANCE_CONTRACT.md
+++ b/docs/internal/session05a15-j08/LOSAT_ACCEPTANCE_CONTRACT.md
@@ -1,0 +1,79 @@
+# LOSAT acceptance schema contract
+
+Newly saved Sessions must be checked against the current writer, while released
+input fixtures retain their historical Session and request versions. Session,
+request, raw protein cache and derived protein cache are independent namespaces;
+a version change in one does not promote the others.
+
+`tests/web/losat-session-schema-contract.test.mjs` enforces this boundary in normal
+PR Web contract discovery. It compares the existing Python and Web writer
+definitions, the Node LOSAT acceptance declarations, and the actual declarations
+loaded from the Python fallback. Loading that fallback does not start a browser.
+The test introduces no runtime schema owner or persisted representation.
+
+When a writer changes, all four schema namespaces must agree before merge. Update only
+the affected current-output expectation. Do not change the released fixture's
+version, bytes or oracle, relax cache assertions, or accept multiple output
+versions to make the contract pass. The existing full browser acceptance remains
+responsible for migration, cancellation/error rollback, TSV bytes and geometry.
+Both adapters use the same browser operations in
+`tests/web/helpers/losat-cache-render-boundary.mjs` for cancellation, renderer
+failure injection and render settlement. Their bodies are copied unchanged from
+the accepted Node adapter; the superseded Python polling and old Worker payload
+probe are removed.
+
+The test is a top-level `tests/web/*.test.mjs` file selected by the existing PR
+Web-contract job. PR smoke remains 10 tests. CI tiers, Node browser assertions,
+timeouts and budgets are unchanged. The Python fallback is aligned with those
+accepted assertions: migrate through Generate before Save, retain legacy
+candidates, keep derived payloads in runtime memory, rebuild them on replay, and
+preserve uploaded TSV bytes through the existing resource-backing reader.
+Derived-reference resolution assertions inspect the live runtime cache, while
+saved documents must contain no derived entries. This removes its obsolete legacy
+pre-Generate Save expectation and the contradictory requirement to persist derived payloads.
+
+## Incident and validation
+
+PR #519 was merged at `4b7e4b62a2e994c1f07c679b5c6902c18bd11155`, tree
+`1d211c001e7bb4d846854cb79875c0e5aa0395c5`. Its required LOSAT job failed at
+`assertCurrentSessionBoundary`: expected Session 41, received 42. The first run
+and both retries failed for the same reason. The two preceding dev LOSAT jobs
+passed; this record does not classify their other CI failures as LOSAT failures.
+
+The new contract first ran against unchanged dev code and acceptance adapters:
+one comparison passed and two failed. It identified the Node Session expectation
+41 versus writer 42 and the Python fallback request expectation 6 versus writer
+7. The correction advances the Node output expectation to 42 and makes the
+Python fallback import the existing canonical request constant.
+
+The identical contract file, SHA-256
+`d43892f2ed5df3be4ec1dc8cde1fe8a2c6f01b77c965954e5aa8f918ff8063ff`, then passed
+all three comparisons. The unchanged Node browser acceptance program passed both
+tests. Existing PR Web contract discovery passed 444 tests across 97 files.
+Ruff and whitespace checks passed. No production file or released fixture changed.
+
+Commands, from the repository root:
+
+```sh
+node --test tests/web/losat-session-schema-contract.test.mjs
+PYTHONPATH=. python tests/run_losat_cache_browser_acceptance.py
+PYTHONPATH=. python tests/run_losat_cache_browser_acceptance.py --python
+```
+
+The initial Python browser fallback stopped at its pre-Generate legacy Session
+Save; unchanged dev reproduced the same failure. Its subsequent run exposed a
+local installed-package mismatch (40 versus source 42). Final verification pins
+Python imports to the candidate source with `PYTHONPATH`. These initial runs
+are not passing fallback evidence. Final browser acceptance passes: Node 2 tests;
+Python 22,567 assertions. The Python run includes strict derived-reference checks against the live cache and
+uses the current resource-backing reader for the final uploaded TSV bytes.
+
+Local logs: `/tmp/gbdraw-j08-cache-contract-evidence`. Exact-dev J08/J16 results
+and GitHub gate snapshots: `/tmp/gbdraw-j08-exact-dev-evidence`. On the resulting
+#519 dev, all 212 functional tests, Python 3.10–3.12 core
+checks (3,756 passed and 17 skipped each), performance (13), Gallery (102),
+recipes (188), and Gallery readiness passed. The LOSAT version mismatch was
+the sole failing required job, so Dev staging / gate failed. The corrected
+candidate is not exact-dev acceptance: that gate must pass after this correction
+is reviewed, integrated and validated on its resulting dev commit. No machine
+gate is human approval.

--- a/tests/run_losat_cache_browser_acceptance.py
+++ b/tests/run_losat_cache_browser_acceptance.py
@@ -20,6 +20,9 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from gbdraw.session_io import CURRENT_SESSION_VERSION
+from gbdraw.session_request_codec import (
+    CANONICAL_REQUEST_SCHEMA as CURRENT_RENDER_REQUEST_SCHEMA,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -27,7 +30,6 @@ NODE_SPEC = REPO_ROOT / "tests" / "web" / "losat-cache-migration.playwright.spec
 FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "sessions"
 FIXTURE_PATH = FIXTURE_DIR / "BGC0000708-BGC0000713.schema-v2.gbdraw-session.json.gz"
 EXPECTED_PATH = FIXTURE_DIR / "BGC0000708-BGC0000713.schema-v2.expected.json"
-CURRENT_RENDER_REQUEST_SCHEMA = 6
 CURRENT_PROTEIN_RAW_SCHEMA = 4
 CURRENT_PROTEIN_DERIVED_SCHEMA = 3
 
@@ -569,11 +571,12 @@ def _install_user_uploaded_tsv(
 def _read_first_uploaded_tsv(page: Any) -> dict[str, Any]:
     return page.evaluate(
         """async () => {
+          const { readFileBytes } = await import('/gbdraw/web/js/services/file-content-cache.js');
           const file = window.__GBDRAW_APP__.linearComparisonPlan.edges[0]?.file;
           return {
             name: file?.name || '',
             bytes: file
-              ? Array.from(new Uint8Array(await file.arrayBuffer()))
+              ? Array.from(await readFileBytes(file))
               : []
           };
         }"""
@@ -583,8 +586,6 @@ def _read_first_uploaded_tsv(page: Any) -> dict[str, Any]:
 def _assert_current_session_boundary(
     session: dict[str, Any],
     checks: AcceptanceChecks,
-    *,
-    require_derived: bool,
 ) -> None:
     raw_entries = session.get("losatCache", {}).get("entries", [])
     derived_entries = session.get("losatDerivedCache", {}).get("entries", [])
@@ -616,59 +617,6 @@ def _assert_current_session_boundary(
             for entry in derived_entries
         ),
         "A legacy entry remains in the current derived cache.",
-    )
-    if require_derived:
-        checks.require(
-            bool(derived_entries),
-            "Generation did not persist a current derived cache entry.",
-        )
-
-
-def _assert_legacy_preserved(
-    session: dict[str, Any],
-    source_session: dict[str, Any],
-    expected: dict[str, Any],
-    checks: AcceptanceChecks,
-) -> None:
-    _assert_current_session_boundary(session, checks, require_derived=False)
-    entries = session.get("losatCache", {}).get("entries", [])
-    legacy_artifacts = session.get("legacyArtifacts", {})
-    raw_envelope = legacy_artifacts.get("proteinRawCandidates", {})
-    candidates = raw_envelope.get("entries", [])
-    derived_entries = session.get("losatDerivedCache", {}).get("entries", [])
-    derived_envelope = legacy_artifacts.get("proteinDerivedEvidence", {})
-    checks.require(entries == [], "Legacy protein entries leaked into the current cache.")
-    checks.require(
-        derived_entries == [],
-        "Legacy derived entries leaked into the current derived cache.",
-    )
-    checks.require(
-        raw_envelope.get("schema") == 1,
-        "Legacy protein candidate envelope is not schema 1.",
-    )
-    checks.require(
-        len(candidates) == expected["storedRawEntries"],
-        "Load -> Save lost legacy protein candidates.",
-    )
-    checks.require(
-        all(
-            candidate.get("state") == "pending"
-            and candidate.get("originalEntry", {}).get("schema") == 2
-            and candidate.get("originalEntry", {}).get("program") == "blastp"
-            for candidate in candidates
-        ),
-        "Saved legacy candidate envelope is not lossless schema 2.",
-    )
-    checks.require(
-        [candidate.get("originalEntry") for candidate in candidates]
-        == source_session.get("losatCache", {}).get("entries", []),
-        "Load -> Save changed a legacy raw candidate.",
-    )
-    checks.require(
-        derived_envelope.get("schema") == 1
-        and derived_envelope.get("entries", [])
-        == source_session.get("losatDerivedCache", {}).get("entries", []),
-        "Load -> Save changed the quarantined legacy derived evidence.",
     )
 
 
@@ -704,8 +652,9 @@ def _assert_current_artifacts(
     source_session: dict[str, Any],
     expected: dict[str, Any],
     checks: AcceptanceChecks,
+    runtime_derived_entries: list[dict[str, Any]],
 ) -> None:
-    _assert_current_session_boundary(session, checks, require_derived=True)
+    _assert_current_session_boundary(session, checks)
     manifest = session.get("proteinIdentityManifest", {})
     entries = session.get("losatCache", {}).get("entries", [])
     derived_entries = session.get("losatDerivedCache", {}).get("entries", [])
@@ -727,13 +676,8 @@ def _assert_current_artifacts(
         "The current protein cache contains a non-schema-4 entry.",
     )
     checks.require(
-        all(
-            entry.get("schema") == CURRENT_PROTEIN_DERIVED_SCHEMA
-            and entry.get("kind") == "derived-losatp-payload"
-            and entry.get("idEncoding") == "runtime-handle-v1"
-            for entry in derived_entries
-        ),
-        "The current derived cache contains a non-schema-3 protein payload.",
+        derived_entries == [],
+        "Derived protein payloads must remain runtime-only after Session Save.",
     )
     legacy_candidates = (
         legacy_artifacts.get("proteinRawCandidates", {}).get("entries", [])
@@ -844,7 +788,13 @@ def _assert_current_artifacts(
                 )
             collect_references(item)
 
-    collect_references(derived_entries)
+    checks.require(
+        all(entry.get("schema") == CURRENT_PROTEIN_DERIVED_SCHEMA
+            and entry.get("idEncoding") == "runtime-handle-v1"
+            for entry in runtime_derived_entries),
+        "Runtime derived entries do not use the current protein schema.",
+    )
+    collect_references(runtime_derived_entries)
     checks.require(
         bool(derived_references),
         "No derived protein references were asserted.",
@@ -855,13 +805,13 @@ def _assert_current_artifacts(
         f"Derived protein references do not resolve through the manifest: {unresolved[:3]}",
     )
     checks.require(
-        "p_r_" not in json.dumps(derived_entries, ensure_ascii=False),
+        "p_r_" not in json.dumps(runtime_derived_entries, ensure_ascii=False),
         "A legacy metadata-derived protein ID remains in the derived cache.",
     )
     checks.require(
         re.search(
             r"@.+\|.+~f_[0-9a-f]{64}",
-            json.dumps(derived_entries, ensure_ascii=False),
+            json.dumps(runtime_derived_entries, ensure_ascii=False),
         )
         is None,
         "A branch-internal readable transport ID remains in the derived cache.",
@@ -903,68 +853,20 @@ def _migration_ui_snapshot(page: Any) -> dict[str, Any]:
     )
 
 
+def _settle_app_render(page: Any) -> None:
+    page.evaluate(
+        """async () => {
+          const contract = await import('/tests/web/helpers/losat-cache-render-boundary.mjs');
+          await contract.settleAppRender();
+        }"""
+    )
+
+
 def _cancel_during_render(page: Any) -> dict[str, Any]:
     return page.evaluate(
         """async () => {
-          const app = window.__GBDRAW_APP__;
-          const { state } = await import('/gbdraw/web/js/state.js');
-          const before = {
-            proteinIdentityManifest: state.proteinIdentityManifest.value,
-            legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
-            legacyProteinDerivedEvidence:
-              state.legacyProteinDerivedEvidence.value,
-            losatCache: Array.from(state.losatCache.value.entries()),
-            losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
-            losatCacheInfo: state.losatCacheInfo.value
-          };
-          let sawRendering = false;
-          let cancelInvoked = false;
-          const cancelPoll = setInterval(() => {
-            if (
-              sawRendering ||
-              String(app.processingStatus || '') !== 'Rendering SVG...'
-            ) return;
-            sawRendering = true;
-            app.cancelGeneration();
-            cancelInvoked = true;
-          }, 0);
-          try {
-            const result = await app.runAnalysis();
-            const sameMapEntries = (entries, current) => (
-              entries.length === current.size &&
-              entries.every(([key, value]) => current.get(key) === value)
-            );
-            const authorityDomains = {
-              proteinIdentityManifestSame:
-                state.proteinIdentityManifest.value === before.proteinIdentityManifest,
-              legacyProteinRawCandidatesSame:
-                state.legacyProteinRawCandidates.value ===
-                  before.legacyProteinRawCandidates,
-              legacyProteinDerivedEvidenceSame:
-                state.legacyProteinDerivedEvidence.value ===
-                  before.legacyProteinDerivedEvidence,
-              losatCacheValuesSame:
-                sameMapEntries(before.losatCache, state.losatCache.value),
-              losatDerivedCacheValuesSame:
-                sameMapEntries(
-                  before.losatDerivedCache,
-                  state.losatDerivedCache.value
-                ),
-              losatCacheInfoSame:
-                state.losatCacheInfo.value === before.losatCacheInfo
-            };
-            return {
-              result,
-              sawRendering,
-              cancelInvoked,
-              errorSummary: String(app.errorLog?.summary || ''),
-              executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
-              ...authorityDomains,
-              authorityRestored: Object.values(authorityDomains).every(Boolean)
-            };
-          } finally {
-            clearInterval(cancelPoll);
-          }
+          const contract = await import('/tests/web/helpers/losat-cache-render-boundary.mjs');
+          return contract.cancelDuringRender();
         }"""
     )
 
@@ -972,73 +874,8 @@ def _cancel_during_render(page: Any) -> dict[str, Any]:
 def _fail_renderer_after_migration(page: Any) -> dict[str, Any]:
     return page.evaluate(
         """async () => {
-          const app = window.__GBDRAW_APP__;
-          const { state } = await import('/gbdraw/web/js/state.js');
-          const {
-            CANONICAL_REQUEST_SCHEMA
-          } = await import('/gbdraw/web/js/services/session-request.js');
-          const before = {
-            proteinIdentityManifest: state.proteinIdentityManifest.value,
-            legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
-            legacyProteinDerivedEvidence:
-              state.legacyProteinDerivedEvidence.value,
-            losatCache: Array.from(state.losatCache.value.entries()),
-            losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
-            losatCacheInfo: state.losatCacheInfo.value
-          };
-          const originalWorkerPostMessage = Worker.prototype.postMessage;
-          let rendererFailureInjected = false;
-          Worker.prototype.postMessage = function (...args) {
-            const message = args[0];
-            if (
-              !rendererFailureInjected &&
-              message?.type === 'run' &&
-              message?.payload?.request?.schema === CANONICAL_REQUEST_SCHEMA &&
-              message?.payload?.resources &&
-              typeof message.payload.resources === 'object' &&
-              !Array.isArray(message.payload.resources)
-            ) {
-              rendererFailureInjected = true;
-              message.payload.request = null;
-            }
-            return originalWorkerPostMessage.apply(this, args);
-          };
-          try {
-            const result = await app.runAnalysis();
-            const sameMapEntries = (entries, current) => (
-              entries.length === current.size &&
-              entries.every(([key, value]) => current.get(key) === value)
-            );
-            const authorityDomains = {
-              proteinIdentityManifestSame:
-                state.proteinIdentityManifest.value === before.proteinIdentityManifest,
-              legacyProteinRawCandidatesSame:
-                state.legacyProteinRawCandidates.value ===
-                  before.legacyProteinRawCandidates,
-              legacyProteinDerivedEvidenceSame:
-                state.legacyProteinDerivedEvidence.value ===
-                  before.legacyProteinDerivedEvidence,
-              losatCacheValuesSame:
-                sameMapEntries(before.losatCache, state.losatCache.value),
-              losatDerivedCacheValuesSame:
-                sameMapEntries(
-                  before.losatDerivedCache,
-                  state.losatDerivedCache.value
-                ),
-              losatCacheInfoSame:
-                state.losatCacheInfo.value === before.losatCacheInfo
-            };
-            return {
-              result,
-              errorSummary: String(app.errorLog?.summary || ''),
-              executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
-              rendererFailureInjected,
-              ...authorityDomains,
-              authorityRestored: Object.values(authorityDomains).every(Boolean)
-            };
-          } finally {
-            Worker.prototype.postMessage = originalWorkerPostMessage;
-          }
+          const contract = await import('/tests/web/helpers/losat-cache-render-boundary.mjs');
+          return contract.failRendererAfterMigration();
         }"""
     )
 
@@ -1274,32 +1111,16 @@ def _run_python_adapter() -> int:
                     "Browser File rename/zero-mtime setup failed.",
                 )
 
-                before_generate_path = _save_session(page, checks)
-                before_generate = _read_session(before_generate_path)
-                _assert_legacy_preserved(
-                    before_generate,
-                    fixture,
-                    expected,
-                    checks,
-                )
-                _assert_renamed_resources(before_generate, checks)
-
-                page.reload(wait_until="domcontentloaded")
-                page.wait_for_function("() => window.__GBDRAW_APP__")
-                _import_session(page, before_generate_path, checks)
-                page.wait_for_function(
-                    "() => Object.keys(window.__GBDRAW_APP__?.paletteDefinitions || {}).length > 0",
-                    timeout=240_000,
-                )
                 legacy_ui_before_cancel = _migration_ui_snapshot(page)
                 canceled_legacy_run = _cancel_during_render(page)
+                _settle_app_render(page)
                 _assert_authority_restored(
                     canceled_legacy_run,
                     "Legacy render cancellation",
                     checks,
                 )
                 checks.require(
-                    canceled_legacy_run.get("sawRendering")
+                    canceled_legacy_run.get("runRequestIssued")
                     and canceled_legacy_run.get("cancelInvoked")
                     and canceled_legacy_run.get("authorityRestored")
                     and canceled_legacy_run.get("result") == {"status": "canceled"},
@@ -1316,6 +1137,7 @@ def _run_python_adapter() -> int:
                 )
                 legacy_ui_before_render_error = _migration_ui_snapshot(page)
                 failed_legacy_run = _fail_renderer_after_migration(page)
+                _settle_app_render(page)
                 _assert_authority_restored(
                     failed_legacy_run,
                     "Legacy renderer failure",
@@ -1335,6 +1157,7 @@ def _run_python_adapter() -> int:
                     "Legacy UI references changed after the failed render.",
                 )
                 _assert_telemetry(_generate(page), expected, checks)
+                _settle_app_render(page)
                 first_layout = _inspect_layout(page)
                 _assert_layout(first_layout, checks)
                 _assert_svg_geometry_parity(
@@ -1345,9 +1168,15 @@ def _run_python_adapter() -> int:
                 _assert_hydrated_downloads(page, expected, checks)
                 _assert_hydrated_utf8_prompt_boundary(page, expected, checks)
 
+                runtime_derived_entries = page.evaluate("""async () => {
+                  const { state } = await import('/gbdraw/web/js/state.js');
+                  return Array.from(state.losatDerivedCache.value.values());
+                }""")
                 migrated_path = _save_session(page, checks)
                 migrated = _read_session(migrated_path)
-                _assert_current_artifacts(migrated, fixture, expected, checks)
+                _assert_current_artifacts(
+                    migrated, fixture, expected, checks, runtime_derived_entries
+                )
                 _assert_renamed_resources(migrated, checks)
 
                 page.reload(wait_until="domcontentloaded")
@@ -1357,7 +1186,20 @@ def _run_python_adapter() -> int:
                     "() => Object.keys(window.__GBDRAW_APP__?.paletteDefinitions || {}).length > 0",
                     timeout=240_000,
                 )
-                _assert_telemetry(_generate(page), expected, checks)
+                regenerated_run = _generate(page)
+                _settle_app_render(page)
+                _assert_telemetry(regenerated_run, expected, checks)
+                checks.require(
+                    regenerated_run["telemetry"].get("proteinDerivedPayloadCacheMisses", 0) > 0,
+                    "Reloaded Session did not rebuild the runtime derived cache.",
+                )
+                checks.require(
+                    page.evaluate("""async () => {
+                      const { state } = await import('/gbdraw/web/js/state.js');
+                      return state.losatDerivedCache.value.size;
+                    }""") > 0,
+                    "Generate did not populate the runtime derived cache.",
+                )
                 second_layout = _inspect_layout(page)
                 _assert_layout(second_layout, checks)
                 checks.require(
@@ -1368,6 +1210,10 @@ def _run_python_adapter() -> int:
 
                 expected_upload_bytes = _install_user_uploaded_tsv(page, expected)
                 uploaded_session_path = _save_session(page, checks)
+                checks.require(
+                    not _read_session(uploaded_session_path).get("losatDerivedCache", {}).get("entries", []),
+                    "Upload Session persisted runtime derived cache entries.",
+                )
                 page.reload(wait_until="domcontentloaded")
                 page.wait_for_function("() => window.__GBDRAW_APP__")
                 _import_session(page, uploaded_session_path, checks)

--- a/tests/web/helpers/losat-cache-render-boundary.mjs
+++ b/tests/web/helpers/losat-cache-render-boundary.mjs
@@ -1,0 +1,139 @@
+// Shared browser operations for Node and Python acceptance.
+// Assert after the same render/rollback completion boundary in either runner.
+
+export async function settleAppRender() {
+  await window.Vue.nextTick();
+  await new Promise((resolveFrame) => requestAnimationFrame(resolveFrame));
+  await window.Vue.nextTick();
+}
+
+export async function cancelDuringRender() {
+  const app = window.__GBDRAW_APP__;
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const {
+    CANONICAL_REQUEST_SCHEMA
+  } = await import('/gbdraw/web/js/services/session-request.js');
+  const before = {
+    proteinIdentityManifest: state.proteinIdentityManifest.value,
+    legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
+    legacyProteinDerivedEvidence: state.legacyProteinDerivedEvidence.value,
+    losatCache: Array.from(state.losatCache.value.entries()),
+    losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
+    losatCacheInfo: state.losatCacheInfo.value
+  };
+  const originalWorkerPostMessage = Worker.prototype.postMessage;
+  let releaseRunRequest;
+  const runRequestIssued = new Promise((resolve) => {
+    releaseRunRequest = resolve;
+  });
+  let heldCanonicalRun = null;
+  let cancelInvoked = false;
+  Worker.prototype.postMessage = function holdFirstCanonicalRun(message, ...args) {
+    if (
+      !heldCanonicalRun &&
+      message?.type === 'run' &&
+      message?.payload?.request?.schema === CANONICAL_REQUEST_SCHEMA
+    ) {
+      heldCanonicalRun = { worker: this, message, args };
+      releaseRunRequest();
+      return;
+    }
+    return originalWorkerPostMessage.call(this, message, ...args);
+  };
+  try {
+    const runPromise = app.runAnalysis();
+    await runRequestIssued;
+    app.cancelGeneration();
+    cancelInvoked = true;
+    const result = await runPromise;
+    const sameMapEntries = (entries, current) => (
+      entries.length === current.size &&
+      entries.every(([key, value]) => current.get(key) === value)
+    );
+    const authorityDomains = {
+      proteinIdentityManifestSame:
+        state.proteinIdentityManifest.value === before.proteinIdentityManifest,
+      legacyProteinRawCandidatesSame:
+        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates,
+      legacyProteinDerivedEvidenceSame:
+        state.legacyProteinDerivedEvidence.value === before.legacyProteinDerivedEvidence,
+      losatCacheValuesSame: sameMapEntries(before.losatCache, state.losatCache.value),
+      losatDerivedCacheValuesSame:
+        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value),
+      losatCacheInfoSame: state.losatCacheInfo.value === before.losatCacheInfo
+    };
+    return {
+      result,
+      runRequestIssued: Boolean(heldCanonicalRun),
+      cancelInvoked,
+      errorSummary: String(app.errorLog?.summary || ''),
+      executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
+      ...authorityDomains,
+      authorityRestored: Object.values(authorityDomains).every(Boolean)
+    };
+  } finally {
+    Worker.prototype.postMessage = originalWorkerPostMessage;
+  }
+}
+
+export async function failRendererAfterMigration() {
+  const app = window.__GBDRAW_APP__;
+  const { state } = await import('/gbdraw/web/js/state.js');
+  const {
+    CANONICAL_REQUEST_SCHEMA
+  } = await import('/gbdraw/web/js/services/session-request.js');
+  const before = {
+    proteinIdentityManifest: state.proteinIdentityManifest.value,
+    legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
+    legacyProteinDerivedEvidence: state.legacyProteinDerivedEvidence.value,
+    losatCache: Array.from(state.losatCache.value.entries()),
+    losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
+    losatCacheInfo: state.losatCacheInfo.value
+  };
+  const originalWorkerPostMessage = Worker.prototype.postMessage;
+  let rendererFailureInjected = false;
+  Worker.prototype.postMessage = function (...args) {
+    const message = args[0];
+    if (
+      !rendererFailureInjected &&
+      message?.type === 'run' &&
+      message?.payload?.request?.schema === CANONICAL_REQUEST_SCHEMA &&
+      Array.isArray(message?.payload?.resourceManifest) &&
+      Array.isArray(message?.payload?.stagedResources) &&
+      !Object.hasOwn(message.payload, 'resources')
+    ) {
+      rendererFailureInjected = true;
+      message.payload.request = null;
+    }
+    return originalWorkerPostMessage.apply(this, args);
+  };
+  try {
+    const result = await app.runAnalysis();
+    const sameMapEntries = (entries, current) => (
+      entries.length === current.size &&
+      entries.every(([key, value]) => current.get(key) === value)
+    );
+    const authorityDomains = {
+      proteinIdentityManifestSame:
+        state.proteinIdentityManifest.value === before.proteinIdentityManifest,
+      legacyProteinRawCandidatesSame:
+        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates,
+      legacyProteinDerivedEvidenceSame:
+        state.legacyProteinDerivedEvidence.value === before.legacyProteinDerivedEvidence,
+      losatCacheValuesSame: sameMapEntries(before.losatCache, state.losatCache.value),
+      losatDerivedCacheValuesSame:
+        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value),
+      losatCacheInfoSame: state.losatCacheInfo.value === before.losatCacheInfo
+    };
+    return {
+      result,
+      errorSummary: String(app.errorLog?.summary || ''),
+      executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
+      rendererFailureInjected,
+      ...authorityDomains,
+      authorityRestored: Object.values(authorityDomains).every(Boolean)
+    };
+  } finally {
+    Worker.prototype.postMessage = originalWorkerPostMessage;
+  }
+}

--- a/tests/web/losat-cache-migration.playwright.spec.js
+++ b/tests/web/losat-cache-migration.playwright.spec.js
@@ -20,7 +20,7 @@ const expected = JSON.parse(readFileSync(join(
   fixtureDir,
   'BGC0000708-BGC0000713.schema-v2.expected.json'
 ), 'utf8'));
-const CURRENT_SESSION_VERSION = 41;
+const CURRENT_SESSION_VERSION = 42;
 const CURRENT_RENDER_REQUEST_SCHEMA = 7;
 const CURRENT_PROTEIN_RAW_SCHEMA = 4;
 const CURRENT_PROTEIN_DERIVED_SCHEMA = 3;
@@ -340,9 +340,8 @@ const generateWithTelemetry = async (page) => page.evaluate(async () => {
 });
 
 const settleAppRender = async (page) => page.evaluate(async () => {
-  await window.Vue.nextTick();
-  await new Promise((resolveFrame) => requestAnimationFrame(resolveFrame));
-  await window.Vue.nextTick();
+  const contract = await import('/tests/web/helpers/losat-cache-render-boundary.mjs');
+  return contract.settleAppRender();
 });
 
 const migrationUiSnapshot = async (page) => page.evaluate(async () => {
@@ -357,134 +356,13 @@ const migrationUiSnapshot = async (page) => page.evaluate(async () => {
 });
 
 const cancelDuringRender = async (page) => page.evaluate(async () => {
-  const app = window.__GBDRAW_APP__;
-  const { state } = await import('/gbdraw/web/js/state.js');
-  const {
-    CANONICAL_REQUEST_SCHEMA
-  } = await import('/gbdraw/web/js/services/session-request.js');
-  const before = {
-    proteinIdentityManifest: state.proteinIdentityManifest.value,
-    legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
-    legacyProteinDerivedEvidence: state.legacyProteinDerivedEvidence.value,
-    losatCache: Array.from(state.losatCache.value.entries()),
-    losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
-    losatCacheInfo: state.losatCacheInfo.value
-  };
-  const originalWorkerPostMessage = Worker.prototype.postMessage;
-  let releaseRunRequest;
-  const runRequestIssued = new Promise((resolve) => {
-    releaseRunRequest = resolve;
-  });
-  let heldCanonicalRun = null;
-  let cancelInvoked = false;
-  Worker.prototype.postMessage = function holdFirstCanonicalRun(message, ...args) {
-    if (
-      !heldCanonicalRun &&
-      message?.type === 'run' &&
-      message?.payload?.request?.schema === CANONICAL_REQUEST_SCHEMA
-    ) {
-      heldCanonicalRun = { worker: this, message, args };
-      releaseRunRequest();
-      return;
-    }
-    return originalWorkerPostMessage.call(this, message, ...args);
-  };
-  try {
-    const runPromise = app.runAnalysis();
-    await runRequestIssued;
-    app.cancelGeneration();
-    cancelInvoked = true;
-    const result = await runPromise;
-    const sameMapEntries = (entries, current) => (
-      entries.length === current.size &&
-      entries.every(([key, value]) => current.get(key) === value)
-    );
-    const authorityDomains = {
-      proteinIdentityManifestSame:
-        state.proteinIdentityManifest.value === before.proteinIdentityManifest,
-      legacyProteinRawCandidatesSame:
-        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates,
-      legacyProteinDerivedEvidenceSame:
-        state.legacyProteinDerivedEvidence.value === before.legacyProteinDerivedEvidence,
-      losatCacheValuesSame: sameMapEntries(before.losatCache, state.losatCache.value),
-      losatDerivedCacheValuesSame:
-        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value),
-      losatCacheInfoSame: state.losatCacheInfo.value === before.losatCacheInfo
-    };
-    return {
-      result,
-      runRequestIssued: Boolean(heldCanonicalRun),
-      cancelInvoked,
-      errorSummary: String(app.errorLog?.summary || ''),
-      executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
-      ...authorityDomains,
-      authorityRestored: Object.values(authorityDomains).every(Boolean)
-    };
-  } finally {
-    Worker.prototype.postMessage = originalWorkerPostMessage;
-  }
+  const contract = await import('/tests/web/helpers/losat-cache-render-boundary.mjs');
+  return contract.cancelDuringRender();
 });
 
 const failRendererAfterMigration = async (page) => page.evaluate(async () => {
-  const app = window.__GBDRAW_APP__;
-  const { state } = await import('/gbdraw/web/js/state.js');
-  const {
-    CANONICAL_REQUEST_SCHEMA
-  } = await import('/gbdraw/web/js/services/session-request.js');
-  const before = {
-    proteinIdentityManifest: state.proteinIdentityManifest.value,
-    legacyProteinRawCandidates: state.legacyProteinRawCandidates.value,
-    legacyProteinDerivedEvidence: state.legacyProteinDerivedEvidence.value,
-    losatCache: Array.from(state.losatCache.value.entries()),
-    losatDerivedCache: Array.from(state.losatDerivedCache.value.entries()),
-    losatCacheInfo: state.losatCacheInfo.value
-  };
-  const originalWorkerPostMessage = Worker.prototype.postMessage;
-  let rendererFailureInjected = false;
-  Worker.prototype.postMessage = function (...args) {
-    const message = args[0];
-    if (
-      !rendererFailureInjected &&
-      message?.type === 'run' &&
-      message?.payload?.request?.schema === CANONICAL_REQUEST_SCHEMA &&
-      Array.isArray(message?.payload?.resourceManifest) &&
-      Array.isArray(message?.payload?.stagedResources) &&
-      !Object.hasOwn(message.payload, 'resources')
-    ) {
-      rendererFailureInjected = true;
-      message.payload.request = null;
-    }
-    return originalWorkerPostMessage.apply(this, args);
-  };
-  try {
-    const result = await app.runAnalysis();
-    const sameMapEntries = (entries, current) => (
-      entries.length === current.size &&
-      entries.every(([key, value]) => current.get(key) === value)
-    );
-    const authorityDomains = {
-      proteinIdentityManifestSame:
-        state.proteinIdentityManifest.value === before.proteinIdentityManifest,
-      legacyProteinRawCandidatesSame:
-        state.legacyProteinRawCandidates.value === before.legacyProteinRawCandidates,
-      legacyProteinDerivedEvidenceSame:
-        state.legacyProteinDerivedEvidence.value === before.legacyProteinDerivedEvidence,
-      losatCacheValuesSame: sameMapEntries(before.losatCache, state.losatCache.value),
-      losatDerivedCacheValuesSame:
-        sameMapEntries(before.losatDerivedCache, state.losatDerivedCache.value),
-      losatCacheInfoSame: state.losatCacheInfo.value === before.losatCacheInfo
-    };
-    return {
-      result,
-      errorSummary: String(app.errorLog?.summary || ''),
-      executorCalls: Number(window.__GBDRAW_LOSAT_EXECUTOR_CALLS__ || 0),
-      rendererFailureInjected,
-      ...authorityDomains,
-      authorityRestored: Object.values(authorityDomains).every(Boolean)
-    };
-  } finally {
-    Worker.prototype.postMessage = originalWorkerPostMessage;
-  }
+  const contract = await import('/tests/web/helpers/losat-cache-render-boundary.mjs');
+  return contract.failRendererAfterMigration();
 });
 
 const assertExpectedTelemetry = (run, migrationExpected = expected) => {

--- a/tests/web/losat-session-schema-contract.test.mjs
+++ b/tests/web/losat-session-schema-contract.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const source = path => readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+const numericConstant = (text, name) => {
+  const matches = [...text.matchAll(new RegExp(`\\bconst\\s+${name}\\s*=\\s*(\\d+)\\s*;`, 'g'))];
+  assert.equal(matches.length, 1, `Expected one declaration of ${name}`);
+  return Number(matches[0][1]);
+};
+
+// Load the fallback's declarations without selecting an adapter or a browser.
+// Compare independent schema namespaces; released input fixtures keep their
+// original versions and are not current-writer expectations.
+const python = JSON.parse(execFileSync('python', ['-c', `
+import json, runpy
+from gbdraw.session_io import CURRENT_SESSION_VERSION, PROTEIN_LOSAT_CACHE_SCHEMA, LOSAT_DERIVED_CACHE_SCHEMA
+from gbdraw.session_request_codec import CANONICAL_REQUEST_SCHEMA
+adapter = runpy.run_path('tests/run_losat_cache_browser_acceptance.py')
+print(json.dumps({
+    'writer': {'session': CURRENT_SESSION_VERSION, 'request': CANONICAL_REQUEST_SCHEMA,
+               'proteinRaw': PROTEIN_LOSAT_CACHE_SCHEMA, 'proteinDerived': LOSAT_DERIVED_CACHE_SCHEMA},
+    'adapter': {'session': adapter['CURRENT_SESSION_VERSION'], 'request': adapter['CURRENT_RENDER_REQUEST_SCHEMA'],
+                'proteinRaw': adapter['CURRENT_PROTEIN_RAW_SCHEMA'], 'proteinDerived': adapter['CURRENT_PROTEIN_DERIVED_SCHEMA']}
+}))
+`], { cwd: root, encoding: 'utf8' }));
+
+test('Web and Python current Session, request and protein-cache schemas agree', () => {
+  const cache = source('gbdraw/web/js/app/losat-cache.js');
+  assert.deepEqual({
+    session: numericConstant(source('gbdraw/web/js/services/config.js'), 'SESSION_VERSION'),
+    request: numericConstant(source('gbdraw/web/js/services/session-request.js'), 'CANONICAL_REQUEST_SCHEMA'),
+    proteinRaw: numericConstant(cache, 'PROTEIN_LOSAT_CACHE_SCHEMA'),
+    proteinDerived: numericConstant(cache, 'LOSAT_DERIVED_CACHE_SCHEMA')
+  }, python.writer);
+});
+
+test('Node LOSAT acceptance expects the current writer for every output schema', () => {
+  const adapter = source('tests/web/losat-cache-migration.playwright.spec.js');
+  assert.deepEqual({
+    session: numericConstant(adapter, 'CURRENT_SESSION_VERSION'),
+    request: numericConstant(adapter, 'CURRENT_RENDER_REQUEST_SCHEMA'),
+    proteinRaw: numericConstant(adapter, 'CURRENT_PROTEIN_RAW_SCHEMA'),
+    proteinDerived: numericConstant(adapter, 'CURRENT_PROTEIN_DERIVED_SCHEMA')
+  }, python.writer);
+});
+
+test('Python LOSAT acceptance expects the current writer for every output schema', () => {
+  assert.deepEqual(python.adapter, python.writer);
+});


### PR DESCRIPTION
## Plain-language summary

This change catches outdated LOSAT acceptance schema expectations in the normal PR contract tests. It fixes the Session 41 expectation that rejected new version-42 files after #519, and aligns the Python fallback with the existing Node acceptance workflow. Both adapters now share the render completion, cancellation and error-injection operations.

## Contract and implementation

A fast test compares four independent schema namespaces across the Python and Web writers and both browser adapters: Session, request, raw protein cache and derived protein cache. Released fixtures keep their original versions and bytes. The Python fallback imports the canonical request schema instead of retaining a stale schema-6 constant.

Three browser operations move unchanged from the accepted Node runner into a shared test helper. The Python fallback now uses those operations, migrates through Generate before Save, verifies that derived payloads stay in runtime memory, and checks that replay rebuilds the cache. Strict manifest/reference, rollback, geometry and uploaded-byte assertions remain. Production code, persisted formats, PR smoke selection (10), CI tiers and timeouts are unchanged.

## Verification

The same contract file first failed for Node Session 41 versus 42 and Python request 6 versus 7, then passed all three checks. The Node browser adapter passed 2 tests; the Python fallback passed 22,567 assertions with imports pinned to the candidate source. The existing PR Web-contract discovery passed 444 tests across 97 files.

The previous Python fallback also failed on unchanged dev at its obsolete pre-Generate legacy Save. Its synchronization follows the already accepted Node workflow; the original failure and the shared-function body hashes are recorded with the local evidence.

See `docs/internal/session05a15-j08/LOSAT_ACCEPTANCE_CONTRACT.md` for the contract and reproduction commands. This is a follow-up to restore the required dev LOSAT gate; acceptance must be repeated on the resulting dev commit after review and integration.
