### PR TITLE
Publish PyPI packages when GitHub Releases are published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@
 name: Publish Python distributions
 
 on:
-  push:
-    tags: ['v[0-9]*.[0-9]*.[0-9]*']
+  release:
+    types: [published]
 
 permissions: {}
 
@@ -20,7 +20,7 @@ jobs:
     outputs:
       artifact-id: ${{ steps.distributions.outputs.artifact-id }}
     steps:
-      - name: Check out exact tag event source and main history
+      - name: Check out exact published release source and main history
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.sha }}

--- a/tests/ci/release-workflow.test.mjs
+++ b/tests/ci/release-workflow.test.mjs
@@ -6,9 +6,9 @@ const source = readFileSync(new URL('../../.github/workflows/release.yml', impor
 const build = source.split('  build-release-distributions:\n')[1].split('  pypi-publish:\n')[0];
 const publish = source.split('  pypi-publish:\n')[1];
 
-test('publishing has only a version tag push entry and immutable actions', () => {
-  assert.match(source, /\non:\n  push:\n    tags: \['v\[0-9\]\*\.\[0-9\]\*\.\[0-9\]\*'\]\n\n/);
-  assert.doesNotMatch(source, /workflow_dispatch|workflow_call|pull_request|\n  release:|branches:/);
+test('publishing starts only when a GitHub Release is published and uses immutable actions', () => {
+  assert.match(source, /\non:\n  release:\n    types: \[published\]\n\n/);
+  assert.doesNotMatch(source, /workflow_dispatch|workflow_call|pull_request|\n  push:|branches:/);
   assert.match(source, /\npermissions: \{\}/);
   assert.equal((source.match(/id-token: write/g) || []).length, 1);
   assert.doesNotMatch(source, /secrets\.|password:|username:|user:|PYPI_TOKEN|TWINE_|repository-url:|continue-on-error|retry|always\(\)/);

--- a/tests/test_release_pipeline.py
+++ b/tests/test_release_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 from runpy import run_path
 import subprocess
@@ -37,9 +38,15 @@ def release_source(tmp_path, monkeypatch):
     read_version.__globals__["PYPROJECT_PATH"] = tmp_path / "pyproject.toml"
     monkeypatch.setitem(check.__globals__, "REPO_ROOT", tmp_path)
     monkeypatch.setitem(check.__globals__, "run_path", lambda _: {"read_project_version": read_version})
+    event_path = tmp_path / "release-event.json"
+    event_path.write_text(json.dumps({
+        "action": "published",
+        "release": {"tag_name": "v0.14.0rc1", "draft": False, "prerelease": True},
+    }))
     for name, value in {
-        "GITHUB_EVENT_NAME": "push", "GITHUB_REF_TYPE": "tag",
+        "GITHUB_EVENT_NAME": "release", "GITHUB_REF_TYPE": "tag",
         "GITHUB_REF": "refs/tags/v0.14.0rc1", "GITHUB_SHA": sha,
+        "GITHUB_EVENT_PATH": str(event_path),
     }.items():
         monkeypatch.setenv(name, value)
     return check, git, tmp_path
@@ -65,6 +72,10 @@ def test_release_admits_final_and_historical_main_source(release_source, monkeyp
     git("checkout", "--detach", final)
     monkeypatch.setenv("GITHUB_SHA", final)
     monkeypatch.setenv("GITHUB_REF", "refs/tags/v0.14.0")
+    (root / "release-event.json").write_text(json.dumps({
+        "action": "published",
+        "release": {"tag_name": "v0.14.0", "draft": False, "prerelease": False},
+    }))
     assert check() == "0.14.0"
 
 
@@ -84,7 +95,7 @@ def test_release_rejects_missing_source_refs(release_source, ref):
     ("GITHUB_REF", "refs/tags/v0.14.0rc1/extra"),
     ("GITHUB_REF_TYPE", "branch"),
     ("GITHUB_EVENT_NAME", "workflow_dispatch"),
-    ("GITHUB_EVENT_NAME", "release"),
+    ("GITHUB_EVENT_NAME", "push"),
     ("GITHUB_SHA", "HEAD"),
     ("GITHUB_SHA", "0" * 40),
 ])
@@ -92,6 +103,31 @@ def test_release_rejects_wrong_event_identity(release_source, monkeypatch, key, 
     check, _, _ = release_source
     monkeypatch.setenv(key, value)
     with pytest.raises(ValueError):
+        check()
+
+
+@pytest.mark.parametrize("action", ["created", "edited", "deleted", "unpublished", "released", "prereleased"])
+def test_release_rejects_other_release_actions(release_source, action):
+    check, _, root = release_source
+    path = root / "release-event.json"
+    event = json.loads(path.read_text())
+    event["action"] = action
+    path.write_text(json.dumps(event))
+    with pytest.raises(ValueError, match="Published GitHub Release and tag ref must agree"):
+        check()
+
+
+@pytest.mark.parametrize("release", [
+    None,
+    {},
+    {"tag_name": "v0.14.0rc1", "draft": True},
+    {"tag_name": "v0.14.0rc1"},
+    {"tag_name": "v0.13.0", "draft": False},
+])
+def test_release_rejects_unpublished_or_mismatched_release(release_source, release):
+    check, _, root = release_source
+    (root / "release-event.json").write_text(json.dumps({"action": "published", "release": release}))
+    with pytest.raises(ValueError, match="Published GitHub Release and tag ref must agree"):
         check()
 
 

--- a/tools/check_release_source.py
+++ b/tools/check_release_source.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Admit only the exact version-tagged release source on main, before building."""
+"""Admit only a published release's exact version-tagged main source."""
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import re
@@ -16,11 +17,20 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 def check_release_source() -> str:
     ref = os.environ["GITHUB_REF"]
     if (
-        os.environ["GITHUB_EVENT_NAME"] != "push"
+        os.environ["GITHUB_EVENT_NAME"] != "release"
         or os.environ["GITHUB_REF_TYPE"] != "tag"
         or not re.fullmatch(r"refs/tags/v\d+\.\d+\.\d+(?:rc\d+)?", ref)
     ):
-        raise ValueError("Release source requires a final or RC version tag push")
+        raise ValueError("Release source requires a published final or RC GitHub Release")
+    event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+    release = event.get("release") if isinstance(event, dict) else None
+    if (
+        not isinstance(release, dict)
+        or event.get("action") != "published"
+        or release.get("draft") is not False
+        or ref != f"refs/tags/{release.get('tag_name')}"
+    ):
+        raise ValueError("Published GitHub Release and tag ref must agree")
     version = run_path(str(REPO_ROOT / "gbdraw/_build_support.py"))["read_project_version"]()
     if ref != f"refs/tags/v{version}":
         raise ValueError("Release tag does not exactly match the project version")


### PR DESCRIPTION
## Plain-language summary

Publishing a GitHub Release now starts the PyPI workflow for that Release's exact tag. Maintainers can publish a Release manually and let PyPI follow the upstream publication that Bioconda detects. Creating a tag or editing a draft does not start PyPI publication.

## Release boundary

- Replace the tag-push trigger with `release: types: [published]` in the existing `release.yml`; there is one publication entry point.
- The existing source gate now checks the published event, non-draft Release, and matching Release tag/ref. Exact project version, checkout/event/tag identity, main first-parent membership, and clean-source checks remain enforced.
- Keep one build, strict metadata/archive checks, isolated installation verification, and publication of the same artifact ID with digest verification. The PyPI Trusted Publisher identity, `pypi` environment, human approval, and OIDC-only credentials remain unchanged.
- No package version or CLI/Python/browser implementation changes. The prior publication candidate's GO is not authorization to publish this changed revision.

## Validation

- `python -m pytest tests/test_release_pipeline.py -q`: 39 passed. Real Git fixtures cover published final/RC tags, historical main, rejected tag pushes and other Release actions, drafts, mismatched tags, unpromoted source, moved tags, and dirty checkouts.
- `node --test tests/ci/release-workflow.test.mjs`: passed, including the sole publication trigger and unchanged artifact/credential separation.
- Focused Ruff and `git diff --check`: passed.
- Normal required CI applies. Original48 and S11 are retained at their accepted technical baseline; no new full acceptance dispatch is added.

## Architecture evidence

The source-admission owner remains `tools/check_release_source.py`, called only by the existing build job in `release.yml`. This replaces one trigger with one trigger and removes the superseded tag-push path in the same change; there is no new owner, compatibility path, or Web behavior. Before any publication, rollback is a normal revert of this workflow/source-gate change and its matching tests.
