### PR TITLE
Fix retained journey Load forwarding and color completion checks

### DIFF
--- a/tests/test_retained_visual_journeys.py
+++ b/tests/test_retained_visual_journeys.py
@@ -1,0 +1,129 @@
+"""Portable regressions for the retained runner's operation adapters."""
+import runpy
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+RUNNER = Path(__file__).parent / 'web/helpers/retained-visual-journeys.py'
+install = runpy.run_path(str(RUNNER))['install_operation_adapters']
+
+
+@pytest.fixture
+def journey():
+    class Journey:
+        jid = 'J42'
+
+        def __init__(self):
+            self.calls = []
+            self.events = []
+            self.pending = True
+            self.wait_error = None
+            self.observation_error = None
+            self.comparison_bytes = 100
+            self.failures = []
+            self.page = SimpleNamespace(wait_for_function=self.wait)
+
+        def wait(self, predicate, **options):
+            self.calls.append(('wait', predicate, options))
+            if self.wait_error:
+                raise self.wait_error
+            self.pending = False
+
+        def load(self, seed, valid=True):
+            self.calls.append(('load', seed, valid))
+            return 'accepted' if valid else 'rejected'
+
+        def edit(self, kind, *args, **kwargs):
+            self.calls.append(('pointer edit', kind, args, kwargs))
+            self.observe('before drawer/popup close')
+            self.calls.append(('close',))
+            self.pending = False
+            self.observe('after completed ' + kind + ' edit')
+            return {'svg_id': 'target'}
+
+        def observe(self, reason):
+            self.calls.append(('observe', reason))
+            if self.observation_error:
+                raise self.observation_error
+            state = {'resultCount': 1, 'failures': self.failures,
+                     'observation_phase': 'IN_PROGRESS' if self.pending else 'SETTLED'}
+            if not self.pending:
+                state.update({key: {'uncompressed_bytes': self.comparison_bytes} for key in [
+                    'selected_semantics', 'mounted_semantics', 'export_semantics',
+                    'export_boundary_selected_semantics', 'export_boundary_mounted_semantics']})
+            self.record('authority', 'PASS', phase=state['observation_phase'])
+            return state
+
+        def record(self, kind, status, **data):
+            event = {'kind': kind, 'status': status, **data}
+            self.events.append(event)
+            return event
+
+    install(Journey)
+    return Journey()
+
+
+@pytest.mark.parametrize('args,kwargs,valid', [
+    (('seed',), {}, True),
+    (('seed', True), {}, True),
+    (('seed', False), {}, False),
+    (('seed',), {'valid': False}, False),
+])
+def test_load_preserves_original_valid_argument(journey, args, kwargs, valid):
+    assert journey.load(*args, **kwargs) == ('accepted' if valid else 'rejected')
+    assert journey.calls == [('load', 'seed', valid)]
+
+
+def test_c01_waits_for_definition_callback_after_valid_load(journey):
+    journey.jid = 'C01'
+    assert journey.load('C01-03-save.json') == 'accepted'
+    assert [call[0] for call in journey.calls] == ['load', 'wait', 'observe']
+    assert journey.calls[1][1] == 'window.__DEFINITION_COMPLETED__ > 0'
+
+
+def test_color_comparison_precedes_close_and_preserves_pointer_arguments(journey):
+    target = journey.edit('color', '#123456', record=2)
+    assert target == {'svg_id': 'target'}
+    assert [call[0] for call in journey.calls] == ['pointer edit', 'wait', 'observe', 'close', 'observe']
+    assert journey.calls[0] == ('pointer edit', 'color', ('#123456',), {'record': 2})
+    assert any(row['kind'] == 'completion_boundary' and row['status'] == 'PASS' for row in journey.events)
+
+
+@pytest.mark.parametrize('failure', ['timeout', 'observer', 'mismatch', 'empty', 'missing'])
+def test_unverified_color_boundary_cannot_close_or_pass(journey, failure):
+    if failure == 'timeout':
+        journey.wait_error = TimeoutError('color owner still pending')
+    elif failure == 'observer':
+        journey.observation_error = RuntimeError('capture failed')
+    elif failure == 'mismatch':
+        journey.failures = ['selected / mounted differ']
+    elif failure == 'empty':
+        journey.comparison_bytes = 2  # [] is not a visual comparison.
+    else:
+        journey.wait = lambda *args, **kwargs: None
+        journey.page.wait_for_function = journey.wait  # Observation is still IN_PROGRESS.
+    with pytest.raises((AssertionError, TimeoutError, RuntimeError)):
+        journey.edit('color')
+    assert ('close',) not in journey.calls
+    assert not any(row['kind'] == 'completion_boundary' and row['status'] == 'PASS' for row in journey.events)
+    # A failed edit must not impose its wait on a later independent operation.
+    journey.wait_error = journey.observation_error = None
+    journey.calls.clear()
+    journey.observe('before drawer/popup close')
+    assert not any(call[0] == 'wait' for call in journey.calls)
+
+
+def test_in_progress_observation_is_explicit_without_blocking_async_generate(journey):
+    journey.observe('after original statement starting Generate')
+    assert journey.events[-1]['status'] == 'IN_PROGRESS'
+    assert not any(call[0] == 'wait' for call in journey.calls)
+    assert journey.record('authority', 'OBSERVATION', phase='IN_PROGRESS')['status'] == 'OBSERVATION'
+
+
+def test_mobile_label_pointer_path_does_not_gain_color_wait(journey):
+    journey.jid = 'J43'
+    journey.edit('label', 'label text', keyboard=False)
+    assert not any(call[0] == 'wait' for call in journey.calls)
+    assert journey.calls[0] == ('pointer edit', 'label', ('label text',), {'keyboard': False})

