### PR TITLE
Prepare 0.14.0 release documentation for publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and full feature descriptions) live under `docs/RELEASE_NOTES_*.md`. This
 file is the short, chronological index; follow the links below for the full
 write-up of a release.
 
-## [0.14.0](./docs/RELEASE_NOTES_0.14.0.md) — unreleased
+## [0.14.0](./docs/RELEASE_NOTES_0.14.0.md)
 
 - Added circular-record display-start rotation and manual feature lane placement.
 - Improved Run Info / Exact replay, Save Session resource preservation, preview
@@ -18,8 +18,8 @@ write-up of a release.
 - Includes the beta's package-root Python API and current session/request
   compatibility, plus isolated wheel/sdist installation and local GUI packaging fixes.
 - See the [full release notes](./docs/RELEASE_NOTES_0.14.0.md) for migration,
-  compatibility, and installation availability. The source version is `0.14.0`
-  (internal final candidate); the final release has not been published.
+  compatibility, and installation availability. Publication dates are recorded
+  in [GitHub Releases](https://github.com/satoshikawato/gbdraw/releases).
 
 ## [0.14.0b0](./docs/RELEASE_NOTES_0.14.0b0.md) — unreleased (beta)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./gbdraw/web/assets/gbdraw-logo-title.png" alt="gbdraw" width="420">
+  <img src="https://raw.githubusercontent.com/satoshikawato/gbdraw/main/gbdraw/web/assets/gbdraw-logo-title.png" alt="gbdraw" width="420">
 </p>
 
 [![Static Badge](https://img.shields.io/badge/gbdraw%20webapp-8A2BE2)](https://gbdraw.app/)
@@ -15,7 +15,7 @@
 
 # gbdraw
 
-![gbdraw](https://github.com/satoshikawato/gbdraw/blob/main/examples/gbdraw_social_preview.png)
+![gbdraw](https://raw.githubusercontent.com/satoshikawato/gbdraw/main/examples/gbdraw_social_preview.png)
 
 `gbdraw` is a command-line and browser-based tool for publication-quality genome diagrams. It accepts GenBank/DDBJ flatfiles or GFF3 + FASTA pairs and produces circular or linear plots in SVG, PNG, PDF, EPS, or PS.
 
@@ -33,18 +33,18 @@
 
 | Route | Use it for |
 | --- | --- |
-| [Tutorials](./docs/TUTORIALS/README.md) | Build complete, reproducible figures in the web app, on the command line, or from Python. |
-| [Technical documentation](./docs/REFERENCE/README.md) | Look up controls, options, schemas, APIs, compatibility, outputs, and source provenance. |
-| [FAQ](./docs/FAQ.md) | Choose a layout, interface, or comparison method and resolve common problems. |
-| [Gallery](./docs/GALLERY.md) | Inspect finished static and interactive figures before choosing a workflow. |
+| [Tutorials](https://github.com/satoshikawato/gbdraw/blob/main/docs/TUTORIALS/README.md) | Build complete, reproducible figures in the web app, on the command line, or from Python. |
+| [Technical documentation](https://github.com/satoshikawato/gbdraw/blob/main/docs/REFERENCE/README.md) | Look up controls, options, schemas, APIs, compatibility, outputs, and source provenance. |
+| [FAQ](https://github.com/satoshikawato/gbdraw/blob/main/docs/FAQ.md) | Choose a layout, interface, or comparison method and resolve common problems. |
+| [Gallery](https://github.com/satoshikawato/gbdraw/blob/main/docs/GALLERY.md) | Inspect finished static and interactive figures before choosing a workflow. |
 
-The [documentation home](./docs/DOCS.md) links the four routes above. Supporting
-pages cover [installation](./docs/INSTALL.md), [tutorial
-inputs](./docs/GETTING_TUTORIAL_DATA.md), [citation and project
-background](./docs/ABOUT.md), and the [changelog](./CHANGELOG.md).
-See the [0.14.0 release notes (unreleased)](./docs/RELEASE_NOTES_0.14.0.md)
-for the upcoming release and migration from 0.13.
-See [Contributing](./CONTRIBUTING.md) to report a bug, set up a development
+The [documentation home](https://github.com/satoshikawato/gbdraw/blob/main/docs/DOCS.md) links the four routes above. Supporting
+pages cover [installation](https://github.com/satoshikawato/gbdraw/blob/main/docs/INSTALL.md), [tutorial
+inputs](https://github.com/satoshikawato/gbdraw/blob/main/docs/GETTING_TUTORIAL_DATA.md), [citation and project
+background](https://github.com/satoshikawato/gbdraw/blob/main/docs/ABOUT.md), and the [changelog](https://github.com/satoshikawato/gbdraw/blob/main/CHANGELOG.md).
+See the [0.14.0 release notes](https://github.com/satoshikawato/gbdraw/blob/main/docs/RELEASE_NOTES_0.14.0.md)
+for changes and migration from 0.13.
+See [Contributing](https://github.com/satoshikawato/gbdraw/blob/main/CONTRIBUTING.md) to report a bug, set up a development
 environment, or submit a pull request.
 
 ## Use without local installation
@@ -81,9 +81,11 @@ python -m pip install -e ".[dev,export]"
 ```
 
 Local GUI/Web assets have no hosted Google Analytics injection.
-See [Installation](./docs/INSTALL.md) for details, supported Python versions,
-platform notes, and the PyPI route after publication. The source version is
-`0.14.0` (internal final candidate); 0.14.0 has not been published to PyPI.
+See [Installation](https://github.com/satoshikawato/gbdraw/blob/main/docs/INSTALL.md) for details, supported Python versions,
+platform notes, and the PyPI route. The source version is `0.14.0`; check
+[PyPI](https://pypi.org/project/gbdraw/) for available packages and
+[GitHub Releases](https://github.com/satoshikawato/gbdraw/releases) for publication
+dates. If the desired package is unavailable, use a source install.
 
 ## Bug reports and suggestions
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -16,7 +16,7 @@ Project links:
 
 - GitHub: https://github.com/satoshikawato/gbdraw/
 - Web app: https://gbdraw.app/
-- [0.14.0 release notes (unreleased)](./RELEASE_NOTES_0.14.0.md),
+- [0.14.0 release notes](./RELEASE_NOTES_0.14.0.md),
   [0.14.0b0 beta history](./RELEASE_NOTES_0.14.0b0.md), and the [full changelog](../CHANGELOG.md)
 - [Contributing](../CONTRIBUTING.md) and the [Code of Conduct](../CODE_OF_CONDUCT.md)
 

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -61,7 +61,7 @@ back to reproducible Tutorials or the relevant technical documentation.
 - [Get the tutorial inputs](./GETTING_TUTORIAL_DATA.md)
 - [Palette Explorer](./PALETTE_EXPLORER.md)
 - [About and citation](./ABOUT.md)
-- [0.14.0 release notes (unreleased)](./RELEASE_NOTES_0.14.0.md)
+- [0.14.0 release notes](./RELEASE_NOTES_0.14.0.md)
 - [0.14.0b0 beta history](./RELEASE_NOTES_0.14.0b0.md)
 
 ## Entry points

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,7 +10,7 @@ Choose an installation route according to the version and interface you need:
 | --- | --- | --- |
 | Hosted web app | Making a diagram without a local installation | Runs at [gbdraw.app](https://gbdraw.app/) in your browser. |
 | Bioconda | Routine command-line use and reproducible environments | Recommended for most users. |
-| PyPI (after publication) | Installing into an existing Python environment | Future release route: `python -m pip install gbdraw`. |
+| PyPI | Installing a published version into an existing Python environment | Check [available packages](https://pypi.org/project/gbdraw/) before installing. |
 | Source install | Developing or testing the current checkout | Uses `pip install -e ".[dev]"`. |
 
 ## 1. Hosted web app
@@ -47,8 +47,8 @@ into local installs.
 ## 2. Bioconda installation
 
 Bioconda is the recommended local installation path for routine command-line use.
-The command installs the version available on that channel; it does not select
-the unreleased 0.14.0 checkout.
+The command installs the version available on that channel. Channel availability
+can differ from the source version or other package indexes.
 
 ```bash
 mamba create -n gbdraw -c conda-forge -c bioconda gbdraw
@@ -64,13 +64,13 @@ gbdraw gui
 
 ## 3. PyPI installation
 
-**Not yet published:** the source version is `0.14.0` (internal final candidate);
-0.14.0 has not been published to PyPI. The Trusted Publishing workflow is prepared;
-publisher setup and the release transaction must complete before this route is
-available. To test the current implementation now, use a source install below.
+Check the [PyPI project](https://pypi.org/project/gbdraw/) for available versions.
+The source version is `0.14.0`; a version is installable from PyPI only after it
+appears there. If the project or desired version is unavailable, use a source
+install below.
 
-After publication, install the released package in an activated environment
-using a supported Python version (3.10, 3.11, or 3.12):
+For a version available on PyPI, install in an activated environment using a
+supported Python version (3.10, 3.11, or 3.12):
 
 ```bash
 python -m pip install gbdraw
@@ -80,7 +80,7 @@ gbdraw -h
 Use an isolated virtual environment rather than modifying the system Python installation.
 An unpinned command selects the version available on PyPI, not an unpublished
 candidate. For the release's migration notes, see
-[0.14.0 release notes (unreleased)](./RELEASE_NOTES_0.14.0.md).
+[0.14.0 release notes](./RELEASE_NOTES_0.14.0.md).
 
 ## 4. Source installation for development
 
@@ -103,7 +103,7 @@ pytest tests/ -v -m "not slow"
 ## Optional: non-SVG export support
 
 SVG export works with the base install. PNG, PDF, EPS, and PS export require
-CairoSVG. After PyPI publication:
+CairoSVG. For a version available on PyPI:
 
 ```bash
 python -m pip install "gbdraw[export]"
@@ -117,7 +117,7 @@ libraries. On Ubuntu, the tested system packages are `libcairo2-dev` and
 
 ## Supported and verified environments
 
-The supported Python versions are 3.10, 3.11, and 3.12. The 0.14.0 development
+The supported Python versions are 3.10, 3.11, and 3.12. The 0.14.0
 package has passed isolated wheel/sdist installation, CLI, Python API, session
 replay, and export checks on Linux across those versions. The installed local
 GUI has also been checked with Chromium. These checks do not establish

--- a/docs/RELEASE_NOTES_0.14.0.md
+++ b/docs/RELEASE_NOTES_0.14.0.md
@@ -2,10 +2,10 @@
 
 # gbdraw 0.14.0 release notes
 
-**Status: unreleased.** These notes describe the implemented changes planned for
-the final 0.14.0 release. The source version is `0.14.0` (internal final candidate);
-0.14.0 has not been published to PyPI. Installation availability is documented in
-[Installation](./INSTALL.md).
+These notes describe version `0.14.0` and migration from 0.13. Check
+[GitHub Releases](https://github.com/satoshikawato/gbdraw/releases) for publication
+dates and [PyPI](https://pypi.org/project/gbdraw/) for available packages.
+See [Installation](./INSTALL.md) for distribution and source-install routes.
 
 ## Highlights
 
@@ -135,14 +135,14 @@ remain sequential: earlier completed files survive a later conversion failure.
 
 ## Packaging / installation
 
-Bioconda remains the recommended local installation route. The PyPI Trusted
-Publishing workflow is prepared, but publication has not occurred. The future
-PyPI command and current source-install route are distinguished in
-[Installation](./INSTALL.md); no final package availability is implied here.
+Bioconda remains the recommended local installation route. Each package index
+provides the versions published there; the source version alone does not establish
+package availability. [Installation](./INSTALL.md) explains how to check the
+distribution and install a checkout when the desired version is unavailable.
 
 Wheel and sdist installation has been verified in isolated Linux environments
 on Python 3.10, 3.11, and 3.12, including CLI, Python API, session replay, and
-non-SVG exports. Package contents exclude development tests, private artifacts,
+non-SVG exports. Installed wheel contents exclude development tests, private artifacts,
 and hosted Gallery examples while retaining the GUI palette data and required
 local browser assets. The local GUI was also verified from an installed package.
 SVG needs only the base package; other formats need the `export` extra and
@@ -223,6 +223,10 @@ requirements.
   losslessly as a CLI recipe; Run Info explains the reason.
 - Generate remains explicit for rotation and placement drafts. A new automatic
   redraw scheduler and new zoom-to-selection navigation are not release features.
+- Very dense Circular external-label layouts can require a long computation
+  until completion or cancellation. There is no completion-time guarantee.
+  Existing label selections and controls remain available; cancellation keeps
+  the previous successful Result.
 - The hosted Gallery is not bundled with local installs. Windows/macOS installed
   package verification remains outstanding.
 

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -90,33 +90,36 @@ def test_release_session_history_and_acceptance_use_current_authority() -> None:
     ) is None
 
 
-def test_release_navigation_retains_beta_history_and_marks_final_unreleased() -> None:
+def test_release_navigation_retains_beta_history_and_delegates_publication_dates() -> None:
     changelog = (REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    final_heading = "## [0.14.0](./docs/RELEASE_NOTES_0.14.0.md) — unreleased"
+    final_heading = "## [0.14.0](./docs/RELEASE_NOTES_0.14.0.md)\n"
     beta_heading = "## [0.14.0b0](./docs/RELEASE_NOTES_0.14.0b0.md) — unreleased (beta)"
     assert changelog.index(final_heading) < changelog.index(beta_heading)
     for relative_path in ("README.md", "docs/DOCS.md", "docs/ABOUT.md"):
         source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
         assert re.search(
-            r"\[0\.14\.0 release notes \(unreleased\)\]\([^)]*RELEASE_NOTES_0\.14\.0\.md\)",
+            r"\[0\.14\.0 release notes\]\([^)]*RELEASE_NOTES_0\.14\.0\.md\)",
             source,
         ), relative_path
     for path in (RELEASE_NOTES, REPO_ROOT / "docs/DOCS.md", REPO_ROOT / "docs/ABOUT.md"):
         assert "RELEASE_NOTES_0.14.0b0.md" in path.read_text(encoding="utf-8")
-    assert "**Status: unreleased.**" in RELEASE_NOTES.read_text(encoding="utf-8")
+    for source in (changelog, RELEASE_NOTES.read_text(encoding="utf-8")):
+        assert "https://github.com/satoshikawato/gbdraw/releases" in source
 
 
-def test_installation_distinguishes_current_package_from_future_pypi_route() -> None:
+def test_installation_distinguishes_source_version_from_index_availability() -> None:
     readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
     install = (REPO_ROOT / "docs/INSTALL.md").read_text(encoding="utf-8")
     for source in (readme, install, RELEASE_NOTES.read_text(encoding="utf-8")):
         prose = " ".join(source.split())
         assert f"`{__version__}`" in prose
-        assert "0.14.0 has not been published to PyPI" in prose
+        assert "https://pypi.org/project/gbdraw/" in prose
+        assert "0.14.0 has not been published to PyPI" not in prose
+        assert "internal final candidate" not in prose
     assert "Bioconda is the main installation path" in readme
     assert "Bioconda is the recommended local installation path" in install
     pypi_section = install.split("## 3. PyPI installation\n", 1)[1].split("\n## ", 1)[0]
-    assert pypi_section.index("After publication") < pypi_section.index(
+    assert pypi_section.index("For a version available on PyPI") < pypi_section.index(
         "python -m pip install gbdraw"
     )
     for command in ('python -m pip install gbdraw', 'python -m pip install "gbdraw[export]"'):

--- a/tests/test_tutorial_documentation_contracts.py
+++ b/tests/test_tutorial_documentation_contracts.py
@@ -43,6 +43,10 @@ def _local_target(source: Path, raw_target: str) -> Path | None:
         target = target[1:].split(">", 1)[0]
     else:
         target = target.split(maxsplit=1)[0]
+    repository_prefix = "https://github.com/satoshikawato/gbdraw/blob/main/"
+    if target.startswith(repository_prefix):
+        path_part = target.removeprefix(repository_prefix).split("#", 1)[0].split("?", 1)[0]
+        return (REPO_ROOT / path_part).resolve()
     if re.match(r"^[a-z][a-z0-9+.-]*:", target, re.IGNORECASE) or target.startswith("//"):
         return None
     path_part = target.split("#", 1)[0].split("?", 1)[0]

--- a/tests/test_web_packaging.py
+++ b/tests/test_web_packaging.py
@@ -1169,7 +1169,7 @@ def test_wrangler_uses_cloudflare_bundle_directory() -> None:
 def test_project_docs_and_citation_metadata_include_preprint_doi() -> None:
     readme = README_PATH.read_text(encoding="utf-8")
     assert PREPRINT_DOI in readme
-    assert "./gbdraw/web/assets/gbdraw-logo-title.png" in readme
+    assert "https://raw.githubusercontent.com/satoshikawato/gbdraw/main/gbdraw/web/assets/gbdraw-logo-title.png" in readme
     assert PREPRINT_DOI in ABOUT_PATH.read_text(encoding="utf-8")
     citation_cff = CITATION_PATH.read_text(encoding="utf-8")
     assert PREPRINT_DOI in citation_cff


### PR DESCRIPTION
## Plain-language summary

Update the 0.14.0 release and installation pages so they remain accurate before and after publication: readers check PyPI for available packages and GitHub Releases for publication dates. Make README documentation and image links work in package descriptions, and describe the known long computation time for very dense Circular external labels. Preserve beta history, citation dates, migration details, and the stated Linux verification scope.

## Changes

- Reconcile the six existing documentation owners; add no public page or generated figure.
- Update only the existing documentation assertions that required the old unpublished wording or relative README logo URL. Session compatibility checks, runtime assertions, CI selection, smoke count, budgets, and timeouts retain their existing contracts.
- Keep version `0.14.0`, runtime source, schemas, package builders, and publishing workflows unchanged.

## Validation and scope

- Focused documentation, links, release-source admission, and package tests: 86 passed on Python 3.12.
- Existing release-workflow test passed.
- Standard wheel/sdist builds, strict Twine checks, distribution inspection, and fresh Python 3.12 installs passed. Both installed-package smokes exercised Circular/Linear CLI output, Session replay, the Python API, and required GUI palette resources.
- README is package-bearing editorial (E2). The three updated test files are also E2 because the sdist contains test source; the other five Markdown files are repository-only editorial (E1). Archive inventories verify this classification and unchanged runtime payloads.
- Technical baseline remains `613657d44de5225a424caaee01b9d3557ec08679` (S11 release-tier run `34741897193`). Its original48 and S11 results are retained as baseline evidence; this PR does not claim that those runs tested its new head.

Publisher readiness is recorded separately from the source diff. The GitHub `pypi` environment is absent, PyPI Trusted Publisher registration is unverified, and the existing draft uses `0.14.0` instead of the workflow's `v0.14.0`. These external conditions require resolution before the final publication GO. This PR changes no external publisher setting and performs no main promotion, tag, package upload, or Release publication.