--- a/tests/web/helpers/retained-visual-journeys.py
+++ b/tests/web/helpers/retained-visual-journeys.py
@@ -15,8 +15,6 @@ from pathlib import Path
 # Retained programs are immutable inputs, including their archive directory.
 sys.dont_write_bytecode = True
 
-from playwright.sync_api import sync_playwright
-
 HASHES = {
     'audit.py': 'd24c4627013cde32a57aa157c015788e1b4caabe5a7ac8265041f883bcea85f1',
     'harness.py': '96f49c44fe172d7eeec374bc2e11d19b174daee9199961844ec2aac2ca2efb51',
@@ -27,7 +25,79 @@ HASHES = {
 }
 
 
+def install_operation_adapters(journey_class):
+    """Adapt current completion boundaries without changing archived programs."""
+    original_edit = journey_class.edit
+    original_observe = journey_class.observe
+    original_record = journey_class.record
+
+    def record(self, kind, status, **data):
+        if kind == 'authority' and status == 'PASS' and data.get('phase') == 'IN_PROGRESS':
+            status = 'IN_PROGRESS'
+        return original_record(self, kind, status, **data)
+
+    def edit(self, kind, *params, **options):
+        self.retained_edit_kind = kind
+        try:
+            target = original_edit(self, kind, *params, **options)
+        finally:
+            self.retained_edit_kind = None
+        if self.jid == 'J13' and kind == 'placement':
+            self.placement_target = target['svg_id']
+        return target
+
+    def observe(self, reason):
+        color_boundary = (reason == 'before drawer/popup close'
+                          and getattr(self, 'retained_edit_kind', None) == 'color')
+        if color_boundary:
+            # The original pointer click has returned, but its async owner may
+            # still be applying color/legend changes. Never poll SVG equality.
+            self.page.wait_for_function('''() => {
+              const app = window.__GBDRAW_APP__, history = window.__GBDRAW_HISTORY__;
+              return !app.processing && !history.restoring.value && !history.capturing.value
+                && !app.featureStyleScopeDialog.show && !app.legendRenameDialog?.show;
+            }''', timeout=180000)
+        state = original_observe(self, reason)
+        if color_boundary:
+            assert state and state['observation_phase'] == 'SETTLED', 'Color action was not observed settled before close'
+            assert state['resultCount'] > 0 and not state['failures'], 'Color completion comparison failed before close'
+            assert all(state.get(key, {}).get('uncompressed_bytes', 0) > 4 for key in [
+                'selected_semantics', 'mounted_semantics', 'export_semantics',
+                'export_boundary_selected_semantics', 'export_boundary_mounted_semantics'
+            ]), 'Color completion lacks nonempty selected/mounted/export evidence before close'
+            self.record('completion_boundary', 'PASS', edit='color', reason=reason)
+        if self.jid != 'J13' or not state or not hasattr(self, 'placement_target'):
+            return state
+        if reason.startswith(('before Undo ', 'before Redo ', 'after Undo ', 'after Redo ')):
+            current = json.loads(gzip.decompress((self.folder / state['mounted_semantics']['path']).read_bytes()))
+            if reason.startswith('before '):
+                self.history_non_targets = current
+            else:
+                differences = self.page.evaluate("""async ({before,after,target})=>{
+                  const {nonTargetFeatures,compareVisualSemantics}=await import('/tests/web/helpers/svg-visual-semantics.mjs');
+                  return compareVisualSemantics(nonTargetFeatures(before,[target]),nonTargetFeatures(after,[target]));
+                }""", {'before': self.history_non_targets, 'after': current, 'target': self.placement_target})
+                self.record('non_target_preservation', 'OBSERVATION' if differences else 'PASS',
+                            reason=reason, differences=differences[:5])
+        return state
+
+    journey_class.edit = edit
+    journey_class.observe = observe
+    journey_class.record = record
+    original_load = journey_class.load
+
+    def load(self, seed, valid=True):
+        result = original_load(self, seed, valid=valid)
+        if self.jid == 'C01' and '-03-save' in str(seed):
+            self.page.wait_for_function('window.__DEFINITION_COMPLETED__ > 0', timeout=180000)
+            self.observe('Web Load definition callback completed before Generate')
+        return result
+    journey_class.load = load
+
+
 def main():
+    from playwright.sync_api import sync_playwright
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--archive', type=Path, required=True)
     parser.add_argument('--output', type=Path, required=True)
@@ -97,48 +167,12 @@ def main():
         }''', document)
 
     audit.AuditJourney.saved_session_valid = saved_session_valid
-    original_edit = audit.AuditJourney.edit
-    original_observe = audit.AuditJourney.observe
-
-    def edit(self, kind, *params, **options):
-        target = original_edit(self, kind, *params, **options)
-        if self.jid == 'J13' and kind == 'placement':
-            self.placement_target = target['svg_id']
-        return target
-
-    def observe(self, reason):
-        state = original_observe(self, reason)
-        if self.jid != 'J13' or not state or not hasattr(self, 'placement_target'):
-            return state
-        if reason.startswith(('before Undo ', 'before Redo ', 'after Undo ', 'after Redo ')):
-            current = json.loads(gzip.decompress((self.folder / state['mounted_semantics']['path']).read_bytes()))
-            if reason.startswith('before '):
-                self.history_non_targets = current
-            else:
-                differences = self.page.evaluate("""async ({before,after,target})=>{
-                  const {nonTargetFeatures,compareVisualSemantics}=await import('/tests/web/helpers/svg-visual-semantics.mjs');
-                  return compareVisualSemantics(nonTargetFeatures(before,[target]),nonTargetFeatures(after,[target]));
-                }""", {'before': self.history_non_targets, 'after': current, 'target': self.placement_target})
-                self.record('non_target_preservation', 'OBSERVATION' if differences else 'PASS',
-                            reason=reason, differences=differences[:5])
-        return state
-
-    audit.AuditJourney.edit = edit
-    audit.AuditJourney.observe = observe
+    install_operation_adapters(audit.AuditJourney)
     harness.ROOT = journeys.ROOT = args.root.resolve()
     harness.OUT = audit.OUT = args.output.resolve()
     harness.LINEAR_FILES = journeys.LINEAR_FILES = [harness.ROOT / 'examples' / name for name in ['MellatMJNV.gb', 'MeenMJNV.gb', 'LvMJNV.gb']]
     # The retained harness uses port 4194 for its local-only request policy.
     harness.INIT = harness.INIT.replace('window.__SWEEP__=', "window.__DEFINITION_COMPLETED__=0;const log=console.log;console.log=(...a)=>{if(a[0]==='Definition text updated')window.__DEFINITION_COMPLETED__++;log(...a)};window.__SWEEP__=")
-    original_load = audit.AuditJourney.load
-
-    def load(self, seed):
-        result = original_load(self, seed)
-        if self.jid == 'C01' and '-03-save' in str(seed):
-            self.page.wait_for_function('window.__DEFINITION_COMPLETED__ > 0', timeout=180000)
-            self.observe('Web Load definition callback completed before Generate')
-        return result
-    audit.AuditJourney.load = load
     manifest = {'archive': str(args.archive.resolve()), 'sourceHashes': HASHES,
                 'comparatorSha256': hashlib.sha256((args.root / 'tests/web/helpers/svg-visual-semantics.mjs').read_bytes()).hexdigest(), 'journeys': args.journeys}
     (args.output / 'runner-inputs.json').write_text(json.dumps(manifest, indent=2))


### PR DESCRIPTION
## Plain-language summary
The retained browser journey runner must deliver rejected Session loads to the application and verify completed color edits before closing the editor. This PR forwards the original Load validity argument and waits for the color action owners before comparing nonempty selected, mounted, and exported diagrams. Original pointer operations and intentionally asynchronous Generate observations remain intact.

## Changes
- Keep the existing adapters in `tests/web/helpers/retained-visual-journeys.py` as their single owner, and expose their installation for portable testing.
- Preserve C01 definition callback handling, J13 non-target feature checks, and mobile pointer Apply. Clear the edit marker on failures and record unfinished authority observations as `IN_PROGRESS`.
- Add 13 portable regressions in `tests/test_retained_visual_journeys.py`. Normal `tests/` discovery and the existing Core PR marker selection include all 13; no CI routing change is needed.

## Validation
- Existing same-head portable tests: 13 passed. Red proof used the base adapters extracted without behavior changes: 9 failures and 4 positive controls; it was not an unchanged-production browser run.
- Existing same-head browser validation: 11 original journeys plus supplemental C01 passed. Four rejected Loads reached the application; all seven dependent assertions passed. J39/J42 each verified settled, nonempty comparisons before close. J13 non-target checks and mobile pointer Apply passed.
- Shared comparator tests and focused Ruff passed. The unchanged focused browser run was reused.
- Production, original journey programs, fixtures, comparator, CI tiers, ten PR smoke cases, and timeouts are unchanged. Generated wheels and large evidence archives are excluded.

After normal merge, the original 48 journeys will receive a separate acceptance run on the resulting exact dev revision. Only acceptance of that run permits S11 with explicit `tier=release`; previous failed full48 and targeted passes remain separate records. AI inspection and gate results are not human reviews.
